### PR TITLE
force-quit: fix force quit not working #69

### DIFF
--- a/force-quit@cinnamon.org/files/force-quit@cinnamon.org/applet.js
+++ b/force-quit@cinnamon.org/files/force-quit@cinnamon.org/applet.js
@@ -23,14 +23,24 @@ MyApplet.prototype = {
         try {        
             this.set_applet_icon_name("window-close");
             this.set_applet_tooltip(_("Click here to kill a window"));                                                
+            this.actor.connect('button-release-event', Lang.bind(this, this._onButtonReleaseEvent));
         }
         catch (e) {
             global.logError(e);
         }
     },
     
-    on_applet_clicked: function(event) {
-        GLib.spawn_command_line_async('xkill');
+    _onButtonReleaseEvent: function(actor, event) {
+        if (this._applet_enabled) {
+            if (event.get_button() == 1) {
+                if (!this._draggable.inhibit) {
+                    return false;
+                } else {
+                    GLib.spawn_command_line_async('xkill');
+                }
+            }
+        }
+        return true;
     }
    
 };


### PR DESCRIPTION
It turns out xkill should get called only after releasing the mouse button, since on_applet_clicked fires on button press event, unless you release the mouse button really quick, it would not work. Calling xkill on button release event fixes it.