### PR TITLE
Desktop Handler (0dyseus@DesktopHandler) update

### DIFF
--- a/0dyseus@DesktopHandler/README.md
+++ b/0dyseus@DesktopHandler/README.md
@@ -37,6 +37,6 @@ This applet is based on [Smart Panel](https://cinnamon-spices.linuxmint.com/exte
 - Left/Middle/Right click on applet can be configured to open the windows list menu.
 - Desktop peek functionality with configurable levels of opacity.
 
-[Contributors/Mentions](https://github.com/Odyseus/CinnamonTools/blob/master/applets/0dyseus%40DesktopHandler/CONTRIBUTORS.md)
-
-[Full change log](https://github.com/Odyseus/CinnamonTools/blob/master/applets/0dyseus%40DesktopHandler/CHANGELOG.md)
+#### [Localized help](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@DesktopHandler.html)
+#### [Contributors/Mentions](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@DesktopHandler.html#xlet-contributors)
+#### [Full change log](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@DesktopHandler.html#xlet-changelog)

--- a/0dyseus@DesktopHandler/files/0dyseus@DesktopHandler/HELP.html
+++ b/0dyseus@DesktopHandler/files/0dyseus@DesktopHandler/HELP.html
@@ -12,6 +12,102 @@ exported toggleLocalizationVisibility
 
 /* jshint varstmt: false */
 
+// Source: https://github.com/julienetie/smooth-scroll
+(function(window, document) {
+    var prefixes = ['moz', 'webkit', 'o'],
+        animationFrame;
+
+    // Modern rAF prefixing without setTimeout
+    function requestAnimationFrameNative() {
+        prefixes.map(function(prefix) {
+            if (!window.requestAnimationFrame) {
+                animationFrame = window[prefix + 'RequestAnimationFrame'];
+            } else {
+                animationFrame = requestAnimationFrame;
+            }
+        });
+    }
+    requestAnimationFrameNative();
+
+    function getOffsetTop(el) {
+        if (!el) {
+            return 0;
+        }
+
+        var yOffset = el.offsetTop,
+            parent = el.offsetParent;
+
+        yOffset += getOffsetTop(parent);
+
+        return yOffset;
+    }
+
+    function getScrollTop(scrollable) {
+        return scrollable.scrollTop || document.body.scrollTop || document.documentElement.scrollTop;
+    }
+
+    function scrollTo(scrollable, coords, millisecondsToTake) {
+        var currentY = getScrollTop(scrollable),
+            diffY = coords.y - currentY,
+            startTimestamp = null;
+
+        if (coords.y === currentY || typeof scrollable.scrollTo !== 'function') {
+            return;
+        }
+
+        function doScroll(currentTimestamp) {
+            if (startTimestamp === null) {
+                startTimestamp = currentTimestamp;
+            }
+
+            var progress = currentTimestamp - startTimestamp,
+                fractionDone = (progress / millisecondsToTake),
+                pointOnSineWave = Math.sin(fractionDone * Math.PI / 2);
+            scrollable.scrollTo(0, currentY + (diffY * pointOnSineWave));
+
+            if (progress < millisecondsToTake) {
+                animationFrame(doScroll);
+            } else {
+                // Ensure we're at our destination
+                scrollable.scrollTo(coords.x, coords.y);
+            }
+        }
+
+        animationFrame(doScroll);
+    }
+
+    // Declaire scroll duration, (before script)
+    var speed = window.smoothScrollSpeed || 750;
+
+    function smoothScroll(e) { // no smooth scroll class to ignore links
+        if (e.target.className === 'no-ss') {
+            return;
+        }
+
+        var source = e.target,
+            targetHref = source.hash,
+            target = null;
+
+        if (!source || !targetHref) {
+            return;
+        }
+
+        targetHref = targetHref.substring(1);
+        target = document.getElementById(targetHref);
+        if (!target) {
+            return;
+        }
+
+        scrollTo(window, {
+            x: 0,
+            y: getOffsetTop(target)
+        }, speed);
+    }
+
+    // Uses target's hash for scroll
+    document.addEventListener('click', smoothScroll, false);
+}(window, document));
+
 if (!window.localStorage) {
     /*
     Storage objects are a recent addition to the standard. As such they may not be present
@@ -449,7 +545,7 @@ body {
 <noscript>
 <div class="alert alert-warning">
 <p><strong>Oh snap! This page needs JavaScript enabled to display correctly.</strong></p>
-<p><strong>This page uses JavaScript only to switch between the available languages.</strong></p>
+<p><strong>This page uses JavaScript only to switch between the available languages and/or display images.</strong></p>
 <p><strong>There are no tracking services of any kind and never will be (at least, not from my side).</strong></p>
 </div> <!-- .alert.alert-warning -->
 </noscript>
@@ -458,9 +554,9 @@ body {
     <div class="container-fluid">
     <div class="navbar-header">
         <ul class="nav navbar-nav">
-            <li><a id="nav-xlet-help" class="navbar-brand" href="#xlet-help"></a></li>
-            <li><a id="nav-xlet-contributors" class="navbar-brand" href="#xlet-contributors"></a></li>
-            <li><a id="nav-xlet-changelog" class="navbar-brand" href="#xlet-changelog"></a></li>
+            <li><a id="nav-xlet-help" class="js_smoothScroll navbar-brand" href="#xlet-help"></a></li>
+            <li><a id="nav-xlet-contributors" class="js_smoothScroll navbar-brand" href="#xlet-contributors"></a></li>
+            <li><a id="nav-xlet-changelog" class="js_smoothScroll navbar-brand" href="#xlet-changelog"></a></li>
         </ul>
     </div>
     <form class="navbar-form navbar-collapse collapse navbar-right">
@@ -476,7 +572,7 @@ body {
     </form>
     </div>
 </nav>
-<span id="xlet-help">
+<span id="xlet-help" style="padding-top:70px;">
 <div class="container boxed">
 
 <div id="zh_CN" class="localization-content hidden">
@@ -501,6 +597,7 @@ body {
 <li>如果该xlet没有您的语言的本地化，您可以按照以下说明进行创建。 <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">以下两个部分仅使用英语。</div>
 </div> <!-- .localization-content -->
 
 
@@ -526,6 +623,7 @@ body {
 <li>Si este xlet no está disponible en su idioma, la localización puede ser creada siguiendo las siguientes instrucciones. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Las siguientes dos secciones están disponibles sólo en Inglés.</div>
 </div> <!-- .localization-content -->
 
 
@@ -551,6 +649,7 @@ body {
 <li>Om ditt språk saknas i denna xlet, kan du översätta den med hjälp av följande instruktioner. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Följande två sektioner är endast tillgängliga på Engelska.</div>
 </div> <!-- .localization-content -->
 
 
@@ -576,11 +675,11 @@ body {
 <li>If this xlet has no locale available for your language, you could create it by following the following instructions. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">The following two sections are available only in English.</div>
 </div> <!-- .localization-content -->
 
 </div> <!-- .container.boxed -->
-<div style="font-weight:bold;" class="container alert alert-info">The following two sections are available only in English.</div>
-<span id="xlet-contributors">
+<span id="xlet-contributors" style="padding-top:140px;">
 <div class="container boxed">
 <h2>Contributors/Mentions</h2>
 <ul>
@@ -591,10 +690,20 @@ body {
 
 </div> <!-- .container.boxed -->
 
-<span id="xlet-changelog">
+<span id="xlet-changelog" style="padding-top:70px;">
 <div class="container boxed">
 <h2>Desktop Handler changelog</h2>
 <h4>This change log is only valid for the version of the xlet hosted on <a href="https://github.com/Odyseus/CinnamonTools">its original repository</a></h4>
+<hr>
+<ul>
+<li><strong>Date:</strong> Tue, 6 Jun 2017 22:29:26 -0300</li>
+<li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/4289024">4289024</a></li>
+<li><strong>Author:</strong> Odyseus</li>
+</ul>
+<pre><code>Desktop Handler applet
+- Better handling of **Settings.BindingDirection**. Just to avoid surprises when that constant is
+removed on future versions of Cinnamon.
+</code></pre>
 <hr>
 <ul>
 <li><strong>Date:</strong> Sun, 4 Jun 2017 19:31:37 +0800</li>
@@ -903,6 +1012,8 @@ Add Chinese translation for Desktop Handler
 </div> <!-- .container.boxed -->
 
 </div> <!-- #mainarea -->
-<script type="text/javascript">toggleLocalizationVisibility(null);</script>
+<script type="text/javascript">toggleLocalizationVisibility(null);
+
+</script>
 </body>
 </html>

--- a/0dyseus@DesktopHandler/files/0dyseus@DesktopHandler/applet.js
+++ b/0dyseus@DesktopHandler/files/0dyseus@DesktopHandler/applet.js
@@ -73,7 +73,13 @@ MyApplet.prototype = {
     },
 
     _bindSettings: function() {
-        let bD = Settings.BindingDirection || null;
+        // Needed for retro-compatibility.
+        // Mark for deletion on EOL.
+        let bD = {
+            IN: 1,
+            OUT: 2,
+            BIDIRECTIONAL: 3
+        };
         let settingsArray = [
             [bD.BIDIRECTIONAL, "pref_applet_background_color", this._setAppletStyle],
             [bD.BIDIRECTIONAL, "pref_applet_with", this._setAppletStyle],

--- a/0dyseus@DesktopHandler/files/0dyseus@DesktopHandler/metadata.json
+++ b/0dyseus@DesktopHandler/files/0dyseus@DesktopHandler/metadata.json
@@ -11,6 +11,6 @@
     "uuid": "0dyseus@DesktopHandler",
     "comments": "Bug reports, feature requests and contributions should be done on this xlet's repository linked below.",
     "contributors": "See this xlet help file.",
-    "version": "1.07",
+    "version": "1.08",
     "description": "Various shortcuts to handle desktop actions."
 }

--- a/0dyseus@DesktopHandler/files/0dyseus@DesktopHandler/po/0dyseus@DesktopHandler.pot
+++ b/0dyseus@DesktopHandler/files/0dyseus@DesktopHandler/po/0dyseus@DesktopHandler.pot
@@ -5,8 +5,8 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 0dyseus@DesktopHandler 1.07\n"
-"POT-Creation-Date: 2017-06-02 17:05-0300\n"
+"Project-Id-Version: 0dyseus@DesktopHandler 1.08\n"
+"POT-Creation-Date: 2017-06-12 22:20-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,278 +15,274 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: make-xlet-pot.py 1.0.32\n"
 
-#: ../../create_localized_help.py:90
-msgid "The following two sections are available only in English."
-msgstr ""
-
 #. TO TRANSLATORS: This is a placeholder.
 #. Here goes your language name in your own language (a.k.a. endonym).
-#: ../../create_localized_help.py:115 ../../create_localized_help.py:187
+#: ../../create_localized_help.py:119 ../../create_localized_help.py:195
 msgid "language-name"
 msgstr ""
 
-#: ../../create_localized_help.py:190 applet.js:480
+#: ../../create_localized_help.py:125
+msgid "The following two sections are available only in English."
+msgstr ""
+
+#: ../../create_localized_help.py:198 applet.js:486
 msgid "Help"
 msgstr ""
 
-#: ../../create_localized_help.py:191
+#: ../../create_localized_help.py:199
 msgid "Contributors"
 msgstr ""
 
-#: ../../create_localized_help.py:192
+#: ../../create_localized_help.py:200
 msgid "Changelog"
 msgstr ""
 
-#: ../../create_localized_help.py:193
+#: ../../create_localized_help.py:201
 msgid "Choose language"
 msgstr ""
 
 #. TO TRANSLATORS: Full sentence:
 #. "Help for <xlet_name>"
-#: ../../create_localized_help.py:194 ../../create_localized_help.py:201
+#: ../../create_localized_help.py:202 ../../create_localized_help.py:209
 #, python-format
 msgid "Help for %s"
 msgstr ""
 
-#: ../../create_localized_help.py:202
+#: ../../create_localized_help.py:210
 msgid "IMPORTANT!!!"
 msgstr ""
 
-#: ../../create_localized_help.py:203
+#: ../../create_localized_help.py:211
 msgid "Never delete any of the files found inside this xlet folder. It might break this xlet functionality."
 msgstr ""
 
-#: ../../create_localized_help.py:204
+#: ../../create_localized_help.py:212
 msgid "Bug reports, feature requests and contributions should be done on this xlet's repository linked next."
 msgstr ""
 
-#: ../../create_localized_help.py:210
+#: ../../create_localized_help.py:218
 msgid "Applets/Desklets/Extensions (a.k.a. xlets) localization"
 msgstr ""
 
-#: ../../create_localized_help.py:211
+#: ../../create_localized_help.py:219
 msgid "If this xlet was installed from Cinnamon Settings, all of this xlet's localizations were automatically installed."
 msgstr ""
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:213
+#: ../../create_localized_help.py:221
 msgid "If this xlet was installed manually and not trough Cinnamon Settings, localizations can be installed by executing the script called **localizations.sh** from a terminal opened inside the xlet's folder."
 msgstr ""
 
-#: ../../create_localized_help.py:214
+#: ../../create_localized_help.py:222
 msgid "If this xlet has no locale available for your language, you could create it by following the following instructions."
 msgstr ""
 
-#: applet.js:244 applet.js:357
+#: applet.js:250 applet.js:363
 msgid "Close window"
 msgstr ""
 
-#: applet.js:298
+#: applet.js:304
 msgid "Close all windows from this wrokspace"
 msgstr ""
 
-#: applet.js:403
+#: applet.js:409
 msgid "No open windows"
 msgstr ""
 
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_left_click_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_down_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_middle_click_action->options
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
-#: applet.js:416 applet.js:698
+#: applet.js:422 applet.js:704
 msgid "Expo"
 msgstr ""
 
-#: applet.js:424
+#: applet.js:430
 msgid "Close all windows from all workspaces"
 msgstr ""
 
 #. NOTE: This string could be left blank because it's a default string,
 #. so it's already translated by Cinnamon. It's up to the translators.
-#: applet.js:491
+#: applet.js:497
 msgid "About..."
 msgstr ""
 
 #. NOTE: This string could be left blank because it's a default string,
 #. so it's already translated by Cinnamon. It's up to the translators.
-#: applet.js:501
+#: applet.js:507
 msgid "Configure..."
 msgstr ""
 
 #. NOTE: This string could be left blank because it's a default string,
 #. so it's already translated by Cinnamon. It's up to the translators.
-#: applet.js:515
+#: applet.js:521
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
 
-#: applet.js:524
+#: applet.js:530
 #, javascript-format
 msgid "Are you sure that you want to remove '%s' from your panel?"
 msgstr ""
 
-#: applet.js:526
+#: applet.js:532
 msgid "Cancel"
 msgstr ""
 
-#: applet.js:526
+#: applet.js:532
 msgid "OK"
 msgstr ""
 
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_left_click_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_down_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_middle_click_action->options
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
-#: applet.js:699
+#: applet.js:705
 msgid "Overview"
 msgstr ""
 
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_left_click_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_down_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_middle_click_action->options
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
-#: applet.js:700
+#: applet.js:706
 msgid "Launch App Switcher"
 msgstr ""
 
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_left_click_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_down_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_middle_click_action->options
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
-#: applet.js:701
+#: applet.js:707
 msgid "Run 1st Custom Command"
 msgstr ""
 
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_left_click_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_down_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_middle_click_action->options
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
-#: applet.js:702
+#: applet.js:708
 msgid "Run 2nd Custom Command"
 msgstr ""
 
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_left_click_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_down_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_middle_click_action->options
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
-#: applet.js:703
+#: applet.js:709
 msgid "Run 3rd Custom Command"
 msgstr ""
 
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_left_click_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_down_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_middle_click_action->options
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
-#: applet.js:704
+#: applet.js:710
 msgid "Run 4rd Custom Command"
 msgstr ""
 
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_left_click_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_down_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_middle_click_action->options
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_action->options
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
-#: applet.js:705
+#: applet.js:711
 msgid "None"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_style->options
-#: applet.js:706
+#: applet.js:712
 msgid "Icons only"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_style->options
-#: applet.js:707
+#: applet.js:713
 msgid "Thumbnails only"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_style->options
-#: applet.js:708
+#: applet.js:714
 msgid "Icons and thumbnails"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_style->options
-#: applet.js:709
+#: applet.js:715
 msgid "Icons and window preview"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_style->options
-#: applet.js:710
+#: applet.js:716
 msgid "Window preview (no icons)"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_style->options
-#: applet.js:711
+#: applet.js:717
 msgid "Coverflow (3D)"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_style->options
-#: applet.js:712
+#: applet.js:718
 msgid "Timeline (3D)"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_style->options
-#: applet.js:713
+#: applet.js:719
 msgid "System default"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_action->options
-#: applet.js:714
+#: applet.js:720
 msgid "Switch between workspaces"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_action->options
-#: applet.js:715
+#: applet.js:721
 msgid "Adjust opacity of windows"
 msgstr ""
 
-#: applet.js:716
+#: applet.js:722
 msgid "Toggle show desktop"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_action->options
-#: applet.js:717
+#: applet.js:723
 msgid "Switch between windows"
 msgstr ""
 
-#: applet.js:718
+#: applet.js:724
 msgid "Open windows list menu"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->metadata.json->name
-#: applet.js:732
+#: applet.js:738
 msgid "Desktop Handler"
 msgstr ""
 
-#: applet.js:735
+#: applet.js:741
 msgid "Scroll Up"
 msgstr ""
 
-#: applet.js:736
+#: applet.js:742
 msgid "Scroll Down"
 msgstr ""
 
-#: applet.js:738
+#: applet.js:744
 msgid "Scroll"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_button_to_open_menu->options
-#: applet.js:745
+#: applet.js:751
 msgid "Left click"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_button_to_open_menu->options
-#: applet.js:751
+#: applet.js:757
 msgid "Middle click"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_button_to_open_menu->options
-#: applet.js:755
+#: applet.js:761
 msgid "Right click"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->metadata.json->contributors
-msgid "See this xlet help file."
 msgstr ""
 
 #. 0dyseus@DesktopHandler->metadata.json->description
@@ -297,31 +293,55 @@ msgstr ""
 msgid "Bug reports, feature requests and contributions should be done on this xlet's repository linked below."
 msgstr ""
 
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_applet_background_color->tooltip
-msgid "I mainly added this so it's easy to see the applet the first time is placed in a panel."
+#. 0dyseus@DesktopHandler->metadata.json->contributors
+msgid "See this xlet help file."
 msgstr ""
 
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_applet_background_color->description
-msgid "Background color for the applet:"
+#. 0dyseus@DesktopHandler->settings-schema.json->head3->description
+msgid "Windows menu options"
 msgstr ""
 
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_custom_icon->tooltip
-msgid "Set a custom icon for the applet."
+#. 0dyseus@DesktopHandler->settings-schema.json->head0->description
+msgid "Applet options: "
 msgstr ""
 
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_custom_icon->description
-msgid "Icon for Applet (Leave blank to remove icon):"
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_show_context_menu_remove->description
+msgid "Show \"Remove this applet\""
 msgstr ""
 
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_left_click_action->description
-msgid "Action on applet left click: "
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_applet_with->units
+msgid "pixels"
 msgstr ""
 
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_applet_with->description
+msgid "Applet custom width (Set to 0 (zero) to not set a width):"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_show_context_menu_about->description
+msgid "Show \"About...\""
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_show_close_all_buttons->description
+msgid "Show close all windows buttons for workspaces"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_style->description
+msgid "App switcher style: "
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_blur_effect_enabled->description
+msgid "Blur windows on hover"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->description
+msgid "Action on scrolling up: "
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_left_click_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_down_action->options
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_middle_click_action->options
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_action->options
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->options
 msgid "Toggle Show desktop"
 msgstr ""
 
@@ -329,128 +349,20 @@ msgstr ""
 msgid "1st Custom Command:"
 msgstr ""
 
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_show_context_menu_about->description
-msgid "Show \"About...\""
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->head0->description
-msgid "Applet options: "
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_custom_cmd3_action->description
-msgid "3rd Custom Command:"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_separated_scroll_action->description
-msgid "Independent actions for scrolling up and down"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_down_action->description
-msgid "Action on scrolling down: "
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_show_close_all_buttons->description
-msgid "Show close all windows buttons for workspaces"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_delay->units
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_peek_desktop_delay->units
-msgid "milliseconds"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_delay->description
-msgid "Minimum delay between scrolls:"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_style->description
-msgid "App switcher style: "
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_show_context_menu_default_items->description
-msgid "Show context menu default items on right click"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_show_context_menu_help->description
-msgid "Show \"Help\""
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_show_close_buttons->description
-msgid "Show close buttons on windows list"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_peek_opacity->description
-msgid "Level of opacity:"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->head3->description
-msgid "Windows menu options"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_middle_click_action->description
-msgid "Action on applet middle click: "
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_peek_desktop_enabled->tooltip
-msgid "Take a glance at your desktop and desklets."
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_peek_desktop_enabled->description
-msgid "Opacify windows on hover (a.k.a. desktop peek)"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_modified->description
-msgid "When a modifier key is pressed, switch between windows from: "
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_modified->options
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_scope->options
-msgid "Current Application"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_modified->options
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_scope->options
-msgid "All workspaces"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_modified->options
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_scope->options
-msgid "Current workspace"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_custom_cmd2_action->description
-msgid "2nd Custom Command:"
-msgstr ""
-
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_opacify_desklets->description
 msgid "Opacify desklets"
 msgstr ""
 
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_scope->description
-msgid "Switch between windows from: "
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_button_to_open_menu->description
-msgid "Mouse button to open menu (It will override mouse click actions):"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->head6->description
-msgid "App Switcher Settings: "
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->head5->description
-msgid "Custom Commands: "
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_show_context_menu_configure->description
-msgid "Show \"Configure...\""
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_keep_menu_open->description
+msgid "Keep menu open while closing windows"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->head1->description
 msgid "Mouse scroll options: "
 msgstr ""
 
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_keep_menu_open->description
-msgid "Keep menu open while closing windows"
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_action->description
+msgid "Action on scrolling: "
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_modifier->description
@@ -465,54 +377,142 @@ msgstr ""
 msgid "Shift"
 msgstr ""
 
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_action->description
-msgid "Action on scrolling: "
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_delay->units
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_peek_desktop_delay->units
+msgid "milliseconds"
 msgstr ""
 
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_windows_list_menu_enabled->description
-msgid "Enable Windows list menu"
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_delay->description
+msgid "Minimum delay between scrolls:"
 msgstr ""
 
-#. 0dyseus@DesktopHandler->settings-schema.json->head4->description
-msgid "Peek at desktop options:"
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_peek_desktop_enabled->description
+msgid "Opacify windows on hover (a.k.a. desktop peek)"
 msgstr ""
 
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_up_action->description
-msgid "Action on scrolling up: "
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_prevent_fast_scroll->description
-msgid "Prevent accidental workspace/window switching on rapid scrolling"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_show_context_menu_remove->description
-msgid "Show \"Remove this applet\""
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_peek_desktop_enabled->tooltip
+msgid "Take a glance at your desktop and desklets."
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_opacify_desktop_icons->description
 msgid "Opacify the icons on the desktop"
 msgstr ""
 
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_applet_with->units
-msgid "pixels"
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_custom_icon->description
+msgid "Icon for Applet (Leave blank to remove icon):"
 msgstr ""
 
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_applet_with->description
-msgid "Applet custom width (Set to 0 (zero) to not set a width):"
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_custom_icon->tooltip
+msgid "Set a custom icon for the applet."
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_show_context_menu_default_items->description
+msgid "Show context menu default items on right click"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_custom_cmd2_action->description
+msgid "2nd Custom Command:"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_show_close_buttons->description
+msgid "Show close buttons on windows list"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_windows_list_menu_enabled->description
+msgid "Enable Windows list menu"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_peek_desktop_delay->description
+msgid "Peek desktop trigger delay:"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_show_context_menu_configure->description
+msgid "Show \"Configure...\""
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_show_context_menu_help->description
+msgid "Show \"Help\""
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->head5->description
+msgid "Custom Commands: "
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_left_click_action->description
+msgid "Action on applet left click: "
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_peek_opacity->description
+msgid "Level of opacity:"
 msgstr ""
 
 #. 0dyseus@DesktopHandler->settings-schema.json->head2->description
 msgid "Mouse click options: "
 msgstr ""
 
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_prevent_fast_scroll->description
+msgid "Prevent accidental workspace/window switching on rapid scrolling"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_custom_cmd3_action->description
+msgid "3rd Custom Command:"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_applet_background_color->description
+msgid "Background color for the applet:"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_applet_background_color->tooltip
+msgid "I mainly added this so it's easy to see the applet the first time is placed in a panel."
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_scope->description
+msgid "Switch between windows from: "
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_scope->options
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_modified->options
+msgid "Current workspace"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_scope->options
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_modified->options
+msgid "Current Application"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_scope->options
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_modified->options
+msgid "All workspaces"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_separated_scroll_action->description
+msgid "Independent actions for scrolling up and down"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_scroll_down_action->description
+msgid "Action on scrolling down: "
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_button_to_open_menu->description
+msgid "Mouse button to open menu (It will override mouse click actions):"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->head4->description
+msgid "Peek at desktop options:"
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->head6->description
+msgid "App Switcher Settings: "
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_middle_click_action->description
+msgid "Action on applet middle click: "
+msgstr ""
+
+#. 0dyseus@DesktopHandler->settings-schema.json->pref_switcher_modified->description
+msgid "When a modifier key is pressed, switch between windows from: "
+msgstr ""
+
 #. 0dyseus@DesktopHandler->settings-schema.json->pref_custom_cmd4_action->description
 msgid "4rd Custom Command:"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_blur_effect_enabled->description
-msgid "Blur windows on hover"
-msgstr ""
-
-#. 0dyseus@DesktopHandler->settings-schema.json->pref_peek_desktop_delay->description
-msgid "Peek desktop trigger delay:"
 msgstr ""


### PR DESCRIPTION
- Redesigned the creation of the help file to be "on-line friendly".
- Finally fixed the annoyance of having titles on the help files hidden behind the top navigation bar when clicking the navigation links (Help/Contributors/Changelog).
- Fixed the display of a translated sentence on the help files that was being displayed untranslated.
- Added smooth scrolling for the links on the navigation bar of the help files.
- Updated localization template, localizations and help file due to changes to the *help file creator* script.
- Added to the xlet README file links to the localized help file.
- Better handling of **Settings.BindingDirection**. Just to avoid surprises when that constant is removed on future versions of Cinnamon.