### PR TITLE
26 Applets: Remove dangerous flags

### DIFF
--- a/0dyseus@CustomCinnamonMenu/files/0dyseus@CustomCinnamonMenu/metadata.json
+++ b/0dyseus@CustomCinnamonMenu/files/0dyseus@CustomCinnamonMenu/metadata.json
@@ -1,7 +1,6 @@
 {
     "uuid": "0dyseus@CustomCinnamonMenu",
     "max-instances": -1,
-    "dangerous": false,
     "multiversion": true,
     "description": "Custom version of the default Cinnamon Menu applet, but infinitely more customizable.",
     "version": "1.20",

--- a/0dyseus@DesktopHandler/files/0dyseus@DesktopHandler/metadata.json
+++ b/0dyseus@DesktopHandler/files/0dyseus@DesktopHandler/metadata.json
@@ -2,7 +2,6 @@
     "description": "Various shortcuts to handle desktop actions.",
     "max-instances": "-1",
     "multiversion": true,
-    "dangerous": false,
     "uuid": "0dyseus@DesktopHandler",
     "version": "1.06",
     "last-edited": "1473874426",

--- a/0dyseus@ExtensionsManager/files/0dyseus@ExtensionsManager/metadata.json
+++ b/0dyseus@ExtensionsManager/files/0dyseus@ExtensionsManager/metadata.json
@@ -1,5 +1,4 @@
 {
-    "dangerous": true,
     "uuid": "0dyseus@ExtensionsManager",
     "max-instances": -1,
     "multiversion": true,

--- a/0dyseus@PopupTranslator/files/0dyseus@PopupTranslator/metadata.json
+++ b/0dyseus@PopupTranslator/files/0dyseus@PopupTranslator/metadata.json
@@ -4,7 +4,6 @@
     "last-edited": 1486432804,
     "contributors": "NikoKrause: German localization and bug reports.,Radek71: Czech localization and bug reports.,muzena: Croatian localization.,muzena: Croatian localization.,giwhub: Chinese localization.",
     "max-instances": "-1",
-    "dangerous": false,
     "description": "Simple translator applet that will allow to display any selected text from any application on a system in a popup.",
     "comments": "Bug reports, feature requests and contributions should be done on this xlet's repository linked below.",
     "name": "Popup Translator",

--- a/0dyseus@QuickMenu/files/0dyseus@QuickMenu/metadata.json
+++ b/0dyseus@QuickMenu/files/0dyseus@QuickMenu/metadata.json
@@ -1,7 +1,6 @@
 {
     "uuid": "0dyseus@QuickMenu",
     "max-instances": "-1",
-    "dangerous": true,
     "name": "Quick Menu",
     "version": "1.06",
     "multiversion": true,

--- a/0dyseus@SysmonitorByOrcus/files/0dyseus@SysmonitorByOrcus/metadata.json
+++ b/0dyseus@SysmonitorByOrcus/files/0dyseus@SysmonitorByOrcus/metadata.json
@@ -3,7 +3,6 @@
     "multiversion": true,
     "description": "Displays CPU, memory, swap, network usage and load in graphs.",
     "contributors": "buzz: Bug fixes.,muzena: Croatian localization.,giwhub: Chinese localization.",
-    "dangerous": true,
     "comments": "Bug reports and feature requests should be reported on this applet's repository linked below.",
     "name": "System Monitor (Fork By Odyseus)",
     "version": "1.10",

--- a/0dyseus@window-list-fork/files/0dyseus@window-list-fork/metadata.json
+++ b/0dyseus@window-list-fork/files/0dyseus@window-list-fork/metadata.json
@@ -1,7 +1,6 @@
 {
     "uuid": "0dyseus@window-list-fork",
     "max-instances": -1,
-    "dangerous": false,
     "description": "Fork of the main Cinnamon Window list applet.",
     "multiversion": true,
     "version": "1.07",

--- a/Cinnamenu@json/files/Cinnamenu@json/metadata.json
+++ b/Cinnamenu@json/files/Cinnamenu@json/metadata.json
@@ -3,7 +3,6 @@
  "name": "Cinnamenu",
  "description": "A flexible menu providing formatting options and bookmarks.",
  "max-instances": -1,
- "dangerous": false,
  "version": "1.1.0",
  "website": "https://github.com/jaszhix/Cinnamenu",
  "cinnamon-version": [

--- a/IcingTaskManager@json/files/IcingTaskManager@json/metadata.json
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/metadata.json
@@ -1,7 +1,6 @@
 {
     "description": "Window list with app grouping and thumbnails", 
     "max-instances": -1, 
-    "dangerous": false, 
     "name": "Icing Task Manager", 
     "version": "4.4.1",
     "role": "panellauncher", 

--- a/IcingTaskManager@json/src/metadata.json
+++ b/IcingTaskManager@json/src/metadata.json
@@ -1,7 +1,6 @@
 {
     "description": "Window list with app grouping and thumbnails", 
-    "max-instances": -1, 
-    "dangerous": false, 
+    "max-instances": -1,  
     "name": "Icing Task Manager", 
     "version": "4.4.1",
     "role": "panellauncher", 

--- a/PDFManager@cinnamon.org/files/PDFManager@cinnamon.org/metadata.json
+++ b/PDFManager@cinnamon.org/files/PDFManager@cinnamon.org/metadata.json
@@ -1,6 +1,5 @@
 {
     "description": "Manager of PDF", 
-    "dangerous": false, 
     "uuid": "PDFManager@cinnamon.org", 
     "name": "PDFManager", 
     "last-edited": "1456619186", 

--- a/axos88@countdown-timer/files/axos88@countdown-timer/metadata.json
+++ b/axos88@countdown-timer/files/axos88@countdown-timer/metadata.json
@@ -1,5 +1,4 @@
 {
-    "dangerous": false,
     "uuid": "axos88@countdown-timer",
     "name": "Countdown timer with notifications",
     "description": "A countdown timer app with visual and auditory notifications based on markbokil's timer-notifications applet",

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/metadata.json
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/metadata.json
@@ -1,6 +1,5 @@
 {
-    "max-instances": "1", 
-    "dangerous": false, 
+    "max-instances": "1",  
     "description": "Displays Charge as Percentage and allows Alerts and Actions", 
     "name": "Battery  Applet with Monitoring and Shutdown (BAMS)",
     "version": "1.2.2", 

--- a/betterlock/files/betterlock/metadata.json
+++ b/betterlock/files/betterlock/metadata.json
@@ -1,5 +1,4 @@
-{
-    "dangerous": false, 
+{ 
     "description": "Shows whether caps lock/num lock is on, and displays a notification when these change.", 
     "icon": "numlock-enabled", 
     "uuid": "betterlock", 

--- a/bumblebee@pdcurtis/files/bumblebee@pdcurtis/metadata.json
+++ b/bumblebee@pdcurtis/files/bumblebee@pdcurtis/metadata.json
@@ -1,6 +1,5 @@
 {
-    "max-instances": "1", 
-    "dangerous": false, 
+    "max-instances": "1",  
     "description": "Displays Status of Bumblebee and nVidia GPU Temperature", 
     "name": "Bumblebee and nVidia Display", 
     "uuid": "bumblebee@pdcurtis"

--- a/collapsible-systray@feuerfuchs.eu/files/collapsible-systray@feuerfuchs.eu/metadata.json
+++ b/collapsible-systray@feuerfuchs.eu/files/collapsible-systray@feuerfuchs.eu/metadata.json
@@ -2,7 +2,6 @@
     "website":       "https://github.com/Feuerfuchs/Collapsible-Systray-Cinnamon-Applet",
     "description":   "A replacement for the abandoned System Tray Collapsible Cinnamon applet",
     "max-instances": 1,
-    "dangerous":     false,
     "uuid":          "collapsible-systray@feuerfuchs.eu",
     "version":       "1.6",
     "last-edited":   "1475854288",

--- a/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/metadata.json
+++ b/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/metadata.json
@@ -1,7 +1,6 @@
 {
     "description": "Displays RSS news feeds", 
     "url": "jonbrettdev.wordpress.com", 
-    "dangerous": false, 
     "name": "Feeds Reader", 
     "max-instances": "10", 
     "original-authors": [

--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/metadata.json
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/metadata.json
@@ -2,7 +2,6 @@
     "website":       "https://github.com/Feuerfuchs/GPaste-Reloaded-Cinnamon-Applet",
     "description":   "A complete rewrite of the GPaste applet based on the Gnome Shell extension",
     "max-instances": -1,
-    "dangerous":     false,
     "uuid":          "gpaste-reloaded@feuerfuchs.eu",
     "version":       "2.4",
     "last-edited":   "1480847249",

--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/metadata.json
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/metadata.json
@@ -1,6 +1,5 @@
 { 
-    "max-instances": "1", 
-    "dangerous": false, 
+    "max-instances": "1",  
     "uuid": "netusagemonitor@pdcurtis", 
     "name": "Network Data Usage Monitor", 
     "description": "A Comprehensive Data Usage Monitor with alerts and cumulative data functions for Cinnamon",

--- a/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/metadata.json
+++ b/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/metadata.json
@@ -1,6 +1,5 @@
 {
     "max-instances": "1", 
-    "dangerous": false, 
     "description": "Displays nVidia GPU Temperature when using Prime", 
     "name": "nVidia Prime GPU Display", 
     "uuid": "nvidiaprime@pdcurtis",

--- a/rancher@centurix/files/rancher@centurix/metadata.json
+++ b/rancher@centurix/files/rancher@centurix/metadata.json
@@ -1,6 +1,5 @@
 {
-    "description": "An applet to manage Homestead.", 
-    "dangerous": true, 
+    "description": "An applet to manage Homestead.",  
     "uuid": "rancher@centurix", 
     "name": "Homestead manager", 
     "version": "0.1.3", 

--- a/sane-menu@nooulaif/files/metadata.json
+++ b/sane-menu@nooulaif/files/metadata.json
@@ -1,5 +1,4 @@
 {
-    "dangerous": false,
     "uuid": "sane-menu@nooulaif",
     "name": "Sane Menu",
     "description": "Cinnamon stock menu applet with improved search.",

--- a/serviceLauncher@hulygun/files/metadata.json
+++ b/serviceLauncher@hulygun/files/metadata.json
@@ -1,5 +1,4 @@
 {
-    "dangerous": false, 
     "description": "Description", 
     "uuid": "serviceLauncher@hulygun", 
     "name": "Service Launcher"

--- a/stopwatch@pdcurtis/files/stopwatch@pdcurtis/metadata.json
+++ b/stopwatch@pdcurtis/files/stopwatch@pdcurtis/metadata.json
@@ -1,7 +1,6 @@
 {
     "uuid": "stopwatch@pdcurtis", 
     "max-instances": "10", 
-    "dangerous": false, 
     "description": "Allows one to time activities such as the time online with multiple instances possible", 
     "name": "Stopwatch for Cinnamon 1.8+", 
     "last-edited": "1378710499"

--- a/window-buttons-with-title2@hanspr/files/window-buttons-with-title2@hanspr/metadata.json
+++ b/window-buttons-with-title2@hanspr/files/window-buttons-with-title2@hanspr/metadata.json
@@ -1,7 +1,6 @@
 {
     "last-edited": "1467411938", 
     "max-instances": "1", 
-    "dangerous": false, 
     "description": "You can control windows with this applet", 
     "uuid": "window-buttons-with-title2@hanspr", 
     "name": "Window Buttons with Title 2", 

--- a/window-buttons-with-title@fmete/files/window-buttons-with-title@fmete/metadata.json
+++ b/window-buttons-with-title@fmete/files/window-buttons-with-title@fmete/metadata.json
@@ -1,7 +1,6 @@
 {
     "last-edited": "1467411938", 
     "max-instances": "5", 
-    "dangerous": false, 
     "description": "You can control windows with this applet", 
     "uuid": "window-buttons-with-title@fmete", 
     "name": "Window Buttons with Title", 

--- a/windowTitle2@hanspr/files/windowTitle2@hanspr/metadata.json
+++ b/windowTitle2@hanspr/files/windowTitle2@hanspr/metadata.json
@@ -1,6 +1,5 @@
 {
     "uuid": "windowTitle2@hanspr",
-    "dangerous": false,
     "description": "Shows the title of the current window in a applet.",
     "name": "Window Title Applet 2",
     "last-edited": "1340546649",


### PR DESCRIPTION
>The dangerous property in metadata.json should not be there. It interferes with the scanning of the applet when it is installed by the user.

pings:
@hulygun @mickaelalbertus @centurix @nooulaif @pdcurtis @hanspr @jaszhix @feuerfuchs @fmete @entelechy @axos88 @Odyseus @jake1164 