### PR TITLE
bash-sensors@pkkk: Correct code style / indentation, simplify loops and fix #553

### DIFF
--- a/bash-sensors@pkkk/files/bash-sensors@pkkk/applet.js
+++ b/bash-sensors@pkkk/files/bash-sensors@pkkk/applet.js
@@ -73,13 +73,11 @@ MyApplet.prototype = {
             if (cmd_output[0]) {
                 cmd_stdout = cmd_output[1].toString();
                 cmd_stdout+= cmd_output[2].toString();
-                cmd_stdout = cmd_stdout.substring(0,50);
-                full += cmd_stdout.replace(/\n/g, "");
-                if (i < scripts.length - 1)
-                    full += '\n';
+                cmd_stdout = cmd_stdout.replace(/\n/g, "").substring(0, 50);
             }
+            full += cmd_stdout + '\n';
         }
-        this.set_applet_label(full);
+        this.set_applet_label(full.trimRight());
         Mainloop.timeout_add(this.refreshInterval * 1000, Lang.bind(this, this.update));
     },
 

--- a/bash-sensors@pkkk/files/bash-sensors@pkkk/applet.js
+++ b/bash-sensors@pkkk/files/bash-sensors@pkkk/applet.js
@@ -86,7 +86,7 @@ MyApplet.prototype = {
         this.bind_settings();
     },
     bind_settings: function () {
-        for (let str of ["refreshInterval", "script1", "script2", "enableScript2", "menuScript"]){
+        for (let str of ["refreshInterval", "script1", "script2", "enableScript2", "menuScript"]) {
             this.settings.bindProperty(Settings.BindingDirection.IN,
                 str,
                 str,

--- a/bash-sensors@pkkk/files/bash-sensors@pkkk/applet.js
+++ b/bash-sensors@pkkk/files/bash-sensors@pkkk/applet.js
@@ -67,8 +67,7 @@ MyApplet.prototype = {
         let full = '';
         let scripts = this.script2 && this.script2.trim() && this.enableScript2 ?
             [this.script1, this.script2] : [this.script1];
-        for (i in scripts) {
-            let cmd = scripts[i];
+        for (let cmd of scripts) {
             let cmd_stdout = _("script error");
             let cmd_output = this.spawn_sync(cmd);
             if (cmd_output[0]) {
@@ -89,7 +88,7 @@ MyApplet.prototype = {
         this.bind_settings();
     },
     bind_settings: function () {
-        for (str of ["refreshInterval", "script1", "script2", "enableScript2", "menuScript"]){
+        for (let str of ["refreshInterval", "script1", "script2", "enableScript2", "menuScript"]){
             this.settings.bindProperty(Settings.BindingDirection.IN,
                 str,
                 str,

--- a/bash-sensors@pkkk/files/bash-sensors@pkkk/applet.js
+++ b/bash-sensors@pkkk/files/bash-sensors@pkkk/applet.js
@@ -22,14 +22,6 @@ function MyApplet(metadata, orientation) {
 MyApplet.prototype = {
     __proto__: Applet.TextApplet.prototype,
 
-    _printKeys: function (obj) {
-        var keys = [];
-        for (var key in obj){
-            keys.push(key);
-        }
-        global.logError(keys);
-    },
-
     _init: function (metadata, orientation, panelHeight, instance_id) {
         Applet.TextApplet.prototype._init.call(this, orientation);
         this.path = metadata.path;

--- a/bash-sensors@pkkk/files/bash-sensors@pkkk/applet.js
+++ b/bash-sensors@pkkk/files/bash-sensors@pkkk/applet.js
@@ -81,16 +81,12 @@ MyApplet.prototype = {
         Mainloop.timeout_add(this.refreshInterval * 1000, Lang.bind(this, this.update));
     },
 
-
-    on_settings_changed: function () {
-        this.bind_settings();
-    },
     bind_settings: function () {
         for (let str of ["refreshInterval", "script1", "script2", "enableScript2", "menuScript"]) {
             this.settings.bindProperty(Settings.BindingDirection.IN,
                 str,
                 str,
-                this.on_settings_changed,
+                null,
                 null);
         }
     }

--- a/bash-sensors@pkkk/files/bash-sensors@pkkk/applet.js
+++ b/bash-sensors@pkkk/files/bash-sensors@pkkk/applet.js
@@ -12,102 +12,102 @@ const UUID = "bash-sensors@pkkk";
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale")
 
 function _(str) {
-  return Gettext.dgettext(UUID, str);
+    return Gettext.dgettext(UUID, str);
 }
 
 function MyApplet(metadata, orientation) {
-	this._init(metadata, orientation);
+    this._init(metadata, orientation);
 };
 
 MyApplet.prototype = {
-	__proto__: Applet.TextApplet.prototype,
-	
-	_printKeys: function (obj) {
-	        var keys = [];
-			for(var key in obj){
-	      		keys.push(key);
-	   		}
-	        global.logError(keys);
-	},
+    __proto__: Applet.TextApplet.prototype,
 
-    _init: function(metadata, orientation, panelHeight, instance_id) {
+    _printKeys: function (obj) {
+        var keys = [];
+        for (var key in obj){
+            keys.push(key);
+        }
+        global.logError(keys);
+    },
+
+    _init: function (metadata, orientation, panelHeight, instance_id) {
         Applet.TextApplet.prototype._init.call(this, orientation);
         this.path = metadata.path;
         this.set_applet_tooltip(_("Bash Sensors!"));
         this.settings = new Settings.AppletSettings(this, metadata.uuid, instance_id);
 
         this.menuManager = new PopupMenu.PopupMenuManager(this);
-	    this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
         let section = new PopupMenu.PopupMenuSection('PopupMenuSection');
         let item = new PopupMenu.PopupMenuItem('');
         this.menuLabel = new St.Label({text: '<init>'});
 
-		this.bind_settings();
-		this.update();
+        this.bind_settings();
+        this.update();
 
         item.addActor(this.menuLabel);
         section.addMenuItem(item);
-        
+
         this.menu.addMenuItem(section);
-	    this.menuManager.addMenu(this.menu);
+        this.menuManager.addMenu(this.menu);
     },
 
-	spawn_sync: function (script) {
-		return GLib.spawn_sync(null, 
-    		['bash', '-c', script],
-    		null,
-    		GLib.SpawnFlags.SEARCH_PATH,
-    		null);
-	},
-
-	on_applet_clicked: function(event) {
-		if(!this.menu.isOpen) {
-			let cmd = (this.menuScript && this.menuScript.trim()) ? this.menuScript : this.script1;
-			let cmd_output = this.spawn_sync(cmd);
-			let cmd_stdout = cmd_output[0] ? cmd_output[1].toString() : _("script error");
-			this.menuLabel.set_text(cmd_stdout);
-		}
-
-		this.menu.toggle();
-	},
-
-    update:function () {
-		let full = '';
-		let scripts = this.script2 && this.script2.trim() && this.enableScript2 ? 
-			[this.script1, this.script2] : [this.script1];
-		for (i in scripts) {
-			let cmd = scripts[i];
-			let cmd_stdout = _("script error");
-			let cmd_output = this.spawn_sync(cmd);
-			if(cmd_output[0]) {
-				cmd_stdout = cmd_output[1].toString();
-				cmd_stdout+= cmd_output[2].toString();
-				cmd_stdout = cmd_stdout.substring(0,50);
-				full += cmd_stdout.replace(/\n/g, "");	
-				if (i < scripts.length - 1)
-					full += '\n';
-			}
-		}
-		this.set_applet_label (full);
-		Mainloop.timeout_add(this.refreshInterval * 1000, Lang.bind(this, this.update));
+    spawn_sync: function (script) {
+        return GLib.spawn_sync(null,
+            ['bash', '-c', script],
+            null,
+            GLib.SpawnFlags.SEARCH_PATH,
+            null);
     },
-	
-	
+
+    on_applet_clicked: function (event) {
+        if (!this.menu.isOpen) {
+            let cmd = (this.menuScript && this.menuScript.trim()) ? this.menuScript : this.script1;
+            let cmd_output = this.spawn_sync(cmd);
+            let cmd_stdout = cmd_output[0] ? cmd_output[1].toString() : _("script error");
+            this.menuLabel.set_text(cmd_stdout);
+        }
+
+        this.menu.toggle();
+    },
+
+    update: function () {
+        let full = '';
+        let scripts = this.script2 && this.script2.trim() && this.enableScript2 ?
+            [this.script1, this.script2] : [this.script1];
+        for (i in scripts) {
+            let cmd = scripts[i];
+            let cmd_stdout = _("script error");
+            let cmd_output = this.spawn_sync(cmd);
+            if (cmd_output[0]) {
+                cmd_stdout = cmd_output[1].toString();
+                cmd_stdout+= cmd_output[2].toString();
+                cmd_stdout = cmd_stdout.substring(0,50);
+                full += cmd_stdout.replace(/\n/g, "");
+                if (i < scripts.length - 1)
+                    full += '\n';
+            }
+        }
+        this.set_applet_label(full);
+        Mainloop.timeout_add(this.refreshInterval * 1000, Lang.bind(this, this.update));
+    },
+
+
     on_settings_changed: function () {
         this.bind_settings();
     },
     bind_settings: function () {
-    	for(str of ["refreshInterval", "script1", "script2", "enableScript2", "menuScript"]){
-	        this.settings.bindProperty(Settings.BindingDirection.IN, 
-	            str, 
-	            str, 
-	            this.on_settings_changed, 
-	            null);
-    	}
+        for (str of ["refreshInterval", "script1", "script2", "enableScript2", "menuScript"]){
+            this.settings.bindProperty(Settings.BindingDirection.IN,
+                str,
+                str,
+                this.on_settings_changed,
+                null);
+        }
     }
 };
 
 function main(metadata, orientation) {
-	let myApplet = new MyApplet(metadata, orientation);
-	return myApplet;
+    let myApplet = new MyApplet(metadata, orientation);
+    return myApplet;
 }


### PR DESCRIPTION
This is the other half of my failed commit (https://github.com/linuxmint/cinnamon-spices-applets/pull/739). This time the `bash-sensors@pkkk` is addressed, solving #553 and correcting some style incongruences. It also marginally simplifies a loop and corrects the trimming done inside it (to avoid under-trimming).