### PR TITLE
netusagemonior@pdcurtis Update to v3.2.1

### DIFF
--- a/netusagemonitor@pdcurtis/README.md
+++ b/netusagemonitor@pdcurtis/README.md
@@ -6,11 +6,11 @@ The Network Usage Monitor Applet (NUMA) enables one to continuously display the 
 
 ## Special Requirements:
 
-   * For the basic facilities the ```gir1.2-gtop-2.0``` library __must be installed__ or the applet will not load. On both Mint and Ubuntu it can be installed by the synaptic package manager or with the terminal command: 
-                      ```sudo apt-get install gir1.2-gtop-2.0```     
-     
-   * For full facilities including notifications, audible alerts and statistics the ```gir1.2-gtop-2.0 vnstat vnstati zenity sox libsox-fmt-mp3``` libraries must be installed. On both Mint and Ubuntu they can be installed  by the synaptic package manager or with the terminal command: 
-            ```sudo apt-get install gir1.2-gtop-2.0 vnstat vnstati zenity sox libsox-fmt-mp3```   
+   * For the basic facilities the ```gir1.2-gtop-2.0``` library __must be installed__ or the applet will not load. It can be installed by the synaptic package manager or with the terminal command:
+                      ```sudo apt-get install gir1.2-gtop-2.0```
+
+   * For full facilities including notifications, audible alerts and statistics the ```gir1.2-gtop-2.0 vnstat vnstati zenity sox libsox-fmt-mp3``` libraries must be installed. They can be installed  by the synaptic package manager or with the terminal command:
+            ```sudo apt-get install gir1.2-gtop-2.0 vnstat vnstati zenity sox libsox-fmt-mp3``
    * Cinnamon Version 1.8 or higher as it make comprehensive use of the new Cinnamon Settings Interface for Applets and Desklets.
 
 ## Features:
@@ -48,8 +48,7 @@ The Network Usage Monitor Applet (NUMA) enables one to continuously display the 
       + The Resolution of displayed upload and downloads (0 to 2 decimal places)
       + Change the units for Data Limits and Cumulative Offsets between Mbytes or Gbytes 
       + Setting an interface to use as Default if no other interface is active at start-up - for Wifi hotspots and Mobile Broadband where the connection is manual.
-      + Enabling Alerts on the current monitored interface and
-        setting the Data Limit for the current connection on that interface and
+      + Enabling Alerts on the current monitored interface and setting the Data Limit for the current connection on that interface and
            - setting the Alert Level as a percentage of the Data Limit by a slider (duplicated in the left click menu as it is frequently used.
            - Enabling each of three Cumulative Usage Monitors
     Setting an offset for each Cumulative Usage Monitors (v20_2.6.0 or higher)
@@ -68,13 +67,21 @@ The Network Usage Monitor Applet (NUMA) enables one to continuously display the 
 
 ## Additional Configuration
 
-The display width, justification and font details are set using an external Cascading Style Sheet (.css) file which is in the main folder (usualy ```~/.local/share/cinnamon/netusage@pdcurtis/stylesheet.css```).
+### Styling
+
+The display width, justification and font details are set using an external Cascading Style Sheet (.css) file which is in the main folder (usualy ```~/.local/share/cinnamon/netusagemonitor@pdcurtis/stylesheet.css```).
 
 The settings in this css file govern the width of the Applet and the font. Changes may be required with some themes to avoid the display width being exceeded which leads to jitter with high network speeds and resolutions or to allow a reduced size width to save panel space. The latest version also allow the backgrounds to be configured using this css file to optimise to a particular theme although the defaults work well on most popular themes.
 
+Note: These settings will be overwritten if the applet is reloaded.
+
+### Interfaces monitored by the optional ```vnstat``` display.
+
+The system program vnstat which provides the option of a graphic history of data used is automatically set up when it is installed to monitor the network devices/interfaces installed in the machine at the time. It is possible to add additional USB network devices and possibly bluetooth devices to the list of monitored interface ```man vnstat``` in a terminal will give details.
+
 ## Status
 
-The applet is based on a well tried core from the netspeed applet and has been tested on various systems initially running Ubuntu 12.04 and Mint 15 with a variety of themes. It has been tested using Cinnamon 1.8, - 3.2 and had minor modifications for the changes introduced in Mint 18. The current Version has been tested with Cinnamon 2.2 - 3.2 and Mint 16 - 18.1
+The author is committed to maintaining and developing the applet. The applet is based on a well tried core from the netspeed applet and has been tested on various systems initially running Mint 15 with a variety of themes. It is designed to work with Cinammon 1.8 and higher. The current Version has been tested with Cinnamon 2.2 - 3.2 and Mint 16 - 18.1. 
 
 ## Translations and other Contributions
 
@@ -82,7 +89,7 @@ The internal changes required in the applet to allow translations are being impl
 
 Although comments and suggestions are always welcome any contributions which are contemplated should follow discussion. Changes can have many unintended consequences and the integrity of the applet is paramount. Unsolicited Pull Requests will never be authorised other than for urgent and critical bug fixes from the Cinnamon Team. 
 
-Thanks are given for the very useful contributions from @collinss and @Odyseus to helping harmonise the menus with other applets.
+Thanks are given for the very useful contributions from @collinss and @Odyseus to help harmonise the menus with other applets.
 
 ## Manual Installation:
 
@@ -95,7 +102,9 @@ Thanks are given for the very useful contributions from @collinss and @Odyseus t
 
 ### Version information prior to the changes introduced by the new Cinnamon Spices Web site in January 2017
 
-There is a full change log in the applet folder called changelog.txt which can also be accessed  through the Context (Right Click) menu in the Housekeeping sub-menu. The earlier  development was carried out on Github along with my other applets at [github.com/pdcurtis/cinnamon-applets](https://github.com/pdcurtis/cinnamon-applets)
+There is a full change log in the applet folder called changelog.txt which can also be accessed  through the Context (Right Click) menu in the Housekeeping sub-menu. The initial  development was carried out on Github along with my other applets at [github.com/pdcurtis/cinnamon-applets](https://github.com/pdcurtis/cinnamon-applets)
 
+### Contact
 
+The author can be contacted via the comments on the [Cinnamon Spices Web Site](http://cinnamon-spices.linuxmint.com/applets/view/141), however that does not automatically notify me so if you want a rapid response please also alert me via the [Form at www.pcurtis.com](http://www.pcurtis.com/contact_form.htm?applets). On github, mentioning @pdcurtis in any conversation will cause it to be emailed to me.
 

--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/README.md
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/README.md
@@ -6,11 +6,11 @@ The Network Usage Monitor Applet (NUMA) enables one to continuously display the 
 
 ## Special Requirements:
 
-   * For the basic facilities the ```gir1.2-gtop-2.0``` library __must be installed__ or the applet will not load. On both Mint and Ubuntu it can be installed by the synaptic package manager or with the terminal command: 
-                      ```sudo apt-get install gir1.2-gtop-2.0```     
-     
-   * For full facilities including notifications, audible alerts and statistics the ```gir1.2-gtop-2.0 vnstat vnstati zenity sox libsox-fmt-mp3``` libraries must be installed. On both Mint and Ubuntu they can be installed  by the synaptic package manager or with the terminal command: 
-            ```sudo apt-get install gir1.2-gtop-2.0 vnstat vnstati zenity sox libsox-fmt-mp3```   
+   * For the basic facilities the ```gir1.2-gtop-2.0``` library __must be installed__ or the applet will not load. It can be installed by the synaptic package manager or with the terminal command:
+                      ```sudo apt-get install gir1.2-gtop-2.0```
+
+   * For full facilities including notifications, audible alerts and statistics the ```gir1.2-gtop-2.0 vnstat vnstati zenity sox libsox-fmt-mp3``` libraries must be installed. They can be installed  by the synaptic package manager or with the terminal command:
+            ```sudo apt-get install gir1.2-gtop-2.0 vnstat vnstati zenity sox libsox-fmt-mp3``
    * Cinnamon Version 1.8 or higher as it make comprehensive use of the new Cinnamon Settings Interface for Applets and Desklets.
 
 ## Features:
