### PR TITLE
search-box@mtwebster: max-instance 1 and ru.po

### DIFF
--- a/search-box@mtwebster/files/search-box@mtwebster/metadata.json
+++ b/search-box@mtwebster/files/search-box@mtwebster/metadata.json
@@ -1,6 +1,5 @@
 {
     "multiversion": true,
-    "max-instances": -1,
     "uuid": "search-box@mtwebster",
     "name": "Internet Search Box",
     "icon": "web-browser",

--- a/search-box@mtwebster/files/search-box@mtwebster/po/ru.po
+++ b/search-box@mtwebster/files/search-box@mtwebster/po/ru.po
@@ -16,7 +16,7 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Last-Translator: \n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"Language: ru_RU\n"
+"Language: ru\n"
 
 #: applet.js:74 3.2/applet.js:72
 msgid "Type to search..."


### PR DESCRIPTION
use proper language ID, i.e. ru.po instead of ru_RU.po

more than one instance causes problems