### PR TITLE
github-projects@morgan-design.com: Add Cinnamon 3.4 compatibility fix

### DIFF
--- a/github-projects@morgan-design.com/files/github-projects@morgan-design.com/applet.js
+++ b/github-projects@morgan-design.com/files/github-projects@morgan-design.com/applet.js
@@ -373,7 +373,7 @@ MyApplet.prototype = {
     },
 
     _createPopupImageMenuItem: function(title, icon, bindFunction, options){
-		let options = options || {};
+		options = options || {};
 		let openRepoItem = new PopupMenu.PopupImageMenuItem(title, icon, options);
 		openRepoItem.connect("activate", Lang.bind(this, bindFunction));
 		return openRepoItem;

--- a/github-projects@morgan-design.com/files/github-projects@morgan-design.com/metadata.json
+++ b/github-projects@morgan-design.com/files/github-projects@morgan-design.com/metadata.json
@@ -2,5 +2,5 @@
 	"uuid": "github-projects@morgan-design.com",
 	"name": "Github Explorer",
 	"description": "Click on the applet to explore your Public Github repositories",
-	"version": "1.5"
+	"version": "1.5.1"
 }

--- a/github-projects@morgan-design.com/files/github-projects@morgan-design.com/metadata.json
+++ b/github-projects@morgan-design.com/files/github-projects@morgan-design.com/metadata.json
@@ -2,5 +2,5 @@
 	"uuid": "github-projects@morgan-design.com",
 	"name": "Github Explorer",
 	"description": "Click on the applet to explore your Public Github repositories",
-	"version": "1.5.1"
+	"version": "1.5"
 }


### PR DESCRIPTION
@jamesmorgan

This prevents the applet from crashing on Cinnamon 3.4 due to a strict
mode error.

```
error t=2017-05-13T20:27:15.664Z redeclaration of formal parameter options
trace t=2017-05-13T20:27:15.664Z 
<----------------
Extension.prototype._init@/usr/share/cinnamon/js/ui/extension.js:155:13
Extension@/usr/share/cinnamon/js/ui/extension.js:116:5
loadExtension@/usr/share/cinnamon/js/ui/extension.js:449:25
onEnabledAppletsChanged@/usr/share/cinnamon/js/ui/appletManager.js:236:13
---------------->
error t=2017-05-13T20:27:15.664Z [Applet "github-projects@morgan-design.com"]: Error importing applet.js from github-projects@morgan-design.com
```