### PR TITLE
Update stopwatch@pdcurtis to version 2.0.5

### DIFF
--- a/stopwatch@pdcurtis/files/stopwatch@pdcurtis/applet.js
+++ b/stopwatch@pdcurtis/files/stopwatch@pdcurtis/applet.js
@@ -6,7 +6,8 @@ and a 'standard' right click (context) menu which opens
 the settings panel and a Housekeeping submenu accessing
 help and a version/update files and also the gnome system monitor program
 in case you want to find out how much machine power this applet is 
-using at various update rates. 
+using at various update rates. It also an example of how to implement 
+l10n localisation/translation support.
 Items with a ++ in the comment are not specific to this applet and useful for re-use
 */
 const Applet = imports.ui.applet; // ++
@@ -14,16 +15,34 @@ const Settings = imports.ui.settings; // ++ Needed if you use Settings Screen
 const St = imports.gi.St; // ++
 const PopupMenu = imports.ui.popupMenu; // ++ Needed for menus
 const Lang = imports.lang; //  ++ Needed for menus
-const GLib = imports.gi.GLib; // ++ Needed for starting programs
+const GLib = imports.gi.GLib; // ++ Needed for starting programs and translations
+const Gettext = imports.gettext; // ++ Needed for translations
 const Mainloop = imports.mainloop; // Needed for timer update loop
 
-// l10n/translation support
-const Gettext = imports.gettext
+/*
+// Old l10n/translation support thanks to @NikoKrause to be removed next update
+const Gettext = imports.gettext 
 const UUID = "stopwatch@pdcurtis"
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale")
 
 function _(str) {
   return Gettext.dgettext(UUID, str);
+}
+*/
+
+// ++ Always needed if you want localisation/translation support
+// New l10n support thanks to ideas from @Odyseus, @lestcape and @NikoKrause
+// Note UUID is set in MyApplet _init: below and before function called
+// and const Gettext = imports.gettext; is now in list above for consistency
+var UUID;
+
+function _(str) {
+    let customTrans = Gettext.dgettext(UUID, str);
+
+    if (customTrans !== str && customTrans !== "")
+        return customTrans;
+
+    return Gettext.gettext(str);
 }
 
 
@@ -83,7 +102,11 @@ MyApplet.prototype = {
             this.changelog = metadata.path + "/changelog.txt";
             this.helpfile = metadata.path + "/README.md";
             this.appletPath = metadata.path;
-//            this.UUID = metadata.uuid;
+
+            // ++ Part of new l10n support
+            UUID = metadata.uuid;
+            Gettext.bindtextdomain(metadata.uuid, GLib.get_home_dir() + "/.local/share/locale");
+
             this.settingsCommand = 'cinnamon-settings applets ' + metadata.uuid;
             this.applet_running = true; //** New
 
@@ -357,7 +380,7 @@ function main(metadata, orientation, panelHeight, instance_id) {
     return myApplet;
 }
 /*
-Version 2.0.4
+Version 2.0.5
 0.9.0 Release Candidate 30-07-2013
 0.9.1 Help file facility added and link to gnome-system-monitor
 0.9.2 Change Hold to Pause in Tooltip
@@ -395,5 +418,9 @@ Version 2.0.4
 2.0.3 Version numbering harmonised with other Cinnamon applets and added to metadata.json so it shows in 'About...'
       icon.png copied back into applet folder so it shows in 'About...'
 2.0.4 Bug corrected at line 138 this.currentCount had comma, not stop.
-      Use of this.UUID = metadata.uuid removed (only used in Config... for Cinnamon <2.0) which makes use of UUID in l10n more obvious. 
+      Use of this.UUID = metadata.uuid removed (only used in Config... for Cinnamon <2.0) which makes use of UUID in l10n more obvious.
+2.0.5 Improved l10n Support:
+        UUID set from metadata.uuid so no need for explicit definition.
+        _() function now checks for system translations if a local one not found.
+        Based on ideas from @Odyseus, @lestcape and @NikoKrause
 */

--- a/stopwatch@pdcurtis/files/stopwatch@pdcurtis/changelog.txt
+++ b/stopwatch@pdcurtis/files/stopwatch@pdcurtis/changelog.txt
@@ -1,4 +1,4 @@
-Version 2.0.4
+Version 2.0.5
 0.9.0 Release Candidate 30-07-2013
 0.9.1 Help file facility added and link to gnome-system-monitor
 0.9.2 Change Hold to Pause in Tooltip
@@ -36,4 +36,8 @@ Version 2.0.4
 2.0.3 Version numbering harmonised with other Cinnamon applets and added to metadata.json so it shows in 'About...'
       icon.png copied back into applet folder so it shows in 'About...'
 2.0.4 Bug corrected at line 138 this.currentCount had comma, not stop.
-      Use of this.UUID = metadata.uuid removed (only used in Config... for Cinnamon <2.0) which makes use of UUID in l10n more obvious. 
+      Use of this.UUID = metadata.uuid removed (only used in Config... for Cinnamon <2.0) which makes use of UUID in l10n more obvious.
+2.0.5 Improved l10n Support:
+        UUID set from metadata.uuid so no need for explicit definition.
+        _() function now checks for system translations if a local one not found.
+        Based on ideas from @Odyseus, @lestcape and @NikoKrause

--- a/stopwatch@pdcurtis/files/stopwatch@pdcurtis/metadata.json
+++ b/stopwatch@pdcurtis/files/stopwatch@pdcurtis/metadata.json
@@ -3,6 +3,6 @@
     "max-instances": "10", 
     "description": "Allows one to time activities such as the time online with multiple instances possible", 
     "name": "Stopwatch for Cinnamon 1.8+", 
-    "version": "2.0.4"
+    "version": "2.0.5"
 }
 


### PR DESCRIPTION
* Improved l10n Support:
  - UUID set from metadata.uuid so no need for explicit definition.
  -  _() function now checks for system translations if a local one not found.

### Rationale for non essential update: 
This applet It is not only useful in its own right but is also provides a 'tutorial' framework for other more complex applets - for example it provides a settings screen and a 'standard' right click (context) menu which opens the settings panel and a housekeeping sub-menu accessing help and a version/update files. It now has an example of how to implement l10n  support in a more general manner based on ideas from @Odyseus, @lestcape and @NikoKrause which will, after further testing, be incorporated into my other current  applets and those under development.