@@ -48,8 +48,7 @@ The Network Usage Monitor Applet (NUMA) enables one to continuously display the 
       + The Resolution of displayed upload and downloads (0 to 2 decimal places)
       + Change the units for Data Limits and Cumulative Offsets between Mbytes or Gbytes 
       + Setting an interface to use as Default if no other interface is active at start-up - for Wifi hotspots and Mobile Broadband where the connection is manual.
-      + Enabling Alerts on the current monitored interface and
-        setting the Data Limit for the current connection on that interface and
+      + Enabling Alerts on the current monitored interface and setting the Data Limit for the current connection on that interface and
            - setting the Alert Level as a percentage of the Data Limit by a slider (duplicated in the left click menu as it is frequently used.
            - Enabling each of three Cumulative Usage Monitors
     Setting an offset for each Cumulative Usage Monitors (v20_2.6.0 or higher)
@@ -68,13 +67,21 @@ The Network Usage Monitor Applet (NUMA) enables one to continuously display the 
 
 ## Additional Configuration
 
-The display width, justification and font details are set using an external Cascading Style Sheet (.css) file which is in the main folder (usualy ```~/.local/share/cinnamon/netusage@pdcurtis/stylesheet.css```).
+### Styling
+
+The display width, justification and font details are set using an external Cascading Style Sheet (.css) file which is in the main folder (usualy ```~/.local/share/cinnamon/netusagemonitor@pdcurtis/stylesheet.css```).
 
 The settings in this css file govern the width of the Applet and the font. Changes may be required with some themes to avoid the display width being exceeded which leads to jitter with high network speeds and resolutions or to allow a reduced size width to save panel space. The latest version also allow the backgrounds to be configured using this css file to optimise to a particular theme although the defaults work well on most popular themes.
 
+Note: These settings will be overwritten if the applet is reloaded.
+
+### Interfaces monitored by the optional ```vnstat``` display.
+
+The system program vnstat which provides the option of a graphic history of data used is automatically set up when it is installed to monitor the network devices/interfaces installed in the machine at the time. It is possible to add additional USB network devices and possibly bluetooth devices to the list of monitored interface ```man vnstat``` in a terminal will give details.
+
 ## Status
 
-The applet is based on a well tried core from the netspeed applet and has been tested on various systems initially running Ubuntu 12.04 and Mint 15 with a variety of themes. It has been tested using Cinnamon 1.8, - 3.2 and had minor modifications for the changes introduced in Mint 18. The current Version has been tested with Cinnamon 2.2 - 3.2 and Mint 16 - 18.1
+The author is committed to maintaining and developing the applet. The applet is based on a well tried core from the netspeed applet and has been tested on various systems initially running Mint 15 with a variety of themes. It is designed to work with Cinammon 1.8 and higher. The current Version has been tested with Cinnamon 2.2 - 3.2 and Mint 16 - 18.1. 
 
 ## Translations and other Contributions
 
@@ -82,7 +89,7 @@ The internal changes required in the applet to allow translations are being impl
 
 Although comments and suggestions are always welcome any contributions which are contemplated should follow discussion. Changes can have many unintended consequences and the integrity of the applet is paramount. Unsolicited Pull Requests will never be authorised other than for urgent and critical bug fixes from the Cinnamon Team. 
 
-Thanks are given for the very useful contributions from @collinss and @Odyseus to helping harmonise the menus with other applets.
+Thanks are given for the very useful contributions from @collinss and @Odyseus to help harmonise the menus with other applets.
 
 ## Manual Installation:
 
@@ -95,7 +102,9 @@ Thanks are given for the very useful contributions from @collinss and @Odyseus t
 
 ### Version information prior to the changes introduced by the new Cinnamon Spices Web site in January 2017
 
-There is a full change log in the applet folder called changelog.txt which can also be accessed  through the Context (Right Click) menu in the Housekeeping sub-menu. The earlier  development was carried out on Github along with my other applets at [github.com/pdcurtis/cinnamon-applets](https://github.com/pdcurtis/cinnamon-applets)
+There is a full change log in the applet folder called changelog.txt which can also be accessed  through the Context (Right Click) menu in the Housekeeping sub-menu. The initial  development was carried out on Github along with my other applets at [github.com/pdcurtis/cinnamon-applets](https://github.com/pdcurtis/cinnamon-applets)
 
+### Contact
 
+The author can be contacted via the comments on the [Cinnamon Spices Web Site](http://cinnamon-spices.linuxmint.com/applets/view/141), however that does not automatically notify me so if you want a rapid response please also alert me via the [Form at www.pcurtis.com](http://www.pcurtis.com/contact_form.htm?applets). On github, mentioning @pdcurtis in any conversation will cause it to be emailed to me.
 

--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/applet.js
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/applet.js
@@ -402,7 +402,7 @@ MyApplet.prototype = {
             //			this.menu.addActor(this.imageWidget);      // Old way with actor added directly to menu
             try {
                 this.menu.addActor(this.mainBox); // Now add mainbox
-                this.mainBox.add_actor(this.imageWidget); // and add actor for to it which can be removed
+                this.mainBox.add_actor(this.imageWidget); // and add actor in way that it can be removed
                 this.mainBox.add_actor(this.textWidget); // and text actor to handle case where vnstat not installed
 
                 GLib.spawn_command_line_async('vnstati -s -ne -i ' + this.monitoredInterfaceName + ' -o ' + this.vnstatImage);
@@ -424,6 +424,11 @@ MyApplet.prototype = {
                 reactive: false
             });
             this.menu.addMenuItem(this.menuitemHead0);
+            this.menuitemHead1 = new PopupMenu.PopupMenuItem("          " + _("If no Interface is Active, the last available information has been displayed"), {
+                reactive: false
+            });
+            this.menu.addMenuItem(this.menuitemHead1);
+
             this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem())
         }
 
@@ -523,41 +528,17 @@ MyApplet.prototype = {
 
     // Build right click context menu
     buildContextMenu: function () {
-      // No longer needed
-      // this._applet_context_menu.removeAll();
 
 /*
 The code following allows me to retain the 'standard' additions of 'About...' 'Configure...' and 'Remove' when rebuilding the Context menu.
-
-The use of a PopupMenu.PopupMenuSection was suggested @collinss with implementation provided by @Odyseus in a way that allowed me to keep your code almost exactly as it was with a minimum number of tweaks. The following code adds all the menu items to the applet context menu without touching the default items.
-
-    // Build right click context menu
-    buildContextMenu: function() {
-        // Not needed.
-        // this._applet_context_menu.removeAll();
-
-        if (this.myMenuSection)
-            this.myMenuSection.destroy();
-
-        this.myMenuSection = new PopupMenu.PopupMenuSection();
-        this._applet_context_menu.addMenuItem(this.myMenuSection, 0);
-
-        // Rest of buildContextMenu function.
-        // Items added to this.myMenuSection insted of this._applet_context_menu.
-    },
-
-Note Odysius has used the index 0 (zero) to insert the menu section to position items in the correct order and avoid the menu section being added after all the default items. Maybe @collinss could shed some light on why this happened?
+The use of a PopupMenu.PopupMenuSection was suggested @collinss with implementation provided by @Odyseus in a way that allowed me to keep your code almost exactly as it was with a minimum number of tweaks. 
+Note Odysius has used the index 0 (zero) to insert the menu section to position items in the correct order and avoid the menu section being added after all the default items.
 */
 
         if (this.myMenuSection)
             this.myMenuSection.destroy();
-
         this.myMenuSection = new PopupMenu.PopupMenuSection();
         this._applet_context_menu.addMenuItem(this.myMenuSection, 0);
-
-
-
-
 
 // Old code continues
 
@@ -731,16 +712,6 @@ Note Odysius has used the index 0 (zero) to insert the menu section to position 
             this.subMenu1.menu.addMenuItem(this.subMenuItem7);
          }
     },
-/*
-//      Following no longer needed as it is provided in default context menu items 
-
-//        this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-        let menuitem = new PopupMenu.PopupMenuItem(_("Configure"));
-        menuitem.connect('activate', Lang.bind(this, function (event) {
-            GLib.spawn_command_line_async('cinnamon-settings applets ' + this.UUID);
-        }));
-        this.myMenuSection.addMenuItem(menuitem);
-*/
 
     setMonitoredInterface: function (name) {
         this.monitoredInterfaceName = name;
@@ -772,7 +743,6 @@ Note Odysius has used the index 0 (zero) to insert the menu section to position 
     playAlert: function(){
         if(this.useAlertSound) {
             GLib.spawn_command_line_async('play ' + this.alertSound);
-//            GLib.spawn_command_line_async('play /usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga');
         }
     },
 
@@ -998,7 +968,7 @@ function main(metadata, orientation, panel_height, instance_id) {
 }
 
 /*
-Version 3.1.2
+Version 3.2.1
 1.0 Applet Settings now used for Update Rate, Resolution and Interface. 
     Built in function used for left click menu. 
 1.1 Right click menu item added to open Settings Screen. 
@@ -1151,4 +1121,10 @@ Transition to new cinnamon-spices-applets repository from github.com/pdcurtis/ci
           Update README.md (2x) for contributions from @collinss and @Odyseus.
 3.1.2     Change spawn_command_line_sync to spawn_command_line_async to remove one reason for 'dangerous' classification.
           Correct several spelling errors in comments and .md files.
+3.2.0     Remove duplicate let declarations occurances in common coding for Cinnamon 3.4 thanks to @NikoKraus  [#604]
+3.2.1     Harmonise with code writen by author for vnstat@cinnamon.org and revert 3.1.2 until further testing.
+          Updated netusagemonitor.pot using cinnamon-json-makepot --js po/netusagemonitor.pot as string added. 
+          Tidy up comments in applet.js
+          Update README.md to remove a couple of references to Ubuntu from early days.
+          Usual updates to new version in applet.js, changelog and metadata.json
 */

--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/changelog.txt
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/changelog.txt
@@ -1,4 +1,4 @@
-Version 3.1.2
+Version 3.2.1
 1.0 Applet Settings now used for Update Rate, Resolution and Interface. 
     Built in function used for left click menu. 
 1.1 Right click menu item added to open Settings Screen. 
@@ -54,7 +54,7 @@ Conclusion - change to a drop down selection of options, initially the three cur
 2.3.5 Major change in use of css styles for the background colours which show connection and alert status.
       This allows the user to match colours etc to a particular theme.
 2.3.6 Minor bug fix - Context Menu not always rebuilt after adding or removing advanced functions submenu.
-2.3.7 Bug fix - cumulative counters 1 and 3 not being saved correctly
+2.3.7 Bug fix - Cumulative counters 1 and 3 not being saved correctly
 2.3.8  Anomoly fix - Avoid calling  GTop.glibtop_get_netload() without valid interface -
        possible latest versions can segfault if interface not valid.
 2.3.9  Add fix for Applet not being fully halted when removed from panel (from dansie)
@@ -151,3 +151,9 @@ Transition to new cinnamon-spices-applets repository from github.com/pdcurtis/ci
           Update README.md (2x) for contributions from @collinss and @Odyseus.
 3.1.2     Change spawn_command_line_sync to spawn_command_line_async to remove one reason for 'dangerous' classification.
           Correct several spelling errors in comments and .md files.
+3.2.0     Remove duplicate let declarations occurances in common coding for Cinnamon 3.4 thanks to @NikoKraus  [#604]
+3.2.1     Harmonise with code writen by author for vnstat@cinnamon.org and revert 3.1.2 until further testing.
+          Updated netusagemonitor.pot using cinnamon-json-makepot --js po/netusagemonitor.pot as string added. 
+          Tidy up comments in applet.js
+          Update README.md to remove a couple of references to Ubuntu from early days.
+          Usual updates to new version in applet.js, changelog and metadata.json

--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/metadata.json
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/metadata.json
@@ -2,7 +2,7 @@
     "max-instances": "1",  
     "uuid": "netusagemonitor@pdcurtis", 
     "name": "Network Data Usage Monitor", 
-    "description": "A Comprehensive Data Usage Monitor with alerts and cumulative data functions for Cinnamon",
-    "version": "3.1.2"
+    "description": "A Comprehensive Data Usage Monitor with alerts and cumulative data functions",
+    "version": "3.2.1"
 }
 

--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/po/netusagemonitor.pot
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/po/netusagemonitor.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-09 15:25+1200\n"
+"POT-Creation-Date: 2017-05-08 04:19+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,112 +37,117 @@ msgid ""
 " at the top right"
 msgstr ""
 
-#: applet.js:434
+#: applet.js:427
+msgid ""
+"If no Interface is Active, the last available information has been displayed"
+msgstr ""
+
+#: applet.js:439
 msgid "Cumulative Data Usage Information:"
 msgstr ""
 
-#: applet.js:461
+#: applet.js:466
 msgid "Current Connection and Interface Information"
 msgstr ""
 
-#: applet.js:473
+#: applet.js:478
 msgid "No network monitored. Please select one right-clicking the applet."
 msgstr ""
 
-#: applet.js:480
+#: applet.js:485
 msgid "Note: Alerts not enabled in Settings"
 msgstr ""
 
-#: applet.js:496
+#: applet.js:501
 msgid "Alert level (Orange):"
 msgstr ""
 
-#: applet.js:496
+#: applet.js:501
 #, c-format
 msgid "% of Data Limit of"
 msgstr ""
 
-#: applet.js:501 applet.js:503 applet.js:509 applet.js:511 applet.js:517
+#: applet.js:506 applet.js:508 applet.js:514 applet.js:516 applet.js:522
 msgid "Cumulative Data Use"
 msgstr ""
 
-#: applet.js:501 applet.js:509 applet.js:517
+#: applet.js:506 applet.js:514 applet.js:522
 msgid "with offset of"
 msgstr ""
 
-#: applet.js:564
+#: applet.js:545
 msgid "Select a network manager interface to be monitored:"
 msgstr ""
 
-#: applet.js:577
+#: applet.js:558
 msgid "(Active)"
 msgstr ""
 
-#: applet.js:590
+#: applet.js:571
 msgid "or Select an independent interface to be monitored:"
 msgstr ""
 
-#: applet.js:594
+#: applet.js:575
 msgid "for most USB Mobile Internet Modems)"
 msgstr ""
 
-#: applet.js:606
+#: applet.js:587
 msgid "for Android Bluetooth PAN Connections)"
 msgstr ""
 
-#: applet.js:616
+#: applet.js:597
 msgid "Check for Changes in Devices and Display Options"
 msgstr ""
 
-#: applet.js:624
+#: applet.js:605
 msgid "Toggle Display from ↓ and ↑ to ⇵"
 msgstr ""
 
-#: applet.js:638 applet.js:648 applet.js:658
+#: applet.js:619 applet.js:629 applet.js:639
 msgid "Reset Cumulative Data Usage"
 msgstr ""
 
-#: applet.js:671
+#: applet.js:652
 msgid "Housekeeping and System Sub Menu"
 msgstr ""
 
-#: applet.js:674
+#: applet.js:655
 msgid "Open System Monitor"
 msgstr ""
 
-#: applet.js:680
+#: applet.js:661
 msgid "View the Changelog"
 msgstr ""
 
-#: applet.js:686
+#: applet.js:667
 msgid "View the Help File"
 msgstr ""
 
-#: applet.js:695
+#: applet.js:676
 msgid "Open stylesheet.css  (Advanced Function)"
 msgstr ""
 
-#: applet.js:701
+#: applet.js:682
 msgid "Open alertScript  (Advanced Function)"
 msgstr ""
 
-#: applet.js:707
+#: applet.js:688
 msgid "Open suspendScript  (Advanced Function)"
 msgstr ""
 
-#: applet.js:715
+#: applet.js:696
 msgid "Test alertScript  (Advanced Test Function)"
 msgstr ""
 
-#: applet.js:721
+#: applet.js:702
 msgid "Test suspendScript  (Advanced Test Function)"
 msgstr ""
 
-#: applet.js:727
+#: applet.js:708
 msgid "Test Crisis Management Function (Advanced Test Function)"
 msgstr ""
 
-#: applet.js:807
+#: applet.js:777
 msgid ""
 "THE DATA USAGE LIMIT HAS BEEN EXCEEDED\n"
 "\n"
@@ -151,15 +156,15 @@ msgid ""
 "or disconnect using the Network Manager Applet"
 msgstr ""
 
-#: applet.js:879
+#: applet.js:849
 msgid "Interface:"
 msgstr ""
 
-#: applet.js:879 applet.js:882
+#: applet.js:849 applet.js:852
 msgid "Downloaded:"
 msgstr ""
 
-#: applet.js:879 applet.js:882
+#: applet.js:849 applet.js:852
 msgid "Uploaded:"
 msgstr ""
 
@@ -498,7 +503,6 @@ msgstr ""
 #. netusagemonitor@pdcurtis->metadata.json->description
 msgid ""
 "A Comprehensive Data Usage Monitor with alerts and cumulative data functions"
-" for Cinnamon"
 msgstr ""
 
 #. netusagemonitor@pdcurtis->metadata.json->name


### PR DESCRIPTION
 * Harmonise with code written by author for vnstat@cinnamon.org and revert 3.1.2 until further testing.
* Updated netusagemonitor.pot using cinnamon-json-makepot --js po/netusagemonitor.pot as string added. 
 * Tidy up comments in applet.js
 * Update README.md to remove a couple of references to Ubuntu from early days.
 * Usual updates to new version in applet.js, changelog and metadata.json

@muzena and @giwhub Please note I have updated the .pot as an extra string has been added. Many thanks for your previous translations. 