### PR TITLE
Update stopwatch@pdcurtis to version 2.0.4

### DIFF
--- a/stopwatch@pdcurtis/README.md
+++ b/stopwatch@pdcurtis/README.md
@@ -13,13 +13,13 @@ It is useful to have a very simple timer quickly and permanently available in th
  
 **The Settings Screen** can be reached from the right click menu as well as System Settings -> Applets. It enables you to:
 
-   * Set the refresh interval - use a slow refresh if you have multiple active counters and/or a slow machine - the default is every two seconds, one second is more pleasing as t gives a continuos count.  
+   * Set the refresh interval - use a slow refresh if you have multiple active counters and/or a slow machine - the default is every two seconds, one second is more pleasing as t gives a continuos count.
    * Provide a meaningful title for the counter which is displayed in the first part of the tooltip - useful for identification if you have multiple instances of counters - default is Stopwatch.
    * Change the mode from the default sequence on clicking of 'start -> pause -> reset' to 'start -> pause -> continue -> pause -> continue etc'. In this continuous mode mode one needs the Right Click (Context) Menu to reset the counter.
 
 **The Right Click (Context)** menu has options to:
 
-  * Start the counter - only for completeness  
+  * Start the counter - only for completeness
   * Pause the counter - only for completeness 
   * Reset the counter - required in 'continuous mode' 
   * Continue counting from the count before pausing - as per the continuous mode. 

--- a/stopwatch@pdcurtis/files/stopwatch@pdcurtis/README.md
+++ b/stopwatch@pdcurtis/files/stopwatch@pdcurtis/README.md
@@ -13,13 +13,13 @@ It is useful to have a very simple timer quickly and permanently available in th
  
 **The Settings Screen** can be reached from the right click menu as well as System Settings -> Applets. It enables you to:
 
-   * Set the refresh interval - use a slow refresh if you have multiple active counters and/or a slow machine - the default is every two seconds, one second is more pleasing as t gives a continuos count.  
+   * Set the refresh interval - use a slow refresh if you have multiple active counters and/or a slow machine - the default is every two seconds, one second is more pleasing as t gives a continuos count.
    * Provide a meaningful title for the counter which is displayed in the first part of the tooltip - useful for identification if you have multiple instances of counters - default is Stopwatch.
    * Change the mode from the default sequence on clicking of 'start -> pause -> reset' to 'start -> pause -> continue -> pause -> continue etc'. In this continuous mode mode one needs the Right Click (Context) Menu to reset the counter.
 
 **The Right Click (Context)** menu has options to:
 
-  * Start the counter - only for completeness  
+  * Start the counter - only for completeness
   * Pause the counter - only for completeness 
   * Reset the counter - required in 'continuous mode' 
   * Continue counting from the count before pausing - as per the continuous mode. 

--- a/stopwatch@pdcurtis/files/stopwatch@pdcurtis/applet.js
+++ b/stopwatch@pdcurtis/files/stopwatch@pdcurtis/applet.js
@@ -78,19 +78,13 @@ MyApplet.prototype = {
                 this.on_generic_changed,
                 null);
 
-//            this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL, 
-//                "cinnamonVersion", 
-//                "cinnamonVersion", 
-//                this.on_generic_changed, 
-//                null);
-
-
             // ++ Make metadata values available within applet for context menu.
             this.cssfile = metadata.path + "/stylesheet.css"; // No longer required
             this.changelog = metadata.path + "/changelog.txt";
             this.helpfile = metadata.path + "/README.md";
             this.appletPath = metadata.path;
-            this.UUID = metadata.uuid;
+//            this.UUID = metadata.uuid;
+            this.settingsCommand = 'cinnamon-settings applets ' + metadata.uuid;
             this.applet_running = true; //** New
 
             // Choose Text Editor depending on whether Mint 18 with Cinnamon 3.0 and latter
@@ -141,7 +135,7 @@ MyApplet.prototype = {
         let menuitem = new PopupMenu.PopupMenuItem(_("Pause"));
         menuitem.connect('activate', Lang.bind(this, function (event) {
             this.counterStatus = "paused";
-            this.pausedAt = this,currentCount; // Changed to reduce load on Settings
+            this.pausedAt = this.currentCount; // Changed to reduce load on Settings
             this.updateUI();
         }));
         this._applet_context_menu.addMenuItem(menuitem);
@@ -209,7 +203,8 @@ MyApplet.prototype = {
 
             let menuitem = new PopupMenu.PopupMenuItem(_("Configure..."));
             menuitem.connect('activate', Lang.bind(this, function (event) {
-                GLib.spawn_command_line_async('cinnamon-settings applets ' + this.UUID);
+//              GLib.spawn_command_line_async('cinnamon-settings applets ' + this.UUID);
+                GLib.spawn_command_line_async(this.settingsCommand);
             }));
             this._applet_context_menu.addMenuItem(menuitem);
         }
@@ -349,8 +344,6 @@ MyApplet.prototype = {
     },
 
 
-
-
     // ++ This finalises the settings when the applet is removed from the panel
     on_applet_removed_from_panel: function () {
         // inhibit the update timer when applet removed from panel
@@ -364,7 +357,7 @@ function main(metadata, orientation, panelHeight, instance_id) {
     return myApplet;
 }
 /*
-Version 2.0.3
+Version 2.0.4
 0.9.0 Release Candidate 30-07-2013
 0.9.1 Help file facility added and link to gnome-system-monitor
 0.9.2 Change Hold to Pause in Tooltip
@@ -401,4 +394,6 @@ Version 2.0.3
       Remove icon.png and help.txt from applet folder
 2.0.3 Version numbering harmonised with other Cinnamon applets and added to metadata.json so it shows in 'About...'
       icon.png copied back into applet folder so it shows in 'About...'
+2.0.4 Bug corrected at line 138 this.currentCount had comma, not stop.
+      Use of this.UUID = metadata.uuid removed (only used in Config... for Cinnamon <2.0) which makes use of UUID in l10n more obvious. 
 */

--- a/stopwatch@pdcurtis/files/stopwatch@pdcurtis/changelog.txt
+++ b/stopwatch@pdcurtis/files/stopwatch@pdcurtis/changelog.txt
@@ -1,4 +1,4 @@
-Version 2.0.3
+Version 2.0.4
 0.9.0 Release Candidate 30-07-2013
 0.9.1 Help file facility added and link to gnome-system-monitor
 0.9.2 Change Hold to Pause in Tooltip
@@ -35,3 +35,5 @@ Version 2.0.3
       Remove icon.png and help.txt from applet folder
 2.0.3 Version numbering harmonised with other Cinnamon applets and added to metadata.json so it shows in 'About...'
       icon.png copied back into applet folder so it shows in 'About...'
+2.0.4 Bug corrected at line 138 this.currentCount had comma, not stop.
+      Use of this.UUID = metadata.uuid removed (only used in Config... for Cinnamon <2.0) which makes use of UUID in l10n more obvious. 

--- a/stopwatch@pdcurtis/files/stopwatch@pdcurtis/metadata.json
+++ b/stopwatch@pdcurtis/files/stopwatch@pdcurtis/metadata.json
@@ -3,6 +3,6 @@
     "max-instances": "10", 
     "description": "Allows one to time activities such as the time online with multiple instances possible", 
     "name": "Stopwatch for Cinnamon 1.8+", 
-    "version": "2.0.3"
+    "version": "2.0.4"
 }
 


### PR DESCRIPTION
 * Bug corrected in Context Menu -> Pause
 * Use of this.UUID = metadata.uuid removed which makes use of const UUID in l10n more obvious. 