### PR TITLE
cheaty@centurix: Stop using the _menuManager in IconApplet as it doesn't play well with the configuration context menu

### DIFF
--- a/cheaty@centurix/files/cheaty@centurix/applet.js
+++ b/cheaty@centurix/files/cheaty@centurix/applet.js
@@ -123,8 +123,9 @@ Cheaty.prototype = {
 		this.set_applet_icon_path(ICON);
 		this.set_applet_tooltip(_("Cheaty: Easy access cheatsheets"));
 
+		this.menuManager = new PopupMenu.PopupMenuManager(this);
 		this.menu = new Applet.AppletPopupMenu(this, orientation);
-		this._menuManager.addMenu(this.menu);
+		this.menuManager.addMenu(this.menu);
 
 		this.settingsApiCheck();
 
@@ -224,12 +225,7 @@ Cheaty.prototype = {
 	},
 
 	on_applet_clicked: function(event) {
-		try {
-			if (!this.menu.isOpen) {
-				this.menu.toggle();
-			}
-		} catch(e) {
-		}
+		this.menu.toggle();
 	}
 }
 

--- a/cheaty@centurix/files/cheaty@centurix/metadata.json
+++ b/cheaty@centurix/files/cheaty@centurix/metadata.json
@@ -1,6 +1,7 @@
 {
-    "description": "An applet to provide quick access to a variety of cheat sheets.", 
+    "dangerous": false, 
     "version": "0.0.1", 
-    "uuid": "cheaty@centurix", 
-    "name": "Cheaty - Cheatsheet keeper"
+    "description": "An applet to provide quick access to a variety of cheat sheets.", 
+    "name": "Cheaty - Cheatsheet keeper", 
+    "uuid": "cheaty@centurix"
 }

--- a/cheaty@centurix/files/cheaty@centurix/metadata.json
+++ b/cheaty@centurix/files/cheaty@centurix/metadata.json
@@ -1,5 +1,4 @@
 {
-    "dangerous": false, 
     "version": "0.0.1", 
     "description": "An applet to provide quick access to a variety of cheat sheets.", 
     "name": "Cheaty - Cheatsheet keeper", 

--- a/cheaty@centurix/files/cheaty@centurix/reload.sh
+++ b/cheaty@centurix/files/cheaty@centurix/reload.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+dbus-send --session --dest=org.Cinnamon.LookingGlass --type=method_call /org/Cinnamon/LookingGlass org.Cinnamon.LookingGlass.ReloadExtension string:'cheaty@centurix' string:'APPLET'


### PR DESCRIPTION
IconApplet's _menuManager property doesn't manage menus correctly when the applet has a right click context menu for configuration options. Left click the applet and then immediately right click can place Cinnamon in a weird state sometimes.