### PR TITLE
Window list (Fork By Odyseus) (0dyseus@window-list-fork) update

### DIFF
--- a/0dyseus@window-list-fork/README.md
+++ b/0dyseus@window-list-fork/README.md
@@ -25,6 +25,6 @@ This applet is a fork of the default Window-list applet shipped with Cinnamon.
 
 ![Inverted menu on top panel](https://odyseus.github.io/CinnamonTools/lib/img/window-list-fork-001.png "Inverted menu on top panel")
 
-[Contributors/Mentions](https://github.com/Odyseus/CinnamonTools/blob/master/applets/0dyseus%40window-list-fork/CONTRIBUTORS.md)
-
-[Full change log](https://github.com/Odyseus/CinnamonTools/blob/master/applets/0dyseus%40window-list-fork/CHANGELOG.md)
+#### [Localized help](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@window-list-fork.html)
+#### [Contributors/Mentions](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@window-list-fork.html#xlet-contributors)
+#### [Full change log](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@window-list-fork.html#xlet-changelog)

--- a/0dyseus@window-list-fork/files/0dyseus@window-list-fork/2.8/applet.js
+++ b/0dyseus@window-list-fork/files/0dyseus@window-list-fork/2.8/applet.js
@@ -88,8 +88,8 @@ WindowPreview.prototype = {
 
         this.scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
 
-        this.actor.set_size(this._applet.pref_window_preview_custom_width * 1.3 * this.scaleFactor,
-            this._applet.pref_window_preview_custom_height * 1.3 * this.scaleFactor);
+        this.actor.set_size(this._applet.pref_window_preview_custom_width * 1.2 * this.scaleFactor,
+            this._applet.pref_window_preview_custom_height * 1.2 * this.scaleFactor);
         Main.uiGroup.add_actor(this.actor);
 
         this.metaWindow = metaWindow;
@@ -144,8 +144,11 @@ WindowPreview.prototype = {
         let muffinWindow = this.metaWindow.get_compositor_private();
         let windowTexture = muffinWindow.get_texture();
         let [width, height] = windowTexture.get_size();
+        // the 18 is 16 for the icon size + 2px min padding
+        // this is not foolproof - the font used might be large enough to make the
+        // label bigger than the icon
         let scale = Math.min(1.0, this._applet.pref_window_preview_custom_width / width,
-            this._applet.pref_window_preview_custom_height / height);
+            (this._applet.pref_window_preview_custom_height - 18) / height);
 
         if (this.thumbnail) {
             this.thumbnailBin.set_child(null);
@@ -854,7 +857,7 @@ AppMenuButtonRightClickMenu.prototype = {
                 if (typeof this._launcher._applet.configureApplet === "function")
                     this._launcher._applet.configureApplet();
                 else
-                    Util.spawn_async(["cinnamon-settings applets",
+                    Util.spawn_async(["cinnamon-settings", "applets",
                         this._launcher._applet._uuid, this._launcher._applet.instance_id
                     ], null);
             })));
@@ -937,7 +940,13 @@ MyApplet.prototype = {
     },
 
     _bindSettings: function() {
-        let bD = Settings.BindingDirection || null;
+        // Needed for retro-compatibility.
+        // Mark for deletion on EOL.
+        let bD = {
+            IN: 1,
+            OUT: 2,
+            BIDIRECTIONAL: 3
+        };
         let settingsArray = [
             [bD.IN, "pref_enable_alerts", this._updateAttentionGrabber],
             [bD.IN, "pref_enable_scrolling", this._onEnableScrollChanged],

--- a/0dyseus@window-list-fork/files/0dyseus@window-list-fork/HELP.html
+++ b/0dyseus@window-list-fork/files/0dyseus@window-list-fork/HELP.html
@@ -12,6 +12,102 @@ exported toggleLocalizationVisibility
 
 /* jshint varstmt: false */
 
+// Source: https://github.com/julienetie/smooth-scroll
+(function(window, document) {
+    var prefixes = ['moz', 'webkit', 'o'],
+        animationFrame;
+
+    // Modern rAF prefixing without setTimeout
+    function requestAnimationFrameNative() {
+        prefixes.map(function(prefix) {
+            if (!window.requestAnimationFrame) {
+                animationFrame = window[prefix + 'RequestAnimationFrame'];
+            } else {
+                animationFrame = requestAnimationFrame;
+            }
+        });
+    }
+    requestAnimationFrameNative();
+
+    function getOffsetTop(el) {
+        if (!el) {
+            return 0;
+        }
+
+        var yOffset = el.offsetTop,
+            parent = el.offsetParent;
+
+        yOffset += getOffsetTop(parent);
+
+        return yOffset;
+    }
+
+    function getScrollTop(scrollable) {
+        return scrollable.scrollTop || document.body.scrollTop || document.documentElement.scrollTop;
+    }
+
+    function scrollTo(scrollable, coords, millisecondsToTake) {
+        var currentY = getScrollTop(scrollable),
+            diffY = coords.y - currentY,
+            startTimestamp = null;
+
+        if (coords.y === currentY || typeof scrollable.scrollTo !== 'function') {
+            return;
+        }
+
+        function doScroll(currentTimestamp) {
+            if (startTimestamp === null) {
+                startTimestamp = currentTimestamp;
+            }
+
+            var progress = currentTimestamp - startTimestamp,
+                fractionDone = (progress / millisecondsToTake),
+                pointOnSineWave = Math.sin(fractionDone * Math.PI / 2);
+            scrollable.scrollTo(0, currentY + (diffY * pointOnSineWave));
+
+            if (progress < millisecondsToTake) {
+                animationFrame(doScroll);
+            } else {
+                // Ensure we're at our destination
+                scrollable.scrollTo(coords.x, coords.y);
+            }
+        }
+
+        animationFrame(doScroll);
+    }
+
+    // Declaire scroll duration, (before script)
+    var speed = window.smoothScrollSpeed || 750;
+
+    function smoothScroll(e) { // no smooth scroll class to ignore links
+        if (e.target.className === 'no-ss') {
+            return;
+        }
+
+        var source = e.target,
+            targetHref = source.hash,
+            target = null;
+
+        if (!source || !targetHref) {
+            return;
+        }
+
+        targetHref = targetHref.substring(1);
+        target = document.getElementById(targetHref);
+        if (!target) {
+            return;
+        }
+
+        scrollTo(window, {
+            x: 0,
+            y: getOffsetTop(target)
+        }, speed);
+    }
+
+    // Uses target's hash for scroll
+    document.addEventListener('click', smoothScroll, false);
+}(window, document));
+
 if (!window.localStorage) {
     /*
     Storage objects are a recent addition to the standard. As such they may not be present
@@ -449,7 +545,7 @@ body {
 <noscript>
 <div class="alert alert-warning">
 <p><strong>Oh snap! This page needs JavaScript enabled to display correctly.</strong></p>
-<p><strong>This page uses JavaScript only to switch between the available languages.</strong></p>
+<p><strong>This page uses JavaScript only to switch between the available languages and/or display images.</strong></p>
 <p><strong>There are no tracking services of any kind and never will be (at least, not from my side).</strong></p>
 </div> <!-- .alert.alert-warning -->
 </noscript>
@@ -458,9 +554,9 @@ body {
     <div class="container-fluid">
     <div class="navbar-header">
         <ul class="nav navbar-nav">
-            <li><a id="nav-xlet-help" class="navbar-brand" href="#xlet-help"></a></li>
-            <li><a id="nav-xlet-contributors" class="navbar-brand" href="#xlet-contributors"></a></li>
-            <li><a id="nav-xlet-changelog" class="navbar-brand" href="#xlet-changelog"></a></li>
+            <li><a id="nav-xlet-help" class="js_smoothScroll navbar-brand" href="#xlet-help"></a></li>
+            <li><a id="nav-xlet-contributors" class="js_smoothScroll navbar-brand" href="#xlet-contributors"></a></li>
+            <li><a id="nav-xlet-changelog" class="js_smoothScroll navbar-brand" href="#xlet-changelog"></a></li>
         </ul>
     </div>
     <form class="navbar-form navbar-collapse collapse navbar-right">
@@ -476,7 +572,7 @@ body {
     </form>
     </div>
 </nav>
-<span id="xlet-help">
+<span id="xlet-help" style="padding-top:70px;">
 <div class="container boxed">
 
 <div id="zh_CN" class="localization-content hidden">
@@ -501,6 +597,7 @@ body {
 <li>如果该xlet没有您的语言的本地化，您可以按照以下说明进行创建。 <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">以下两个部分仅使用英语。</div>
 </div> <!-- .localization-content -->
 
 
@@ -526,6 +623,7 @@ body {
 <li>Si este xlet no está disponible en su idioma, la localización puede ser creada siguiendo las siguientes instrucciones. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Las siguientes dos secciones están disponibles sólo en Inglés.</div>
 </div> <!-- .localization-content -->
 
 
@@ -551,6 +649,7 @@ body {
 <li>Om ditt språk saknas i denna xlet, kan du översätta den med hjälp av följande instruktioner. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Följande två sektioner är endast tillgängliga på Engelska.</div>
 </div> <!-- .localization-content -->
 
 
@@ -576,11 +675,11 @@ body {
 <li>If this xlet has no locale available for your language, you could create it by following the following instructions. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">The following two sections are available only in English.</div>
 </div> <!-- .localization-content -->
 
 </div> <!-- .container.boxed -->
-<div style="font-weight:bold;" class="container alert alert-info">The following two sections are available only in English.</div>
-<span id="xlet-contributors">
+<span id="xlet-contributors" style="padding-top:140px;">
 <div class="container boxed">
 <h2>Contributors/Mentions</h2>
 <ul>
@@ -592,10 +691,32 @@ body {
 
 </div> <!-- .container.boxed -->
 
-<span id="xlet-changelog">
+<span id="xlet-changelog" style="padding-top:70px;">
 <div class="container boxed">
 <h2>Window list (Fork By Odyseus) changelog</h2>
 <h4>This change log is only valid for the version of the xlet hosted on <a href="https://github.com/Odyseus/CinnamonTools">its original repository</a></h4>
+<hr>
+<ul>
+<li><strong>Date:</strong> Sun, 11 Jun 2017 03:13:23 -0300</li>
+<li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/68a7103">68a7103</a></li>
+<li><strong>Author:</strong> Odyseus</li>
+</ul>
+<pre><code>Window list (Fork By Odyseus) applet
+- Fixed the impossibility to open the applet settings window. This was caused when I changed the use
+of spawnCommandLine for spawn_async and passed the wrong arguments. Affected only Cinnamon versions
+2.8 and 3.0.
+- Applied window preview upstream tweaks.
+</code></pre>
+<hr>
+<ul>
+<li><strong>Date:</strong> Tue, 6 Jun 2017 22:31:11 -0300</li>
+<li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/19e2766">19e2766</a></li>
+<li><strong>Author:</strong> Odyseus</li>
+</ul>
+<pre><code>Window list (Fork By Odyseus) applet
+- Better handling of **Settings.BindingDirection**. Just to avoid surprises when that constant is
+removed on future versions of Cinnamon.
+</code></pre>
 <hr>
 <ul>
 <li><strong>Date:</strong> Sun, 4 Jun 2017 19:43:55 +0800</li>
@@ -1030,6 +1151,8 @@ Testing German localization.
 </div> <!-- .container.boxed -->
 
 </div> <!-- #mainarea -->
-<script type="text/javascript">toggleLocalizationVisibility(null);</script>
+<script type="text/javascript">toggleLocalizationVisibility(null);
+
+</script>
 </body>
 </html>

--- a/0dyseus@window-list-fork/files/0dyseus@window-list-fork/applet.js
+++ b/0dyseus@window-list-fork/files/0dyseus@window-list-fork/applet.js
@@ -89,8 +89,8 @@ WindowPreview.prototype = {
 
         this.scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
 
-        this.actor.set_size(this._applet.pref_window_preview_custom_width * 1.3 * this.scaleFactor,
-            this._applet.pref_window_preview_custom_height * 1.3 * this.scaleFactor);
+        this.actor.set_size(this._applet.pref_window_preview_custom_width * 1.2 * this.scaleFactor,
+            this._applet.pref_window_preview_custom_height * 1.2 * this.scaleFactor);
         Main.uiGroup.add_actor(this.actor);
 
         this.metaWindow = metaWindow;
@@ -151,8 +151,12 @@ WindowPreview.prototype = {
         this.muffinWindow = this.metaWindow.get_compositor_private();
         let windowTexture = this.muffinWindow.get_texture();
         let [width, height] = windowTexture.get_size();
+
+        // the 18 is 16 for the icon size + 2px min padding
+        // this is not foolproof - the font used might be large enough to make the
+        // label bigger than the icon
         let scale = Math.min(1.0, this._applet.pref_window_preview_custom_width / width,
-            this._applet.pref_window_preview_custom_height / height);
+            (this._applet.pref_window_preview_custom_height - 18) / height);
 
         if (this.thumbnail) {
             this.thumbnailBin.set_child(null);
@@ -168,7 +172,7 @@ WindowPreview.prototype = {
         this._setSize = function() {
             [width, height] = windowTexture.get_size();
             scale = Math.min(1.0, this._applet.pref_window_preview_custom_width / width,
-                this._applet.pref_window_preview_custom_height / height);
+             (this._applet.pref_window_preview_custom_height - 18) / height);
             this.thumbnail.set_size(width * scale * this.scaleFactor, height * scale * this.scaleFactor);
         };
         this._sizeChangedId = this.muffinWindow.connect('size-changed',
@@ -951,7 +955,7 @@ AppMenuButtonRightClickMenu.prototype = {
                 if (typeof this._launcher._applet.configureApplet === "function")
                     this._launcher._applet.configureApplet();
                 else
-                    Util.spawn_async(["cinnamon-settings applets",
+                    Util.spawn_async(["cinnamon-settings", "applets",
                         this._launcher._applet._uuid, this._launcher._applet.instance_id
                     ], null);
             })));
@@ -1067,7 +1071,13 @@ MyApplet.prototype = {
     },
 
     _bindSettings: function() {
-        let bD = Settings.BindingDirection || null;
+        // Needed for retro-compatibility.
+        // Mark for deletion on EOL.
+        let bD = {
+            IN: 1,
+            OUT: 2,
+            BIDIRECTIONAL: 3
+        };
         let settingsArray = [
             [bD.IN, "pref_enable_alerts", this._updateAttentionGrabber],
             [bD.IN, "pref_enable_scrolling", this._onEnableScrollChanged],

--- a/0dyseus@window-list-fork/files/0dyseus@window-list-fork/metadata.json
+++ b/0dyseus@window-list-fork/files/0dyseus@window-list-fork/metadata.json
@@ -6,7 +6,7 @@
     "max-instances": -1,
     "description": "Fork of the main Cinnamon Window list applet.",
     "comments": "Bug reports, feature requests and contributions should be done on this xlet's repository linked below.",
-    "version": "1.09",
+    "version": "1.10",
     "cinnamon-version": [
         "2.8",
         "3.0",

--- a/0dyseus@window-list-fork/files/0dyseus@window-list-fork/po/0dyseus@window-list-fork.pot
+++ b/0dyseus@window-list-fork/files/0dyseus@window-list-fork/po/0dyseus@window-list-fork.pot
@@ -5,8 +5,8 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 0dyseus@window-list-fork 1.09\n"
-"POT-Creation-Date: 2017-06-02 17:05-0300\n"
+"Project-Id-Version: 0dyseus@window-list-fork 1.10\n"
+"POT-Creation-Date: 2017-06-12 22:20-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,135 +15,135 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: make-xlet-pot.py 1.0.32\n"
 
-#: ../../create_localized_help.py:90
-msgid "The following two sections are available only in English."
-msgstr ""
-
 #. TO TRANSLATORS: This is a placeholder.
 #. Here goes your language name in your own language (a.k.a. endonym).
-#: ../../create_localized_help.py:115 ../../create_localized_help.py:187
+#: ../../create_localized_help.py:119 ../../create_localized_help.py:195
 msgid "language-name"
 msgstr ""
 
-#: ../../create_localized_help.py:190 2.8/applet.js:836 applet.js:933
+#: ../../create_localized_help.py:125
+msgid "The following two sections are available only in English."
+msgstr ""
+
+#: ../../create_localized_help.py:198 2.8/applet.js:839 applet.js:937
 msgid "Help"
 msgstr ""
 
-#: ../../create_localized_help.py:191
+#: ../../create_localized_help.py:199
 msgid "Contributors"
 msgstr ""
 
-#: ../../create_localized_help.py:192
+#: ../../create_localized_help.py:200
 msgid "Changelog"
 msgstr ""
 
-#: ../../create_localized_help.py:193
+#: ../../create_localized_help.py:201
 msgid "Choose language"
 msgstr ""
 
 #. TO TRANSLATORS: Full sentence:
 #. "Help for <xlet_name>"
-#: ../../create_localized_help.py:194 ../../create_localized_help.py:201
+#: ../../create_localized_help.py:202 ../../create_localized_help.py:209
 #, python-format
 msgid "Help for %s"
 msgstr ""
 
-#: ../../create_localized_help.py:202
+#: ../../create_localized_help.py:210
 msgid "IMPORTANT!!!"
 msgstr ""
 
-#: ../../create_localized_help.py:203
+#: ../../create_localized_help.py:211
 msgid "Never delete any of the files found inside this xlet folder. It might break this xlet functionality."
 msgstr ""
 
-#: ../../create_localized_help.py:204
+#: ../../create_localized_help.py:212
 msgid "Bug reports, feature requests and contributions should be done on this xlet's repository linked next."
 msgstr ""
 
-#: ../../create_localized_help.py:210
+#: ../../create_localized_help.py:218
 msgid "Applets/Desklets/Extensions (a.k.a. xlets) localization"
 msgstr ""
 
-#: ../../create_localized_help.py:211
+#: ../../create_localized_help.py:219
 msgid "If this xlet was installed from Cinnamon Settings, all of this xlet's localizations were automatically installed."
 msgstr ""
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:213
+#: ../../create_localized_help.py:221
 msgid "If this xlet was installed manually and not trough Cinnamon Settings, localizations can be installed by executing the script called **localizations.sh** from a terminal opened inside the xlet's folder."
 msgstr ""
 
-#: ../../create_localized_help.py:214
+#: ../../create_localized_help.py:222
 msgid "If this xlet has no locale available for your language, you could create it by following the following instructions."
 msgstr ""
 
-#: 2.8/applet.js:699 applet.js:797
+#: 2.8/applet.js:702 applet.js:801
 msgid "Preferences"
 msgstr ""
 
-#: 2.8/applet.js:714 applet.js:808
+#: 2.8/applet.js:717 applet.js:812
 msgid "Move to the other monitor"
 msgstr ""
 
-#: 2.8/applet.js:723 applet.js:817
+#: 2.8/applet.js:726 applet.js:821
 #, javascript-format
 msgid "Move to monitor %d"
 msgstr ""
 
-#: 2.8/applet.js:734 applet.js:828
+#: 2.8/applet.js:737 applet.js:832
 msgid "Only on this workspace"
 msgstr ""
 
-#: 2.8/applet.js:740 applet.js:834
+#: 2.8/applet.js:743 applet.js:838
 msgid "Visible on all workspaces"
 msgstr ""
 
-#: 2.8/applet.js:746 applet.js:840
+#: 2.8/applet.js:749 applet.js:844
 msgid "Move to another workspace"
 msgstr ""
 
 #. Close all/others
-#: 2.8/applet.js:768 applet.js:865
+#: 2.8/applet.js:771 applet.js:869
 msgid "Close all"
 msgstr ""
 
-#: 2.8/applet.js:777 applet.js:874
+#: 2.8/applet.js:780 applet.js:878
 msgid "Close others"
 msgstr ""
 
-#: 2.8/applet.js:791 applet.js:888
+#: 2.8/applet.js:794 applet.js:892
 msgid "Restore to full opacity"
 msgstr ""
 
-#: 2.8/applet.js:799 applet.js:896
+#: 2.8/applet.js:802 applet.js:900
 msgid "Restore"
 msgstr ""
 
-#: 2.8/applet.js:804 applet.js:901
+#: 2.8/applet.js:807 applet.js:905
 msgid "Minimize"
 msgstr ""
 
-#: 2.8/applet.js:812 applet.js:909
+#: 2.8/applet.js:815 applet.js:913
 msgid "Unmaximize"
 msgstr ""
 
-#: 2.8/applet.js:817 applet.js:914
+#: 2.8/applet.js:820 applet.js:918
 msgid "Maximize"
 msgstr ""
 
-#: 2.8/applet.js:824 applet.js:921
+#: 2.8/applet.js:827 applet.js:925
 msgid "Close"
 msgstr ""
 
-#: 2.8/applet.js:843 applet.js:940
+#: 2.8/applet.js:846 applet.js:944
 msgid "About..."
 msgstr ""
 
-#: 2.8/applet.js:849 applet.js:946
+#: 2.8/applet.js:852 applet.js:950
 msgid "Configure..."
 msgstr ""
 
-#: 2.8/applet.js:864 applet.js:961
+#: 2.8/applet.js:867 applet.js:965
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
@@ -156,20 +156,16 @@ msgstr ""
 msgid "Fork of the main Cinnamon Window list applet."
 msgstr ""
 
-#. 0dyseus@window-list-fork->metadata.json->name
-msgid "Window list (Fork By Odyseus)"
-msgstr ""
-
 #. 0dyseus@window-list-fork->metadata.json->contributors
 msgid "See this xlet help file."
 msgstr ""
 
-#. 0dyseus@window-list-fork->settings-schema.json->pref_enable_scrolling->description
-msgid "Enable mouse-wheel scrolling in the window list"
+#. 0dyseus@window-list-fork->metadata.json->name
+msgid "Window list (Fork By Odyseus)"
 msgstr ""
 
-#. 0dyseus@window-list-fork->settings-schema.json->pref_middle_click_close->description
-msgid "Middle click to close window"
+#. 0dyseus@window-list-fork->settings-schema.json->pref_window_preview_custom_width->description
+msgid "Custom width for window thumbnails"
 msgstr ""
 
 #. 0dyseus@window-list-fork->settings-schema.json->pref_window_preview_custom_width->units
@@ -177,28 +173,16 @@ msgstr ""
 msgid "pixels"
 msgstr ""
 
-#. 0dyseus@window-list-fork->settings-schema.json->pref_window_preview_custom_width->description
-msgid "Custom width for window thumbnails"
+#. 0dyseus@window-list-fork->settings-schema.json->pref_enable_alerts->description
+msgid "Show an alert in the window list when a window from another workspace requires attention"
 msgstr ""
 
-#. 0dyseus@window-list-fork->settings-schema.json->pref_reverse_scrolling->description
-msgid "Reverse the direction of mouse-wheel scrolling in the window list"
-msgstr ""
-
-#. 0dyseus@window-list-fork->settings-schema.json->pref_hide_labels->description
-msgid "Hide labels in the window list buttons"
-msgstr ""
-
-#. 0dyseus@window-list-fork->settings-schema.json->pref_window_preview->description
-msgid "Show window thumbnails on hover"
-msgstr ""
-
-#. 0dyseus@window-list-fork->settings-schema.json->pref_hide_tooltips->description
-msgid "Do not display tooltips"
+#. 0dyseus@window-list-fork->settings-schema.json->pref_sub_menu_placement->description
+msgid "Where to display the \"Preferences\" sub-menu?"
 msgstr ""
 
 #. 0dyseus@window-list-fork->settings-schema.json->pref_sub_menu_placement->options
-msgid "Do not display"
+msgid "Bottom of menu"
 msgstr ""
 
 #. 0dyseus@window-list-fork->settings-schema.json->pref_sub_menu_placement->options
@@ -206,29 +190,45 @@ msgid "Top of menu"
 msgstr ""
 
 #. 0dyseus@window-list-fork->settings-schema.json->pref_sub_menu_placement->options
-msgid "Bottom of menu"
-msgstr ""
-
-#. 0dyseus@window-list-fork->settings-schema.json->pref_sub_menu_placement->description
-msgid "Where to display the \"Preferences\" sub-menu?"
+msgid "Do not display"
 msgstr ""
 
 #. 0dyseus@window-list-fork->settings-schema.json->pref_sub_menu_placement->tooltip
 msgid "If the option \"Invert context menu items order\" is enabled, the \"Top of menu\" will actually be the \"Bottom of menu\" and vice versa."
 msgstr ""
 
-#. 0dyseus@window-list-fork->settings-schema.json->pref_invert_menu_items_order->description
-msgid "Invert context menu items order"
-msgstr ""
-
-#. 0dyseus@window-list-fork->settings-schema.json->pref_window_preview_custom_height->description
-msgid "Custom height for window thumbnails"
+#. 0dyseus@window-list-fork->settings-schema.json->pref_enable_scrolling->description
+msgid "Enable mouse-wheel scrolling in the window list"
 msgstr ""
 
 #. 0dyseus@window-list-fork->settings-schema.json->pref_buttons_use_entire_space->description
 msgid "Window buttons can have different sizes and use the entire space available"
 msgstr ""
 
-#. 0dyseus@window-list-fork->settings-schema.json->pref_enable_alerts->description
-msgid "Show an alert in the window list when a window from another workspace requires attention"
+#. 0dyseus@window-list-fork->settings-schema.json->pref_hide_tooltips->description
+msgid "Do not display tooltips"
+msgstr ""
+
+#. 0dyseus@window-list-fork->settings-schema.json->pref_window_preview->description
+msgid "Show window thumbnails on hover"
+msgstr ""
+
+#. 0dyseus@window-list-fork->settings-schema.json->pref_invert_menu_items_order->description
+msgid "Invert context menu items order"
+msgstr ""
+
+#. 0dyseus@window-list-fork->settings-schema.json->pref_reverse_scrolling->description
+msgid "Reverse the direction of mouse-wheel scrolling in the window list"
+msgstr ""
+
+#. 0dyseus@window-list-fork->settings-schema.json->pref_middle_click_close->description
+msgid "Middle click to close window"
+msgstr ""
+
+#. 0dyseus@window-list-fork->settings-schema.json->pref_window_preview_custom_height->description
+msgid "Custom height for window thumbnails"
+msgstr ""
+
+#. 0dyseus@window-list-fork->settings-schema.json->pref_hide_labels->description
+msgid "Hide labels in the window list buttons"
 msgstr ""


### PR DESCRIPTION
- Redesigned the creation of the help file to be "on-line friendly".
- Finally fixed the annoyance of having titles on the help files hidden behind the top navigation bar when clicking the navigation links (Help/Contributors/Changelog).
- Fixed the display of a translated sentence on the help files that was being displayed untranslated.
- Added smooth scrolling for the links on the navigation bar of the help files.
- Updated localization template, localizations and help file due to changes to the *help file creator* script.
- Added to the xlet README file links to the localized help file.
- Better handling of **Settings.BindingDirection**. Just to avoid surprises when that constant is removed on future versions of Cinnamon.