### PR TITLE
6 applets: set author to none for abanonded applets

### DIFF
--- a/a4techTool@mous/info.json
+++ b/a4techTool@mous/info.json
@@ -1,1 +1,4 @@
-{"author": "mous"}
+{
+    "author": "none",
+    "original_author": "mous"
+}

--- a/binaryclock@entelechy/info.json
+++ b/binaryclock@entelechy/info.json
@@ -1,1 +1,4 @@
-{"author": "entelechy"}
+{
+    "author": "none",
+    "original_author": "entelechy"
+}

--- a/location-detection@heimdall/info.json
+++ b/location-detection@heimdall/info.json
@@ -1,1 +1,4 @@
-{"author": "heimdall"}
+{
+    "author": "none",
+    "original_author": "heimdall"
+}

--- a/restart-cinnamon@kolle/info.json
+++ b/restart-cinnamon@kolle/info.json
@@ -1,1 +1,4 @@
-{"author": "kolle"}
+{
+    "author": "none",
+    "original_author": "kolle"
+}

--- a/temperature@fevimu/info.json
+++ b/temperature@fevimu/info.json
@@ -1,1 +1,4 @@
-{"author": "fevimu"}
+{
+    "author": "none",
+    "original_author": "fevimu"
+}

--- a/toggle_LookingGlass@kolle/info.json
+++ b/toggle_LookingGlass@kolle/info.json
@@ -1,1 +1,4 @@
-{"author": "kolle"}
+{
+    "author": "none",
+    "original_author": "kolle"
+}


### PR DESCRIPTION
Those applets are abandoned. The authors have never responded and they haven't been active on GitHub for years. So set author to `none` and mention them in `original_author`

@entelechy
@heimdall
@mous
@kolle
@fevimu