### PR TITLE
clipboard-qr@wrouesnel: fix applet from crashing

### DIFF
--- a/clipboard-qr@wrouesnel/README.md
+++ b/clipboard-qr@wrouesnel/README.md
@@ -1,0 +1,11 @@
+Create and Scan QR codes directly from your Cinnamon desktop!
+
+Easily move snippets of text between your phone and your desktop or laptop using just your webcam!
+
+This handy applet uses the python-zbar library to fully support scanning QR codes (and barcodes!) directly into your clipboard with the click of a button.
+
+You will need to "sudo apt-get install python-zbar" for scanning functionality to work but that's ALL you'll need to do.
+
+This is a fork of the original Clipboard QR Code applet by ebbes, with the added scanning functionality and general patches to make it work on modern Cinnamon.
+
+Requests for features welcome!

--- a/clipboard-qr@wrouesnel/files/clipboard-qr@wrouesnel/applet.js
+++ b/clipboard-qr@wrouesnel/files/clipboard-qr@wrouesnel/applet.js
@@ -140,7 +140,11 @@ MyApplet.prototype = {
             clipboard.get_text(Lang.bind(this,
                 function(clipboard, text) {
                     this._qr.set_text(text);
-                    this._errorString.label.text = this._qr.error;
+                    try {
+                        this._errorString.label.text = this._qr.error;
+                    } catch (e) {
+                        this._errorString.label.text = _("No QR code scanned.");
+                    }
                     this.menu.toggle();
                 }));
     }


### PR DESCRIPTION
When closing QR scanner without having scanned anything, the applet does not pop up anymore.
Catch this error.

Restore Readme from wayback machine