### PR TITLE
vnstat@linuxmint.com Patch 1

### DIFF
--- a/vnstat@linuxmint.com/README.md
+++ b/vnstat@linuxmint.com/README.md
@@ -2,13 +2,13 @@
 
 This applet keeps track of your Internet usage.
 
-In some countries, ISPs limit the amount of data their customers can use. Passed a certain amount of bits downloaded/uploaded, you either get cut off, you pay more or your connection speed is reduced.
+In some countries, ISPs limit the amount of data their customers can use. Passed a certain amount of bits downloaded/uploaded, you either get cut off, you pay more or your connection speed is reduced. The situation is even worse if you are using a mobile connection, especially when roaming.
 
 ## How it does it:
 
 The vnstat daemon runs in the background and collects info about your Internet usage.
 
-The applet detect which device you're currently using, and simply export a graph using vnstati.
+The applet detects which device you're currently using, and simply exports a graph using vnstati.
 
 ## What you need for it to work:
 
@@ -16,8 +16,11 @@ You need:
 * To install vnstat
 * To install vnstati
 * To have the vnstat daemon running
+* To have vnstat configured for the devices you are using.
 
-Note: In Linux Mint, you can simply run `apt install vnstati` and that will take care of everything. In other distributions it might depend on the way things are packaged but it's likely to be similar.
+Notes: In Linux Mint, you can simply run `apt install vnstati` and that will take care of everything for the built in devices. In other distributions it might depend on the way things are packaged but it's likely to be similar.
+
+It is possible to add additional devices, for example a USB Mobile Internet stick. Running `man vnstat` will give some information on how to proceed but beware it is not trivial.
 
 ## You're not alone:
 

--- a/vnstat@linuxmint.com/files/vnstat@linuxmint.com/applet.js
+++ b/vnstat@linuxmint.com/files/vnstat@linuxmint.com/applet.js
@@ -9,6 +9,7 @@ const PopupMenu = imports.ui.popupMenu;
 const UPowerGlib = imports.gi.UPowerGlib;
 const GLib = imports.gi.GLib;
 const NMClient = imports.gi.NMClient;
+const NetworkManager = imports.gi.NetworkManager;
 
 // l10n/translation
 const Gettext = imports.gettext;
@@ -44,15 +45,16 @@ MyApplet.prototype = {
             this.menu.addActor(this.imageWidget);
             this.menu.addActor(this.textWidget);
             
-            this._device = "eth0";
+            this._device = "null";
+            this.vnstatImage = GLib.get_home_dir() + "/vnstatlmapplet.png";
             this._client = NMClient.Client.new();
-            //this._update();            
+            
         }
         catch (e) {
             global.logError(e);
         }
     },
-    
+
     on_applet_clicked: function(event) {
         if (!this.menu.isOpen) {
             this._update();
@@ -63,40 +65,56 @@ MyApplet.prototype = {
     _update: function() {
         this._updateDevice();
         this._updateGraph();
-        //Mainloop.timeout_add_seconds(5, Lang.bind(this, this._update));
-        //return false;
     },
-    
+
+    getInterfaces: function () {
+        return this._client.get_devices();
+    },
+
+    isInterfaceAvailable: function (name) {
+        let interfaces = this.getInterfaces();
+        if (interfaces != null) {
+           for (let i = 0; i < interfaces.length; i++) {
+                let iname = interfaces[i].get_iface();
+                if (iname == name && interfaces[i].state == NetworkManager.DeviceState.ACTIVATED) {
+                   return true;
+                 }
+             }
+        }
+        return false;
+    },
+
     _updateDevice: function() {
-        try {
-            global.logError("device: " + this._device);
-            let activeConnections = this._client.get_active_connections();
-            for (let i = 0; i < activeConnections.length; i++) {
-                let a = activeConnections[i];
-                if (a['default']) {
-                    let devices = a.get_devices();
-                    for (let j = 0; j < devices.length; j++) {
-                        let d = devices[j];
-                        if (d._delegate) {
-                            this._device = d.get_iface();
-                            break;
-                        }
-                    }                        
+         try {
+             this._device = "null"
+             let interfaces = this.getInterfaces();
+             if (interfaces != null) {
+                 for (let i = 0; i < interfaces.length; i++) {
+                    let iname = interfaces[i].get_iface();
+                    if (this.isInterfaceAvailable(iname)) {
+                        this._device = iname; 
+//                        global.logError("Test output - vnstat using device: " + this._device);   
+                    }
                 }
-            }                                                  
+            }
         }
         catch (e) {
-            this._device = "eth0";
             global.logError(e);
-        }
+        } 
     },
        
     _updateGraph: function() {
-        try {                                                    
-            GLib.spawn_command_line_sync('vnstati -s -ne -i ' + this._device + ' -o /tmp/vnstatlmapplet.png');
+        try {
+            if (this._device != "null") {                                     
+               GLib.spawn_command_line_sync('vnstati -s -ne -i ' + this._device + ' -o ' +  this.vnstatImage ); 
+//               this.textWidget.set_text(" " + _("Current Active Interface:") + " " + this._device + "  " + _("Last update time is at top right") );
+            }
+            else {
+                this.textWidget.set_text(" " + _("No interface devices currently active - Showing last update") + " ");
+            }
             let l = new Clutter.BinLayout();
             let b = new Clutter.Box();
-            let c = new Clutter.Texture({keep_aspect_ratio: true, filter_quality: 2, filename: "/tmp/vnstatlmapplet.png"});
+            let c = new Clutter.Texture({keep_aspect_ratio: true, filter_quality: 2, filename: this.vnstatImage });
             b.set_layout_manager(l);            
             b.add_actor(c);
             this.imageWidget.set_child(b);
@@ -105,12 +123,12 @@ MyApplet.prototype = {
             this.textWidget.set_text(" " + _("Please make sure vnstat and vnstati are installed and that the vnstat daemon is running!") + " " + e + " ");
             global.logError(e);
         }
-                
     },
-            
+         
 };
 
 function main(metadata, orientation) {  
     let myApplet = new MyApplet(metadata, orientation);
     return myApplet;      
 }
+


### PR DESCRIPTION
 * Changes made by because `_updateDevice` function was not working - Issue #152
         `_UpdateDevice()` commented out and replaced by a cut down version of the one used in
         networkusagemonitor@pdcurtis 
        with two associated functions getInterfaces() and isInterfaceAvailable() added
        `const NetworkManager = imports.gi.NetworkManager` added
        diagnostic call `global.logError("Test not error - vnstat using device: " + this._device);` added. 
        `GLib.spawn_command_line_sync()` replaced by` GLib.spawn_command_line_async()`
 * Tested with normal connections made by network manager.
 
 * Will probably not find connections not made within Network Manager such as Bluetooth PAN connections or USB mobile internet modems.

@clefebvre I failed to find the error in the original active device identification function which sometimes worked but more often did not and always gave errors in the glass log. You may wish to use this version until you have time to debug the original routine which I am sure is more elegant.

I have commented the changes and left the original code in place but commented out and have left in one diagnostic call to `global.logError(e)` I can tidy up if required.

I also carried out the change to an asynchronous call as suggested in #420 which was all I had intended to do - it will teach me not to volunteer suggestions! 