### PR TITLE
 temperature@fevimu: Degree symbol

### DIFF
--- a/temperature@fevimu/files/temperature@fevimu/applet.js
+++ b/temperature@fevimu/files/temperature@fevimu/applet.js
@@ -363,13 +363,13 @@ MyApplet.prototype = {
     },
 
     _getContent: function(c){
-        return c.toString()+"\u1d3cC / "+this._toFahrenheit(c).toString()+"\u1d3cF";
+        return c.toString()+" °C / "+this._toFahrenheit(c).toString()+" °F";
     },
 
     _formatTemp: function(t) {
         //uncomment the next line to display temperature in Fahrenheit
-        //return this._toFahrenheit(t).toString()+"\u1d3cF";
-        return (Math.round(t*10)/10).toFixed(1).toString()+"\u1d3cC";
+        //return this._toFahrenheit(t).toString()+" °F";
+        return (Math.round(t*10)/10).toFixed(1).toString()+" °C";
     }
     
     


### PR DESCRIPTION
Replace unspaced unicode upper O symbol with real degree symbol and spacing between numbers and °C
https://en.wikipedia.org/wiki/Celsius