### PR TITLE
Icing Task Manager: Skip Babel transform if mozjs38 is in use

### DIFF
--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/applet.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/applet.js
@@ -57,7 +57,7 @@ function main(metadata, orientation, panel_height, instance_id) {
       },
       TRANSFORM: {
         enumerable: true,
-        value: !ARGV.some(arg => arg === '--no-transform')
+        value: typeof Symbol === 'undefined'
       }
     }
   );


### PR DESCRIPTION
The Babel transpiler turns ES2015 code into ES5, but all of the features used in this applet are available in the mozjs38 engine. This decreases initialization time for Cinnamon 3.4 using mozjs38, as Babel is a large file.