### PR TITLE
[3.4] Several applets: remove duplicate 'let' declarations

### DIFF
--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/2.6/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/2.6/applet.js
@@ -3834,13 +3834,13 @@ MyApplet.prototype = {
                 actor.hide();
             }
         }
-        let actors = this.categoriesBox.get_children();
+        actors = this.categoriesBox.get_children();
         for (var i=0; i<actors.length; i++){
             let actor = actors[i];
             actor.style_class = "menu-category-button";
             actor.show();
         }
-        let actors = this.favoritesBox.get_children();
+        actors = this.favoritesBox.get_children();
         for (var i=0; i<actors.length; i++){
             let actor = actors[i];
             actor.remove_style_pseudo_class("hover");

--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/3.2/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/3.2/applet.js
@@ -3838,13 +3838,13 @@ MyApplet.prototype = {
                 actor.hide();
             }
         }
-        let actors = this.categoriesBox.get_children();
+        actors = this.categoriesBox.get_children();
         for (var i=0; i<actors.length; i++){
             let actor = actors[i];
             actor.style_class = "menu-category-button";
             actor.show();
         }
-        let actors = this.favoritesBox.get_children();
+        actors = this.favoritesBox.get_children();
         for (var i=0; i<actors.length; i++){
             let actor = actors[i];
             actor.remove_style_pseudo_class("hover");

--- a/betterplaces@bownz/files/betterplaces@bownz/applet.js
+++ b/betterplaces@bownz/files/betterplaces@bownz/applet.js
@@ -428,7 +428,7 @@ if (SHOW_RECENT_DOCUMENTS){
         });
         sectionMenu.addMenuItem(this.networkItem);
         
