### PR TITLE
CinnVIIStarkMenu@NikoKrause: use _select_category to select recents a…

### DIFF
--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/3.2/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/3.2/applet.js
@@ -2493,9 +2493,11 @@ MyApplet.prototype = {
             this._activeActor = null;
             this._appsBoxWidthResized = false;
 
+            this.lastSelectedCategory = null;
+
             if(visiblePane == "apps") {
                 this._allAppsCategoryButton.actor.style_class = "menu-category-button-selected";
-                this._select_category(null, this._allAppsCategoryButton);
+                this._select_category(null);
             }
 
             if(this.menuLayout == "stark-menu" || this.quicklinksupdated) {
@@ -3320,7 +3322,7 @@ MyApplet.prototype = {
                     this._clearPrevCatSelection(this.placesButton);
                     this.placesButton.actor.style_class = "menu-category-button-selected";
                     this.closeContextMenus(null, false);
-                    this._displayButtons(null, -1);
+                    this._select_category("places");
 
                     this.makeVectorBox(this.placesButton.actor);
                 }
@@ -3388,7 +3390,7 @@ MyApplet.prototype = {
                         this._clearPrevCatSelection(this.recentButton.actor);
                         this.recentButton.actor.style_class = "menu-category-button-selected";
                         this.closeContextMenus(null, false);
-                        this._displayButtons(null, null, -1);
+                        this._select_category("recent");
 
                         this.makeVectorBox(this.recentButton.actor);
                     }
@@ -3621,7 +3623,7 @@ MyApplet.prototype = {
 
                 this._clearPrevCatSelection(this._allAppsCategoryButton.actor);
                 this._allAppsCategoryButton.actor.style_class = "menu-category-button-selected";
-                this._select_category(null, this._allAppsCategoryButton);
+                this._select_category(null);
 
                 this.makeVectorBox(this._allAppsCategoryButton.actor);
             }
@@ -3686,7 +3688,7 @@ MyApplet.prototype = {
 
                         this._clearPrevCatSelection(categoryButton.actor);
                         categoryButton.actor.style_class = "menu-category-button-selected";
-                        this._select_category(dir, categoryButton);
+                        this._select_category(dir.get_menu_id());
 
                         this.makeVectorBox(categoryButton.actor);
                     }
@@ -4095,7 +4097,7 @@ MyApplet.prototype = {
 
     _clearAllSelections: function(hide_apps) {
         let actors = this.applicationsBox.get_children();
-        for (var i=0; i<actors.length; i++) {
+        for (let i = 0; i < actors.length; i++) {
             let actor = actors[i];
             actor.style_class = "menu-application-button";
             if (hide_apps) {
@@ -4103,13 +4105,13 @@ MyApplet.prototype = {
             }
         }
         actors = this.categoriesBox.get_children();
-        for (var i=0; i<actors.length; i++){
+        for (let i = 0; i < actors.length; i++){
             let actor = actors[i];
             actor.style_class = "menu-category-button";
             actor.show();
         }
         actors = this.favoritesBox.get_children();
-        for (var i=0; i<actors.length; i++){
+        for (let i = 0; i < actors.length; i++){
             let actor = actors[i];
             actor.remove_style_pseudo_class("hover");
             if (hide_apps) {
@@ -4118,17 +4120,26 @@ MyApplet.prototype = {
         }
     },
 
-    _select_category : function(dir, categoryButton) {
-        if (dir == this.lastSelectedCategory) {
+    _select_category : function(name) {
+        if (name === this.lastSelectedCategory) {
             return;
         }
 
-        this.lastSelectedCategory = dir;
+        this.lastSelectedCategory = name;
 
-        if (dir)
-            this._displayButtons(this._listApplications(dir.get_menu_id()));
-        else
-            this._displayButtons(this._listApplications(null));
+        if (name === "places") {
+            this._displayButtons(null, -1);
+        } else
+        if (name === "recent") {
+            this._displayButtons(null, null, -1);
+        } else
+        if (name == null) {
+             this._displayButtons(this._listApplications(null));
+        } else
+        {
+            this._displayButtons(this._listApplications(name));
+        }
+
         this.closeContextMenus(null, false);
     },
 
@@ -4305,7 +4316,7 @@ MyApplet.prototype = {
                     this._searchIconClickedId = this.searchEntry.connect('secondary-icon-clicked',
                         Lang.bind(this, function() {
                             this.resetSearch();
-                            this._select_category(null, this._allAppsCategoryButton);
+                            this._select_category(null);
                         }));
                 }
                 this._setCategoriesButtonActive(false);
@@ -4319,7 +4330,7 @@ MyApplet.prototype = {
                 this.searchEntry.set_secondary_icon(this._searchInactiveIcon);
                 this._previousSearchPattern = "";
                 this._setCategoriesButtonActive(true);
-                this._select_category(null, this._allAppsCategoryButton);
+                this._select_category(null);
                 this._allAppsCategoryButton.actor.style_class = "menu-category-button-selected";
                 this._activeContainer = null;
                 this.selectedAppTitle.set_text("");


### PR DESCRIPTION
…nd places, so we can cache the current selection more accurately and prevent
needless calls to _displayButtons.

[upstream: https://github.com/linuxmint/Cinnamon/commit/2157d126d5e01eaab6cf0be2cbc7825274c18a3d]