### PR TITLE
Popup Translator (0dyseus@PopupTranslator) update

### DIFF
--- a/0dyseus@PopupTranslator/README.md
+++ b/0dyseus@PopupTranslator/README.md
@@ -35,8 +35,6 @@ Simple translator applet that will allow to display the translation of any selec
 
 ![Translation history window](https://odyseus.github.io/CinnamonTools/lib/img/PopupTranslator-001.png "Translation history window")
 
-[Contributors/Mentions](https://github.com/Odyseus/CinnamonTools/blob/master/applets/0dyseus%40PopupTranslator/CONTRIBUTORS.md)
-
-[Full change log](https://github.com/Odyseus/CinnamonTools/blob/master/applets/0dyseus%40PopupTranslator/CHANGELOG.md)
-
-[ToDo](https://github.com/Odyseus/CinnamonTools/blob/master/applets/0dyseus%40PopupTranslator/TODO)
+#### [Localized help](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@PopupTranslator.html)
+#### [Contributors/Mentions](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@PopupTranslator.html#xlet-contributors)
+#### [Full change log](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@PopupTranslator.html#xlet-changelog)

--- a/0dyseus@PopupTranslator/files/0dyseus@PopupTranslator/HELP.html
+++ b/0dyseus@PopupTranslator/files/0dyseus@PopupTranslator/HELP.html
@@ -12,6 +12,102 @@ exported toggleLocalizationVisibility
 
 /* jshint varstmt: false */
 
+// Source: https://github.com/julienetie/smooth-scroll
+(function(window, document) {
+    var prefixes = ['moz', 'webkit', 'o'],
+        animationFrame;
+
+    // Modern rAF prefixing without setTimeout
+    function requestAnimationFrameNative() {
+        prefixes.map(function(prefix) {
+            if (!window.requestAnimationFrame) {
+                animationFrame = window[prefix + 'RequestAnimationFrame'];
+            } else {
+                animationFrame = requestAnimationFrame;
+            }
+        });
+    }
+    requestAnimationFrameNative();
+
+    function getOffsetTop(el) {
+        if (!el) {
+            return 0;
+        }
+
+        var yOffset = el.offsetTop,
+            parent = el.offsetParent;
+
+        yOffset += getOffsetTop(parent);
+
+        return yOffset;
+    }
+
+    function getScrollTop(scrollable) {
+        return scrollable.scrollTop || document.body.scrollTop || document.documentElement.scrollTop;
+    }
+
+    function scrollTo(scrollable, coords, millisecondsToTake) {
+        var currentY = getScrollTop(scrollable),
+            diffY = coords.y - currentY,
+            startTimestamp = null;
+
+        if (coords.y === currentY || typeof scrollable.scrollTo !== 'function') {
+            return;
+        }
+
+        function doScroll(currentTimestamp) {
+            if (startTimestamp === null) {
+                startTimestamp = currentTimestamp;
+            }
+
+            var progress = currentTimestamp - startTimestamp,
+                fractionDone = (progress / millisecondsToTake),
+                pointOnSineWave = Math.sin(fractionDone * Math.PI / 2);
+            scrollable.scrollTo(0, currentY + (diffY * pointOnSineWave));
+
+            if (progress < millisecondsToTake) {
+                animationFrame(doScroll);
+            } else {
+                // Ensure we're at our destination
+                scrollable.scrollTo(coords.x, coords.y);
+            }
+        }
+
+        animationFrame(doScroll);
+    }
+
+    // Declaire scroll duration, (before script)
+    var speed = window.smoothScrollSpeed || 750;
+
+    function smoothScroll(e) { // no smooth scroll class to ignore links
+        if (e.target.className === 'no-ss') {
+            return;
+        }
+
+        var source = e.target,
+            targetHref = source.hash,
+            target = null;
+
+        if (!source || !targetHref) {
+            return;
+        }
+
+        targetHref = targetHref.substring(1);
+        target = document.getElementById(targetHref);
+        if (!target) {
+            return;
+        }
+
+        scrollTo(window, {
+            x: 0,
+            y: getOffsetTop(target)
+        }, speed);
+    }
+
+    // Uses target's hash for scroll
+    document.addEventListener('click', smoothScroll, false);
+}(window, document));
+
 if (!window.localStorage) {
     /*
     Storage objects are a recent addition to the standard. As such they may not be present
@@ -449,7 +545,7 @@ body {
 <noscript>
 <div class="alert alert-warning">
 <p><strong>Oh snap! This page needs JavaScript enabled to display correctly.</strong></p>
-<p><strong>This page uses JavaScript only to switch between the available languages.</strong></p>
+<p><strong>This page uses JavaScript only to switch between the available languages and/or display images.</strong></p>
 <p><strong>There are no tracking services of any kind and never will be (at least, not from my side).</strong></p>
 </div> <!-- .alert.alert-warning -->
 </noscript>
@@ -458,16 +554,16 @@ body {
     <div class="container-fluid">
     <div class="navbar-header">
         <ul class="nav navbar-nav">
-            <li><a id="nav-xlet-help" class="navbar-brand" href="#xlet-help"></a></li>
-            <li><a id="nav-xlet-contributors" class="navbar-brand" href="#xlet-contributors"></a></li>
-            <li><a id="nav-xlet-changelog" class="navbar-brand" href="#xlet-changelog"></a></li>
+            <li><a id="nav-xlet-help" class="js_smoothScroll navbar-brand" href="#xlet-help"></a></li>
+            <li><a id="nav-xlet-contributors" class="js_smoothScroll navbar-brand" href="#xlet-contributors"></a></li>
+            <li><a id="nav-xlet-changelog" class="js_smoothScroll navbar-brand" href="#xlet-changelog"></a></li>
         </ul>
     </div>
     <form class="navbar-form navbar-collapse collapse navbar-right">
         <div class="form-group">
             <label id="localization-chooser-label" class="control-label" for="localization-switch"></label>
             <select class="form-control input-sm" id="localization-switch" onchange="self.toggleLocalizationVisibility(value, this);">
-                <!-- Česky --><option data-title="Nápověda pro Popup Translator" data-language-chooser-label="Zvolte jazyk" data-xlet-help="Nápověda" data-xlet-contributors="Contributors" data-xlet-changelog="Changelog" value="cs">Česky</option>
+                <!-- Česky --><option data-title="Nápověda pro Popup Translator" data-language-chooser-label="Zvolte jazyk" data-xlet-help="Nápověda" data-xlet-contributors="Přispěvatelé" data-xlet-changelog="Changelog" value="cs">Česky</option>
 <!-- English --><option selected data-title="Help for Popup Translator" data-language-chooser-label="Choose language" data-xlet-help="Help" data-xlet-contributors="Contributors" data-xlet-changelog="Changelog" value="en">English</option>
 <!-- Español --><option data-title="Ayuda para Popup Translator" data-language-chooser-label="Elegir idioma" data-xlet-help="Ayuda" data-xlet-contributors="Colaboradores" data-xlet-changelog="Registro de cambios" value="es">Español</option>
 <!-- Svenska --><option data-title="Hjälp för Popup Translator" data-language-chooser-label="Välj språk" data-xlet-help="Hjälp" data-xlet-contributors="Medhjälpare" data-xlet-changelog="Ändringslogg" value="sv">Svenska</option>
@@ -477,7 +573,7 @@ body {
     </form>
     </div>
 </nav>
-<span id="xlet-help">
+<span id="xlet-help" style="padding-top:70px;">
 <div class="container boxed">
 
 <div id="zh_CN" class="localization-content hidden">
@@ -565,6 +661,7 @@ body {
 <li>如果该xlet没有您的语言的本地化，您可以按照以下说明进行创建。 <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">以下两个部分仅使用英语。</div>
 </div> <!-- .localization-content -->
 
 
@@ -653,6 +750,7 @@ En el menú contextual de este applet existe un ítem que permite abrir la carpe
 <li>Si este xlet no está disponible en su idioma, la localización puede ser creada siguiendo las siguientes instrucciones. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Las siguientes dos secciones están disponibles sólo en Inglés.</div>
 </div> <!-- .localization-content -->
 
 
@@ -741,6 +839,7 @@ V kontextovém menu tohoto apletu je položka, která může otevřít složku s
 <li>Pokud tento xlet nemá k dispozici překlad pro váš jazyk, můžete jej vytvořit podle následujících pokynů. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Následující dvě části jsou k dispozici pouze v angličtině.</div>
 </div> <!-- .localization-content -->
 
 
@@ -829,6 +928,7 @@ I panelprogrammets kontextmeny (högerklick på ikonen) kan du öppna den mapp d
 <li>Om ditt språk saknas i denna xlet, kan du översätta den med hjälp av följande instruktioner. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Följande två sektioner är endast tillgängliga på Engelska.</div>
 </div> <!-- .localization-content -->
 
 
@@ -917,11 +1017,11 @@ In the context menu of this applet is an item that can open the folder were the 
 <li>If this xlet has no locale available for your language, you could create it by following the following instructions. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">The following two sections are available only in English.</div>
 </div> <!-- .localization-content -->
 
 </div> <!-- .container.boxed -->
-<div style="font-weight:bold;" class="container alert alert-info">The following two sections are available only in English.</div>
-<span id="xlet-contributors">
+<span id="xlet-contributors" style="padding-top:140px;">
 <div class="container boxed">
 <h2>Contributors/Mentions</h2>
 <ul>
@@ -935,10 +1035,29 @@ In the context menu of this applet is an item that can open the folder were the 
 
 </div> <!-- .container.boxed -->
 
-<span id="xlet-changelog">
+<span id="xlet-changelog" style="padding-top:70px;">
 <div class="container boxed">
 <h2>Popup Translator changelog</h2>
 <h4>This change log is only valid for the version of the xlet hosted on <a href="https://github.com/Odyseus/CinnamonTools">its original repository</a></h4>
+<hr>
+<ul>
+<li><strong>Date:</strong> Thu, 8 Jun 2017 01:19:07 -0300</li>
+<li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/a92c7fd">a92c7fd</a></li>
+<li><strong>Author:</strong> Odyseus</li>
+</ul>
+<pre><code>Popup Translator applet
+- Updated Czech localization.
+</code></pre>
+<hr>
+<ul>
+<li><strong>Date:</strong> Tue, 6 Jun 2017 22:29:58 -0300</li>
+<li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/3a58c02">3a58c02</a></li>
+<li><strong>Author:</strong> Odyseus</li>
+</ul>
+<pre><code>Popup Translator applet
+- Better handling of **Settings.BindingDirection**. Just to avoid surprises when that constant is
+removed on future versions of Cinnamon.
+</code></pre>
 <hr>
 <ul>
 <li><strong>Date:</strong> Sun, 4 Jun 2017 19:35:05 +0800</li>
@@ -1320,6 +1439,8 @@ Closes #21 - Added missing translatable strings
 </div> <!-- .container.boxed -->
 
 </div> <!-- #mainarea -->
-<script type="text/javascript">toggleLocalizationVisibility(null);</script>
+<script type="text/javascript">toggleLocalizationVisibility(null);
+
+</script>
 </body>
 </html>

--- a/0dyseus@PopupTranslator/files/0dyseus@PopupTranslator/applet.js
+++ b/0dyseus@PopupTranslator/files/0dyseus@PopupTranslator/applet.js
@@ -511,7 +511,13 @@ MyApplet.prototype = {
     },
 
     _bindSettings: function() {
-        let bD = Settings.BindingDirection || null;
+        // Needed for retro-compatibility.
+        // Mark for deletion on EOL.
+        let bD = {
+            IN: 1,
+            OUT: 2,
+            BIDIRECTIONAL: 3
+        };
         let settingsArray = [
             [bD.IN, "pref_custom_icon_for_applet", this._updateIconAndLabel],
             [bD.IN, "pref_custom_label_for_applet", this._updateIconAndLabel],

--- a/0dyseus@PopupTranslator/files/0dyseus@PopupTranslator/metadata.json
+++ b/0dyseus@PopupTranslator/files/0dyseus@PopupTranslator/metadata.json
@@ -5,7 +5,7 @@
     "max-instances": "-1",
     "uuid": "0dyseus@PopupTranslator",
     "comments": "Bug reports, feature requests and contributions should be done on this xlet's repository linked below.",
-    "version": "1.05",
+    "version": "1.06",
     "cinnamon-version": [
         "2.8",
         "3.0",

--- a/0dyseus@PopupTranslator/files/0dyseus@PopupTranslator/po/0dyseus@PopupTranslator.pot
+++ b/0dyseus@PopupTranslator/files/0dyseus@PopupTranslator/po/0dyseus@PopupTranslator.pot
@@ -5,8 +5,8 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 0dyseus@PopupTranslator 1.05\n"
-"POT-Creation-Date: 2017-06-02 17:05-0300\n"
+"Project-Id-Version: 0dyseus@PopupTranslator 1.06\n"
+"POT-Creation-Date: 2017-06-12 22:20-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -218,65 +218,65 @@ msgstr ""
 msgid "With each Yandex translator API key you can translate **UP TO** 1.000.000 (1 million) characters per day **BUT NOT MORE** than 10.000.000 (10 millions) per month."
 msgstr ""
 
-#: ../../create_localized_help.py:175
-msgid "The following two sections are available only in English."
-msgstr ""
-
 #. TO TRANSLATORS: This is a placeholder.
 #. Here goes your language name in your own language (a.k.a. endonym).
-#: ../../create_localized_help.py:200 ../../create_localized_help.py:272
+#: ../../create_localized_help.py:204 ../../create_localized_help.py:280
 msgid "language-name"
 msgstr ""
 
-#: ../../create_localized_help.py:275 applet.js:348
+#: ../../create_localized_help.py:210
+msgid "The following two sections are available only in English."
+msgstr ""
+
+#: ../../create_localized_help.py:283 applet.js:348
 msgid "Help"
 msgstr ""
 
-#: ../../create_localized_help.py:276
+#: ../../create_localized_help.py:284
 msgid "Contributors"
 msgstr ""
 
-#: ../../create_localized_help.py:277
+#: ../../create_localized_help.py:285
 msgid "Changelog"
 msgstr ""
 
-#: ../../create_localized_help.py:278
+#: ../../create_localized_help.py:286
 msgid "Choose language"
 msgstr ""
 
 #. TO TRANSLATORS: Full sentence:
 #. "Help for <xlet_name>"
-#: ../../create_localized_help.py:279 ../../create_localized_help.py:286
+#: ../../create_localized_help.py:287 ../../create_localized_help.py:294
 #, python-format
 msgid "Help for %s"
 msgstr ""
 
-#: ../../create_localized_help.py:287
+#: ../../create_localized_help.py:295
 msgid "IMPORTANT!!!"
 msgstr ""
 
-#: ../../create_localized_help.py:288
+#: ../../create_localized_help.py:296
 msgid "Never delete any of the files found inside this xlet folder. It might break this xlet functionality."
 msgstr ""
 
-#: ../../create_localized_help.py:289
+#: ../../create_localized_help.py:297
 msgid "Bug reports, feature requests and contributions should be done on this xlet's repository linked next."
 msgstr ""
 
-#: ../../create_localized_help.py:295
+#: ../../create_localized_help.py:303
 msgid "Applets/Desklets/Extensions (a.k.a. xlets) localization"
 msgstr ""
 
-#: ../../create_localized_help.py:296
+#: ../../create_localized_help.py:304
 msgid "If this xlet was installed from Cinnamon Settings, all of this xlet's localizations were automatically installed."
 msgstr ""
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:298
+#: ../../create_localized_help.py:306
 msgid "If this xlet was installed manually and not trough Cinnamon Settings, localizations can be installed by executing the script called **localizations.sh** from a terminal opened inside the xlet's folder."
 msgstr ""
 
-#: ../../create_localized_help.py:299
+#: ../../create_localized_help.py:307
 msgid "If this xlet has no locale available for your language, you could create it by following the following instructions."
 msgstr ""
 
@@ -362,11 +362,11 @@ msgstr ""
 msgid "Force translation hotkey"
 msgstr ""
 
-#: applet.js:198 applet.js:980 applet.js:1003
+#: applet.js:198 applet.js:991 applet.js:1014
 msgid "Unmet dependencies found!!!"
 msgstr ""
 
-#: applet.js:199 applet.js:848 applet.js:981
+#: applet.js:199 applet.js:859 applet.js:992
 msgid "A detailed error has been logged into ~/.cinnamon/glass.log file."
 msgstr ""
 
@@ -423,68 +423,68 @@ msgstr ""
 msgid "Open this applet help file."
 msgstr ""
 
-#: applet.js:481
+#: applet.js:486
 msgid "History"
 msgstr ""
 
-#: applet.js:497
+#: applet.js:502
 #, javascript-format
 msgid "Go to %s's website"
 msgstr ""
 
-#: applet.js:499
+#: applet.js:504
 #, javascript-format
 msgid "Powered By %s"
 msgstr ""
 
-#: applet.js:607
+#: applet.js:618
 msgid "No Yandex API keys were found!!!"
 msgstr ""
 
-#: applet.js:608 applet.js:1005
+#: applet.js:619 applet.js:1016
 msgid "Check this applet help file for instructions."
 msgstr ""
 
-#: applet.js:609 applet.js:1006
+#: applet.js:620 applet.js:1017
 msgid "It can be accessed from this applet context menu."
 msgstr ""
 
-#: applet.js:674
+#: applet.js:685
 msgid "API key is invalid"
 msgstr ""
 
-#: applet.js:677
+#: applet.js:688
 msgid "Blocked API key"
 msgstr ""
 
-#: applet.js:680
+#: applet.js:691
 msgid "Exceeded the daily limit on the amount of translated text"
 msgstr ""
 
-#: applet.js:683
+#: applet.js:694
 msgid "Exceeded the maximum text size"
 msgstr ""
 
-#: applet.js:686
+#: applet.js:697
 msgid "The text cannot be translated"
 msgstr ""
 
-#: applet.js:689
+#: applet.js:700
 msgid "The specified translation direction is not supported"
 msgstr ""
 
-#: applet.js:847
+#: applet.js:858
 #, javascript-format
 msgid "Error parsing %s's request."
 msgstr ""
 
-#: applet.js:1012
+#: applet.js:1023
 msgid "All dependencies seem to be met."
 msgstr ""
 
 #. TO TRANSLATORS: Full sentence:
 #. "Unable to execute file/command 'FileName or Command':"
-#: applet.js:1064
+#: applet.js:1075
 #, javascript-format
 msgid "Unable to execute file/command '%s':"
 msgstr ""
@@ -513,43 +513,42 @@ msgstr ""
 msgid "It allows to save the translation history data with indentation."
 msgstr ""
 
-#. 0dyseus@PopupTranslator->settings-schema.json->head4->description
-msgid "Yandex translator settings"
-msgstr ""
-
-#. 0dyseus@PopupTranslator->settings-schema.json->head0->description
-msgid "Applet settings"
-msgstr ""
-
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_1->description
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_2->description
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_4->description
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_3->description
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_4->description
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_1->description
 msgid "Keyboard shortcut to perform a translation"
 msgstr ""
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_1->tooltip
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_2->tooltip
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_4->tooltip
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_3->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_4->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_1->tooltip
 msgid "Choose a keybinding to perform a translation."
 msgstr ""
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_initial_window_height->description
-msgid "History window initial height"
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_initial_window_width->description
+msgid "History window initial width"
 msgstr ""
 
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_initial_window_width->units
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_history_initial_window_height->units
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_history_width_to_trigger_word_wrap->units
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_initial_window_width->units
 msgid "pixels"
 msgstr ""
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_1->tooltip
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_4->tooltip
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_3->tooltip
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_2->tooltip
-msgid "Choose translation service provider."
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_4->description
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_3->description
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_1->description
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_2->description
+msgid "Keyboard shortcut to perform a FORCED translation"
+msgstr ""
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_4->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_3->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_1->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_2->tooltip
+msgid "Choose a keybinding to perform a FORCED translation. A \"forced translation\" forces the translation of any string stored on the translation history and overwrites the existing one."
 msgstr ""
 
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_1->options
@@ -566,34 +565,19 @@ msgstr ""
 msgid "Google Translator"
 msgstr ""
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_loggin_enabled->description
-msgid "Enable logging"
-msgstr ""
-
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_loggin_enabled->tooltip
-msgid "It enables the ability to log the output of several functions used by the applet."
-msgstr ""
-
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_3->description
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_4->description
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_2->description
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_1->description
-msgid "Keyboard shortcut to perform a FORCED translation"
-msgstr ""
-
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_3->tooltip
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_4->tooltip
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_2->tooltip
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_1->tooltip
-msgid "Choose a keybinding to perform a FORCED translation. A \"forced translation\" forces the translation of any string stored on the translation history and overwrites the existing one."
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_1->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_4->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_3->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_2->tooltip
+msgid "Choose translation service provider."
 msgstr ""
 
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_style_for_language_pair->description
 msgid "Language pair style"
 msgstr ""
 
-#. 0dyseus@PopupTranslator->settings-schema.json->head3->description
-msgid "Translation history settings"
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_custom_icon_for_applet->description
+msgid "Custom icon"
 msgstr ""
 
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_yandex_api_keys->description
@@ -606,28 +590,12 @@ msgid ""
 "Read the help file (Help item on this applet context menu) found inside this applet folder to know how to get free Yandex API keys."
 msgstr ""
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_width_to_trigger_word_wrap->description
-msgid "Width to trigger word wrap"
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_loggin_enabled->description
+msgid "Enable logging"
 msgstr ""
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_width_to_trigger_word_wrap->tooltip
-msgid "The \"Source text\" and \"Target text\" columns on the history window will wrap its text at the width defined by this setting."
-msgstr ""
-
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_custom_label_for_applet->description
-msgid "Custom label"
-msgstr ""
-
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_custom_icon_for_applet->description
-msgid "Custom icon"
-msgstr ""
-
-#. 0dyseus@PopupTranslator->settings-schema.json->head2->description
-msgid "Popup elements appearance"
-msgstr ""
-
-#. 0dyseus@PopupTranslator->settings-schema.json->label5->description
-msgid "(*) This options are only useful for the applet developer"
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_loggin_enabled->tooltip
+msgid "It enables the ability to log the output of several functions used by the applet."
 msgstr ""
 
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_history_timestamp_custom->description
@@ -645,16 +613,44 @@ msgid ""
 "ss: seconds"
 msgstr ""
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_initial_window_width->description
-msgid "History window initial width"
+#. 0dyseus@PopupTranslator->settings-schema.json->label5->description
+msgid "(*) This options are only useful for the applet developer"
 msgstr ""
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_style_for_translated_text->description
-msgid "Translated text style"
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_initial_window_height->description
+msgid "History window initial height"
+msgstr ""
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_style_for_footer->description
+msgid "Footer style"
+msgstr ""
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_width_to_trigger_word_wrap->description
+msgid "Width to trigger word wrap"
+msgstr ""
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_width_to_trigger_word_wrap->tooltip
+msgid "The \"Source text\" and \"Target text\" columns on the history window will wrap its text at the width defined by this setting."
 msgstr ""
 
 #. 0dyseus@PopupTranslator->settings-schema.json->head5->description
 msgid "Debugging settings"
+msgstr ""
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_custom_label_for_applet->description
+msgid "Custom label"
+msgstr ""
+
+#. 0dyseus@PopupTranslator->settings-schema.json->head4->description
+msgid "Yandex translator settings"
+msgstr ""
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_timestamp->description
+msgid "Timestamp for translation history entries"
+msgstr ""
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_timestamp->options
+msgid "Custom"
 msgstr ""
 
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_history_timestamp->options
@@ -665,14 +661,18 @@ msgstr ""
 msgid "YYYY DD-MM hh:mm:ss (European)"
 msgstr ""
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_timestamp->options
-msgid "Custom"
+#. 0dyseus@PopupTranslator->settings-schema.json->head3->description
+msgid "Translation history settings"
 msgstr ""
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_timestamp->description
-msgid "Timestamp for translation history entries"
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_style_for_translated_text->description
+msgid "Translated text style"
 msgstr ""
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_style_for_footer->description
-msgid "Footer style"
+#. 0dyseus@PopupTranslator->settings-schema.json->head0->description
+msgid "Applet settings"
+msgstr ""
+
+#. 0dyseus@PopupTranslator->settings-schema.json->head2->description
+msgid "Popup elements appearance"
 msgstr ""

--- a/0dyseus@PopupTranslator/files/0dyseus@PopupTranslator/po/cs.po
+++ b/0dyseus@PopupTranslator/files/0dyseus@PopupTranslator/po/cs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-17 07:40+0200\n"
-"PO-Revision-Date: 2017-05-29 06:12+0200\n"
+"POT-Creation-Date: 2017-06-08 06:10+0200\n"
+"PO-Revision-Date: 2017-06-08 06:14+0200\n"
 "Last-Translator: Radek Otáhal <radek.otahal@email.cz>\n"
 "Language-Team: \n"
 "Language: cs\n"
@@ -18,204 +18,414 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: applet.js:83
-msgid "Source language"
-msgstr "Zdrojový jazyk"
+#: ../../create_localized_help.py:64
+msgid "Dependencies"
+msgstr "Závislosti"
 
-#: applet.js:84
-msgid "Target language"
-msgstr "Cílový jazyk"
-
-#: applet.js:85
+#: ../../create_localized_help.py:65
 msgid ""
-"(G) = Language supported only by Google Translate.\n"
-"(Y) = Language supported only by Yandex Translate."
+"If one or more of these dependencies are missing in your system, you will "
+"not be able to use this applet."
 msgstr ""
-"(G) = Jazyk podporovaný pouze překladačem Google.\n"
-"(Y) = Jazyk podporovaný pouze překladačem Yandex."
+"Pokud v systému chybí jedna nebo více těchto závislostí, nebudete moci tento "
+"aplet používat."
 
-#. 0dyseus@PopupTranslator->settings-schema.json->head_1->description
-#: applet.js:151
-msgid "First translation mechanism (Left click on applet)"
-msgstr "Mechanismus prvního překladu (Klikněte levým tlačítkem na aplet)"
+#: ../../create_localized_help.py:66
+msgid "xsel command"
+msgstr "xsel příkaz"
 
-#. 0dyseus@PopupTranslator->settings-schema.json->head_2->description
-#: applet.js:155
-msgid "Second translation mechanism (Middle click on applet)"
-msgstr "Mechanismus druhého překladu (Klikněte středním tlačítkem na aplet)"
+#: ../../create_localized_help.py:67
+msgid ""
+"XSel is a command-line program for getting and setting the contents of the X "
+"selection."
+msgstr ""
+"XSel je program příkazového řádku pro získání a nastavení obsahu výběru X."
 
-#. 0dyseus@PopupTranslator->settings-schema.json->head_3->description
-#: applet.js:161
-msgid "Third translation mechanism (Hotkey #1)"
-msgstr "Mechanismus třetího překladu (Klávesová zkratka #1)"
+#: ../../create_localized_help.py:69 ../../create_localized_help.py:77
+#: ../../create_localized_help.py:89
+msgid "Debian and Archlinux based distributions:"
+msgstr "Distribuce založené na Debianu a Archlinuxu:"
 
-#. 0dyseus@PopupTranslator->settings-schema.json->head_4->description
-#: applet.js:167
-msgid "Fourth translation mechanism (Hotkey #2)"
-msgstr "Mechanismus čtvrtého překladu (Klávesová zkratka #2)"
+#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
+#: ../../create_localized_help.py:71
+msgid "The package is called **xsel**."
+msgstr "Balík se nazývá **xsel**."
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_1->description
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_4->description
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_3->description
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_2->description
-#: applet.js:172
-msgid "Service provider"
-msgstr "Poskytovatel služby"
+#: ../../create_localized_help.py:74
+msgid "xdg-open command"
+msgstr "xdg-open příkaz"
 
-#: applet.js:174 appletHelper.py:347
-msgid "Language pair"
-msgstr "Vybrané jazyky"
+#: ../../create_localized_help.py:75
+msgid ""
+"Open a URI in the user's preferred application that handles the respective "
+"URI or file type."
+msgstr ""
+"Otevře URI v aplikaci preferované uživatelem, která zpracovává příslušný URI "
+"nebo typ souboru."
 
-#: applet.js:181
-msgid "Translation hotkey"
-msgstr "Klávesová zkratka pro překlad"
+#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
+#: ../../create_localized_help.py:79 ../../create_localized_help.py:91
+msgid "This command is installed with the package called **xdg-utils**."
+msgstr "Tento příkaz je nainstalován s balíčkem s názvem **xdg-utils**."
 
-#: applet.js:189
-msgid "Force translation hotkey"
-msgstr "Klávesová zkratka pro vynucený překlad"
+#: ../../create_localized_help.py:80 ../../create_localized_help.py:92
+#: ../../create_localized_help.py:98
+msgid "Installed by default in modern versions of Linux Mint."
+msgstr "Instalováno ve výchozím nastavení v moderních verzích Linux Mint."
 
-#: applet.js:197 applet.js:979 applet.js:1002
-msgid "Unmet dependencies found!!!"
-msgstr "Nalezeny nesplněné závislosti!!!"
+#: ../../create_localized_help.py:83
+msgid "Python 3"
+msgstr "Python 3"
 
-#: applet.js:198 applet.js:847 applet.js:980
-msgid "A detailed error has been logged into ~/.cinnamon/glass.log file."
-msgstr "Podrobnosti chyby byly zaznamenány do ~/.cinnamon/glass.log souboru."
+#: ../../create_localized_help.py:84
+msgid "It should come already installed in all Linux distributions."
+msgstr "Mělo by být již nainstalováno ve všech distribucích Linuxu."
 
-#: applet.js:240
-msgid "Left click on applet"
-msgstr "Kliknout levým tlačítkem na apletu"
+#: ../../create_localized_help.py:86
+msgid "requests Python 3 module"
+msgstr "requests Python 3 modul"
 
-#: applet.js:243
-msgid "Middle click on applet"
-msgstr "Kliknout prostředním tlačítkem na apletu"
+#: ../../create_localized_help.py:87
+msgid ""
+"Requests allow you to send HTTP/1.1 requests. You can add headers, form "
+"data, multi-part files, and parameters with simple Python dictionaries, and "
+"access the response data in the same way. It's powered by httplib and "
+"urllib3, but it does all the hard work and crazy hacks for you."
+msgstr ""
+"Requests knihovna umožňuje posílat HTTP / 1.1 požadavky. Můžete přidat "
+"hlavičky, data formuláře, vícedílné soubory a parametry pomocí jednoduchých "
+"slovníků Pythonu a přístup k datům odezvy stejným způsobem. Využívá httplib "
+"a urllib3, ale dělá pro vás všechnu všechnu zbývající tvrdou práci. "
 
-#: applet.js:246
-msgid "Hotkey #1"
-msgstr "Klávesová zkratka #1"
+#: ../../create_localized_help.py:95
+msgid "Debian based distributions:"
+msgstr "Distribuce založené na Debianu:"
 
-#: applet.js:249
-msgid "Hotkey #2"
-msgstr "Klávesová zkratka #2"
+#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
+#: ../../create_localized_help.py:97
+msgid "The package is called **python3-requests**."
+msgstr "Balík se nazývá **python3-requests**."
 
-#: applet.js:262 applet.js:273
-#, javascript-format
-msgid "Set %s as default translation engine."
-msgstr "Nastavit %s jako výchozí překladač."
+#: ../../create_localized_help.py:101
+msgid "Archlinux based distributions:"
+msgstr "Distribuce založené na Archlinuxu:"
 
-#: applet.js:292
-msgid "Applet extras"
-msgstr "Extra nastavení apletu"
+#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
+#: ../../create_localized_help.py:103
+msgid "The package is called **python-requests**."
+msgstr "Balík se nazývá **python-requests**."
 
-#: applet.js:296
-msgid "Translation history"
-msgstr "Historie překladu"
+#: ../../create_localized_help.py:106
+msgid ""
+"After installing any of the missing dependencies, Cinnamon needs to be "
+"restarted"
+msgstr ""
+"Po instalaci jakékoli chybějících závislosti je nutné restartovat Cinnamon."
 
-#: applet.js:302
-msgid "Open translation history window."
-msgstr "Otevřít okno historie překladu"
+#: ../../create_localized_help.py:108
+msgid ""
+"I don't use any other type of Linux distribution (Gentoo based, Slackware "
+"based, etc.). If any of the previous packages/modules are named differently, "
+"please, let me know and I will specify them in this help file."
+msgstr ""
+"Nepoužívám žádný jiný typ distribuce Linuxu (založený na Gentoo, založeném "
+"na Slackware atd.). Pokud se některý z předchozích balíčků / modulů jmenuje "
+"jinak, dejte mi vědět a já doplním tento soubor s nápovědou. "
 
-#: applet.js:314
-msgid "History storage"
-msgstr "Úložiště historie"
+#: ../../create_localized_help.py:108
+msgid "Note:"
+msgstr "Poznámka:"
 
-#: applet.js:320
-msgid "Open the location where the translation history file is stored."
-msgstr "Otevřít umístění kde je uložena historie překladu."
+#: ../../create_localized_help.py:110
+msgid "Usage"
+msgstr "Používání"
 
-#: applet.js:333
-msgid "Check dependencies"
-msgstr "Zkontrolovat závislosti"
+#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
+#: ../../create_localized_help.py:112
+msgid ""
+"There are 4 *translations mechanisms* (**Left click**, **Middle click**, "
+"**Hotkey #1** and **Hotkey #2**). Each translation mechanism can be "
+"configured with their own service providers, language pairs and hotkeys."
+msgstr ""
+"Existují 4 *mechanismy překladů* (**levým tlačítkem**, **středním "
+"tlačítkem**, **klávesová zkratka # 1** a **klávesová zkratka # 2**). Každý "
+"mechanismus překladu může být konfigurován s vlastními poskytovateli služeb, "
+"jazykovými páry a klávesovými zkratkami. "
 
-#: applet.js:339
-msgid "Check whether the dependencies for this applet are met."
-msgstr "Zkontrolovat jestli jsou splněny závislosti pro tento aplet."
+#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
+#: ../../create_localized_help.py:114
+msgid ""
+"**First translation mechanism (Left click):** Translates any selected text "
+"from any application on your system. A hotkey can be assigned to perform "
+"this task."
+msgstr ""
+"**Mechanismus prvního překladu (levým tlačítkem myši):** Převede libovolný "
+"vybraný text z jakékoliv aplikace ve vašem systému. K provedení této úlohy "
+"může být přiřazena klávesová zkratka. "
 
-#: applet.js:347
+#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
+#: ../../create_localized_help.py:116
+msgid ""
+"**First translation mechanism ([[Ctrl]] + Left click):** Same as **Left "
+"click**, but it will bypass the translation history. A hotkey can be "
+"assigned to perform this task."
+msgstr ""
+"**Mechanismus prvního překladu ([[Ctrl]] + levým tlačítkem myši):** Stejné "
+"jako **levým tlačítkem**, ale obchází historii překladu. K provedení této "
+"úlohy může být přiřazena klávesová zkratka. "
+
+#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
+#: ../../create_localized_help.py:118
+msgid ""
+"**Second translation mechanism (Middle click):** Same as **Left click**."
+msgstr ""
+"**Mechanismus druhého překladu (prostředním tlačítkem myši):** Stejné jako "
+"**levým tlačítkem**."
+
+#: ../../create_localized_help.py:121
+msgid ""
+"**Second translation mechanism ([[Ctrl]] + Middle click):** Same as [[Ctrl]] "
+"+ **Left click**."
+msgstr ""
+"**Mechanismus druhého překladu ([[Ctrl]] + prostředním tlačítkem myši):** "
+"Stejné jako [[Ctrl]] + **levým tlačítkem**."
+
+#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
+#: ../../create_localized_help.py:123
+msgid ""
+"**Third translation mechanism (Hotkey #1):** Two hotkeys can be configured "
+"to perform a translation and a forced translation."
+msgstr ""
+"**Mechanismus třetího překladu (klávesová zkratka # 1):** Dvě klávesové "
+"zkratky mohou být nakonfigurovány pro překlad a vynucený překlad."
+
+#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
+#: ../../create_localized_help.py:125
+msgid ""
+"**Fourth translation mechanism (Hotkey #2):** Two hotkeys can be configured "
+"to perform a translation and a forced translation."
+msgstr ""
+"**Mechanismus čtvrtého překladu (klávesová zkratka # 2):** Dvě klávesové "
+"zkratky mohou být nakonfigurovány pro překlad a vynucený překlad."
+
+#: ../../create_localized_help.py:126
+msgid ""
+"All translations are stored into the translation history. If a string of "
+"text was already translated in the past, the popup will display that stored "
+"translated text without making use of the provider's translation service."
+msgstr ""
+"Všechny překlady jsou uloženy do historie překladů. Pokud byl řetězec textu "
+"již v minulosti přeložen, vyskakovací okno zobrazí tento uložený přeložený "
+"text bez použití služby poskytovatele překladu. "
+
+#: ../../create_localized_help.py:128
+msgid "About translation history"
+msgstr "O historii překladů"
+
+#: ../../create_localized_help.py:129
+msgid ""
+"I created the translation history mechanism mainly to avoid the abuse of the "
+"translation services."
+msgstr ""
+"Vytvořil jsem mechanismus historie překladu hlavně proto, aby se zabránilo "
+"zneužívání překladatelských služeb."
+
+#: ../../create_localized_help.py:130
+msgid ""
+"If the Google Translate service is \"abused\", Google may block temporarily "
+"your IP. Or what is worse, they could change the translation mechanism "
+"making this applet useless and forcing me to update its code."
+msgstr ""
+"Pokud je služba Google Translate \"zneužívána\", může společnost Google "
+"dočasně zablokovat vaši IP adresu. Nebo co je horší, mohou změnit překladový "
+"mechanismus, což způsobí nepoužitelnost tohoto apletu a donutí mě "
+"aktualizovat jeho kód. "
+
+#: ../../create_localized_help.py:131
+msgid ""
+"If the Yandex Translate service is \"abused\", you are \"wasting\" your API "
+"keys quota and they will be blocked (temporarily or permanently)."
+msgstr ""
+"Pokud je služba Yandex Translate \"zneužívána\", \"utrácíte\" kvótu na klíče "
+"API a ty budou blokovány (dočasně nebo trvale)."
+
+#: ../../create_localized_help.py:132
+msgid ""
+"In the context menu of this applet is an item that can open the folder were "
+"the translation history file is stored. From there, the translation history "
+"file can be backed up or deleted."
+msgstr ""
+"V kontextovém menu tohoto apletu je položka, která může otevřít složku se "
+"souborem historie překladů. Odtud může být soubor historie překladů "
+"zálohován nebo smazán. "
+
+#: ../../create_localized_help.py:134
+msgid "NEVER edit the translation history file manually!!!"
+msgstr "NIKDY neupravujte soubor historie překladu ručně!!!"
+
+#: ../../create_localized_help.py:136
+msgid ""
+"If the translation history file is deleted/renamed/moved, Cinnamon needs to "
+"be restarted."
+msgstr ""
+"Pokud je soubor s historií překladů smazán/přejmenován/přesunut, je třeba "
+"restartovat Cinnamon."
+
+#: ../../create_localized_help.py:138
+msgid "How to get Yandex translator API keys"
+msgstr "Jak získat klíče API pro překladač Yandex"
+
+#: ../../create_localized_help.py:139
+msgid ""
+"Visit one of the following links and register a Yandex account (or use one "
+"of the available social services)."
+msgstr ""
+"Navštivte některý z následujících odkazů a zaregistrujte účet Yandex (nebo "
+"použijte jednu z dostupných sociálních služeb)."
+
+#. TO TRANSLATORS: URL pointing to website in English
+#: ../../create_localized_help.py:141
+msgid "English:"
+msgstr "Anglicky:"
+
+#. TO TRANSLATORS: URL pointing to website in Russian
+#: ../../create_localized_help.py:143
+msgid "Russian:"
+msgstr "Rusky:"
+
+#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
+#: ../../create_localized_help.py:145
+msgid ""
+"Once you successfully finish creating your Yandex account, you can visit the "
+"link provided several times to create several API keys. **DO NOT ABUSE!!!**"
+msgstr ""
+"Jakmile úspěšně dokončíte vytváření účtu Yandex, můžete několikrát navštívit "
+"odkaz k vytvoření několika klíčů API. **NEZNEUŽÍVEJTE !!!**"
+
+#: ../../create_localized_help.py:146
+msgid ""
+"Once you have several API keys, you can add them to Popup Translator's "
+"settings window (one API key per line)."
+msgstr ""
+"Jakmile máte k dispozici několik klíčů API, můžete je přidat do okna "
+"nastavení Popup překladače (jeden klíč API na každý řádek)."
+
+#: ../../create_localized_help.py:148
+msgid "Important notes about Yandex API keys"
+msgstr "Důležité poznámky o klíčích API služby Yandex"
+
+#: ../../create_localized_help.py:149
+msgid ""
+"The API keys will be stored into a preference. Keep your API keys backed up "
+"in case you reset Popup Translator's preferences."
+msgstr ""
+"Klíče API budou uloženy do předvoleb. Udržujte klíč API zálohované pro "
+"případ, že zresetujete předvolby Popup překladače. "
+
+#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
+#: ../../create_localized_help.py:151
+msgid ""
+"**NEVER make your API keys public!!!** The whole purpose of going to the "
+"trouble of getting your own API keys is that the only one \"consuming their "
+"limits\" is you and nobody else."
+msgstr ""
+"**NIKDY nezveřejňujte své klíče API** Celý proces získání vlastních klíčů "
+"API, má jediný účel a tím je, že jediný kdo spotřebovává jejich limity jste "
+"vy a nikdo jiný."
+
+#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
+#: ../../create_localized_help.py:153
+msgid ""
+"With each Yandex translator API key you can translate **UP TO** 1.000.000 (1 "
+"million) characters per day **BUT NOT MORE** than 10.000.000 (10 millions) "
+"per month."
+msgstr ""
+"S každým klíčem API pro překladač Yandex můžete přeložit **AŽ DO** 1.000.000 "
+"(1 milion) znaků za den **ALE NE VÍCE** než 10.000.000 (10 milionů) za měsíc."
+
+#: ../../create_localized_help.py:175
+msgid "The following two sections are available only in English."
+msgstr "Následující dvě části jsou k dispozici pouze v angličtině."
+
+#. TO TRANSLATORS: This is a placeholder.
+#. Here goes your language name in your own language (a.k.a. endonym).
+#: ../../create_localized_help.py:200 ../../create_localized_help.py:272
+msgid "language-name"
+msgstr "Česky"
+
+#: ../../create_localized_help.py:275 applet.js:348
 msgid "Help"
 msgstr "Nápověda"
 
-#: applet.js:353
-msgid "Open this applet help file."
-msgstr "Otevřít soubor s nápovědou tohoto apletu."
+#: ../../create_localized_help.py:276
+msgid "Contributors"
+msgstr "Přispěvatelé"
 
-#: applet.js:480
-msgid "History"
-msgstr "Historie"
+#: ../../create_localized_help.py:277
+msgid "Changelog"
+msgstr "Changelog"
 
-#: applet.js:496
-#, javascript-format
-msgid "Go to %s's website"
-msgstr "Přejít na %s web"
-
-#: applet.js:498
-#, javascript-format
-msgid "Powered By %s"
-msgstr "S využitím %s"
-
-#: applet.js:606
-msgid "No Yandex API keys were found!!!"
-msgstr "Žádné Yandex API klíče nebyly nalezeny!!!"
-
-#: applet.js:607 applet.js:1004
-msgid "Check this applet help file for instructions."
-msgstr "Zkontrolujte soubor s nápovědou tohoto apletu pro získání instrukcí."
-
-#: applet.js:608 applet.js:1005
-msgid "It can be accessed from this applet context menu."
-msgstr "Může být zpřístupněn z kontextového menu tohoto apletu."
-
-#: applet.js:673
-msgid "API key is invalid"
-msgstr "API klíč je neplatný"
-
-#: applet.js:676
-msgid "Blocked API key"
-msgstr "Blokovaný API klíč"
-
-#: applet.js:679
-msgid "Exceeded the daily limit on the amount of translated text"
-msgstr "Překročen denní limit množství přeloženého textu"
-
-#: applet.js:682
-msgid "Exceeded the maximum text size"
-msgstr "Překročena maximální délka textu"
-
-#: applet.js:685
-msgid "The text cannot be translated"
-msgstr "Text nemůže být přeložen"
-
-#: applet.js:688
-msgid "The specified translation direction is not supported"
-msgstr "Vybraný směr překladu není podporován"
-
-#: applet.js:846
-#, javascript-format
-msgid "Error parsing %s's request."
-msgstr "Chyba parsování %s požadavku."
-
-#: applet.js:1011
-msgid "All dependencies seem to be met."
-msgstr "Všechny závislosti jsou splněny."
+#: ../../create_localized_help.py:278
+msgid "Choose language"
+msgstr "Zvolte jazyk"
 
 #. TO TRANSLATORS: Full sentence:
-#. "Unable to execute file/command 'FileName or Command':"
-#: applet.js:1063
-#, javascript-format
-msgid "Unable to execute file/command '%s':"
-msgstr "Nelze spustit soubor/příkaz '%s':"
+#. "Help for <xlet_name>"
+#: ../../create_localized_help.py:279 ../../create_localized_help.py:286
+#, python-format
+msgid "Help for %s"
+msgstr "Nápověda pro %s"
 
-#: __init__.js:252
-msgid "Copy translated text to clipboard"
-msgstr "Kopírovat přeložený text do schránky"
+#: ../../create_localized_help.py:287
+msgid "IMPORTANT!!!"
+msgstr "DŮLEŽITÉ!!!"
 
-#: __init__.js:258
-msgid "Translate text on provider's website"
-msgstr "Přeložit text na webu poskytovatele překladu"
+#: ../../create_localized_help.py:288
+msgid ""
+"Never delete any of the files found inside this xlet folder. It might break "
+"this xlet functionality."
+msgstr ""
+"Nikdy neodstraňujte soubory ze složky tohoto xletu. Mohlo by to narušit "
+"funkčnost xletu. "
 
-#: __init__.js:264
-msgid "Open translation history"
-msgstr "Otevřít historii překladu"
+#: ../../create_localized_help.py:289
+msgid ""
+"Bug reports, feature requests and contributions should be done on this "
+"xlet's repository linked next."
+msgstr ""
+"Zprávy o chybách, požadavky na funkce a příspěvky by měly být prováděny v "
+"repozitáři tohoto xletu, na který je odkaz dále."
+
+#: ../../create_localized_help.py:295
+msgid "Applets/Desklets/Extensions (a.k.a. xlets) localization"
+msgstr "Lokalizace apletů/deskletů/rozšíření (a.k.a. xlety)"
+
+#: ../../create_localized_help.py:296
+msgid ""
+"If this xlet was installed from Cinnamon Settings, all of this xlet's "
+"localizations were automatically installed."
+msgstr ""
+"Pokud byl tento xlet nainstalován z nastavení systému v Cinnamonu, byly "
+"všechny tyto lokalizace xletu automaticky nainstalovány."
+
+#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
+#: ../../create_localized_help.py:298
+msgid ""
+"If this xlet was installed manually and not trough Cinnamon Settings, "
+"localizations can be installed by executing the script called "
+"**localizations.sh** from a terminal opened inside the xlet's folder."
+msgstr ""
+"Pokud byl tento xlet nainstalován ručně a nikoliv pomocí nastavení systému v "
+"Cinnamonu, mohou být lokalizace instalovány spuštěním skriptu nazvaného ** "
+"localizations.sh ** z terminálu otevřeného uvnitř složky xletu."
+
+#: ../../create_localized_help.py:299
+msgid ""
+"If this xlet has no locale available for your language, you could create it "
+"by following the following instructions."
+msgstr ""
+"Pokud tento xlet nemá k dispozici překlad pro váš jazyk, můžete jej vytvořit "
+"podle následujících pokynů."
 
 #: appletHelper.py:310
 msgid "Popup Translator history"
@@ -229,430 +439,204 @@ msgstr "Datum"
 msgid "Source text"
 msgstr "Zdrojový text"
 
+#: appletHelper.py:347 applet.js:175
+msgid "Language pair"
+msgstr "Vybrané jazyky"
+
 #: appletHelper.py:355
 msgid "Target text"
 msgstr "Cílový text"
 
-#: ../../create_localized_help.py:63
-msgid "Dependencies"
-msgstr "Závislosti"
+#: __init__.js:252
+msgid "Copy translated text to clipboard"
+msgstr "Kopírovat přeložený text do schránky"
 
-#: ../../create_localized_help.py:64
+#: __init__.js:258
+msgid "Translate text on provider's website"
+msgstr "Přeložit text na webu poskytovatele překladu"
+
+#: __init__.js:264
+msgid "Open translation history"
+msgstr "Otevřít historii překladu"
+
+#: applet.js:84
+msgid "Source language"
+msgstr "Zdrojový jazyk"
+
+#: applet.js:85
+msgid "Target language"
+msgstr "Cílový jazyk"
+
+#: applet.js:86
 msgid ""
-"If one or more of these dependencies are missing in your system, you will "
-"not be able to use this applet."
+"(G) = Language supported only by Google Translate.\n"
+"(Y) = Language supported only by Yandex Translate."
 msgstr ""
-"Pokud v systému chybí jedna nebo více těchto závislostí, nebudete moci tento "
-"aplet používat."
+"(G) = Jazyk podporovaný pouze překladačem Google.\n"
+"(Y) = Jazyk podporovaný pouze překladačem Yandex."
 
-#: ../../create_localized_help.py:65
-msgid "xsel command"
-msgstr "xsel příkaz"
+#. 0dyseus@PopupTranslator->settings-schema.json->head_1->description
+#: applet.js:152
+msgid "First translation mechanism (Left click on applet)"
+msgstr "Mechanismus prvního překladu (Klikněte levým tlačítkem na aplet)"
 
-#: ../../create_localized_help.py:66
-msgid ""
-"XSel is a command-line program for getting and setting the contents of the X "
-"selection."
-msgstr ""
-"XSel je program příkazového řádku pro získání a nastavení obsahu výběru X."
+#. 0dyseus@PopupTranslator->settings-schema.json->head_2->description
+#: applet.js:156
+msgid "Second translation mechanism (Middle click on applet)"
+msgstr "Mechanismus druhého překladu (Klikněte středním tlačítkem na aplet)"
 
-#: ../../create_localized_help.py:68 ../../create_localized_help.py:76
-#: ../../create_localized_help.py:88
-msgid "Debian and Archlinux based distributions:"
-msgstr "Distribuce založené na Debianu a Archlinuxu:"
+#. 0dyseus@PopupTranslator->settings-schema.json->head_3->description
+#: applet.js:162
+msgid "Third translation mechanism (Hotkey #1)"
+msgstr "Mechanismus třetího překladu (Klávesová zkratka #1)"
 
-#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:70
-msgid "The package is called **xsel**."
-msgstr "Balík se nazývá **xsel**."
+#. 0dyseus@PopupTranslator->settings-schema.json->head_4->description
+#: applet.js:168
+msgid "Fourth translation mechanism (Hotkey #2)"
+msgstr "Mechanismus čtvrtého překladu (Klávesová zkratka #2)"
 
-#: ../../create_localized_help.py:73
-msgid "xdg-open command"
-msgstr "xdg-open příkaz"
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_1->description
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_4->description
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_3->description
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_2->description
+#: applet.js:173
+msgid "Service provider"
+msgstr "Poskytovatel služby"
 
-#: ../../create_localized_help.py:74
-msgid ""
-"Open a URI in the user's preferred application that handles the respective "
-"URI or file type."
-msgstr ""
-"Otevře URI v aplikaci preferované uživatelem, která zpracovává příslušný URI "
-"nebo typ souboru."
+#: applet.js:182
+msgid "Translation hotkey"
+msgstr "Klávesová zkratka pro překlad"
 
-#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:78 ../../create_localized_help.py:90
-msgid "This command is installed with the package called **xdg-utils**."
-msgstr "Tento příkaz je nainstalován s balíčkem s názvem **xdg-utils**."
+#: applet.js:190
+msgid "Force translation hotkey"
+msgstr "Klávesová zkratka pro vynucený překlad"
 
-#: ../../create_localized_help.py:79 ../../create_localized_help.py:91
-#: ../../create_localized_help.py:97
-msgid "Installed by default in modern versions of Linux Mint."
-msgstr "Instalováno ve výchozím nastavení v moderních verzích Linux Mint."
+#: applet.js:198 applet.js:980 applet.js:1003
+msgid "Unmet dependencies found!!!"
+msgstr "Nalezeny nesplněné závislosti!!!"
 
-#: ../../create_localized_help.py:82
-msgid "Python 3"
-msgstr "Python 3"
+#: applet.js:199 applet.js:848 applet.js:981
+msgid "A detailed error has been logged into ~/.cinnamon/glass.log file."
+msgstr "Podrobnosti chyby byly zaznamenány do ~/.cinnamon/glass.log souboru."
 
-#: ../../create_localized_help.py:83
-msgid "It should come already installed in all Linux distributions."
-msgstr "Mělo by být již nainstalováno ve všech distribucích Linuxu."
+#: applet.js:241
+msgid "Left click on applet"
+msgstr "Kliknout levým tlačítkem na apletu"
 
-#: ../../create_localized_help.py:85
-msgid "requests Python 3 module"
-msgstr "requests Python 3 modul"
+#: applet.js:244
+msgid "Middle click on applet"
+msgstr "Kliknout prostředním tlačítkem na apletu"
 
-#: ../../create_localized_help.py:86
-msgid ""
-"Requests allow you to send HTTP/1.1 requests. You can add headers, form "
-"data, multi-part files, and parameters with simple Python dictionaries, and "
-"access the response data in the same way. It's powered by httplib and "
-"urllib3, but it does all the hard work and crazy hacks for you."
-msgstr ""
-"Requests knihovna umožňuje posílat HTTP / 1.1 požadavky. Můžete přidat "
-"hlavičky, data formuláře, vícedílné soubory a parametry pomocí jednoduchých "
-"slovníků Pythonu a přístup k datům odezvy stejným způsobem. Využívá httplib "
-"a urllib3, ale dělá pro vás všechnu všechnu zbývající tvrdou práci. "
+#: applet.js:247
+msgid "Hotkey #1"
+msgstr "Klávesová zkratka #1"
 
-#: ../../create_localized_help.py:94
-msgid "Debian based distributions:"
-msgstr "Distribuce založené na Debianu:"
+#: applet.js:250
+msgid "Hotkey #2"
+msgstr "Klávesová zkratka #2"
 
-#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:96
-msgid "The package is called **python3-requests**."
-msgstr "Balík se nazývá **python3-requests**."
+#: applet.js:263 applet.js:274
+#, javascript-format
+msgid "Set %s as default translation engine."
+msgstr "Nastavit %s jako výchozí překladač."
 
-#: ../../create_localized_help.py:100
-msgid "Archlinux based distributions:"
-msgstr "Distribuce založené na Archlinuxu:"
+#: applet.js:293
+msgid "Applet extras"
+msgstr "Extra nastavení apletu"
 
-#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:102
-msgid "The package is called **python-requests**."
-msgstr "Balík se nazývá **python-requests**."
+#: applet.js:297
+msgid "Translation history"
+msgstr "Historie překladu"
 
-#: ../../create_localized_help.py:105
-msgid ""
-"After installing any of the missing dependencies, Cinnamon needs to be "
-"restarted"
-msgstr ""
-"Po instalaci jakékoli chybějících závislosti je nutné restartovat Cinnamon."
+#: applet.js:303
+msgid "Open translation history window."
+msgstr "Otevřít okno historie překladu"
 
-#: ../../create_localized_help.py:107
-msgid "Note:"
-msgstr "Poznámka:"
+#: applet.js:315
+msgid "History storage"
+msgstr "Úložiště historie"
 
-#: ../../create_localized_help.py:107
-msgid ""
-"I don't use any other type of Linux distribution (Gentoo based, Slackware "
-"based, etc.). If any of the previous packages/modules are named differently, "
-"please, let me know and I will specify them in this help file."
-msgstr ""
-"Nepoužívám žádný jiný typ distribuce Linuxu (založený na Gentoo, založeném "
-"na Slackware atd.). Pokud se některý z předchozích balíčků / modulů jmenuje "
-"jinak, dejte mi vědět a já doplním tento soubor s nápovědou. "
+#: applet.js:321
+msgid "Open the location where the translation history file is stored."
+msgstr "Otevřít umístění kde je uložena historie překladu."
 
-#: ../../create_localized_help.py:109
-msgid "Usage"
-msgstr "Používání"
+#: applet.js:334
+msgid "Check dependencies"
+msgstr "Zkontrolovat závislosti"
 
-#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:111
-msgid ""
-"There are 4 *translations mechanisms* (**Left click**, **Middle click**, "
-"**Hotkey #1** and **Hotkey #2**). Each translation mechanism can be "
-"configured with their own service providers, language pairs and hotkeys."
-msgstr ""
-"Existují 4 *mechanismy překladů* (**levým tlačítkem**, **středním "
-"tlačítkem**, **klávesová zkratka # 1** a **klávesová zkratka # 2**). Každý "
-"mechanismus překladu může být konfigurován s vlastními poskytovateli služeb, "
-"jazykovými páry a klávesovými zkratkami. "
+#: applet.js:340
+msgid "Check whether the dependencies for this applet are met."
+msgstr "Zkontrolovat jestli jsou splněny závislosti pro tento aplet."
 
-#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:113
-msgid ""
-"**First translation mechanism (Left click):** Translates any selected text "
-"from any application on your system. A hotkey can be assigned to perform "
-"this task."
-msgstr ""
-"**Mechanismus prvního překladu (levým tlačítkem myši):** Převede libovolný "
-"vybraný text z jakékoliv aplikace ve vašem systému. K provedení této úlohy "
-"může být přiřazena klávesová zkratka. "
+#: applet.js:354
+msgid "Open this applet help file."
+msgstr "Otevřít soubor s nápovědou tohoto apletu."
 
-#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:115
-msgid ""
-"**First translation mechanism ([[Ctrl]] + Left click):** Same as **Left "
-"click**, but it will bypass the translation history. A hotkey can be "
-"assigned to perform this task."
-msgstr ""
-"**Mechanismus prvního překladu ([[Ctrl]] + levým tlačítkem myši):** Stejné "
-"jako **levým tlačítkem**, ale obchází historii překladu. K provedení této "
-"úlohy může být přiřazena klávesová zkratka. "
+#: applet.js:481
+msgid "History"
+msgstr "Historie"
 
-#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:117
-msgid ""
-"**Second translation mechanism (Middle click):** Same as **Left click**."
-msgstr ""
-"**Mechanismus druhého překladu (prostředním tlačítkem myši):** Stejné jako "
-"**levým tlačítkem**."
+#: applet.js:497
+#, javascript-format
+msgid "Go to %s's website"
+msgstr "Přejít na %s web"
 
-#: ../../create_localized_help.py:120
-msgid ""
-"**Second translation mechanism ([[Ctrl]] + Middle click):** Same as [[Ctrl]] "
-"+ **Left click**."
-msgstr ""
-"**Mechanismus druhého překladu ([[Ctrl]] + prostředním tlačítkem myši):** "
-"Stejné jako [[Ctrl]] + **levým tlačítkem**."
+#: applet.js:499
+#, javascript-format
+msgid "Powered By %s"
+msgstr "S využitím %s"
 
-#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:122
-msgid ""
-"**Third translation mechanism (Hotkey #1):** Two hotkeys can be configured "
-"to perform a translation and a forced translation."
-msgstr ""
-"**Mechanismus třetího překladu (klávesová zkratka # 1):** Dvě klávesové "
-"zkratky mohou být nakonfigurovány pro překlad a vynucený překlad."
+#: applet.js:607
+msgid "No Yandex API keys were found!!!"
+msgstr "Žádné Yandex API klíče nebyly nalezeny!!!"
 
-#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:124
-msgid ""
-"**Fourth translation mechanism (Hotkey #2):** Two hotkeys can be configured "
-"to perform a translation and a forced translation."
-msgstr ""
-"**Mechanismus čtvrtého překladu (klávesová zkratka # 2):** Dvě klávesové "
-"zkratky mohou být nakonfigurovány pro překlad a vynucený překlad."
+#: applet.js:608 applet.js:1005
+msgid "Check this applet help file for instructions."
+msgstr "Zkontrolujte soubor s nápovědou tohoto apletu pro získání instrukcí."
 
-#: ../../create_localized_help.py:125
-msgid ""
-"All translations are stored into the translation history. If a string of "
-"text was already translated in the past, the popup will display that stored "
-"translated text without making use of the provider's translation service."
-msgstr ""
-"Všechny překlady jsou uloženy do historie překladů. Pokud byl řetězec textu "
-"již v minulosti přeložen, vyskakovací okno zobrazí tento uložený přeložený "
-"text bez použití služby poskytovatele překladu. "
+#: applet.js:609 applet.js:1006
+msgid "It can be accessed from this applet context menu."
+msgstr "Může být zpřístupněn z kontextového menu tohoto apletu."
 
-#: ../../create_localized_help.py:127
-msgid "About translation history"
-msgstr "O historii překladů"
+#: applet.js:674
+msgid "API key is invalid"
+msgstr "API klíč je neplatný"
 
-#: ../../create_localized_help.py:128
-msgid ""
-"I created the translation history mechanism mainly to avoid the abuse of the "
-"translation services."
-msgstr ""
-"Vytvořil jsem mechanismus historie překladu hlavně proto, aby se zabránilo "
-"zneužívání překladatelských služeb."
+#: applet.js:677
+msgid "Blocked API key"
+msgstr "Blokovaný API klíč"
 
-#: ../../create_localized_help.py:129
-msgid ""
-"If the Google Translate service is \"abused\", Google may block temporarily "
-"your IP. Or what is worse, they could change the translation mechanism "
-"making this applet useless and forcing me to update its code."
-msgstr ""
-"Pokud je služba Google Translate \"zneužívána\", může společnost Google "
-"dočasně zablokovat vaši IP adresu. Nebo co je horší, mohou změnit překladový "
-"mechanismus, což způsobí nepoužitelnost tohoto apletu a donutí mě "
-"aktualizovat jeho kód. "
+#: applet.js:680
+msgid "Exceeded the daily limit on the amount of translated text"
+msgstr "Překročen denní limit množství přeloženého textu"
 
-#: ../../create_localized_help.py:130
-msgid ""
-"If the Yandex Translate service is \"abused\", you are \"wasting\" your API "
-"keys quota and they will be blocked (temporarily or permanently)."
-msgstr ""
-"Pokud je služba Yandex Translate \"zneužívána\", \"utrácíte\" kvótu na klíče "
-"API a ty budou blokovány (dočasně nebo trvale)."
+#: applet.js:683
+msgid "Exceeded the maximum text size"
+msgstr "Překročena maximální délka textu"
 
-#: ../../create_localized_help.py:131
-msgid ""
-"In the context menu of this applet is an item that can open the folder were "
-"the translation history file is stored. From there, the translation history "
-"file can be backed up or deleted."
-msgstr ""
-"V kontextovém menu tohoto apletu je položka, která může otevřít složku se "
-"souborem historie překladů. Odtud může být soubor historie překladů "
-"zálohován nebo smazán. "
+#: applet.js:686
+msgid "The text cannot be translated"
+msgstr "Text nemůže být přeložen"
 
-#: ../../create_localized_help.py:133
-msgid "NEVER edit the translation history file manually!!!"
-msgstr "NIKDY neupravujte soubor historie překladu ručně!!!"
+#: applet.js:689
+msgid "The specified translation direction is not supported"
+msgstr "Vybraný směr překladu není podporován"
 
-#: ../../create_localized_help.py:135
-msgid ""
-"If the translation history file is deleted/renamed/moved, Cinnamon needs to "
-"be restarted."
-msgstr ""
-"Pokud je soubor s historií překladů smazán/přejmenován/přesunut, je třeba "
-"restartovat Cinnamon."
+#: applet.js:847
+#, javascript-format
+msgid "Error parsing %s's request."
+msgstr "Chyba parsování %s požadavku."
 
-#: ../../create_localized_help.py:137
-msgid "How to get Yandex translator API keys"
-msgstr "Jak získat klíče API pro překladač Yandex"
-
-#: ../../create_localized_help.py:138
-msgid ""
-"Visit one of the following links and register a Yandex account (or use one "
-"of the available social services)."
-msgstr ""
-"Navštivte některý z následujících odkazů a zaregistrujte účet Yandex (nebo "
-"použijte jednu z dostupných sociálních služeb)."
-
-#. TO TRANSLATORS: URL pointing to website in English
-#: ../../create_localized_help.py:140
-msgid "English:"
-msgstr "Anglicky:"
-
-#. TO TRANSLATORS: URL pointing to website in Russian
-#: ../../create_localized_help.py:142
-msgid "Russian:"
-msgstr "Rusky:"
-
-#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:144
-msgid ""
-"Once you successfully finish creating your Yandex account, you can visit the "
-"link provided several times to create several API keys. **DO NOT ABUSE!!!**"
-msgstr ""
-"Jakmile úspěšně dokončíte vytváření účtu Yandex, můžete několikrát navštívit "
-"odkaz k vytvoření několika klíčů API. **NEZNEUŽÍVEJTE !!!**"
-
-#: ../../create_localized_help.py:145
-msgid ""
-"Once you have several API keys, you can add them to Popup Translator's "
-"settings window (one API key per line)."
-msgstr ""
-"Jakmile máte k dispozici několik klíčů API, můžete je přidat do okna "
-"nastavení Popup překladače (jeden klíč API na každý řádek)."
-
-#: ../../create_localized_help.py:147
-msgid "Important notes about Yandex API keys"
-msgstr "Důležité poznámky o klíčích API služby Yandex"
-
-#: ../../create_localized_help.py:148
-msgid ""
-"The API keys will be stored into a preference. Keep your API keys backed up "
-"in case you reset Popup Translator's preferences."
-msgstr ""
-"Klíče API budou uloženy do předvoleb. Udržujte klíč API zálohované pro "
-"případ, že zresetujete předvolby Popup překladače. "
-
-#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:150
-msgid ""
-"**NEVER make your API keys public!!!** The whole purpose of going to the "
-"trouble of getting your own API keys is that the only one \"consuming their "
-"limits\" is you and nobody else."
-msgstr ""
-"**NIKDY nezveřejňujte své klíče API** Celý proces získání vlastních klíčů "
-"API, má jediný účel a tím je, že jediný kdo spotřebovává jejich limity jste "
-"vy a nikdo jiný."
-
-#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:152
-msgid ""
-"With each Yandex translator API key you can translate **UP TO** 1.000.000 (1 "
-"million) characters per day **BUT NOT MORE** than 10.000.000 (10 millions) "
-"per month."
-msgstr ""
-"S každým klíčem API pro překladač Yandex můžete přeložit **AŽ DO** 1.000.000 "
-"(1 milion) znaků za den **ALE NE VÍCE** než 10.000.000 (10 milionů) za měsíc."
-
-#. TO TRANSLATORS: This is a placeholder.
-#. Here goes your language name in your own language (a.k.a. endonym).
-#: ../../create_localized_help.py:179 ../../create_localized_help.py:248
-msgid "language-name"
-msgstr "Česky"
-
-#: ../../create_localized_help.py:251
-msgid "Choose language"
-msgstr "Zvolte jazyk"
+#: applet.js:1012
+msgid "All dependencies seem to be met."
+msgstr "Všechny závislosti jsou splněny."
 
 #. TO TRANSLATORS: Full sentence:
-#. "Help for <xlet_name>"
-#: ../../create_localized_help.py:252 ../../create_localized_help.py:259
-#, python-format
-msgid "Help for %s"
-msgstr "Nápověda pro %s"
-
-#: ../../create_localized_help.py:260
-msgid "IMPORTANT!!!"
-msgstr "DŮLEŽITÉ!!!"
-
-#: ../../create_localized_help.py:261
-msgid ""
-"Never delete any of the files found inside this xlet folder. It might break "
-"this xlet functionality."
-msgstr ""
-"Nikdy neodstraňujte soubory ze složky tohoto xletu. Mohlo by to narušit "
-"funkčnost xletu. "
-
-#: ../../create_localized_help.py:262
-msgid ""
-"Bug reports, feature requests and contributions should be done on this "
-"xlet's repository linked next."
-msgstr ""
-"Zprávy o chybách, požadavky na funkce a příspěvky by měly být prováděny v "
-"repozitáři tohoto xletu, na který je odkaz dále."
-
-#: ../../create_localized_help.py:268
-msgid "Applets/Desklets/Extensions (a.k.a. xlets) localization"
-msgstr "Lokalizace apletů/deskletů/rozšíření (a.k.a. xlety)"
-
-#: ../../create_localized_help.py:269
-msgid ""
-"If this xlet was installed from Cinnamon Settings, all of this xlet's "
-"localizations were automatically installed."
-msgstr ""
-"Pokud byl tento xlet nainstalován z nastavení systému v Cinnamonu, byly "
-"všechny tyto lokalizace xletu automaticky nainstalovány."
-
-#. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:271
-msgid ""
-"If this xlet was installed manually and not trough Cinnamon Settings, "
-"localizations can be installed by executing the script called "
-"**localizations.sh** from a terminal opened inside the xlet's folder."
-msgstr ""
-"Pokud byl tento xlet nainstalován ručně a nikoliv pomocí nastavení systému v "
-"Cinnamonu, mohou být lokalizace instalovány spuštěním skriptu nazvaného ** "
-"localizations.sh ** z terminálu otevřeného uvnitř složky xletu."
-
-#: ../../create_localized_help.py:272
-msgid ""
-"If this xlet has no locale available for your language, you could create it "
-"by following the following instructions."
-msgstr ""
-"Pokud tento xlet nemá k dispozici překlad pro váš jazyk, můžete jej vytvořit "
-"podle následujících pokynů."
-
-#. 0dyseus@PopupTranslator->metadata.json->contributors
-msgid "NikoKrause: German localization and bug reports."
-msgstr "NikoKrause: Německá lokalizace a hlášení chyb."
-
-#. 0dyseus@PopupTranslator->metadata.json->contributors
-msgid "Radek71: Czech localization and bug reports."
-msgstr "Radek71: Česká lokalizace a hlášení chyb."
-
-#. 0dyseus@PopupTranslator->metadata.json->contributors
-msgid "muzena: Croatian localization."
-msgstr "muzena: Chorvatská lokalizace."
-
-#. 0dyseus@PopupTranslator->metadata.json->contributors
-msgid "giwhub: Chinese localization."
-msgstr "giwhub: Čínská lokalizace."
-
-#. 0dyseus@PopupTranslator->metadata.json->contributors
-msgid "eson57: Swedish localization."
-msgstr "eson57: Švédská lokalizace."
-
-#. 0dyseus@PopupTranslator->metadata.json->contributors
-msgid "Ilis: Russian localization."
-msgstr "Ilis: Ruská lokalizace."
-
-#. 0dyseus@PopupTranslator->metadata.json->name
-msgid "Popup Translator"
-msgstr "Popup překladač"
+#. "Unable to execute file/command 'FileName or Command':"
+#: applet.js:1064
+#, javascript-format
+msgid "Unable to execute file/command '%s':"
+msgstr "Nelze spustit soubor/příkaz '%s':"
 
 #. 0dyseus@PopupTranslator->metadata.json->description
 msgid ""
@@ -662,6 +646,10 @@ msgstr ""
 "Aplet umožňující zobrazit překlad vybraného textu z jakékoliv aplikace v "
 "popup okně."
 
+#. 0dyseus@PopupTranslator->metadata.json->contributors
+msgid "See this xlet help file."
+msgstr "Viz soubor s nápovědou tohoto xletu."
+
 #. 0dyseus@PopupTranslator->metadata.json->comments
 msgid ""
 "Bug reports, feature requests and contributions should be done on this "
@@ -670,25 +658,56 @@ msgstr ""
 "Zprávy o chybách, požadavky na funkce a příspěvky by měly být prováděny v "
 "repozitáři tohoto xletu, na který je odkaz níže."
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_3->description
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_4->description
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_1->description
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_2->description
-msgid "Keyboard shortcut to perform a FORCED translation"
-msgstr "Klávesová zkratka pro vyvolání vynuceného překladu"
+#. 0dyseus@PopupTranslator->metadata.json->name
+msgid "Popup Translator"
+msgstr "Popup překladač"
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_3->tooltip
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_4->tooltip
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_1->tooltip
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_2->tooltip
-msgid ""
-"Choose a keybinding to perform a FORCED translation. A \"forced translation"
-"\" forces the translation of any string stored on the translation history "
-"and overwrites the existing one."
-msgstr ""
-"Zvolit klávesovou zkratku pro vyvolání vynuceného překladu. \"Vynucený "
-"překlad\" vynutí překlad jakéhokoliv řetězce uloženého v historii překladů a "
-"přepíše existující."
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_loggin_save_history_indented->description
+msgid "Indent translation history data"
+msgstr "Odsadit data historie překladu"
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_loggin_save_history_indented->tooltip
+msgid "It allows to save the translation history data with indentation."
+msgstr "Umožňuje ukládat data o historii překladu s odsazením."
+
+#. 0dyseus@PopupTranslator->settings-schema.json->head4->description
+msgid "Yandex translator settings"
+msgstr "Nastavení překladače Yandex"
+
+#. 0dyseus@PopupTranslator->settings-schema.json->head0->description
+msgid "Applet settings"
+msgstr "Nastavení apletu"
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_1->description
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_2->description
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_4->description
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_3->description
+msgid "Keyboard shortcut to perform a translation"
+msgstr "Klávesová zkratka pro vyvolání překladu"
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_1->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_2->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_4->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_3->tooltip
+msgid "Choose a keybinding to perform a translation."
+msgstr "Zvolit klávesovou zkratku pro vyvolání překladu."
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_initial_window_height->description
+msgid "History window initial height"
+msgstr "Výchozí výška okna historie"
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_initial_window_height->units
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_width_to_trigger_word_wrap->units
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_initial_window_width->units
+msgid "pixels"
+msgstr "pixelů"
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_1->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_4->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_3->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_2->tooltip
+msgid "Choose translation service provider."
+msgstr "Zvolit poskytovatele služby překladu."
 
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_1->options
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_4->options
@@ -704,31 +723,6 @@ msgstr "Překladač Yandex"
 msgid "Google Translator"
 msgstr "Překladač Google"
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_1->tooltip
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_4->tooltip
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_3->tooltip
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_service_provider_2->tooltip
-msgid "Choose translation service provider."
-msgstr "Zvolit poskytovatele služby překladu."
-
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_custom_label_for_applet->description
-msgid "Custom label"
-msgstr "Uživatelský název"
-
-#. 0dyseus@PopupTranslator->settings-schema.json->head2->description
-msgid "Popup elements appearance"
-msgstr "Vzhled prvků okna"
-
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_initial_window_height->units
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_width_to_trigger_word_wrap->units
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_initial_window_width->units
-msgid "pixels"
-msgstr "pixelů"
-
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_initial_window_height->description
-msgid "History window initial height"
-msgstr "Výchozí výška okna historie"
-
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_loggin_enabled->description
 msgid "Enable logging"
 msgstr "Povolit protokolování"
@@ -739,63 +733,37 @@ msgid ""
 "applet."
 msgstr "Povoluje možnost logovat výstup z několika funkcí používaných apletem."
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_style_for_translated_text->description
-msgid "Translated text style"
-msgstr "Styl přeloženého textu"
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_3->description
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_4->description
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_2->description
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_1->description
+msgid "Keyboard shortcut to perform a FORCED translation"
+msgstr "Klávesová zkratka pro vyvolání vynuceného překladu"
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_timestamp->options
-msgid "Custom"
-msgstr "Vlastní"
-
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_timestamp->options
-msgid "YYYY MM-DD hh:mm:ss (ISO8601)"
-msgstr "YYYY MM-DD hh:mm:ss (ISO8601)"
-
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_timestamp->options
-msgid "YYYY DD-MM hh:mm:ss (European)"
-msgstr "YYYY DD-MM hh:mm:ss (Evropské)"
-
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_timestamp->description
-msgid "Timestamp for translation history entries"
-msgstr "Časové razítko pro záznamy v historii překladů"
-
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_2->description
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_4->description
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_3->description
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_1->description
-msgid "Keyboard shortcut to perform a translation"
-msgstr "Klávesová zkratka pro vyvolání překladu"
-
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_2->tooltip
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_4->tooltip
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_3->tooltip
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_1->tooltip
-msgid "Choose a keybinding to perform a translation."
-msgstr "Zvolit klávesovou zkratku pro vyvolání překladu."
-
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_width_to_trigger_word_wrap->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_3->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_4->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_2->tooltip
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_translate_key_forced_1->tooltip
 msgid ""
-"The \"Source text\" and \"Target text\" columns on the history window will "
-"wrap its text at the width defined by this setting."
+"Choose a keybinding to perform a FORCED translation. A \"forced translation"
+"\" forces the translation of any string stored on the translation history "
+"and overwrites the existing one."
 msgstr ""
-"Text ve sloupcích \"Zdrojový text\" a \"Cílový text\" v okně historie bude "
-"zalomen na šířku definovanou tímto nastavením."
+"Zvolit klávesovou zkratku pro vyvolání vynuceného překladu. \"Vynucený "
+"překlad\" vynutí překlad jakéhokoliv řetězce uloženého v historii překladů a "
+"přepíše existující."
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_width_to_trigger_word_wrap->description
-msgid "Width to trigger word wrap"
-msgstr "Šířka pro zalomení řádků"
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_style_for_language_pair->description
+msgid "Language pair style"
+msgstr "Styl hlavičky s vybranými jazyky"
 
-#. 0dyseus@PopupTranslator->settings-schema.json->label5->description
-msgid "(*) This options are only useful for the applet developer"
-msgstr "(*) Tyto volby jsou užitečné pouze pro vývojáře apletu"
+#. 0dyseus@PopupTranslator->settings-schema.json->head3->description
+msgid "Translation history settings"
+msgstr "Nastavení historie překladu"
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_loggin_save_history_indented->description
-msgid "Indent translation history data"
-msgstr "Odsadit data historie překladu"
-
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_loggin_save_history_indented->tooltip
-msgid "It allows to save the translation history data with indentation."
-msgstr "Umožňuje ukládat data o historii překladu s odsazením."
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_yandex_api_keys->description
+msgid "API keys"
+msgstr "API klíče"
 
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_yandex_api_keys->tooltip
 msgid ""
@@ -808,13 +776,33 @@ msgstr ""
 "apletu), který je umístěn ve složce tohoto apletu s popisem jak získat  "
 "Yandex API klíče."
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_yandex_api_keys->description
-msgid "API keys"
-msgstr "API klíče"
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_width_to_trigger_word_wrap->description
+msgid "Width to trigger word wrap"
+msgstr "Šířka pro zalomení řádků"
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_style_for_language_pair->description
-msgid "Language pair style"
-msgstr "Styl hlavičky s vybranými jazyky"
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_width_to_trigger_word_wrap->tooltip
+msgid ""
+"The \"Source text\" and \"Target text\" columns on the history window will "
+"wrap its text at the width defined by this setting."
+msgstr ""
+"Text ve sloupcích \"Zdrojový text\" a \"Cílový text\" v okně historie bude "
+"zalomen na šířku definovanou tímto nastavením."
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_custom_label_for_applet->description
+msgid "Custom label"
+msgstr "Uživatelský název"
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_custom_icon_for_applet->description
+msgid "Custom icon"
+msgstr "Vlastní ikona"
+
+#. 0dyseus@PopupTranslator->settings-schema.json->head2->description
+msgid "Popup elements appearance"
+msgstr "Vzhled prvků okna"
+
+#. 0dyseus@PopupTranslator->settings-schema.json->label5->description
+msgid "(*) This options are only useful for the applet developer"
+msgstr "(*) Tyto volby jsou užitečné pouze pro vývojáře apletu"
 
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_history_timestamp_custom->description
 msgid "Custom timestamp"
@@ -838,33 +826,55 @@ msgstr ""
 "mm: minuty\n"
 "ss: sekundy"
 
-#. 0dyseus@PopupTranslator->settings-schema.json->head3->description
-msgid "Translation history settings"
-msgstr "Nastavení historie překladu"
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_initial_window_width->description
+msgid "History window initial width"
+msgstr "Výchozí šířka okna historie"
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_style_for_translated_text->description
+msgid "Translated text style"
+msgstr "Styl přeloženého textu"
 
 #. 0dyseus@PopupTranslator->settings-schema.json->head5->description
 msgid "Debugging settings"
 msgstr "Nastavení ladění"
 
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_timestamp->options
+msgid "YYYY MM-DD hh:mm:ss (ISO8601)"
+msgstr "YYYY MM-DD hh:mm:ss (ISO8601)"
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_timestamp->options
+msgid "YYYY DD-MM hh:mm:ss (European)"
+msgstr "YYYY DD-MM hh:mm:ss (Evropské)"
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_timestamp->options
+msgid "Custom"
+msgstr "Vlastní"
+
+#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_timestamp->description
+msgid "Timestamp for translation history entries"
+msgstr "Časové razítko pro záznamy v historii překladů"
+
 #. 0dyseus@PopupTranslator->settings-schema.json->pref_style_for_footer->description
 msgid "Footer style"
 msgstr "Styl zápatí"
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_history_initial_window_width->description
-msgid "History window initial width"
-msgstr "Výchozí šířka okna historie"
+#~ msgid "NikoKrause: German localization and bug reports."
+#~ msgstr "NikoKrause: Německá lokalizace a hlášení chyb."
 
-#. 0dyseus@PopupTranslator->settings-schema.json->head0->description
-msgid "Applet settings"
-msgstr "Nastavení apletu"
+#~ msgid "Radek71: Czech localization and bug reports."
+#~ msgstr "Radek71: Česká lokalizace a hlášení chyb."
 
-#. 0dyseus@PopupTranslator->settings-schema.json->head4->description
-msgid "Yandex translator settings"
-msgstr "Nastavení překladače Yandex"
+#~ msgid "muzena: Croatian localization."
+#~ msgstr "muzena: Chorvatská lokalizace."
 
-#. 0dyseus@PopupTranslator->settings-schema.json->pref_custom_icon_for_applet->description
-msgid "Custom icon"
-msgstr "Vlastní ikona"
+#~ msgid "giwhub: Chinese localization."
+#~ msgstr "giwhub: Čínská lokalizace."
+
+#~ msgid "eson57: Swedish localization."
+#~ msgstr "eson57: Švédská lokalizace."
+
+#~ msgid "Ilis: Russian localization."
+#~ msgstr "Ilis: Ruská lokalizace."
 
 #~ msgid "General"
 #~ msgstr "Obecné"


### PR DESCRIPTION
- Redesigned the creation of the help file to be "on-line friendly".
- Finally fixed the annoyance of having titles on the help files hidden behind the top navigation bar when clicking the navigation links (Help/Contributors/Changelog).
- Fixed the display of a translated sentence on the help files that was being displayed untranslated.
- Added smooth scrolling for the links on the navigation bar of the help files.
- Updated localization template, localizations and help file due to changes to the *help file creator* script.
- Added to the xlet README file links to the localized help file.
- Better handling of **Settings.BindingDirection**. Just to avoid surprises when that constant is removed on future versions of Cinnamon.