### PR TITLE
9 Applets: remove unused `const PanelMenu` - bugfix for Cinnamon 3.4

### DIFF
--- a/BgRadio@spacy01/files/BgRadio@spacy01/applet.js
+++ b/BgRadio@spacy01/files/BgRadio@spacy01/applet.js
@@ -4,7 +4,6 @@ const PopupMenu = imports.ui.popupMenu;
 const Util = imports.misc.util;
 const Lang = imports.lang;
 const St = imports.gi.St;
-const PanelMenu = imports.ui.panelMenu;
 const GLib = imports.gi.GLib;
 
 const Gettext = imports.gettext.domain('bgradio');

--- a/axos88@countdown-timer/files/axos88@countdown-timer/applet.js
+++ b/axos88@countdown-timer/files/axos88@countdown-timer/applet.js
@@ -13,7 +13,6 @@ const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
 const Mainloop = imports.mainloop;
 const ModalDialog = imports.ui.modalDialog;
-const PanelMenu = imports.ui.panelMenu;
 const Gettext = imports.gettext;
 const UUID = "axos88@countdown-timer";
 const AppletMeta = imports.ui.appletManager.applets[UUID];

--- a/netctlstatus@prmurthy/files/netctlstatus@prmurthy/applet.js
+++ b/netctlstatus@prmurthy/files/netctlstatus@prmurthy/applet.js
@@ -22,7 +22,6 @@ const Applet = imports.ui.applet;
 const GLib = imports.gi.GLib;
 const Lang = imports.lang;
 const Main = imports.ui.main;
-const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
 const Gettext = imports.gettext;

--- a/netctlsystraymenu@prmurthy/files/netctlsystraymenu@prmurthy/applet.js
+++ b/netctlsystraymenu@prmurthy/files/netctlsystraymenu@prmurthy/applet.js
@@ -23,7 +23,6 @@ const Applet = imports.ui.applet;
 const GLib = imports.gi.GLib;
 const Lang = imports.lang;
 const Main = imports.ui.main;
-const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
 

--- a/search-box@mtwebster/files/search-box@mtwebster/applet.js
+++ b/search-box@mtwebster/files/search-box@mtwebster/applet.js
@@ -7,7 +7,6 @@ const St = imports.gi.St;
 const Util = imports.misc.util;
 const PopupMenu = imports.ui.popupMenu;
 const UPowerGlib = imports.gi.UPowerGlib;
-const PanelMenu = imports.ui.panelMenu;
 const Main = imports.ui.main;
 const Gtk = imports.gi.Gtk;
 const GLib = imports.gi.GLib;

--- a/shutdown-timer@webum.by/files/applet.js
+++ b/shutdown-timer@webum.by/files/applet.js
@@ -8,7 +8,6 @@ const PopupMenu = imports.ui.popupMenu;
 const Util = imports.misc.util;
 const ModalDialog = imports.ui.modalDialog;
 const Mainloop = imports.mainloop;
-const PanelMenu = imports.ui.panelMenu;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 

--- a/system-monitor@ebbes/files/system-monitor@ebbes/applet.js
+++ b/system-monitor@ebbes/files/system-monitor@ebbes/applet.js
@@ -58,7 +58,6 @@ try {
 
 const Main = imports.ui.main;
 const Panel = imports.ui.panel;
-const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
 
 const Gettext = imports.gettext;

--- a/temperature@fevimu/files/temperature@fevimu/applet.js
+++ b/temperature@fevimu/files/temperature@fevimu/applet.js
@@ -1,6 +1,5 @@
 const St = imports.gi.St;
 const Lang = imports.lang;
-const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
 const Main = imports.ui.main;
 const GLib = imports.gi.GLib;

--- a/timer-notifications@markbokil.com/files/timer-notifications@markbokil.com/applet.js
+++ b/timer-notifications@markbokil.com/files/timer-notifications@markbokil.com/applet.js
@@ -13,7 +13,6 @@ const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
 const Mainloop = imports.mainloop;
 const ModalDialog = imports.ui.modalDialog;
-const PanelMenu = imports.ui.panelMenu;
 const Gettext = imports.gettext;
 
 const AppletMeta = imports.ui.appletManager.applets['timer-notifications@markbokil.com'];


### PR DESCRIPTION
PanelMenu was removed in Cinnamon 3.4
These applets import PanelMenu, but never use them, which will cause these applets to crash in Cinnamon 3.4.

notify authors about this bugfix:
@mtwebster 
@spacy01 
@axos88 
@prmurthy
@webum.by
@mbokil
@fevimu
@ebbes

Fixes https://github.com/linuxmint/cinnamon-spices-applets/issues/332