### PR TITLE
rancher@centurix: Add a Vagrant version check, deal with older Homestead config locations

### DIFF
--- a/rancher@centurix/files/rancher@centurix/applet.js
+++ b/rancher@centurix/files/rancher@centurix/applet.js
@@ -259,6 +259,10 @@ Rancher.prototype = {
 		Main.Util.spawnCommandLine("xdg-open http://laravel.com/docs/homestead");
 	},
 
+	openVagrantDownload: function() {
+		Main.Util.spawnCommandLine("xdg-open https://www.vagrantup.com/downloads.html");
+	},
+
 	editHosts: function() {
 		Main.Util.spawnCommandLine("gksudo " + this.editor + " /etc/hosts");
 	},
@@ -273,6 +277,12 @@ Rancher.prototype = {
 			}
 
 			this.set_applet_icon_path(ICON_DOWN);
+
+			if (status == Homestead.STATUS_VAGRANT_OUT_OF_DATE) {
+				this.set_applet_icon_path(ICON_MISSING);
+				this.set_applet_tooltip(_("Vagrant is out of date, please update."));
+				this.notification(_("Vagrant is out of date, please update."));				
+			}
 
 			if (status == Homestead.STATUS_KERNAL_NOT_LOADED) {
 				this.set_applet_icon_path(ICON_MISSING);
@@ -323,6 +333,13 @@ Rancher.prototype = {
 			if (status == Homestead.STATUS_KERNAL_NOT_LOADED) {
 				this.menu.addMenuItem(this.newIconMenuItem('apport', _('Kernel Module not loaded. Needs recompilation.'), null, {reactive: false}));
 				this.menu.addMenuItem(this.newIconMenuItem('system-run', _('Recompile Kernel Module.'), this.homesteadRecompile));
+				return false;
+			}
+
+			if (status == Homestead.STATUS_VAGRANT_OUT_OF_DATE) {
+				this.menu.addMenuItem(this.newIconMenuItem('apport', _('Vagrant is out of date for this version of Homestead, please update.'), null, {reactive: false}));
+				this.menu.addMenuItem(this.newIconMenuItem('emblem-web', _('Click here for the Vagrant download page.'), this.openVagrantDownload));
+				this.menu.addMenuItem(this.newIconMenuItem('view-refresh', _('Refresh this menu'), this.refreshApplet));
 				return false;
 			}
 

--- a/rancher@centurix/files/rancher@centurix/homestead.js
+++ b/rancher@centurix/files/rancher@centurix/homestead.js
@@ -11,6 +11,7 @@ const STATUS_POWER_OFF = 2;
 const STATUS_NOT_CREATED = 3;
 const STATUS_HOMESTEAD_MISSING = 4;
 const STATUS_KERNAL_NOT_LOADED = 5;
+const STATUS_VAGRANT_OUT_OF_DATE = 6;
 
 /**
  * Homestead/Vagrant manager
@@ -21,10 +22,10 @@ function Homestead(project_folder, config_folder, vagrant_cmd, editor) {
 
 Homestead.prototype = {
 	_init: function(project_folder, config_folder, vagrant_cmd, editor) {
-		this._project_folder = project_folder;
-		this._config_folder = config_folder;
-		this._vagrant_cmd = vagrant_cmd;
-		this._editor = editor;
+		this.setProjectFolder(project_folder);
+		this.setConfigFolder(config_folder);
+		this.setVagrantCmd(vagrant_cmd);
+		this.setEditor(editor);
 
 		this._up = null;
 		this._status_pause = null;
@@ -36,7 +37,15 @@ Homestead.prototype = {
 	},
 
 	setConfigFolder: function(folder) {
-		this._config_folder = folder;
+		try {
+			// If this folder doesn't exist, default to the _project_folder
+			if (!GLib.file_test(Util.resolveHome(folder) + "/Homestead.yaml", GLib.FileTest.EXISTS)) {
+				folder = this._project_folder;
+			}
+			this._config_folder = folder;
+		} catch(e) {
+			global.log(UUID + "::setConfigFolder: " + e);
+		}
 	},
 
 	setVagrantCmd: function(cmd) {
@@ -85,32 +94,37 @@ Homestead.prototype = {
 		try {
 			reader = new TerminalReader.TerminalReader(Util.resolveHome(this._project_folder), this._vagrant_cmd + ' status', Lang.bind(this, function (command, status, stdout) {
 				reader.destroy();
-				if (new RegExp('running').test(stdout)) {
+				if (new RegExp('Please change your Vagrant version').test(stdout)) {
+					if (typeof callback == 'function') {
+						callback(this.exists(), STATUS_VAGRANT_OUT_OF_DATE)
+					}
+				}
+				else if (new RegExp('running').test(stdout)) {
 					if (typeof callback == 'function') {
 						callback(this.exists(), STATUS_RUNNING);
 					}
 				}
-				if (new RegExp('saved').test(stdout)) {
+				else if (new RegExp('saved').test(stdout)) {
 					if (typeof callback == 'function') {
 						callback(this.exists(), STATUS_SAVED);
 					}
 				}
-				if (new RegExp('poweroff').test(stdout)) {
+				else if (new RegExp('poweroff').test(stdout)) {
 					if (typeof callback == 'function') {
 						callback(this.exists(), STATUS_POWER_OFF);
 					}
 				}
-				if (new RegExp('not created').test(stdout)) {
+				else if (new RegExp('not created').test(stdout)) {
 					if (typeof callback == 'function') {
 						callback(this.exists(), STATUS_NOT_CREATED);
 					}
 				}
-				if (new RegExp('can\'t cd to').test(stdout)) {
+				else if (new RegExp('can\'t cd to').test(stdout)) {
 					if (typeof callback == 'function') {
 						callback(this.exists(), STATUS_HOMESTEAD_MISSING);
 					}
 				}
-				if (new RegExp('VBoxManage --version').test(stdout)) {
+				else if (new RegExp('VBoxManage --version').test(stdout)) {
 					if (typeof callback == 'function') {
 						callback(this.exists(), STATUS_KERNAL_NOT_LOADED);
 					}

--- a/rancher@centurix/files/rancher@centurix/metadata.json
+++ b/rancher@centurix/files/rancher@centurix/metadata.json
@@ -1,6 +1,5 @@
 {
     "description": "An applet to manage Homestead.", 
-    "dangerous": true, 
     "uuid": "rancher@centurix", 
     "name": "Homestead manager", 
     "version": "0.1.3", 

--- a/rancher@centurix/files/rancher@centurix/metadata.json
+++ b/rancher@centurix/files/rancher@centurix/metadata.json
@@ -1,7 +1,8 @@
 {
-    "last-edited": "1478743846", 
+    "description": "An applet to manage Homestead.", 
+    "dangerous": true, 
     "uuid": "rancher@centurix", 
     "name": "Homestead manager", 
     "version": "0.1.3", 
-    "description": "An applet to manage Homestead."
+    "last-edited": "1478743846"
 }


### PR DESCRIPTION
Homestead and Vagrant are upgrade independently, later versions of Homestead require Vagrant v1.9 or higher. Provide behaviour to download the latest Vagrant.

Provide a configuration folder fallback location to assist in older Homestead installations still located in the ~/.homestead location.