### PR TITLE
reactivate  places-with-terminal@mtwebster

### DIFF
--- a/places-with-terminal@mtwebster/files/places-with-terminal@mtwebster/applet.js
+++ b/places-with-terminal@mtwebster/files/places-with-terminal@mtwebster/applet.js
@@ -91,15 +91,15 @@ MyMenu.prototype = {
 		}
 };
 
-function MyApplet(orientation) {
-	this._init(orientation);
+function MyApplet(metadata, orientation, panelHeight, instanceId) {
+	this._init(orientation, panelHeight, instanceId);
 }
 
 MyApplet.prototype = {
 		__proto__: Applet.IconApplet.prototype,
 
-		_init: function(orientation) {
-			Applet.IconApplet.prototype._init.call(this, orientation);
+		_init: function(orientation, panelHeight, instanceId) {
+			Applet.IconApplet.prototype._init.call(this, orientation, panelHeight, instanceId);
 
 			try {
 				this.set_applet_icon_symbolic_name('folder');
@@ -190,7 +190,7 @@ MyApplet.prototype = {
 		}
 };
 
-function main(metadata, orientation) {  
-	let myApplet = new MyApplet(orientation);
+function main(metadata, orientation, panelHeight, instanceId) {  
+	let myApplet = new MyApplet(metadata, orientation, panelHeight, instanceId);
 	return myApplet;      
 };

--- a/places-with-terminal@mtwebster/files/places-with-terminal@mtwebster/applet.js
+++ b/places-with-terminal@mtwebster/files/places-with-terminal@mtwebster/applet.js
@@ -94,11 +94,11 @@ MyApplet.prototype = {
 				this.menuManager.addMenu(this.menu);
 
 				this._display();
-                this.refresh_menu_item = new Applet.MenuItem(_("Refresh bookmarks..."), 'view-refresh-symbolic',
-                        Lang.bind(this, this._refresh));
+				this.refresh_menu_item = new PopupMenu.PopupIconMenuItem(_("Refresh bookmarks..."), 'view-refresh-symbolic', St.IconType.SYMBOLIC);
+                this.refresh_menu_item.connect('activate', Lang.bind(this, this._refresh));
                 this._applet_context_menu.addMenuItem(this.refresh_menu_item);
-                this.defaults_menu_item = new Applet.MenuItem(_("Change default programs..."), 'system-run-symbolic',
-                        Lang.bind(this, this._defaults));
+                this.defaults_menu_item = new PopupMenu.PopupIconMenuItem(_("Change default programs..."), 'system-run-symbolic', St.IconType.SYMBOLIC);
+                this.refresh_menu_item.connect('activate', Lang.bind(this, this._defaults));
                 this._applet_context_menu.addMenuItem(this.defaults_menu_item);
 			}
 			catch (e) {
@@ -113,7 +113,7 @@ MyApplet.prototype = {
         },
 
         _defaults: function() {
-            Util.spawn(['gnome-control-center', 'info']);
+            Util.spawn(['cinnamon-settings', 'default']);
         },
 
 		on_applet_clicked: function(event) {    

--- a/places-with-terminal@mtwebster/files/places-with-terminal@mtwebster/applet.js
+++ b/places-with-terminal@mtwebster/files/places-with-terminal@mtwebster/applet.js
@@ -145,7 +145,7 @@ MyApplet.prototype = {
 			
 			this.menu.addMenuItem(this.computerItem);
 			this.computerItem.connect('activate', function(actor, event) {
-                            Main.Util.spawnCommandLine("nautilus computer://");
+                            Main.Util.spawnCommandLine("xdg-open computer://");
 			});
 			
 			let icon = new St.Icon({icon_name: "harddrive", icon_size: ICON_SIZE, icon_type: St.IconType.FULLCOLOR, style_class: 'popup-menu-icon'});
@@ -153,7 +153,7 @@ MyApplet.prototype = {
 			
 			this.menu.addMenuItem(this.filesystemItem);
 			this.filesystemItem.connect('activate', function(actor, event) {
-                            Main.Util.spawnCommandLine("gksudo nautilus /");
+                            Main.Util.spawnCommandLine("gksudo xdg-open /");
 			});
 			
 			// Separator

--- a/places-with-terminal@mtwebster/files/places-with-terminal@mtwebster/applet.js
+++ b/places-with-terminal@mtwebster/files/places-with-terminal@mtwebster/applet.js
@@ -35,12 +35,13 @@ function MyPopupMenuItem()
 MyPopupMenuItem.prototype =
 {
 		__proto__: PopupMenu.PopupBaseMenuItem.prototype,
-		_init: function(icon, text, loc, params)
+		_init: function(icon, text, loc, menu_actor, params)
 		{
 		    let term_icon = new St.Icon({icon_name: "terminal", icon_size: 16, icon_type: St.IconType.FULLCOLOR});
 			PopupMenu.PopupBaseMenuItem.prototype._init.call(this, params);
 			this.icon = icon;
             this.loc = loc;
+			this.menu_actor = menu_actor;
 			this.addActor(this.icon);
             this.labeltext = text;
 			this.label = new St.Label({ text: text });
@@ -72,6 +73,7 @@ MyPopupMenuItem.prototype =
                 this.loc = "/";
             } 
             Main.Util.spawnCommandLine("gnome-terminal --working-directory="+this.loc);
+			this.menu_actor.hide();
         }
 };
 
@@ -130,7 +132,7 @@ MyApplet.prototype = {
 			for ( placeid; placeid < this.defaultPlaces.length; placeid++) {
 				let icon = this.defaultPlaces[placeid].iconFactory(ICON_SIZE);
 				this.placeItems[placeid] = new MyPopupMenuItem(icon, _(this.defaultPlaces[placeid].name),
-                                    this.defaultPlaces[placeid].id.replace('bookmark:file://',''));
+                                    this.defaultPlaces[placeid].id.replace('bookmark:file://',''), this.menu.actor);
 				this.placeItems[placeid].place = this.defaultPlaces[placeid];
 
 				this.menu.addMenuItem(this.placeItems[placeid]);
@@ -149,7 +151,7 @@ MyApplet.prototype = {
 			});
 			
 			let icon = new St.Icon({icon_name: "harddrive", icon_size: ICON_SIZE, icon_type: St.IconType.FULLCOLOR, style_class: 'popup-menu-icon'});
-			this.filesystemItem = new MyPopupMenuItem(icon, _("File System"), "root");
+			this.filesystemItem = new MyPopupMenuItem(icon, _("File System"), "root", this.menu.actor);
 			
 			this.menu.addMenuItem(this.filesystemItem);
 			this.filesystemItem.connect('activate', function(actor, event) {
@@ -164,7 +166,7 @@ MyApplet.prototype = {
 			for ( bookmarkid; bookmarkid < this.bookmarks.length; bookmarkid++, placeid++) {
 				let icon = this.bookmarks[bookmarkid].iconFactory(ICON_SIZE);
 				this.placeItems[placeid] = new MyPopupMenuItem(icon, _(this.bookmarks[bookmarkid].name),
-                        this.bookmarks[bookmarkid].id.replace('bookmark:file://',''));
+                        this.bookmarks[bookmarkid].id.replace('bookmark:file://',''), this.menu.actor);
 				this.placeItems[placeid].place = this.bookmarks[bookmarkid];
 				this.menu.addMenuItem(this.placeItems[placeid]);
 				this.placeItems[placeid].connect('activate', function(actor, event) {

--- a/places-with-terminal@mtwebster/files/places-with-terminal@mtwebster/applet.js
+++ b/places-with-terminal@mtwebster/files/places-with-terminal@mtwebster/applet.js
@@ -75,22 +75,6 @@ MyPopupMenuItem.prototype =
         }
 };
 
-function MyMenu(launcher, orientation) {
-	this._init(launcher, orientation);
-}
-
-MyMenu.prototype = {
-		__proto__: PopupMenu.PopupMenu.prototype,
-
-		_init: function(launcher, orientation) {
-			this._launcher = launcher;
-
-			PopupMenu.PopupMenu.prototype._init.call(this, launcher.actor, 0.0, orientation, 0);
-			Main.uiGroup.add_actor(this.actor);
-			this.actor.hide();            
-		}
-};
-
 function MyApplet(metadata, orientation, panelHeight, instanceId) {
 	this._init(orientation, panelHeight, instanceId);
 }
@@ -106,7 +90,7 @@ MyApplet.prototype = {
 				this.set_applet_tooltip(_("Places and bookmarks"));
 
 				this.menuManager = new PopupMenu.PopupMenuManager(this);
-				this.menu = new MyMenu(this, orientation);
+				this.menu = new Applet.AppletPopupMenu(this, orientation);
 				this.menuManager.addMenu(this.menu);
 
 				this._display();


### PR DESCRIPTION
 places-with-terminal@mtwebster has not been working for some time because it
1. referenced `nautilus` and `gnome-control-center`
2. used a custom Menu that contained a function call `PopupMenu.PopupMenu.prototype._init` that used an invalid signature

This fix brings the applet back to a working state and additionally contains one small improvement: After clicking the terminal icon for a place, the popup menu now closes.