### PR TITLE
rancher@centurix: Correctly resolve directories selected through the settings dialog

### DIFF
--- a/rancher@centurix/files/rancher@centurix/metadata.json
+++ b/rancher@centurix/files/rancher@centurix/metadata.json
@@ -1,7 +1,7 @@
 {
-    "description": "An applet to manage Homestead.",  
+    "last-edited": "1478743846", 
     "uuid": "rancher@centurix", 
     "name": "Homestead manager", 
     "version": "0.1.3", 
-    "last-edited": "1478743846"
+    "description": "An applet to manage Homestead."
 }

--- a/rancher@centurix/files/rancher@centurix/reload.sh
+++ b/rancher@centurix/files/rancher@centurix/reload.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+dbus-send --session --dest=org.Cinnamon.LookingGlass --type=method_call /org/Cinnamon/LookingGlass org.Cinnamon.LookingGlass.ReloadExtension string:'rancher@centurix' string:'APPLET'

--- a/rancher@centurix/files/rancher@centurix/util.js
+++ b/rancher@centurix/files/rancher@centurix/util.js
@@ -8,6 +8,7 @@ function objectSniff(object_sniff) {
 }
 
 function resolveHome(path) {
+	path = path.replace('file://', '');
 	home = GLib.get_home_dir();
 	return path.replace('~', home);
 }


### PR DESCRIPTION
Ensure that the configuration dialog settings are resolved correctly before being used. By default the configuration dialog will always prefix selected paths with file://. In order to wrangle ~ locations using GLib.get_home_dir(), we need to remove this prefix.