-        let icon = new St.Icon({icon_name: "gnome-globe", icon_size: ICON_SIZE, icon_type: St.IconType.FULLCOLOR});
+        icon = new St.Icon({icon_name: "gnome-globe", icon_size: ICON_SIZE, icon_type: St.IconType.FULLCOLOR});
         this.connectItem = new MenuItem(icon, _("Connect to..."));
         this.connectItem.connect('activate', function(actor, event) {
             new launch().command("nautilus-connect-server");

--- a/betterplaces@dewman12/files/betterplaces@dewman12/applet.js
+++ b/betterplaces@dewman12/files/betterplaces@dewman12/applet.js
@@ -428,7 +428,7 @@ if (SHOW_RECENT_DOCUMENTS){
         });
         sectionMenu.addMenuItem(this.networkItem);
         
-        let icon = new St.Icon({icon_name: "gnome-globe", icon_size: ICON_SIZE, icon_type: St.IconType.FULLCOLOR});
+        icon = new St.Icon({icon_name: "gnome-globe", icon_size: ICON_SIZE, icon_type: St.IconType.FULLCOLOR});
         this.connectItem = new MenuItem(icon, _("Connect to..."));
         this.connectItem.connect('activate', function(actor, event) {
             new launch().command("nemo-connect-server");

--- a/cwgMintMenu@clockworkgobin.org/files/cwgMintMenu@clockworkgobin.org/applet.js
+++ b/cwgMintMenu@clockworkgobin.org/files/cwgMintMenu@clockworkgobin.org/applet.js
@@ -2331,13 +2331,13 @@ MyApplet.prototype = {
                 actor.hide();
             }
         }
-        let actors = this.categoriesBox.get_children();
+        actors = this.categoriesBox.get_children();
         for (var i=0; i<actors.length; i++){
             let actor = actors[i];
             actor.style_class = "menu-category-button";
             actor.show();
         }
-        let actors = this.favoritesBox.get_children();
+        actors = this.favoritesBox.get_children();
         for (var i=0; i<actors.length; i++){
             let actor = actors[i];
             actor.remove_style_pseudo_class("hover");

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/applet.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/applet.js
@@ -547,9 +547,9 @@ MyApplet.prototype = {
         this.update_bytes_total();
 
         let received = this.scale(this.bytes_received_iteration);
-        let received = this.convert_to_readable_string(received);
+        received = this.convert_to_readable_string(received);
         let sent = this.scale(this.bytes_sent_iteration);
-        let sent = this.convert_to_readable_string(sent);
+        sent = this.convert_to_readable_string(sent);
         let received_total = this.convert_to_two_decimals_string(this.bytes_received_total);
         let sent_total = this.convert_to_two_decimals_string(this.bytes_sent_total);
 
@@ -709,7 +709,7 @@ MyApplet.prototype = {
         let precision = decimals - 1;
         let rounded = number.toFixed(precision);
         let zero = 0.0;
-        let zero = zero.toFixed(precision);
+        zero = zero.toFixed(precision);
         return rounded == zero;
     },
 

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/appletGui.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/appletGui.js
@@ -126,7 +126,7 @@ GuiSpeed.prototype = {
         icon_path = this._remove_file_schema(icon_path);
         icon_path = this._replace_tilde_with_home_directory(icon_path)
         let icon_file = Gio.file_new_for_path(icon_path);
-        let icon_file = new Gio.FileIcon({ file: icon_file });
+        icon_file = new Gio.FileIcon({ file: icon_file });
         return icon_file;
     },
 

--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/applet.js
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/applet.js
@@ -607,13 +607,13 @@ Note Odysius has used the index 0 (zero) to insert the menu section to position 
         if (this.monitoredInterfaceName == "bnep0") {
             displayname3 = "\u2714" + displayname3;
         }
-        let menuitem = new PopupMenu.PopupMenuItem(displayname3);
+        menuitem = new PopupMenu.PopupMenuItem(displayname3);
         menuitem.connect('activate', Lang.bind(this, function () {
             this.setMonitoredInterface("bnep0");
         }));
         this.myMenuSection.addMenuItem(menuitem)
 
-        let menuitem = new PopupMenu.PopupMenuItem(_("Check for Changes in Devices and Display Options"));
+        menuitem = new PopupMenu.PopupMenuItem(_("Check for Changes in Devices and Display Options"));
         menuitem.connect('activate', Lang.bind(this, function (event) {
             this.rebuildFlag = true;
         }));
@@ -621,7 +621,7 @@ Note Odysius has used the index 0 (zero) to insert the menu section to position 
 
         this.myMenuSection.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-        let menuitem = new PopupMenu.PopupMenuItem(_("Toggle Display from \u2193 and \u2191 to \u21f5"));
+        menuitem = new PopupMenu.PopupMenuItem(_("Toggle Display from \u2193 and \u2191 to \u21f5"));
         menuitem.connect('activate', Lang.bind(this, function (event) {
             if (this.compactDisplay) {
                 this.compactDisplay = false;
@@ -635,7 +635,7 @@ Note Odysius has used the index 0 (zero) to insert the menu section to position 
 
         // Code to reset Cumulative Data Usage and set their comments to the current date and time
 
-        let menuitem = new PopupMenu.PopupMenuItem(_("Reset Cumulative Data Usage") + " 1 (" + this.cumulativeInterface1 + ")");
+        menuitem = new PopupMenu.PopupMenuItem(_("Reset Cumulative Data Usage") + " 1 (" + this.cumulativeInterface1 + ")");
         menuitem.connect('activate', Lang.bind(this, function (event) {
         let d = new Date();
         this.cT1 = 0;
@@ -645,7 +645,7 @@ Note Odysius has used the index 0 (zero) to insert the menu section to position 
         }));
         this.myMenuSection.addMenuItem(menuitem);
 
-        let menuitem = new PopupMenu.PopupMenuItem(_("Reset Cumulative Data Usage") + " 2 (" + this.cumulativeInterface2 + ")");
+        menuitem = new PopupMenu.PopupMenuItem(_("Reset Cumulative Data Usage") + " 2 (" + this.cumulativeInterface2 + ")");
         menuitem.connect('activate', Lang.bind(this, function (event) {
         let d = new Date();
         this.cT2 = 0;
@@ -655,7 +655,7 @@ Note Odysius has used the index 0 (zero) to insert the menu section to position 
         }));
         this.myMenuSection.addMenuItem(menuitem);
 
-        let menuitem = new PopupMenu.PopupMenuItem(_("Reset Cumulative Data Usage") + " 3 (" + this.cumulativeInterface3 + ")");
+        menuitem = new PopupMenu.PopupMenuItem(_("Reset Cumulative Data Usage") + " 3 (" + this.cumulativeInterface3 + ")");
         menuitem.connect('activate', Lang.bind(this, function (event) {
         let d = new Date();
         this.cT3 = 0;

--- a/profile-switcher@pixunil/files/profile-switcher@pixunil/applet.js
+++ b/profile-switcher@pixunil/files/profile-switcher@pixunil/applet.js
@@ -95,7 +95,7 @@ ProfileMenuItem.prototype = {
         removeItem.activate = bind(manager.removeProfile, manager, this);
         this.menu.addMenuItem(removeItem);
 
-        let removeItem = new IconMenuItem(_("Rename Profile"), "text-editor");
+        removeItem = new IconMenuItem(_("Rename Profile"), "text-editor");
         removeItem.connect("activate", bind(manager.renameProfile, manager, this));
         this.menu.addMenuItem(removeItem);
     },

--- a/sane-menu@nooulaif/files/applet.js
+++ b/sane-menu@nooulaif/files/applet.js
@@ -2097,7 +2097,7 @@ MyApplet.prototype = {
         this.favoritesBox.add_actor(button.actor, { y_align: St.Align.END, y_fill: false });
 
         //Logout button
-        let button = new SystemButton(this, "system-log-out", launchers.length + 3,
+        button = new SystemButton(this, "system-log-out", launchers.length + 3,
                                       _("Logout"),
                                       _("Leave the session"));
 
@@ -2112,7 +2112,7 @@ MyApplet.prototype = {
         this.favoritesBox.add_actor(button.actor, { y_align: St.Align.END, y_fill: false });
 
         //Shutdown button
-        let button = new SystemButton(this, "system-shutdown", launchers.length + 3,
+        button = new SystemButton(this, "system-shutdown", launchers.length + 3,
                                       _("Quit"),
                                       _("Shutdown the computer"));
 
@@ -2340,13 +2340,13 @@ MyApplet.prototype = {
                 actor.hide();
             }
         }
-        let actors = this.categoriesBox.get_children();
+        actors = this.categoriesBox.get_children();
         for (var i=0; i<actors.length; i++){
             let actor = actors[i];
             actor.style_class = "menu-category-button";
             actor.show();
         }
-        let actors = this.favoritesBox.get_children();
+        actors = this.favoritesBox.get_children();
         for (var i=0; i<actors.length; i++){
             let actor = actors[i];
             actor.remove_style_pseudo_class("hover");

--- a/stopwatch@pdcurtis/files/stopwatch@pdcurtis/applet.js
+++ b/stopwatch@pdcurtis/files/stopwatch@pdcurtis/applet.js
@@ -155,7 +155,7 @@ MyApplet.prototype = {
         }));
         this._applet_context_menu.addMenuItem(menuitem);
 
-        let menuitem = new PopupMenu.PopupMenuItem(_("Pause"));
+        menuitem = new PopupMenu.PopupMenuItem(_("Pause"));
         menuitem.connect('activate', Lang.bind(this, function (event) {
             this.counterStatus = "paused";
             this.pausedAt = this.currentCount; // Changed to reduce load on Settings
@@ -163,14 +163,14 @@ MyApplet.prototype = {
         }));
         this._applet_context_menu.addMenuItem(menuitem);
 
-        let menuitem = new PopupMenu.PopupMenuItem(_("Reset counter"));
+        menuitem = new PopupMenu.PopupMenuItem(_("Reset counter"));
         menuitem.connect('activate', Lang.bind(this, function (event) {
             this.counterStatus = "ready";
             this.updateUI();
         }));
         this._applet_context_menu.addMenuItem(menuitem);
 
-        let menuitem = new PopupMenu.PopupMenuItem(_("If paused, continue counting from now"));
+        menuitem = new PopupMenu.PopupMenuItem(_("If paused, continue counting from now"));
         menuitem.connect('activate', Lang.bind(this, function (event) {
             if (this.counterStatus == "paused") {
                 this.updateUI();
@@ -181,7 +181,7 @@ MyApplet.prototype = {
         }));
         this._applet_context_menu.addMenuItem(menuitem);
 
-        let menuitem = new PopupMenu.PopupMenuItem(_("If paused, continue counting from original start time"));
+        menuitem = new PopupMenu.PopupMenuItem(_("If paused, continue counting from original start time"));
         menuitem.connect('activate', Lang.bind(this, function (event) {
             if (this.counterStatus == "paused") {
                 this.counterStatus = "running";

--- a/text-to-speech-applet@cardsurf/files/text-to-speech-applet@cardsurf/applet.js
+++ b/text-to-speech-applet@cardsurf/files/text-to-speech-applet@cardsurf/applet.js
@@ -344,7 +344,7 @@ MyApplet.prototype = {
 
     split_lines: function () {
         let array_lines = this.current_text.split(this.line_separator_regex);
-        let array_lines = this.remove_last_line_if_whitespace(array_lines);
+        array_lines = this.remove_last_line_if_whitespace(array_lines);
         return array_lines;
     },
 


### PR DESCRIPTION
mozjs38 crashes if one is ecountered within the same scope

this prevents the applet to crash in Cinnamon 3.4

@collinss 
@NikoKrause
@cardsurf
@pdcurtis 
@bownz
@dewman12
@clockworksimon
@pixunil
@nooulaif
