### PR TITLE
Places (places-bookmarks@dmo60.de) update

### DIFF
--- a/places-bookmarks@dmo60.de/README.md
+++ b/places-bookmarks@dmo60.de/README.md
@@ -12,5 +12,4 @@ Installation
 Applet Style
 ================
 
-It is possible to change the applet appearance. You can choose between the default icon, symbolic icons or a text label.
-All you have to do is to modify the highlighted line in the "applet.js" file and select one of the options provided.
+The icon, label and menu items icon size can be modified from this applet settings found on its context menu.

--- a/places-bookmarks@dmo60.de/files/places-bookmarks@dmo60.de/applet.js
+++ b/places-bookmarks@dmo60.de/files/places-bookmarks@dmo60.de/applet.js
@@ -2,155 +2,243 @@ const St = imports.gi.St;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
 const Applet = imports.ui.applet;
-
+const GLib = imports.gi.GLib;
+const Gtk = imports.gi.Gtk;
+const Settings = imports.ui.settings;
+const Lang = imports.lang;
+const Mainloop = imports.mainloop;
 const Gettext = imports.gettext;
-const _ = Gettext.gettext;
 
-const ICON_SIZE = 22;
+var UUID;
 
-/* Set APPLET_STYLE to one of the following and restart Cinnamon to apply changes:
- * "icon-home", "icon-home-symbolic", "icon-folder-symbolic", "text"  */
-const APPLET_STYLE = "icon-home";
+function _(aStr) {
+    let customTrans = Gettext.dgettext(UUID, aStr);
 
-/* Set custom APPLET_TEXT here. Set empty string ("") for default.
- * The text is only shown when APPLET_STYLE is set to "text". */
-const APPLET_TEXT = "";
+    if (customTrans !== aStr)
+        return customTrans;
 
-
-function MyPopupMenuItem()
-{
-	this._init.apply(this, arguments);
+    return Gettext.gettext(aStr);
 }
 
-MyPopupMenuItem.prototype =
-{
-		__proto__: PopupMenu.PopupBaseMenuItem.prototype,
-		_init: function(icon, text, params)
-		{
-			PopupMenu.PopupBaseMenuItem.prototype._init.call(this, params);
-			this.icon = icon;
-			this.addActor(this.icon);
-			this.label = new St.Label({ text: text });
-			this.addActor(this.label);
-		}
-};
-
-function MyMenu(launcher, orientation) {
-	this._init(launcher, orientation);
+function MyPopupMenuItem() {
+    this._init.apply(this, arguments);
 }
 
-MyMenu.prototype = {
-		__proto__: PopupMenu.PopupMenu.prototype,
+MyPopupMenuItem.prototype = {
+    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
 
-		_init: function(launcher, orientation) {
-			this._launcher = launcher;
-
-			PopupMenu.PopupMenu.prototype._init.call(this, launcher.actor, 0.0, orientation, 0);
-			Main.uiGroup.add_actor(this.actor);
-			this.actor.hide();
-		}
+    _init: function(icon, text, params) {
+        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, params);
+        this.icon = icon;
+        this.addActor(this.icon);
+        this.label = new St.Label({
+            text: text
+        });
+        this.addActor(this.label);
+    }
 };
 
-function MyApplet(orientation) {
-	this._init(orientation);
+function MyApplet(metadata, orientation, panel_height, instance_id) {
+    this._init(metadata, orientation, panel_height, instance_id);
 }
 
 MyApplet.prototype = {
-		__proto__: Applet.TextIconApplet.prototype,
+    __proto__: Applet.TextIconApplet.prototype,
 
-		_init: function(orientation) {
-			Applet.TextIconApplet.prototype._init.call(this, orientation);
+    _init: function(metadata, orientation, panel_height, instance_id) {
+        Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
 
-			try {
-				
-				switch (APPLET_STYLE) {
-				case "text":
-					if (APPLET_TEXT)
-						this.set_applet_label(APPLET_TEXT);
-					else
-						this.set_applet_label(_("Places"));
-					break;
-				case "icon-folder-symbolic":
-					this.set_applet_icon_symbolic_name("folder");
-					break;
-				case "icon-home-symbolic":
-					this.set_applet_icon_symbolic_name("user-home");
-					break;
-				default:
-					this.set_applet_icon_name("user-home");
-					break;
-				}
+        // Condition needed for retro-compatibility.
+        // Mark for deletion on EOL.
+        if (Applet.hasOwnProperty("AllowedLayout"))
+            this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
-				this.menuManager = new PopupMenu.PopupMenuManager(this);
-				this.menu = new MyMenu(this, orientation);
-				this.menuManager.addMenu(this.menu);
+        this.settings = new Settings.AppletSettings(this, metadata.uuid, instance_id);
 
-				this._display();
-			}
-			catch (e) {
-				global.logError(e);
-			};
-		},
+        try {
+            this._bindSettings();
+            UUID = metadata.uuid;
+            this.display_id = 0;
+            this.orientation = orientation;
+            this.instance_id = instance_id;
 
-		on_applet_clicked: function(event) {
-			this.menu.toggle();
-		},
+            this.menuManager = new PopupMenu.PopupMenuManager(this);
 
-		_display: function() {
-			let placeid = 0;
-			this.placeItems = [];
+            Main.placesManager.connect("places-updated", Lang.bind(this, this._display));
 
-			this.defaultPlaces = Main.placesManager.getDefaultPlaces();
-			this.bookmarks     = Main.placesManager.getBookmarks();
+            this._display();
+            this._updateIconAndLabel();
+        } catch (e) {
+            global.logError(e);
+        }
+    },
 
-			// Display default places
-			for ( placeid; placeid < this.defaultPlaces.length; placeid++) {
-				let icon = this.defaultPlaces[placeid].iconFactory(ICON_SIZE);
-				this.placeItems[placeid] = new MyPopupMenuItem(icon, _(this.defaultPlaces[placeid].name));
-				this.placeItems[placeid].place = this.defaultPlaces[placeid];
+    _bindSettings: function() {
+        let bD = Settings.BindingDirection || null;
+        let settingsArray = [
+            [bD.IN, "pref_applet_label", this._updateIconAndLabel],
+            [bD.IN, "pref_applet_icon", this._updateIconAndLabel],
+            [bD.IN, "pref_icon_size", this._display],
+        ];
+        let newBinding = typeof this.settings.bind === "function";
+        for (let [binding, property_name, callback] of settingsArray) {
+            // Condition needed for retro-compatibility.
+            // Mark for deletion on EOL.
+            if (newBinding)
+                this.settings.bind(property_name, property_name, callback);
+            else
+                this.settings.bindProperty(binding, property_name, property_name, callback, null);
+        }
+    },
 
-				this.menu.addMenuItem(this.placeItems[placeid]);
-				this.placeItems[placeid].connect('activate', function(actor, event) {
-					actor.place.launch();
-				});
-			}
+    on_orientation_changed: function(orientation) {
+        this.orientation = orientation;
+        this._display();
+        this._updateIconAndLabel();
+    },
 
-			// Display Computer / Filesystem
-			let icon = new St.Icon({icon_name: "computer", icon_size: ICON_SIZE, icon_type: St.IconType.FULLCOLOR});
-			this.computerItem = new MyPopupMenuItem(icon, _("Computer"));
+    _updateIconAndLabel: function() {
+        try {
+            if (this.pref_applet_icon !== "" ||
+                !(this.orientation === St.Side.TOP || this.orientation === St.Side.BOTTOM)) {
+                if (this.pref_applet_icon === "") {
+                    this.set_applet_icon_name("");
+                } else if (GLib.path_is_absolute(this.pref_applet_icon) &&
+                    GLib.file_test(this.pref_applet_icon, GLib.FileTest.EXISTS)) {
+                    if (this.pref_applet_icon.search("-symbolic") != -1)
+                        this.set_applet_icon_symbolic_path(this.pref_applet_icon);
+                    else
+                        this.set_applet_icon_path(this.pref_applet_icon);
+                } else if (Gtk.IconTheme.get_default().has_icon(this.pref_applet_icon)) {
+                    if (this.pref_applet_icon.search("-symbolic") != -1)
+                        this.set_applet_icon_symbolic_name(this.pref_applet_icon);
+                    else
+                        this.set_applet_icon_name(this.pref_applet_icon);
+                }
+            } else {
+                this.hide_applet_icon();
+            }
+        } catch (aErr) {
+            global.logWarning("Could not load icon file \"%s\" for menu button."
+                .format(this.pref_applet_icon));
+        }
 
-			this.menu.addMenuItem(this.computerItem);
-			this.computerItem.connect('activate', function(actor, event) {
-                Main.Util.spawnCommandLine("xdg-open computer://");
-			});
+        if (this.pref_applet_icon === "") {
+            if (this.orientation === St.Side.TOP || this.orientation === St.Side.BOTTOM)
+                this._applet_icon_box.hide();
+            else // Display icon box anyways in vertical panels.
+                this._applet_icon_box.show();
+        } else {
+            this._applet_icon_box.show();
+        }
 
-			let icon = new St.Icon({icon_name: "harddrive", icon_size: ICON_SIZE, icon_type: St.IconType.FULLCOLOR});
-			this.filesystemItem = new MyPopupMenuItem(icon, _("File System"));
+        if (this.orientation === St.Side.TOP || this.orientation === St.Side.BOTTOM) { // no menu label if in a vertical panel
+            if (this.pref_applet_label !== "")
+                this.set_applet_label(_(this.pref_applet_label));
+            else
+                this.set_applet_label("");
+        } else {
+            this.set_applet_label("");
+        }
 
-			this.menu.addMenuItem(this.filesystemItem);
-			this.filesystemItem.connect('activate', function(actor, event) {
-                Main.Util.spawnCommandLine("xdg-open /");
-			});
+        this.update_label_visible();
+    },
 
-			// Separator
-			this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+    update_label_visible: function() {
+        // Condition needed for retro-compatibility.
+        // Mark for deletion on EOL.
+        if (typeof this.hide_applet_label !== "function")
+            return;
 
-			let bookmarkid = 0;
-			// Display default bookmarks
-			for ( bookmarkid; bookmarkid < this.bookmarks.length; bookmarkid++, placeid++) {
-				let icon = this.bookmarks[bookmarkid].iconFactory(ICON_SIZE);
-				this.placeItems[placeid] = new MyPopupMenuItem(icon, _(this.bookmarks[bookmarkid].name));
-				this.placeItems[placeid].place = this.bookmarks[bookmarkid];
+        if (this.orientation == St.Side.LEFT || this.orientation == St.Side.RIGHT)
+            this.hide_applet_label(true);
+        else
+            this.hide_applet_label(false);
+    },
 
-				this.menu.addMenuItem(this.placeItems[placeid]);
-				this.placeItems[placeid].connect('activate', function(actor, event) {
-					actor.place.launch();
-				});
-			};
-		}
+    on_applet_clicked: function(event) {
+        this.menu.toggle();
+    },
+
+    _display: function() {
+        if (this.display_id > 0) {
+            Mainloop.source_remove(this.display_id);
+            this.display_id = 0;
+        }
+
+        this.display_id = Mainloop.timeout_add(300,
+            Lang.bind(this, function() {
+                if (this.menu)
+                    this.menu.destroy();
+
+                this.menu = new Applet.AppletPopupMenu(this, this.orientation, this.instance_id);
+                this.menuManager.addMenu(this.menu);
+
+                let placeid = 0;
+                this.placeItems = [];
+
+                this.defaultPlaces = Main.placesManager.getDefaultPlaces();
+                this.bookmarks = Main.placesManager.getBookmarks();
+
+                // Display default places
+                for (placeid; placeid < this.defaultPlaces.length; placeid++) {
+                    let icon = this.defaultPlaces[placeid].iconFactory(this.pref_icon_size);
+                    this.placeItems[placeid] = new MyPopupMenuItem(icon, _(this.defaultPlaces[placeid].name));
+                    this.placeItems[placeid].place = this.defaultPlaces[placeid];
+
+                    this.menu.addMenuItem(this.placeItems[placeid]);
+                    this.placeItems[placeid].connect('activate', function(actor, event) {
+                        actor.place.launch();
+                    });
+                }
+
+                // Display Computer / Filesystem
+                let icon = new St.Icon({
+                    icon_name: "computer",
+                    icon_size: this.pref_icon_size,
+                    icon_type: St.IconType.FULLCOLOR
+                });
+                // TO TRANSLATORS: Could be left blank.
+                this.computerItem = new MyPopupMenuItem(icon, _("Computer"));
+
+                this.menu.addMenuItem(this.computerItem);
+                this.computerItem.connect('activate', function(actor, event) {
+                    Main.Util.spawnCommandLine("xdg-open computer://");
+                });
+
+                icon = new St.Icon({
+                    icon_name: "harddrive",
+                    icon_size: this.pref_icon_size,
+                    icon_type: St.IconType.FULLCOLOR
+                });
+                // TO TRANSLATORS: Could be left blank.
+                this.filesystemItem = new MyPopupMenuItem(icon, _("File System"));
+
+                this.menu.addMenuItem(this.filesystemItem);
+                this.filesystemItem.connect('activate', function(actor, event) {
+                    Main.Util.spawnCommandLine("xdg-open /");
+                });
+
+                // Separator
+                this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
+                let bookmarkid = 0;
+                // Display default bookmarks
+                for (bookmarkid; bookmarkid < this.bookmarks.length; bookmarkid++, placeid++) {
+                    let icon = this.bookmarks[bookmarkid].iconFactory(this.pref_icon_size);
+                    this.placeItems[placeid] = new MyPopupMenuItem(icon, _(this.bookmarks[bookmarkid].name));
+                    this.placeItems[placeid].place = this.bookmarks[bookmarkid];
+
+                    this.menu.addMenuItem(this.placeItems[placeid]);
+                    this.placeItems[placeid].connect('activate', function(actor, event) {
+                        actor.place.launch();
+                    });
+                }
+            }));
+    }
 };
 
-function main(metadata, orientation) {
-	let myApplet = new MyApplet(orientation);
-	return myApplet;
-};
+function main(metadata, orientation, panel_height, instance_id) {
+    let myApplet = new MyApplet(metadata, orientation, panel_height, instance_id);
+    return myApplet;
+}

--- a/places-bookmarks@dmo60.de/files/places-bookmarks@dmo60.de/metadata.json
+++ b/places-bookmarks@dmo60.de/files/places-bookmarks@dmo60.de/metadata.json
@@ -1,6 +1,7 @@
 {
-"uuid": "places-bookmarks@dmo60.de",
-"name": "Places",
-"description": "Access your places and bookmarks",
-"icon": "user-home"
+    "uuid": "places-bookmarks@dmo60.de",
+    "max-instances": -1,
+    "description": "Access your places and bookmarks",
+    "name": "Places",
+    "icon": "user-home"
 }

--- a/places-bookmarks@dmo60.de/files/places-bookmarks@dmo60.de/po/es.po
+++ b/places-bookmarks@dmo60.de/files/places-bookmarks@dmo60.de/po/es.po
@@ -1,0 +1,59 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-22 12:23-0300\n"
+"PO-Revision-Date: 2017-03-22 12:48-0300\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.7.1\n"
+"Last-Translator: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: es\n"
+
+#: applet.js:199
+msgid "Computer"
+msgstr "PC"
+
+#: applet.js:211
+msgid "File System"
+msgstr "Sistema de archivos"
+
+#. places-bookmarks@dmo60.de->metadata.json->name
+msgid "Places"
+msgstr "Lugares"
+
+#. places-bookmarks@dmo60.de->metadata.json->description
+msgid "Access your places and bookmarks"
+msgstr "Acceder a lugares y favoritos"
+
+#. places-bookmarks@dmo60.de->settings-
+#. schema.json->pref_icon_size->description
+msgid "Menu items icon size"
+msgstr "Tamaño de íconos de los elementos del menú"
+
+#. places-bookmarks@dmo60.de->settings-schema.json->pref_icon_size->units
+msgid "pixels"
+msgstr "píxeles"
+
+#. places-bookmarks@dmo60.de->settings-
+#. schema.json->pref_applet_icon->description
+msgid "Applet icon"
+msgstr "Ícono del applet"
+
+#. places-bookmarks@dmo60.de->settings-schema.json->pref_applet_icon->tooltip
+#. places-bookmarks@dmo60.de->settings-schema.json->pref_applet_label->tooltip
+msgid "Leave blank to remove."
+msgstr "Dejar en blanco para eliminar."
+
+#. places-bookmarks@dmo60.de->settings-
+#. schema.json->pref_applet_label->description
+msgid "Applet label"
+msgstr "Etiqueta para el applet"

--- a/places-bookmarks@dmo60.de/files/places-bookmarks@dmo60.de/po/localization-template.pot
+++ b/places-bookmarks@dmo60.de/files/places-bookmarks@dmo60.de/po/localization-template.pot
@@ -1,0 +1,58 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-22 12:21-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: \n"
+
+#: applet.js:199
+msgid "Computer"
+msgstr ""
+
+#: applet.js:211
+msgid "File System"
+msgstr ""
+
+#. places-bookmarks@dmo60.de->metadata.json->name
+msgid "Places"
+msgstr ""
+
+#. places-bookmarks@dmo60.de->metadata.json->description
+msgid "Access your places and bookmarks"
+msgstr ""
+
+#. places-bookmarks@dmo60.de->settings-
+#. schema.json->pref_icon_size->description
+msgid "Menu items icon size"
+msgstr ""
+
+#. places-bookmarks@dmo60.de->settings-schema.json->pref_icon_size->units
+msgid "pixels"
+msgstr ""
+
+#. places-bookmarks@dmo60.de->settings-
+#. schema.json->pref_applet_icon->description
+msgid "Applet icon"
+msgstr ""
+
+#. places-bookmarks@dmo60.de->settings-schema.json->pref_applet_icon->tooltip
+#. places-bookmarks@dmo60.de->settings-schema.json->pref_applet_label->tooltip
+msgid "Leave blank to remove."
+msgstr ""
+
+#. places-bookmarks@dmo60.de->settings-
+#. schema.json->pref_applet_label->description
+msgid "Applet label"
+msgstr ""

--- a/places-bookmarks@dmo60.de/files/places-bookmarks@dmo60.de/settings-schema.json
+++ b/places-bookmarks@dmo60.de/files/places-bookmarks@dmo60.de/settings-schema.json
@@ -1,0 +1,23 @@
+{
+    "pref_applet_label": {
+        "type": "entry",
+        "default": "Places",
+        "description": "Applet label",
+        "tooltip": "Leave blank to remove."
+    },
+    "pref_applet_icon": {
+        "type": "iconfilechooser",
+        "default": "user-home",
+        "description": "Applet icon",
+        "tooltip": "Leave blank to remove."
+    },
+    "pref_icon_size": {
+        "type": "spinbutton",
+        "default": 22,
+        "min": 16,
+        "max": 512,
+        "step": 1,
+        "units": "pixels",
+        "description": "Menu items icon size"
+    }
+}


### PR DESCRIPTION
- Removed custom menu prototype in favor of using **Applet.AppletPopupMenu**. Fixes #245.
- Added full support for Cinnamon 3.2 and its vertical panels.
- Added possibility to configure applet using Cinnamon's native settings system.
- Removed single instance restriction due to the implementation of a settings system.
- Added custom translation mechanism and localizations to be able to translate the new strings added by the settings system implementation.
- Added connection to automatically update applet menu when adding/removing/reordering bookmarks/places.

Ping to applet author: @dmo60

Sorry, I got a little carried away with the changes. My initial intention was to just fix #245, but then I saw that I could add some other improvements and I just did it. Of course, feel free to reject this entire pull request or implement the changes as you see fit. Also, if you prefer that I made this pull request in [your own repository](https://github.com/dmo60/Cinnamon-PlacesApplet), just let me know.
