### PR TITLE
System Monitor (Fork By Odyseus) (0dyseus@SysmonitorByOrcus) update

### DIFF
--- a/0dyseus@SysmonitorByOrcus/README.md
+++ b/0dyseus@SysmonitorByOrcus/README.md
@@ -32,6 +32,6 @@ system.
 
 **Important note:** NetworkManager is only used if the **GTop** library version installed on a system is < **2.32** and doesn't support certain library calls. So, basically, if the network graph on this applet works without having installed NetworkManager, then you don't need to install it.
 
-[Contributors/Mentions](https://github.com/Odyseus/CinnamonTools/blob/master/applets/0dyseus%40SysmonitorByOrcus/CONTRIBUTORS.md)
-
-[Full change log](https://github.com/Odyseus/CinnamonTools/blob/master/applets/0dyseus%40SysmonitorByOrcus/CHANGELOG.md)
+#### [Localized help](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@SysmonitorByOrcus.html)
+#### [Contributors/Mentions](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@SysmonitorByOrcus.html#xlet-contributors)
+#### [Full change log](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@SysmonitorByOrcus.html#xlet-changelog)

--- a/0dyseus@SysmonitorByOrcus/files/0dyseus@SysmonitorByOrcus/HELP.html
+++ b/0dyseus@SysmonitorByOrcus/files/0dyseus@SysmonitorByOrcus/HELP.html
@@ -12,6 +12,102 @@ exported toggleLocalizationVisibility
 
 /* jshint varstmt: false */
 
+// Source: https://github.com/julienetie/smooth-scroll
+(function(window, document) {
+    var prefixes = ['moz', 'webkit', 'o'],
+        animationFrame;
+
+    // Modern rAF prefixing without setTimeout
+    function requestAnimationFrameNative() {
+        prefixes.map(function(prefix) {
+            if (!window.requestAnimationFrame) {
+                animationFrame = window[prefix + 'RequestAnimationFrame'];
+            } else {
+                animationFrame = requestAnimationFrame;
+            }
+        });
+    }
+    requestAnimationFrameNative();
+
+    function getOffsetTop(el) {
+        if (!el) {
+            return 0;
+        }
+
+        var yOffset = el.offsetTop,
+            parent = el.offsetParent;
+
+        yOffset += getOffsetTop(parent);
+
+        return yOffset;
+    }
+
+    function getScrollTop(scrollable) {
+        return scrollable.scrollTop || document.body.scrollTop || document.documentElement.scrollTop;
+    }
+
+    function scrollTo(scrollable, coords, millisecondsToTake) {
+        var currentY = getScrollTop(scrollable),
+            diffY = coords.y - currentY,
+            startTimestamp = null;
+
+        if (coords.y === currentY || typeof scrollable.scrollTo !== 'function') {
+            return;
+        }
+
+        function doScroll(currentTimestamp) {
+            if (startTimestamp === null) {
+                startTimestamp = currentTimestamp;
+            }
+
+            var progress = currentTimestamp - startTimestamp,
+                fractionDone = (progress / millisecondsToTake),
+                pointOnSineWave = Math.sin(fractionDone * Math.PI / 2);
+            scrollable.scrollTo(0, currentY + (diffY * pointOnSineWave));
+
+            if (progress < millisecondsToTake) {
+                animationFrame(doScroll);
+            } else {
+                // Ensure we're at our destination
+                scrollable.scrollTo(coords.x, coords.y);
+            }
+        }
+
+        animationFrame(doScroll);
+    }
+
+    // Declaire scroll duration, (before script)
+    var speed = window.smoothScrollSpeed || 750;
+
+    function smoothScroll(e) { // no smooth scroll class to ignore links
+        if (e.target.className === 'no-ss') {
+            return;
+        }
+
+        var source = e.target,
+            targetHref = source.hash,
+            target = null;
+
+        if (!source || !targetHref) {
+            return;
+        }
+
+        targetHref = targetHref.substring(1);
+        target = document.getElementById(targetHref);
+        if (!target) {
+            return;
+        }
+
+        scrollTo(window, {
+            x: 0,
+            y: getOffsetTop(target)
+        }, speed);
+    }
+
+    // Uses target's hash for scroll
+    document.addEventListener('click', smoothScroll, false);
+}(window, document));
+
 if (!window.localStorage) {
     /*
     Storage objects are a recent addition to the standard. As such they may not be present
@@ -449,7 +545,7 @@ body {
 <noscript>
 <div class="alert alert-warning">
 <p><strong>Oh snap! This page needs JavaScript enabled to display correctly.</strong></p>
-<p><strong>This page uses JavaScript only to switch between the available languages.</strong></p>
+<p><strong>This page uses JavaScript only to switch between the available languages and/or display images.</strong></p>
 <p><strong>There are no tracking services of any kind and never will be (at least, not from my side).</strong></p>
 </div> <!-- .alert.alert-warning -->
 </noscript>
@@ -458,9 +554,9 @@ body {
     <div class="container-fluid">
     <div class="navbar-header">
         <ul class="nav navbar-nav">
-            <li><a id="nav-xlet-help" class="navbar-brand" href="#xlet-help"></a></li>
-            <li><a id="nav-xlet-contributors" class="navbar-brand" href="#xlet-contributors"></a></li>
-            <li><a id="nav-xlet-changelog" class="navbar-brand" href="#xlet-changelog"></a></li>
+            <li><a id="nav-xlet-help" class="js_smoothScroll navbar-brand" href="#xlet-help"></a></li>
+            <li><a id="nav-xlet-contributors" class="js_smoothScroll navbar-brand" href="#xlet-contributors"></a></li>
+            <li><a id="nav-xlet-changelog" class="js_smoothScroll navbar-brand" href="#xlet-changelog"></a></li>
         </ul>
     </div>
     <form class="navbar-form navbar-collapse collapse navbar-right">
@@ -476,7 +572,7 @@ body {
     </form>
     </div>
 </nav>
-<span id="xlet-help">
+<span id="xlet-help" style="padding-top:70px;">
 <div class="container boxed">
 
 <div id="zh_CN" class="localization-content hidden">
@@ -519,6 +615,7 @@ body {
 <li>如果该xlet没有您的语言的本地化，您可以按照以下说明进行创建。 <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">以下两个部分仅使用英语。</div>
 </div> <!-- .localization-content -->
 
 
@@ -562,6 +659,7 @@ body {
 <li>Si este xlet no está disponible en su idioma, la localización puede ser creada siguiendo las siguientes instrucciones. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Las siguientes dos secciones están disponibles sólo en Inglés.</div>
 </div> <!-- .localization-content -->
 
 
@@ -605,6 +703,7 @@ body {
 <li>Om ditt språk saknas i denna xlet, kan du översätta den med hjälp av följande instruktioner. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Följande två sektioner är endast tillgängliga på Engelska.</div>
 </div> <!-- .localization-content -->
 
 
@@ -648,11 +747,11 @@ body {
 <li>If this xlet has no locale available for your language, you could create it by following the following instructions. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">The following two sections are available only in English.</div>
 </div> <!-- .localization-content -->
 
 </div> <!-- .container.boxed -->
-<div style="font-weight:bold;" class="container alert alert-info">The following two sections are available only in English.</div>
-<span id="xlet-contributors">
+<span id="xlet-contributors" style="padding-top:140px;">
 <div class="container boxed">
 <h2>Contributors/Mentions</h2>
 <ul>
@@ -664,10 +763,20 @@ body {
 
 </div> <!-- .container.boxed -->
 
-<span id="xlet-changelog">
+<span id="xlet-changelog" style="padding-top:70px;">
 <div class="container boxed">
 <h2>System Monitor (Fork By Odyseus) changelog</h2>
 <h4>This change log is only valid for the version of the xlet hosted on <a href="https://github.com/Odyseus/CinnamonTools">its original repository</a></h4>
+<hr>
+<ul>
+<li><strong>Date:</strong> Tue, 6 Jun 2017 22:30:49 -0300</li>
+<li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/8e86351">8e86351</a></li>
+<li><strong>Author:</strong> Odyseus</li>
+</ul>
+<pre><code>System Monitor (Fork By Odyseus) applet
+- Better handling of **Settings.BindingDirection**. Just to avoid surprises when that constant is
+removed on future versions of Cinnamon.
+</code></pre>
 <hr>
 <ul>
 <li><strong>Date:</strong> Sun, 4 Jun 2017 19:40:15 +0800</li>
@@ -1027,6 +1136,8 @@ NetworkManager was removed.
 </div> <!-- .container.boxed -->
 
 </div> <!-- #mainarea -->
-<script type="text/javascript">toggleLocalizationVisibility(null);</script>
+<script type="text/javascript">toggleLocalizationVisibility(null);
+
+</script>
 </body>
 </html>

--- a/0dyseus@SysmonitorByOrcus/files/0dyseus@SysmonitorByOrcus/applet.js
+++ b/0dyseus@SysmonitorByOrcus/files/0dyseus@SysmonitorByOrcus/applet.js
@@ -214,7 +214,13 @@ MyApplet.prototype = {
     },
 
     _bindSettings: function() {
-        let bD = Settings.BindingDirection || null;
+        // Needed for retro-compatibility.
+        // Mark for deletion on EOL.
+        let bD = {
+            IN: 1,
+            OUT: 2,
+            BIDIRECTIONAL: 3
+        };
         let settingsArray = [
             [bD.IN, "pref_align_tooltip_text_to_the_left", null],
             [bD.IN, "pref_custom_command", null],

--- a/0dyseus@SysmonitorByOrcus/files/0dyseus@SysmonitorByOrcus/metadata.json
+++ b/0dyseus@SysmonitorByOrcus/files/0dyseus@SysmonitorByOrcus/metadata.json
@@ -10,6 +10,6 @@
     "contributors": "See this xlet help file.",
     "uuid": "0dyseus@SysmonitorByOrcus",
     "comments": "Bug reports, feature requests and contributions should be done on this xlet's repository linked below.",
-    "version": "1.13",
+    "version": "1.14",
     "description": "Displays CPU, memory, swap, network usage and load in graphs."
 }

--- a/0dyseus@SysmonitorByOrcus/files/0dyseus@SysmonitorByOrcus/po/0dyseus@SysmonitorByOrcus.pot
+++ b/0dyseus@SysmonitorByOrcus/files/0dyseus@SysmonitorByOrcus/po/0dyseus@SysmonitorByOrcus.pot
@@ -5,8 +5,8 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 0dyseus@SysmonitorByOrcus 1.13\n"
-"POT-Creation-Date: 2017-06-02 17:05-0300\n"
+"Project-Id-Version: 0dyseus@SysmonitorByOrcus 1.14\n"
+"POT-Creation-Date: 2017-06-12 22:20-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -82,65 +82,65 @@ msgstr ""
 msgid "Restart Cinnamon after installing the packages for the applet to recognize them."
 msgstr ""
 
-#: ../../create_localized_help.py:114
-msgid "The following two sections are available only in English."
-msgstr ""
-
 #. TO TRANSLATORS: This is a placeholder.
 #. Here goes your language name in your own language (a.k.a. endonym).
-#: ../../create_localized_help.py:139 ../../create_localized_help.py:211
+#: ../../create_localized_help.py:143 ../../create_localized_help.py:219
 msgid "language-name"
 msgstr ""
 
-#: ../../create_localized_help.py:214 applet.js:343
+#: ../../create_localized_help.py:149
+msgid "The following two sections are available only in English."
+msgstr ""
+
+#: ../../create_localized_help.py:222 applet.js:349
 msgid "Help"
 msgstr ""
 
-#: ../../create_localized_help.py:215
+#: ../../create_localized_help.py:223
 msgid "Contributors"
 msgstr ""
 
-#: ../../create_localized_help.py:216
+#: ../../create_localized_help.py:224
 msgid "Changelog"
 msgstr ""
 
-#: ../../create_localized_help.py:217
+#: ../../create_localized_help.py:225
 msgid "Choose language"
 msgstr ""
 
 #. TO TRANSLATORS: Full sentence:
 #. "Help for <xlet_name>"
-#: ../../create_localized_help.py:218 ../../create_localized_help.py:225
+#: ../../create_localized_help.py:226 ../../create_localized_help.py:233
 #, python-format
 msgid "Help for %s"
 msgstr ""
 
-#: ../../create_localized_help.py:226
+#: ../../create_localized_help.py:234
 msgid "IMPORTANT!!!"
 msgstr ""
 
-#: ../../create_localized_help.py:227
+#: ../../create_localized_help.py:235
 msgid "Never delete any of the files found inside this xlet folder. It might break this xlet functionality."
 msgstr ""
 
-#: ../../create_localized_help.py:228
+#: ../../create_localized_help.py:236
 msgid "Bug reports, feature requests and contributions should be done on this xlet's repository linked next."
 msgstr ""
 
-#: ../../create_localized_help.py:234
+#: ../../create_localized_help.py:242
 msgid "Applets/Desklets/Extensions (a.k.a. xlets) localization"
 msgstr ""
 
-#: ../../create_localized_help.py:235
+#: ../../create_localized_help.py:243
 msgid "If this xlet was installed from Cinnamon Settings, all of this xlet's localizations were automatically installed."
 msgstr ""
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:237
+#: ../../create_localized_help.py:245
 msgid "If this xlet was installed manually and not trough Cinnamon Settings, localizations can be installed by executing the script called **localizations.sh** from a terminal opened inside the xlet's folder."
 msgstr ""
 
-#: ../../create_localized_help.py:238
+#: ../../create_localized_help.py:246
 msgid "If this xlet has no locale available for your language, you could create it by following the following instructions."
 msgstr ""
 
@@ -199,71 +199,119 @@ msgstr ""
 msgid "Bug reports, feature requests and contributions should be done on this xlet's repository linked below."
 msgstr ""
 
-#. 0dyseus@SysmonitorByOrcus->metadata.json->description
-msgid "Displays CPU, memory, swap, network usage and load in graphs."
-msgstr ""
-
 #. 0dyseus@SysmonitorByOrcus->metadata.json->name
 msgid "System Monitor (Fork By Odyseus)"
 msgstr ""
 
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_use_smooth_graphs->description
-msgid "Use smooth graphs"
+#. 0dyseus@SysmonitorByOrcus->metadata.json->description
+msgid "Displays CPU, memory, swap, network usage and load in graphs."
 msgstr ""
 
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head1->description
-msgid "CPU graph"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->demo-button1->tooltip
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->demo-button2->tooltip
-msgid "Restart Cinnamon"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->demo-button1->description
 #. 0dyseus@SysmonitorByOrcus->settings-schema.json->demo-button2->description
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->demo-button1->description
 msgid "To apply these settings, Cinnamon needs to be restarted. Click me!!!"
 msgstr ""
 
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head0->description
-msgid "General settings"
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->demo-button2->tooltip
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->demo-button1->tooltip
+msgid "Restart Cinnamon"
 msgstr ""
 
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head3->description
-msgid "Swap graph"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_network_graph_color_download->description
-msgid "Download:"
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_border_color->description
+msgid "Border color:"
 msgstr ""
 
 #. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_memory_graph_color_cached->description
 msgid "Cached:"
 msgstr ""
 
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_cpu_graph_color_kernel->description
-msgid "Kernel:"
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_cpu_graph_color_nice->description
+msgid "Nice:"
 msgstr ""
 
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head22->description
-msgid "Memory graph colors"
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_show_memmory_graph->description
+msgid "Show Memory graph:"
 msgstr ""
 
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_memory_graph_color_used->description
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_swap_graph_color_used->description
-msgid "Used:"
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_draw_background->description
+msgid "Draw graph background"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_refresh_rate->units
+msgid "milliseconds"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_refresh_rate->description
+msgid "Refresh rate:"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head1->description
+msgid "CPU graph"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_cpu_graph_color_iowait->description
+msgid "IOWait:"
 msgstr ""
 
 #. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_cpu_graph_color_user->description
 msgid "User:"
 msgstr ""
 
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_show_swap_graph->description
-msgid "Show Swap graph:"
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head33->description
+msgid "Swap graph colors"
 msgstr ""
 
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_cpu_graph_color_nice->description
-msgid "Nice:"
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_swap_graph_color_used->description
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_memory_graph_color_used->description
+msgid "Used:"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_network_graph_color_upload->description
+msgid "Upload:"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head55->description
+msgid "Load graph colors"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_draw_border->description
+msgid "Draw graph border"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_network_graph_color_download->description
+msgid "Download:"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_cpu_graph_width->units
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_swap_graph_width->units
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_memory_graph_width->units
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_network_graph_width->units
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_load_graph_width->units
+msgid "pixels"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_cpu_graph_width->description
+msgid "CPU graph width"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_swap_graph_width->description
+msgid "Swap graph width"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_cpu_graph_color_kernel->description
+msgid "Kernel:"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head0->description
+msgid "General settings"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head44->description
+msgid "Network graph colors"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_load_graph_color_load->description
+msgid "Load:"
 msgstr ""
 
 #. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_align_tooltip_text_to_the_left->tooltip
@@ -274,114 +322,66 @@ msgstr ""
 msgid "Align tooltip text to the left"
 msgstr ""
 
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_network_graph_width->description
-msgid "Network graph width"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_network_graph_width->units
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_swap_graph_width->units
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_cpu_graph_width->units
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_memory_graph_width->units
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_load_graph_width->units
-msgid "pixels"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head5->description
-msgid "Load graph"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_show_memmory_graph->description
-msgid "Show Memory graph:"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_swap_graph_width->description
-msgid "Swap graph width"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_show_load_graph->description
-msgid "Show Load graph:"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_show_network_graph->description
-msgid "Show Network graph:"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head11->description
-msgid "CPU graph colors"
-msgstr ""
-
 #. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_background_color->description
 msgid "Background color:"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_border_color->description
-msgid "Border color:"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head44->description
-msgid "Network graph colors"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head33->description
-msgid "Swap graph colors"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head2->description
-msgid "Memory graph"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_custom_command->description
-msgid "Custom command on applet click:"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_load_graph_color_load->description
-msgid "Load:"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_cpu_graph_width->description
-msgid "CPU graph width"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_refresh_rate->description
-msgid "Refresh rate:"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_refresh_rate->units
-msgid "milliseconds"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_cpu_graph_color_iowait->description
-msgid "IOWait:"
-msgstr ""
-
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_network_graph_color_upload->description
-msgid "Upload:"
 msgstr ""
 
 #. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_memory_graph_width->description
 msgid "Memory graph width"
 msgstr ""
 
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_draw_border->description
-msgid "Draw graph border"
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_show_load_graph->description
+msgid "Show Load graph:"
 msgstr ""
 
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_load_graph_width->description
-msgid "Load graph width"
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head22->description
+msgid "Memory graph colors"
 msgstr ""
 
 #. 0dyseus@SysmonitorByOrcus->settings-schema.json->head4->description
 msgid "Network graph"
 msgstr ""
 
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_use_smooth_graphs->description
+msgid "Use smooth graphs"
+msgstr ""
+
 #. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_show_cpu_graph->description
 msgid "Show CPU graph:"
 msgstr ""
 
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_draw_background->description
-msgid "Draw graph background"
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_show_network_graph->description
+msgid "Show Network graph:"
 msgstr ""
 
-#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head55->description
-msgid "Load graph colors"
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head2->description
+msgid "Memory graph"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_show_swap_graph->description
+msgid "Show Swap graph:"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head11->description
+msgid "CPU graph colors"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head5->description
+msgid "Load graph"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_network_graph_width->description
+msgid "Network graph width"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_custom_command->description
+msgid "Custom command on applet click:"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->head3->description
+msgid "Swap graph"
+msgstr ""
+
+#. 0dyseus@SysmonitorByOrcus->settings-schema.json->pref_load_graph_width->description
+msgid "Load graph width"
 msgstr ""


### PR DESCRIPTION
- Redesigned the creation of the help file to be "on-line friendly".
- Finally fixed the annoyance of having titles on the help files hidden behind the top navigation bar when clicking the navigation links (Help/Contributors/Changelog).
- Fixed the display of a translated sentence on the help files that was being displayed untranslated.
- Added smooth scrolling for the links on the navigation bar of the help files.
- Updated localization template, localizations and help file due to changes to the *help file creator* script.
- Added to the xlet README file links to the localized help file.
- Better handling of **Settings.BindingDirection**. Just to avoid surprises when that constant is removed on future versions of Cinnamon.