### PR TITLE
weather@mockturtl: Added option to show high temperature first in forecast

### DIFF
--- a/weather@mockturtl/files/weather@mockturtl/applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/applet.js
@@ -75,6 +75,7 @@ const WEATHER_FORECAST_DAYS = 'forecastDays'
 const WEATHER_SHOW_TEXT_IN_PANEL_KEY = 'showTextInPanel'
 const WEATHER_TRANSLATE_CONDITION_KEY = 'translateCondition'
 const WEATHER_TEMPERATURE_UNIT_KEY = 'temperatureUnit'
+const WEATHER_TEMPERATURE_HIGH_FIRST_KEY = 'temperatureHighFirst'
 const WEATHER_PRESSURE_UNIT_KEY = 'pressureUnit'
 const WEATHER_USE_SYMBOLIC_ICONS_KEY = 'useSymbolicIcons'
 const WEATHER_WIND_SPEED_UNIT_KEY = 'windSpeedUnit'
@@ -82,6 +83,7 @@ const WEATHER_WOEID_KEY = 'woeid'
 
 const KEYS = [
   WEATHER_TEMPERATURE_UNIT_KEY,
+  WEATHER_TEMPERATURE_HIGH_FIRST_KEY,
   WEATHER_WIND_SPEED_UNIT_KEY,
   WEATHER_CITY_KEY,
   WEATHER_WOEID_KEY,
@@ -600,13 +602,16 @@ MyApplet.prototype = {
         let code = forecastData.code
         let t_low = forecastData.low
         let t_high = forecastData.high
+        
+        let first_temperature = this._temperatureHighFirst ? t_high : t_low
+        let second_temperature = this._temperatureHighFirst ? t_low : t_high
 
         let comment = forecastData.text
         if (this._translateCondition)
           comment = this.weatherCondition(code)
 
         forecastUi.Day.text = this.localeDay(forecastData.day)
-        forecastUi.Temperature.text = t_low + ' ' + '\u002F' + ' ' + t_high + ' ' + this.unitToUnicode()
+        forecastUi.Temperature.text = first_temperature + ' ' + '\u002F' + ' ' + second_temperature + ' ' + this.unitToUnicode()
         forecastUi.Summary.text = comment
         forecastUi.Icon.icon_name = this.weatherIconSafely(code)
       }

--- a/weather@mockturtl/files/weather@mockturtl/metadata.json
+++ b/weather@mockturtl/files/weather@mockturtl/metadata.json
@@ -3,5 +3,5 @@
 "name": "Weather",
 "description": "View your local weather forecast",
 "max-instances": 3,
-"version": "1.13.7"
+"version": "1.14.0"
 }

--- a/weather@mockturtl/files/weather@mockturtl/settings-schema.json
+++ b/weather@mockturtl/files/weather@mockturtl/settings-schema.json
@@ -29,6 +29,11 @@
     , "fahrenheit": "fahrenheit"
     }
   }
+, "temperatureHighFirst":
+  { "type": "checkbox"
+  , "default": false
+  , "description": "Show high temperature first in forecast"
+  }
 , "windSpeedUnit":
   { "type": "combobox"
   , "default": "kph"


### PR DESCRIPTION
In most weather forecasts, it is extremely common to display the high temperature first and the low temperature second (I believe it's the convention). Examples include https://www.weather.com, the weather displayed in Google search, and the weather displayed in the iOS weather app. 

Before, this weather applet only displayed the low temperature first. I have added the option to display the high temperature first. This should improve experience for many users.

Note, this is my first public contribution and I'm not quite sure how the versioning works. I read the semantic versioning document, but I'm not sure if this counts as a minor or patch update. Let me know if I did it wrong and I'll fix the metadata.json appropriately!