### PR TITLE
rancher@centurix: The IconApplet _menuManager doesn't play well with AppletSettings configuration menu

### DIFF
--- a/rancher@centurix/files/rancher@centurix/applet.js
+++ b/rancher@centurix/files/rancher@centurix/applet.js
@@ -49,8 +49,9 @@ Rancher.prototype = {
 		Applet.IconApplet.prototype._init.call(this, orientation, panelHeight, instanceId);
 
 		try {
+		    this.menuManager = new PopupMenu.PopupMenuManager(this);
 			this.menu = new Applet.AppletPopupMenu(this, orientation);
-			this._menuManager.addMenu(this.menu);
+			this.menuManager.addMenu(this.menu);
 
 			this._msgsrc = new MessageTray.SystemNotificationSource("Rancher");
 			Main.messageTray.add(this._msgsrc);
@@ -169,13 +170,7 @@ Rancher.prototype = {
 	},
 
 	on_applet_clicked: function(event) {
-		try {
-			if (!this.menu.isOpen) {
-				this.menu.toggle();
-			}
-		} catch(e) {
-			global.log(UUID + '::on_applet_clicked: ' + e);
-		}
+		this.menu.toggle();
 	},
 
 	editHomestead: function() {


### PR DESCRIPTION
It was assumed that the IconApplet's built in _menuManager was a good idea to use as a menu manager for the applet as a whole, but it doesn't play well with the AppletSettings menu. Left clicking a menu built with _menuManager and then immediately right-clicking for the configuration menu can leave Cinnamon in a partially un-working state. Might need more probing around that area to figure out what the exact cause is as it looks like an issue upstream in the Applet.