### PR TITLE
Num Lock/Caps Lock indicator with MessageTray notifications (betterlock) update

### DIFF
--- a/betterlock/files/betterlock/metadata.json
+++ b/betterlock/files/betterlock/metadata.json
@@ -1,6 +1,7 @@
-{ 
-    "description": "Shows whether caps lock/num lock is on, and displays a notification when these change.", 
-    "icon": "numlock-enabled", 
-    "uuid": "betterlock", 
+{
+    "description": "Shows whether caps lock/num lock is on, and displays a notification when these change.",
+    "icon": "numlock-enabled",
+    "uuid": "betterlock",
+    "hide-configuration": true,
     "name": "Num Lock/Caps Lock indicator with MessageTray notifications"
 }

--- a/betterlock/files/betterlock/po/es.po
+++ b/betterlock/files/betterlock/po/es.po
@@ -1,0 +1,63 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-09 09:21-0300\n"
+"PO-Revision-Date: 2017-04-09 09:28-0300\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.7.1\n"
+"Last-Translator: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: es\n"
+
+#: applet.js:70
+msgid "Num Lock"
+msgstr "Bloqueo numérico"
+
+#: applet.js:74
+msgid "Caps Lock"
+msgstr "Bloqueo de mayúsculas"
+
+#: applet.js:79
+msgid "Notifications"
+msgstr "Notificaciones"
+
+#: applet.js:114
+msgid "Lock Keys"
+msgstr "Teclas de bloqueo"
+
+#: applet.js:148
+msgid "Num lock on"
+msgstr "Bloqueo numérico activado"
+
+#: applet.js:153
+msgid "Num lock off"
+msgstr "Bloqueo numérico desactivado"
+
+#: applet.js:163
+msgid "Caps lock on"
+msgstr "Bloqueo de mayúsculas activado"
+
+#: applet.js:168
+msgid "Caps lock off"
+msgstr "Bloqueo de mayúsculas desactivado"
+
+#. betterlock->metadata.json->description
+msgid ""
+"Shows whether caps lock/num lock is on, and displays a notification when "
+"these change."
+msgstr ""
+"Muestra cuando el Bloq. Mayús./Bloq. Num. se encuentra activado y "
+"muestra una notificación en su cambio de estado."
+
+#. betterlock->metadata.json->name
+msgid "Num Lock/Caps Lock indicator with MessageTray notifications"
+msgstr "Indicador de Bloq. Mayús./Bloq. Num. con notificaciones"


### PR DESCRIPTION
- Added *hide-configuration* property to the metadata.json file to hide the *Configure...* item on applet context menu since it isn't really needed.
- Added Spanish localization.

Ping to author: @entelechy