### PR TITLE
weather@mockturtl: Apply 3.4 fixes

### DIFF
--- a/weather@mockturtl/files/weather@mockturtl/applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/applet.js
@@ -409,9 +409,15 @@ MyApplet.prototype = {
         // Polling for likely API throttling
         Mainloop.timeout_add_seconds(5, Lang.bind(this, function() {
           this.refreshWeather(false)
-        }))  
+        }))
       }
+
       let weather = json.query.results.channel
+
+      if (!weather.item) {
+        return false
+      }
+
       let weather_c = weather.item.condition
       let forecast = weather.item.forecast
 


### PR DESCRIPTION
@mockturtl 

```
(cinnamon:6699): Cjs-WARNING **: JS ERROR: TypeError: weather.item is undefined
refreshWeather/<@/home/jason/.local/share/cinnamon/applets/weather@mockturtl/applet.js:415:11
soupQueue@/home/jason/.local/share/cinnamon/applets/weather@mockturtl/applet.js:390:7

```