### PR TITLE
Wallpaper Changer (0dyseus@WallpaperChangerApplet) update

### DIFF
--- a/0dyseus@WallpaperChangerApplet/README.md
+++ b/0dyseus@WallpaperChangerApplet/README.md
@@ -31,6 +31,6 @@ Applet based on the gnome-shell extension called [Desk Changer](https://github.c
 
 **Note:** This applet doesn't complement the Cinnamon option called **Play backgrounds as a slideshow**, it replaces it. The Cinnamon option should be disabled at all times for this applet to work as expected. No worries, nothing *fatal* could happen.
 
-[Contributors/Mentions](https://github.com/Odyseus/CinnamonTools/blob/master/applets/0dyseus%40WallpaperChangerApplet/CONTRIBUTORS.md)
-
-[Full change log](https://github.com/Odyseus/CinnamonTools/blob/master/applets/0dyseus%40WallpaperChangerApplet/CHANGELOG.md)
+#### [Localized help](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@WallpaperChangerApplet.html)
+#### [Contributors/Mentions](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@WallpaperChangerApplet.html#xlet-contributors)
+#### [Full change log](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@WallpaperChangerApplet.html#xlet-changelog)

--- a/0dyseus@WallpaperChangerApplet/files/0dyseus@WallpaperChangerApplet/HELP.html
+++ b/0dyseus@WallpaperChangerApplet/files/0dyseus@WallpaperChangerApplet/HELP.html
@@ -12,6 +12,102 @@ exported toggleLocalizationVisibility
 
 /* jshint varstmt: false */
 
+// Source: https://github.com/julienetie/smooth-scroll
+(function(window, document) {
+    var prefixes = ['moz', 'webkit', 'o'],
+        animationFrame;
+
+    // Modern rAF prefixing without setTimeout
+    function requestAnimationFrameNative() {
+        prefixes.map(function(prefix) {
+            if (!window.requestAnimationFrame) {
+                animationFrame = window[prefix + 'RequestAnimationFrame'];
+            } else {
+                animationFrame = requestAnimationFrame;
+            }
+        });
+    }
+    requestAnimationFrameNative();
+
+    function getOffsetTop(el) {
+        if (!el) {
+            return 0;
+        }
+
+        var yOffset = el.offsetTop,
+            parent = el.offsetParent;
+
+        yOffset += getOffsetTop(parent);
+
+        return yOffset;
+    }
+
+    function getScrollTop(scrollable) {
+        return scrollable.scrollTop || document.body.scrollTop || document.documentElement.scrollTop;
+    }
+
+    function scrollTo(scrollable, coords, millisecondsToTake) {
+        var currentY = getScrollTop(scrollable),
+            diffY = coords.y - currentY,
+            startTimestamp = null;
+
+        if (coords.y === currentY || typeof scrollable.scrollTo !== 'function') {
+            return;
+        }
+
+        function doScroll(currentTimestamp) {
+            if (startTimestamp === null) {
+                startTimestamp = currentTimestamp;
+            }
+
+            var progress = currentTimestamp - startTimestamp,
+                fractionDone = (progress / millisecondsToTake),
+                pointOnSineWave = Math.sin(fractionDone * Math.PI / 2);
+            scrollable.scrollTo(0, currentY + (diffY * pointOnSineWave));
+
+            if (progress < millisecondsToTake) {
+                animationFrame(doScroll);
+            } else {
+                // Ensure we're at our destination
+                scrollable.scrollTo(coords.x, coords.y);
+            }
+        }
+
+        animationFrame(doScroll);
+    }
+
+    // Declaire scroll duration, (before script)
+    var speed = window.smoothScrollSpeed || 750;
+
+    function smoothScroll(e) { // no smooth scroll class to ignore links
+        if (e.target.className === 'no-ss') {
+            return;
+        }
+
+        var source = e.target,
+            targetHref = source.hash,
+            target = null;
+
+        if (!source || !targetHref) {
+            return;
+        }
+
+        targetHref = targetHref.substring(1);
+        target = document.getElementById(targetHref);
+        if (!target) {
+            return;
+        }
+
+        scrollTo(window, {
+            x: 0,
+            y: getOffsetTop(target)
+        }, speed);
+    }
+
+    // Uses target's hash for scroll
+    document.addEventListener('click', smoothScroll, false);
+}(window, document));
+
 if (!window.localStorage) {
     /*
     Storage objects are a recent addition to the standard. As such they may not be present
@@ -449,7 +545,7 @@ body {
 <noscript>
 <div class="alert alert-warning">
 <p><strong>Oh snap! This page needs JavaScript enabled to display correctly.</strong></p>
-<p><strong>This page uses JavaScript only to switch between the available languages.</strong></p>
+<p><strong>This page uses JavaScript only to switch between the available languages and/or display images.</strong></p>
 <p><strong>There are no tracking services of any kind and never will be (at least, not from my side).</strong></p>
 </div> <!-- .alert.alert-warning -->
 </noscript>
@@ -458,16 +554,16 @@ body {
     <div class="container-fluid">
     <div class="navbar-header">
         <ul class="nav navbar-nav">
-            <li><a id="nav-xlet-help" class="navbar-brand" href="#xlet-help"></a></li>
-            <li><a id="nav-xlet-contributors" class="navbar-brand" href="#xlet-contributors"></a></li>
-            <li><a id="nav-xlet-changelog" class="navbar-brand" href="#xlet-changelog"></a></li>
+            <li><a id="nav-xlet-help" class="js_smoothScroll navbar-brand" href="#xlet-help"></a></li>
+            <li><a id="nav-xlet-contributors" class="js_smoothScroll navbar-brand" href="#xlet-contributors"></a></li>
+            <li><a id="nav-xlet-changelog" class="js_smoothScroll navbar-brand" href="#xlet-changelog"></a></li>
         </ul>
     </div>
     <form class="navbar-form navbar-collapse collapse navbar-right">
         <div class="form-group">
             <label id="localization-chooser-label" class="control-label" for="localization-switch"></label>
             <select class="form-control input-sm" id="localization-switch" onchange="self.toggleLocalizationVisibility(value, this);">
-                <!-- Česky --><option data-title="Nápověda pro Wallpaper Changer" data-language-chooser-label="Zvolte jazyk" data-xlet-help="Nápověda" data-xlet-contributors="Contributors" data-xlet-changelog="Changelog" value="cs">Česky</option>
+                <!-- Česky --><option data-title="Nápověda pro Wallpaper Changer" data-language-chooser-label="Zvolte jazyk" data-xlet-help="Nápověda" data-xlet-contributors="Přispěvatelé" data-xlet-changelog="Changelog" value="cs">Česky</option>
 <!-- English --><option selected data-title="Help for Wallpaper Changer" data-language-chooser-label="Choose language" data-xlet-help="Help" data-xlet-contributors="Contributors" data-xlet-changelog="Changelog" value="en">English</option>
 <!-- Español --><option data-title="Ayuda para Wallpaper Changer" data-language-chooser-label="Elegir idioma" data-xlet-help="Ayuda" data-xlet-contributors="Colaboradores" data-xlet-changelog="Registro de cambios" value="es">Español</option>
 <!-- Svenska --><option data-title="Hjälp för Wallpaper Changer" data-language-chooser-label="Välj språk" data-xlet-help="Hjälp" data-xlet-contributors="Medhjälpare" data-xlet-changelog="Ändringslogg" value="sv">Svenska</option>
@@ -477,7 +573,7 @@ body {
     </form>
     </div>
 </nav>
-<span id="xlet-help">
+<span id="xlet-help" style="padding-top:70px;">
 <div class="container boxed">
 
 <div id="zh_CN" class="localization-content hidden">
@@ -502,6 +598,7 @@ body {
 <li>如果该xlet没有您的语言的本地化，您可以按照以下说明进行创建。 <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">以下两个部分仅使用英语。</div>
 </div> <!-- .localization-content -->
 
 
@@ -527,6 +624,7 @@ body {
 <li>Si este xlet no está disponible en su idioma, la localización puede ser creada siguiendo las siguientes instrucciones. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Las siguientes dos secciones están disponibles sólo en Inglés.</div>
 </div> <!-- .localization-content -->
 
 
@@ -552,6 +650,7 @@ body {
 <li>Pokud tento xlet nemá k dispozici překlad pro váš jazyk, můžete jej vytvořit podle následujících pokynů. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Následující dvě části jsou k dispozici pouze v angličtině.</div>
 </div> <!-- .localization-content -->
 
 
@@ -577,6 +676,7 @@ body {
 <li>Om ditt språk saknas i denna xlet, kan du översätta den med hjälp av följande instruktioner. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Följande två sektioner är endast tillgängliga på Engelska.</div>
 </div> <!-- .localization-content -->
 
 
@@ -602,11 +702,11 @@ body {
 <li>If this xlet has no locale available for your language, you could create it by following the following instructions. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">The following two sections are available only in English.</div>
 </div> <!-- .localization-content -->
 
 </div> <!-- .container.boxed -->
-<div style="font-weight:bold;" class="container alert alert-info">The following two sections are available only in English.</div>
-<span id="xlet-contributors">
+<span id="xlet-contributors" style="padding-top:140px;">
 <div class="container boxed">
 <h2>Contributors/Mentions</h2>
 <ul>
@@ -618,10 +718,19 @@ body {
 
 </div> <!-- .container.boxed -->
 
-<span id="xlet-changelog">
+<span id="xlet-changelog" style="padding-top:70px;">
 <div class="container boxed">
 <h2>Wallpaper Changer changelog</h2>
 <h4>This change log is only valid for the version of the xlet hosted on <a href="https://github.com/Odyseus/CinnamonTools">its original repository</a></h4>
+<hr>
+<ul>
+<li><strong>Date:</strong> Thu, 8 Jun 2017 01:25:40 -0300</li>
+<li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/ef6cc75">ef6cc75</a></li>
+<li><strong>Author:</strong> Odyseus</li>
+</ul>
+<pre><code>Wallpaper Changer applet
+- Updated Czech localization.
+</code></pre>
 <hr>
 <ul>
 <li><strong>Date:</strong> Sun, 4 Jun 2017 19:42:19 +0800</li>
@@ -834,6 +943,8 @@ es.po     0
 </div> <!-- .container.boxed -->
 
 </div> <!-- #mainarea -->
-<script type="text/javascript">toggleLocalizationVisibility(null);</script>
+<script type="text/javascript">toggleLocalizationVisibility(null);
+
+</script>
 </body>
 </html>

--- a/0dyseus@WallpaperChangerApplet/files/0dyseus@WallpaperChangerApplet/metadata.json
+++ b/0dyseus@WallpaperChangerApplet/files/0dyseus@WallpaperChangerApplet/metadata.json
@@ -11,7 +11,7 @@
     "description": "Cinnamon wallpaper slideshow applet with multiple profiles support.",
     "comments": "Bug reports, feature requests and contributions should be done on this xlet's repository linked below.",
     "website": "https://github.com/Odyseus/CinnamonTools",
-    "version": "1.00",
+    "version": "1.01",
     "schema-file": "schemas/org.cinnamon.applets.0dyseus@WallpaperChangerApplet.gschema.xml",
     "name": "Wallpaper Changer"
 }

--- a/0dyseus@WallpaperChangerApplet/files/0dyseus@WallpaperChangerApplet/po/0dyseus@WallpaperChangerApplet.pot
+++ b/0dyseus@WallpaperChangerApplet/files/0dyseus@WallpaperChangerApplet/po/0dyseus@WallpaperChangerApplet.pot
@@ -5,8 +5,8 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 0dyseus@WallpaperChangerApplet 1.00\n"
-"POT-Creation-Date: 2017-06-02 17:05-0300\n"
+"Project-Id-Version: 0dyseus@WallpaperChangerApplet 1.01\n"
+"POT-Creation-Date: 2017-06-12 22:20-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,65 +15,65 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: make-xlet-pot.py 1.0.32\n"
 
-#: ../../create_localized_help.py:90
-msgid "The following two sections are available only in English."
-msgstr ""
-
 #. TO TRANSLATORS: This is a placeholder.
 #. Here goes your language name in your own language (a.k.a. endonym).
-#: ../../create_localized_help.py:115 ../../create_localized_help.py:187
+#: ../../create_localized_help.py:119 ../../create_localized_help.py:195
 msgid "language-name"
 msgstr ""
 
-#: ../../create_localized_help.py:190 settings.py:1022
+#: ../../create_localized_help.py:125
+msgid "The following two sections are available only in English."
+msgstr ""
+
+#: ../../create_localized_help.py:198 settings.py:1022
 msgid "Help"
 msgstr ""
 
-#: ../../create_localized_help.py:191
+#: ../../create_localized_help.py:199
 msgid "Contributors"
 msgstr ""
 
-#: ../../create_localized_help.py:192
+#: ../../create_localized_help.py:200
 msgid "Changelog"
 msgstr ""
 
-#: ../../create_localized_help.py:193
+#: ../../create_localized_help.py:201
 msgid "Choose language"
 msgstr ""
 
 #. TO TRANSLATORS: Full sentence:
 #. "Help for <xlet_name>"
-#: ../../create_localized_help.py:194 ../../create_localized_help.py:201
+#: ../../create_localized_help.py:202 ../../create_localized_help.py:209
 #, python-format
 msgid "Help for %s"
 msgstr ""
 
-#: ../../create_localized_help.py:202
+#: ../../create_localized_help.py:210
 msgid "IMPORTANT!!!"
 msgstr ""
 
-#: ../../create_localized_help.py:203
+#: ../../create_localized_help.py:211
 msgid "Never delete any of the files found inside this xlet folder. It might break this xlet functionality."
 msgstr ""
 
-#: ../../create_localized_help.py:204
+#: ../../create_localized_help.py:212
 msgid "Bug reports, feature requests and contributions should be done on this xlet's repository linked next."
 msgstr ""
 
-#: ../../create_localized_help.py:210
+#: ../../create_localized_help.py:218
 msgid "Applets/Desklets/Extensions (a.k.a. xlets) localization"
 msgstr ""
 
-#: ../../create_localized_help.py:211
+#: ../../create_localized_help.py:219
 msgid "If this xlet was installed from Cinnamon Settings, all of this xlet's localizations were automatically installed."
 msgstr ""
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:213
+#: ../../create_localized_help.py:221
 msgid "If this xlet was installed manually and not trough Cinnamon Settings, localizations can be installed by executing the script called **localizations.sh** from a terminal opened inside the xlet's folder."
 msgstr ""
 
-#: ../../create_localized_help.py:214
+#: ../../create_localized_help.py:222
 msgid "If this xlet has no locale available for your language, you could create it by following the following instructions."
 msgstr ""
 
@@ -521,10 +521,10 @@ msgstr ""
 msgid "Bug reports, feature requests and contributions should be done on this xlet's repository linked below."
 msgstr ""
 
-#. 0dyseus@WallpaperChangerApplet->metadata.json->description
-msgid "Cinnamon wallpaper slideshow applet with multiple profiles support."
-msgstr ""
-
 #. 0dyseus@WallpaperChangerApplet->metadata.json->contributors
 msgid "See this xlet help file."
+msgstr ""
+
+#. 0dyseus@WallpaperChangerApplet->metadata.json->description
+msgid "Cinnamon wallpaper slideshow applet with multiple profiles support."
 msgstr ""

--- a/0dyseus@WallpaperChangerApplet/files/0dyseus@WallpaperChangerApplet/po/cs.po
+++ b/0dyseus@WallpaperChangerApplet/files/0dyseus@WallpaperChangerApplet/po/cs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.00\n"
 "Report-Msgid-Bugs-To: Odyseus\n"
-"POT-Creation-Date: 2017-05-29 06:39+0200\n"
-"PO-Revision-Date: 2017-05-29 06:42+0200\n"
+"POT-Creation-Date: 2017-06-08 06:19+0200\n"
+"PO-Revision-Date: 2017-06-08 06:21+0200\n"
 "Last-Translator: Radek Otáhal <radek.otahal@email.cz>\n"
 "Language-Team: \n"
 "Language: cs\n"
@@ -18,28 +18,44 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
+#: ../../create_localized_help.py:90
+msgid "The following two sections are available only in English."
+msgstr "Následující dvě části jsou k dispozici pouze v angličtině."
+
 #. TO TRANSLATORS: This is a placeholder.
 #. Here goes your language name in your own language (a.k.a. endonym).
-#: ../../create_localized_help.py:94 ../../create_localized_help.py:163
+#: ../../create_localized_help.py:115 ../../create_localized_help.py:187
 msgid "language-name"
 msgstr "Česky"
 
-#: ../../create_localized_help.py:166
+#: ../../create_localized_help.py:190 settings.py:1022
+msgid "Help"
+msgstr "Nápověda"
+
+#: ../../create_localized_help.py:191
+msgid "Contributors"
+msgstr "Přispěvatelé"
+
+#: ../../create_localized_help.py:192
+msgid "Changelog"
+msgstr "Changelog"
+
+#: ../../create_localized_help.py:193
 msgid "Choose language"
 msgstr "Zvolte jazyk"
 
 #. TO TRANSLATORS: Full sentence:
 #. "Help for <xlet_name>"
-#: ../../create_localized_help.py:167 ../../create_localized_help.py:174
+#: ../../create_localized_help.py:194 ../../create_localized_help.py:201
 #, python-format
 msgid "Help for %s"
 msgstr "Nápověda pro %s"
 
-#: ../../create_localized_help.py:175
+#: ../../create_localized_help.py:202
 msgid "IMPORTANT!!!"
 msgstr "DŮLEŽITÉ!!!"
 
-#: ../../create_localized_help.py:176
+#: ../../create_localized_help.py:203
 msgid ""
 "Never delete any of the files found inside this xlet folder. It might break "
 "this xlet functionality."
@@ -47,7 +63,7 @@ msgstr ""
 "Nikdy neodstraňujte soubory ze složky tohoto xletu. Mohlo by to narušit "
 "funkčnost xletu. "
 
-#: ../../create_localized_help.py:177
+#: ../../create_localized_help.py:204
 msgid ""
 "Bug reports, feature requests and contributions should be done on this "
 "xlet's repository linked next."
@@ -55,11 +71,11 @@ msgstr ""
 "Zprávy o chybách, požadavky na funkce a příspěvky by měly být prováděny v "
 "repozitáři tohoto xletu, na který je odkaz dále."
 
-#: ../../create_localized_help.py:183
+#: ../../create_localized_help.py:210
 msgid "Applets/Desklets/Extensions (a.k.a. xlets) localization"
 msgstr "Lokalizace apletů/deskletů/rozšíření (a.k.a. xlety)"
 
-#: ../../create_localized_help.py:184
+#: ../../create_localized_help.py:211
 msgid ""
 "If this xlet was installed from Cinnamon Settings, all of this xlet's "
 "localizations were automatically installed."
@@ -68,7 +84,7 @@ msgstr ""
 "všechny tyto lokalizace xletu automaticky nainstalovány."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:186
+#: ../../create_localized_help.py:213
 msgid ""
 "If this xlet was installed manually and not trough Cinnamon Settings, "
 "localizations can be installed by executing the script called "
@@ -78,7 +94,7 @@ msgstr ""
 "Cinnamonu, mohou být lokalizace instalovány spuštěním skriptu nazvaného ** "
 "localizations.sh ** z terminálu otevřeného uvnitř složky xletu."
 
-#: ../../create_localized_help.py:187
+#: ../../create_localized_help.py:214
 msgid ""
 "If this xlet has no locale available for your language, you could create it "
 "by following the following instructions."
@@ -353,10 +369,6 @@ msgstr "Pamatovat si velikost okna"
 msgid "Restart Cinnamon"
 msgstr "Restartovat Cinnamon"
 
-#: settings.py:1022
-msgid "Help"
-msgstr "Nápověda"
-
 #: settings.py:1024
 msgid "About"
 msgstr "O aplikaci"
@@ -561,22 +573,6 @@ msgstr "Profil změněn na %s"
 msgid "Configure..."
 msgstr "Nastavit..."
 
-#. 0dyseus@WallpaperChangerApplet->metadata.json->contributors
-msgid ""
-"Eric Gach: Author of Desk Changer gnome-shell extension. https://github.com/"
-"BigE/desk-changer"
-msgstr ""
-"Eric Gach: Autor rozšíření Desk CHanger pro gnome-shell. https://github.com/"
-"BigE/desk-changer "
-
-#. 0dyseus@WallpaperChangerApplet->metadata.json->contributors
-msgid "eson57: Swedish localization."
-msgstr "eson57: Švédská lokalizace."
-
-#. 0dyseus@WallpaperChangerApplet->metadata.json->contributors
-msgid "giwhub: Chinese localization."
-msgstr "giwhub: Čínská lokalizace."
-
 #. 0dyseus@WallpaperChangerApplet->metadata.json->comments
 msgid ""
 "Bug reports, feature requests and contributions should be done on this "
@@ -588,3 +584,20 @@ msgstr ""
 #. 0dyseus@WallpaperChangerApplet->metadata.json->description
 msgid "Cinnamon wallpaper slideshow applet with multiple profiles support."
 msgstr "Cinnamon aplet pro změnu tapet/pozadí s podporou více profilů."
+
+#. 0dyseus@WallpaperChangerApplet->metadata.json->contributors
+msgid "See this xlet help file."
+msgstr "Viz soubor s nápovědou tohoto xletu."
+
+#~ msgid ""
+#~ "Eric Gach: Author of Desk Changer gnome-shell extension. https://github."
+#~ "com/BigE/desk-changer"
+#~ msgstr ""
+#~ "Eric Gach: Autor rozšíření Desk CHanger pro gnome-shell. https://github."
+#~ "com/BigE/desk-changer "
+
+#~ msgid "eson57: Swedish localization."
+#~ msgstr "eson57: Švédská lokalizace."
+
+#~ msgid "giwhub: Chinese localization."
+#~ msgstr "giwhub: Čínská lokalizace."


### PR DESCRIPTION
- Redesigned the creation of the help file to be "on-line friendly".
- Finally fixed the annoyance of having titles on the help files hidden behind the top navigation bar when clicking the navigation links (Help/Contributors/Changelog).
- Fixed the display of a translated sentence on the help files that was being displayed untranslated.
- Added smooth scrolling for the links on the navigation bar of the help files.
- Updated localization template, localizations and help file due to changes to the *help file creator* script.
- Added to the xlet README file links to the localized help file.