### PR TITLE
Several applets: Set author with no corresponding github user name to none

### DIFF
--- a/betterlock/info.json
+++ b/betterlock/info.json
@@ -1,1 +1,4 @@
-{"author": "entelechy"}
+{
+    "author": "none",
+    "original_author": "entelechy"
+}

--- a/rprego@rprego.com/info.json
+++ b/rprego@rprego.com/info.json
@@ -1,1 +1,4 @@
-{"author": "rprego.com"}
+{
+    "author": "none",
+    "original_author": "rprego.com"
+}

--- a/sysmenu@tuxuls@gmail.com/info.json
+++ b/sysmenu@tuxuls@gmail.com/info.json
@@ -1,1 +1,4 @@
-{"author": "tuxuls"}
+{
+    "author": "none",
+    "original_author": "tuxuls"
+}

--- a/uptime@vatanuki.kun/info.json
+++ b/uptime@vatanuki.kun/info.json
@@ -1,1 +1,4 @@
-{"author": "vatanuki.kun"}
+{
+    "author": "none",
+    "original_author": "vatanuki.kun"
+}


### PR DESCRIPTION
The author names do not respond to any github user name or the authors do not respond at all, therefore set author to 'none' and give credit to them as original author.