### PR TITLE
Cinnamenu: Skip Babel transform if mozjs38 is in use, add debug state

### DIFF
--- a/Cinnamenu@json/files/Cinnamenu@json/applet.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/applet.js
@@ -1,7 +1,11 @@
 const Applet = imports.ui.applet;
 
+// If this is true, it will force all modules to reload when an xlet is restarted.
+window.__DEBUG = false;
+
 function main(metadata, orientation, panel_height, instance_id) {
   global[metadata.uuid] = [metadata, orientation, panel_height, instance_id];
+
   const runtime = Function;
   const replace = String.prototype.replace;
 
@@ -53,7 +57,7 @@ function main(metadata, orientation, panel_height, instance_id) {
       },
       TRANSFORM: {
         enumerable: true,
-        value: !ARGV.some(arg => arg === '--no-transform')
+        value: typeof Symbol === 'undefined'
       }
     }
   );

--- a/Cinnamenu@json/files/Cinnamenu@json/cinnode_modules/cinnode/node_modules.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/cinnode_modules/cinnode/node_modules.js
@@ -106,7 +106,7 @@
   function load(module, dir) {
     let fd = getModuleFile(module, dir);
     let id = fd.get_path();
-    if (exp.has(id)) {
+    if (exp.has(id) && !window.__DEBUG) {
       return exp.get(id);
     } else if (id.slice(-5) === '.json') {
       let [success, json] = fd.load_contents(null);


### PR DESCRIPTION
The Babel transpiler turns ES2015 code into ES5, but all of the features used in this applet are available in the mozjs38 engine. This decreases initialization time for Cinnamon 3.4 using mozjs38, as Babel is a large file. This also adds a debug state that prevents module caching.