### PR TITLE
scripts@paucapo: change "title" to "paneltitle" in settings-schema

### DIFF
--- a/scripts@paucapo.com/files/scripts@paucapo.com/applet.js
+++ b/scripts@paucapo.com/files/scripts@paucapo.com/applet.js
@@ -23,7 +23,7 @@ MyApplet.prototype = {
       this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL, "directory", "directory", this._onSettingsDirectory, null)
 
       this.settings.bindProperty(Settings.BindingDirection.IN, "showtitle", "showtitle", this._onSettingsTitle, null)
-      this.settings.bindProperty(Settings.BindingDirection.IN, "title", "title", this._onSettingsTitle, null)
+      this.settings.bindProperty(Settings.BindingDirection.IN, "paneltitle", "paneltitle", this._onSettingsTitle, null)
 
       this.settings.bindProperty(Settings.BindingDirection.IN, "customicon", "customicon", this._onSettingsIcon, null)
       this.settings.bindProperty(Settings.BindingDirection.IN, "icon", "icon", this._onSettingsIcon, null)
@@ -73,8 +73,8 @@ MyApplet.prototype = {
 
    _onSettingsTitle: function() {
       if (this.showtitle) {
-         this.set_applet_label(this.title);
-         this.set_applet_tooltip(this.title);
+         this.set_applet_label(this.paneltitle);
+         this.set_applet_tooltip(this.paneltitle);
       } else {
          this.set_applet_label("");
          this.set_applet_tooltip(_("Scripts"));

--- a/scripts@paucapo.com/files/scripts@paucapo.com/settings-schema.json
+++ b/scripts@paucapo.com/files/scripts@paucapo.com/settings-schema.json
@@ -19,7 +19,7 @@
       "default" : true,
       "description" : "Show title"
    },
-   "title": {
+   "paneltitle": {
       "type" : "entry",
       "default" : "Scripts",
       "description" : "Title"


### PR DESCRIPTION
Using "title" as name for an setting causes problems with cinnamon-json-makepot, i.e. when you want to create a translation template. (see https://github.com/linuxmint/cinnamon-spices-applets/issues/37)
Because there's an item called "title" for "pages" and "sections", which is expecting a value.