### PR TITLE
[vboxlauncher@mockturtl] Fixed startVmplayerImage Function : not starting VMs with spaces in its name

### DIFF
--- a/vboxlauncher@mockturtl/files/vboxlauncher@mockturtl/applet.js
+++ b/vboxlauncher@mockturtl/files/vboxlauncher@mockturtl/applet.js
@@ -213,18 +213,7 @@ MyApplet.prototype = {
 ,  startVmplayer: function() {
     Util.spawnCommandLine(CMD_VMPLAYER)
   }
-    // Modified by MuhmdRaouf E-mail: mohammed.raouf.m AT gmail DOT com
-    /* this line modified by @MuhmdRaouf
-     * added single quote before and after the path in order to capture
-     * the full path and pass it to the VMplayer
-     * in this case even if the VM has spaces in its name it will work
-     * as example before the modification the command will run like that
-     * ( vmplayer /home/username/vmware/vm machine/vm machine.vmx )
-     * but unfortunately it wont run like that
-     * now it will be like this
-     * ( vmplayer '/home/username/vmware/vm machine/vm machine.vmx' )
-     * its okey to has spaces as long its inside of 2 quotes
-     */
+
 ,  startVmplayerImage: function(path) {
     Util.spawnCommandLine(CMD_VMPLAYER + " '" + path + "' ")
   }

--- a/vboxlauncher@mockturtl/files/vboxlauncher@mockturtl/applet.js
+++ b/vboxlauncher@mockturtl/files/vboxlauncher@mockturtl/applet.js
@@ -213,9 +213,20 @@ MyApplet.prototype = {
 ,  startVmplayer: function() {
     Util.spawnCommandLine(CMD_VMPLAYER)
   }
-
+    // Modified by MuhmdRaouf E-mail: mohammed.raouf.m AT gmail DOT com
+    /* this line modified by @MuhmdRaouf
+     * added single quote before and after the path in order to capture
+     * the full path and pass it to the VMplayer
+     * in this case even if the VM has spaces in its name it will work
+     * as example before the modification the command will run like that
+     * ( vmplayer /home/username/vmware/vm machine/vm machine.vmx )
+     * but unfortunately it wont run like that
+     * now it will be like this
+     * ( vmplayer '/home/username/vmware/vm machine/vm machine.vmx' )
+     * its okey to has spaces as long its inside of 2 quotes
+     */
 ,  startVmplayerImage: function(path) {
-    Util.spawnCommandLine(CMD_VMPLAYER + " " + path)
+    Util.spawnCommandLine(CMD_VMPLAYER + " '" + path + "' ")
   }
 
 ,  on_applet_clicked: function(event) {


### PR DESCRIPTION
now the function able to run any image even if it's has spaces in its name.
before the single quote the command will be like this
( vmplayer /home/username/vmware/vm machine/vm machine.vmx )
but unfortunately it wont run becouse of those spaces,
after wraping the path with single quotes it will run smoothly :+1: 
( vmplayer '/home/username/vmware/vm machine/vm machine.vmx' )