### PR TITLE
Custom Cinnamon Menu (0dyseus@CustomCinnamonMenu) update

### DIFF
--- a/0dyseus@CustomCinnamonMenu/README.md
+++ b/0dyseus@CustomCinnamonMenu/README.md
@@ -54,8 +54,6 @@ This applet is a custom version of the default Cinnamon Menu applet, but infinit
 
 ![Whisker menu](https://odyseus.github.io/CinnamonTools/lib/img/CustomCinnamonMenu-001.png "Whisker menu")
 
-[Contributors/Mentions](https://github.com/Odyseus/CinnamonTools/blob/master/applets/0dyseus%40CustomCinnamonMenu/CONTRIBUTORS.md)
-
-[Full change log](https://github.com/Odyseus/CinnamonTools/blob/master/applets/0dyseus%40CustomCinnamonMenu/CHANGELOG.md)
-
-[ToDo](https://github.com/Odyseus/CinnamonTools/blob/master/applets/0dyseus%40CustomCinnamonMenu/TODO)
+#### [Localized help](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@CustomCinnamonMenu.html)
+#### [Contributors/Mentions](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@CustomCinnamonMenu.html#xlet-contributors)
+#### [Full change log](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@CustomCinnamonMenu.html#xlet-changelog)

--- a/0dyseus@CustomCinnamonMenu/files/0dyseus@CustomCinnamonMenu/HELP.html
+++ b/0dyseus@CustomCinnamonMenu/files/0dyseus@CustomCinnamonMenu/HELP.html
@@ -12,6 +12,102 @@ exported toggleLocalizationVisibility
 
 /* jshint varstmt: false */
 
+// Source: https://github.com/julienetie/smooth-scroll
+(function(window, document) {
+    var prefixes = ['moz', 'webkit', 'o'],
+        animationFrame;
+
+    // Modern rAF prefixing without setTimeout
+    function requestAnimationFrameNative() {
+        prefixes.map(function(prefix) {
+            if (!window.requestAnimationFrame) {
+                animationFrame = window[prefix + 'RequestAnimationFrame'];
+            } else {
+                animationFrame = requestAnimationFrame;
+            }
+        });
+    }
+    requestAnimationFrameNative();
+
+    function getOffsetTop(el) {
+        if (!el) {
+            return 0;
+        }
+
+        var yOffset = el.offsetTop,
+            parent = el.offsetParent;
+
+        yOffset += getOffsetTop(parent);
+
+        return yOffset;
+    }
+
+    function getScrollTop(scrollable) {
+        return scrollable.scrollTop || document.body.scrollTop || document.documentElement.scrollTop;
+    }
+
+    function scrollTo(scrollable, coords, millisecondsToTake) {
+        var currentY = getScrollTop(scrollable),
+            diffY = coords.y - currentY,
+            startTimestamp = null;
+
+        if (coords.y === currentY || typeof scrollable.scrollTo !== 'function') {
+            return;
+        }
+
+        function doScroll(currentTimestamp) {
+            if (startTimestamp === null) {
+                startTimestamp = currentTimestamp;
+            }
+
+            var progress = currentTimestamp - startTimestamp,
+                fractionDone = (progress / millisecondsToTake),
+                pointOnSineWave = Math.sin(fractionDone * Math.PI / 2);
+            scrollable.scrollTo(0, currentY + (diffY * pointOnSineWave));
+
+            if (progress < millisecondsToTake) {
+                animationFrame(doScroll);
+            } else {
+                // Ensure we're at our destination
+                scrollable.scrollTo(coords.x, coords.y);
+            }
+        }
+
+        animationFrame(doScroll);
+    }
+
+    // Declaire scroll duration, (before script)
+    var speed = window.smoothScrollSpeed || 750;
+
+    function smoothScroll(e) { // no smooth scroll class to ignore links
+        if (e.target.className === 'no-ss') {
+            return;
+        }
+
+        var source = e.target,
+            targetHref = source.hash,
+            target = null;
+
+        if (!source || !targetHref) {
+            return;
+        }
+
+        targetHref = targetHref.substring(1);
+        target = document.getElementById(targetHref);
+        if (!target) {
+            return;
+        }
+
+        scrollTo(window, {
+            x: 0,
+            y: getOffsetTop(target)
+        }, speed);
+    }
+
+    // Uses target's hash for scroll
+    document.addEventListener('click', smoothScroll, false);
+}(window, document));
+
 if (!window.localStorage) {
     /*
     Storage objects are a recent addition to the standard. As such they may not be present
@@ -449,7 +545,7 @@ body {
 <noscript>
 <div class="alert alert-warning">
 <p><strong>Oh snap! This page needs JavaScript enabled to display correctly.</strong></p>
-<p><strong>This page uses JavaScript only to switch between the available languages.</strong></p>
+<p><strong>This page uses JavaScript only to switch between the available languages and/or display images.</strong></p>
 <p><strong>There are no tracking services of any kind and never will be (at least, not from my side).</strong></p>
 </div> <!-- .alert.alert-warning -->
 </noscript>
@@ -458,16 +554,16 @@ body {
     <div class="container-fluid">
     <div class="navbar-header">
         <ul class="nav navbar-nav">
-            <li><a id="nav-xlet-help" class="navbar-brand" href="#xlet-help"></a></li>
-            <li><a id="nav-xlet-contributors" class="navbar-brand" href="#xlet-contributors"></a></li>
-            <li><a id="nav-xlet-changelog" class="navbar-brand" href="#xlet-changelog"></a></li>
+            <li><a id="nav-xlet-help" class="js_smoothScroll navbar-brand" href="#xlet-help"></a></li>
+            <li><a id="nav-xlet-contributors" class="js_smoothScroll navbar-brand" href="#xlet-contributors"></a></li>
+            <li><a id="nav-xlet-changelog" class="js_smoothScroll navbar-brand" href="#xlet-changelog"></a></li>
         </ul>
     </div>
     <form class="navbar-form navbar-collapse collapse navbar-right">
         <div class="form-group">
             <label id="localization-chooser-label" class="control-label" for="localization-switch"></label>
             <select class="form-control input-sm" id="localization-switch" onchange="self.toggleLocalizationVisibility(value, this);">
-                <!-- Česky --><option data-title="Nápověda pro Custom Cinnamon Menu" data-language-chooser-label="Zvolte jazyk" data-xlet-help="Nápověda" data-xlet-contributors="Contributors" data-xlet-changelog="Changelog" value="cs">Česky</option>
+                <!-- Česky --><option data-title="Nápověda pro Custom Cinnamon Menu" data-language-chooser-label="Zvolte jazyk" data-xlet-help="Nápověda" data-xlet-contributors="Přispěvatelé" data-xlet-changelog="Changelog" value="cs">Česky</option>
 <!-- English --><option selected data-title="Help for Custom Cinnamon Menu" data-language-chooser-label="Choose language" data-xlet-help="Help" data-xlet-contributors="Contributors" data-xlet-changelog="Changelog" value="en">English</option>
 <!-- Español --><option data-title="Ayuda para Custom Cinnamon Menu" data-language-chooser-label="Elegir idioma" data-xlet-help="Ayuda" data-xlet-contributors="Colaboradores" data-xlet-changelog="Registro de cambios" value="es">Español</option>
 <!-- Svenska --><option data-title="Hjälp för Custom Cinnamon Menu" data-language-chooser-label="Välj språk" data-xlet-help="Hjälp" data-xlet-contributors="Medhjälpare" data-xlet-changelog="Ändringslogg" value="sv">Svenska</option>
@@ -477,7 +573,7 @@ body {
     </form>
     </div>
 </nav>
-<span id="xlet-help">
+<span id="xlet-help" style="padding-top:70px;">
 <div class="container boxed">
 
 <div id="zh_CN" class="localization-content hidden">
@@ -565,6 +661,7 @@ body {
 <li>如果该xlet没有您的语言的本地化，您可以按照以下说明进行创建。 <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">以下两个部分仅使用英语。</div>
 </div> <!-- .localization-content -->
 
 
@@ -653,6 +750,7 @@ body {
 <li>Si este xlet no está disponible en su idioma, la localización puede ser creada siguiendo las siguientes instrucciones. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Las siguientes dos secciones están disponibles sólo en Inglés.</div>
 </div> <!-- .localization-content -->
 
 
@@ -681,10 +779,10 @@ body {
 <li>Klávesa <kbd>Tab</kbd>:<ul>
 <li>Pokud je zaměřena oblast oblíbených položek, aplikací nebo kategorií, klávesa <kbd>Tab</kbd> změní zaostření na oblast uživatelských spouštěčů.</li>
 <li>Pokud je zaměřena oblast uživatelských spouštěčů, zaostření se vrátí zpět na oblast kategorií.</li>
-<li>Není-li oblast uživatelských spouštěčů součástí menu, stiskem klávesy <kbd>Tab</kbd> nebo kláves <kbd>Ctrl</kbd> / <kbd>Shift</kbd> + <kbd>Tab</kbd> se bude cyklicky přepínat mezi oblíbenými položkami, aplikacemi a kategoriemi. </li>
+<li>Není-li oblast uživatelských spouštěčů součástí menu, stiskem klávesy <kbd>Tab</kbd> nebo kláves <kbd>Ctrl</kbd> / <kbd>Shift</kbd> + [[Tab] se bude cyklicky přepínat mezi oblíbenými položkami, aplikacemi a kategoriemi. </li>
 </ul>
 </li>
-<li>Klávesy <kbd>Šipka nahoru</kbd> a <kbd>Šipka dolů</kbd>:<ul>
+<li>Klávesy <kbd>Šipka nahoru] a [[Šipka dolů</kbd>:<ul>
 <li>Pokud je zaměřena oblast oblíbených položek, aplikací nebo kategorií, budou tyto klávesy procházet položky v aktuálně zvýrazněném poli.</li>
 <li>Pokud je zaměřena oblast uživatelských spouštěčů, zaostření se vrátí zpět na oblast kategorií.</li>
 </ul>
@@ -741,6 +839,7 @@ body {
 <li>Pokud tento xlet nemá k dispozici překlad pro váš jazyk, můžete jej vytvořit podle následujících pokynů. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Následující dvě části jsou k dispozici pouze v angličtině.</div>
 </div> <!-- .localization-content -->
 
 
@@ -829,6 +928,7 @@ body {
 <li>Om ditt språk saknas i denna xlet, kan du översätta den med hjälp av följande instruktioner. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Följande två sektioner är endast tillgängliga på Engelska.</div>
 </div> <!-- .localization-content -->
 
 
@@ -917,11 +1017,11 @@ body {
 <li>If this xlet has no locale available for your language, you could create it by following the following instructions. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">The following two sections are available only in English.</div>
 </div> <!-- .localization-content -->
 
 </div> <!-- .container.boxed -->
-<div style="font-weight:bold;" class="container alert alert-info">The following two sections are available only in English.</div>
-<span id="xlet-contributors">
+<span id="xlet-contributors" style="padding-top:140px;">
 <div class="container boxed">
 <h2>Contributors/Mentions</h2>
 <ul>
@@ -937,10 +1037,29 @@ body {
 
 </div> <!-- .container.boxed -->
 
-<span id="xlet-changelog">
+<span id="xlet-changelog" style="padding-top:70px;">
 <div class="container boxed">
 <h2>Custom Cinnamon Menu changelog</h2>
 <h4>This change log is only valid for the version of the xlet hosted on <a href="https://github.com/Odyseus/CinnamonTools">its original repository</a></h4>
+<hr>
+<ul>
+<li><strong>Date:</strong> Thu, 8 Jun 2017 01:04:02 -0300</li>
+<li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/7681195">7681195</a></li>
+<li><strong>Author:</strong> Odyseus</li>
+</ul>
+<pre><code>Custom Cinnamon Menu applet
+- Updated Czech localization.
+</code></pre>
+<hr>
+<ul>
+<li><strong>Date:</strong> Tue, 6 Jun 2017 22:29:10 -0300</li>
+<li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/b2a628f">b2a628f</a></li>
+<li><strong>Author:</strong> Odyseus</li>
+</ul>
+<pre><code>Custom Cinnamon Menu applet
+- Better handling of **Settings.BindingDirection**. Just to avoid surprises when that constant is
+removed on future versions of Cinnamon.
+</code></pre>
 <hr>
 <ul>
 <li><strong>Date:</strong> Sun, 4 Jun 2017 19:24:26 +0800</li>
@@ -1583,6 +1702,8 @@ applications set as Favorite.
 </div> <!-- .container.boxed -->
 
 </div> <!-- #mainarea -->
-<script type="text/javascript">toggleLocalizationVisibility(null);</script>
+<script type="text/javascript">toggleLocalizationVisibility(null);
+
+</script>
 </body>
 </html>

--- a/0dyseus@CustomCinnamonMenu/files/0dyseus@CustomCinnamonMenu/applet.js
+++ b/0dyseus@CustomCinnamonMenu/files/0dyseus@CustomCinnamonMenu/applet.js
@@ -214,7 +214,13 @@ MyApplet.prototype = {
      * START mark Odyseus
      */
     _bindSettings: function() {
-        let bD = Settings.BindingDirection || null;
+        // Needed for retro-compatibility.
+        // Mark for deletion on EOL.
+        let bD = {
+            IN: 1,
+            OUT: 2,
+            BIDIRECTIONAL: 3
+        };
         let settingsArray = [
             [bD.BIDIRECTIONAL, "pref_hide_allapps_category", null],
             [bD.BIDIRECTIONAL, "pref_display_favorites_as_category_menu", null],

--- a/0dyseus@CustomCinnamonMenu/files/0dyseus@CustomCinnamonMenu/metadata.json
+++ b/0dyseus@CustomCinnamonMenu/files/0dyseus@CustomCinnamonMenu/metadata.json
@@ -6,7 +6,7 @@
     "max-instances": -1,
     "comments": "Bug reports, feature requests and contributions should be done on this xlet's repository linked below.",
     "name": "Custom Cinnamon Menu",
-    "version": "1.22",
+    "version": "1.23",
     "cinnamon-version": [
         "3.0",
         "3.2",

--- a/0dyseus@CustomCinnamonMenu/files/0dyseus@CustomCinnamonMenu/po/0dyseus@CustomCinnamonMenu.pot
+++ b/0dyseus@CustomCinnamonMenu/files/0dyseus@CustomCinnamonMenu/po/0dyseus@CustomCinnamonMenu.pot
@@ -5,8 +5,8 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 0dyseus@CustomCinnamonMenu 1.22\n"
-"POT-Creation-Date: 2017-06-02 17:05-0300\n"
+"Project-Id-Version: 0dyseus@CustomCinnamonMenu 1.23\n"
+"POT-Creation-Date: 2017-06-12 22:20-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -200,65 +200,65 @@ msgstr ""
 msgid "There is a folder named **icons** inside this applet directory. It contains several symbolic icons (most of them are from the Faenza icon theme) and each icon can be used directly by name (on a custom launcher, for example)."
 msgstr ""
 
-#: ../../create_localized_help.py:168
-msgid "The following two sections are available only in English."
-msgstr ""
-
 #. TO TRANSLATORS: This is a placeholder.
 #. Here goes your language name in your own language (a.k.a. endonym).
-#: ../../create_localized_help.py:193 ../../create_localized_help.py:265
+#: ../../create_localized_help.py:197 ../../create_localized_help.py:273
 msgid "language-name"
 msgstr ""
 
-#: ../../create_localized_help.py:268 applet.js:3254
+#: ../../create_localized_help.py:203
+msgid "The following two sections are available only in English."
+msgstr ""
+
+#: ../../create_localized_help.py:276 applet.js:3267
 msgid "Help"
 msgstr ""
 
-#: ../../create_localized_help.py:269
+#: ../../create_localized_help.py:277
 msgid "Contributors"
 msgstr ""
 
-#: ../../create_localized_help.py:270
+#: ../../create_localized_help.py:278
 msgid "Changelog"
 msgstr ""
 
-#: ../../create_localized_help.py:271
+#: ../../create_localized_help.py:279
 msgid "Choose language"
 msgstr ""
 
 #. TO TRANSLATORS: Full sentence:
 #. "Help for <xlet_name>"
-#: ../../create_localized_help.py:272 ../../create_localized_help.py:279
+#: ../../create_localized_help.py:280 ../../create_localized_help.py:287
 #, python-format
 msgid "Help for %s"
 msgstr ""
 
-#: ../../create_localized_help.py:280
+#: ../../create_localized_help.py:288
 msgid "IMPORTANT!!!"
 msgstr ""
 
-#: ../../create_localized_help.py:281
+#: ../../create_localized_help.py:289
 msgid "Never delete any of the files found inside this xlet folder. It might break this xlet functionality."
 msgstr ""
 
-#: ../../create_localized_help.py:282
+#: ../../create_localized_help.py:290
 msgid "Bug reports, feature requests and contributions should be done on this xlet's repository linked next."
 msgstr ""
 
-#: ../../create_localized_help.py:288
+#: ../../create_localized_help.py:296
 msgid "Applets/Desklets/Extensions (a.k.a. xlets) localization"
 msgstr ""
 
-#: ../../create_localized_help.py:289
+#: ../../create_localized_help.py:297
 msgid "If this xlet was installed from Cinnamon Settings, all of this xlet's localizations were automatically installed."
 msgstr ""
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:291
+#: ../../create_localized_help.py:299
 msgid "If this xlet was installed manually and not trough Cinnamon Settings, localizations can be installed by executing the script called **localizations.sh** from a terminal opened inside the xlet's folder."
 msgstr ""
 
-#: ../../create_localized_help.py:292
+#: ../../create_localized_help.py:300
 msgid "If this xlet has no locale available for your language, you could create it by following the following instructions."
 msgstr ""
 
@@ -417,271 +417,210 @@ msgstr ""
 msgid "Menu"
 msgstr ""
 
-#: applet.js:188 applet.js:565
+#: applet.js:188 applet.js:576
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
 
-#: applet.js:1816
+#: applet.js:1829
 msgid "This file is no longer available"
 msgstr ""
 
 #. NOTE: This string could be left blank because it's a default string,
 #. so it's already translated by Cinnamon. It's up to the translators.
-#: applet.js:1876
+#: applet.js:1889
 msgid "No recent documents"
 msgstr ""
 
-#: applet.js:2006
+#: applet.js:2019
 msgid "No recent applications"
 msgstr ""
 
-#: applet.js:2093
+#: applet.js:2106
 msgid "Favorites"
 msgstr ""
 
 #. NOTE: This string could be left blank because it's a default string,
 #. so it's already translated by Cinnamon. It's up to the translators.
-#: applet.js:2504 applet.js:3182
+#: applet.js:2517 applet.js:3195
 msgid "Lock screen"
 msgstr ""
 
 #. NOTE: This string could be left blank because it's a default string,
 #. so it's already translated by Cinnamon. It's up to the translators.
-#: applet.js:2507 applet.js:3181
+#: applet.js:2520 applet.js:3194
 msgid "Lock the screen"
 msgstr ""
 
 #. NOTE: This string could be left blank because it's a default string,
 #. so it's already translated by Cinnamon. It's up to the translators.
-#: applet.js:2538 applet.js:3213
+#: applet.js:2551 applet.js:3226
 msgid "Logout"
 msgstr ""
 
 #. NOTE: This string could be left blank because it's a default string,
 #. so it's already translated by Cinnamon. It's up to the translators.
-#: applet.js:2541 applet.js:3212
+#: applet.js:2554 applet.js:3225
 msgid "Leave the session"
 msgstr ""
 
 #. NOTE: This string could be left blank because it's a default string,
 #. so it's already translated by Cinnamon. It's up to the translators.
-#: applet.js:2559 applet.js:3231
+#: applet.js:2572 applet.js:3244
 msgid "Quit"
 msgstr ""
 
 #. NOTE: This string could be left blank because it's a default string,
 #. so it's already translated by Cinnamon. It's up to the translators.
-#: applet.js:2562 applet.js:3230
+#: applet.js:2575 applet.js:3243
 msgid "Shutdown the computer"
 msgstr ""
 
 #. NOTE: This string could be left blank because it's a default string,
 #. so it's already translated by Cinnamon. It's up to the translators.
-#: applet.js:2866
+#: applet.js:2879
 msgid "Type to search..."
 msgstr ""
 
 #. NOTE: This string could be left blank because it's a default string,
 #. so it's already translated by Cinnamon. It's up to the translators.
-#: applet.js:3249
+#: applet.js:3262
 msgid "Open the menu editor"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_command_9_icon->description
-#. 3.2->settings-schema.json->pref_command_2_icon->description
-#. 3.2->settings-schema.json->pref_command_10_icon->description
-#. 3.2->settings-schema.json->pref_command_7_icon->description
-#. 3.2->settings-schema.json->pref_command_1_icon->description
-#. 3.2->settings-schema.json->pref_command_8_icon->description
-#. 3.2->settings-schema.json->pref_command_3_icon->description
-#. 3.2->settings-schema.json->pref_command_5_icon->description
-#. 3.2->settings-schema.json->pref_command_6_icon->description
-#. 3.2->settings-schema.json->pref_command_4_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10_icon->description
-msgid "*Icon:"
+#. 3.2->settings-schema.json->pref_max_width_for_buttons->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_width_for_buttons->tooltip
+msgid "Define the maximum width of menu items inside the applications box."
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_command_5_command->description
-#. 3.2->settings-schema.json->pref_command_3_command->description
-#. 3.2->settings-schema.json->pref_command_4_command->description
-#. 3.2->settings-schema.json->pref_command_8_command->description
-#. 3.2->settings-schema.json->pref_command_1_command->description
-#. 3.2->settings-schema.json->pref_command_7_command->description
-#. 3.2->settings-schema.json->pref_command_2_command->description
-#. 3.2->settings-schema.json->pref_command_6_command->description
-#. 3.2->settings-schema.json->pref_command_9_command->description
-#. 3.2->settings-schema.json->pref_command_10_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9_command->description
-msgid "*Command or path to file:"
+#. 3.2->settings-schema.json->pref_max_width_for_buttons->units
+#. 3.2->settings-schema.json->pref_info_box_title_font_size->units
+#. 3.2->settings-schema.json->pref_info_box_description_font_size->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_description_font_size->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_title_font_size->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_width_for_buttons->units
+msgid "ems"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_show_lock_button->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_lock_button->description
-msgid "Show \"Lock screen\" button"
+#. 3.2->settings-schema.json->pref_max_width_for_buttons->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_width_for_buttons->description
+msgid "Maximum button width:"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_command_7_description->description
-#. 3.2->settings-schema.json->pref_command_8_description->description
-#. 3.2->settings-schema.json->pref_command_4_description->description
-#. 3.2->settings-schema.json->pref_command_2_description->description
-#. 3.2->settings-schema.json->pref_command_3_description->description
-#. 3.2->settings-schema.json->pref_command_1_description->description
-#. 3.2->settings-schema.json->pref_command_6_description->description
-#. 3.2->settings-schema.json->pref_command_10_description->description
-#. 3.2->settings-schema.json->pref_command_5_description->description
-#. 3.2->settings-schema.json->pref_command_9_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9_description->description
-msgid "Description:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_menu_layout_third_place->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->description
-msgid "Third place element"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
-#. 3.2->settings-schema.json->section_appearance_search_box->title
-#. 3.2->settings-schema.json->pref_menu_layout_first_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head4->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance4->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
-msgid "Search box"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
-#. 3.2->settings-schema.json->pref_appinfo_display_method->options
-#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_appinfo_display_method->options
-msgid "None"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_first_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
-msgid "Applications/Categories boxes"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_first_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance3->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
-msgid "Applications info box"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_first_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
-msgid "Custom Launchers box"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_category_icon_size->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_category_icon_size->description
-msgid "Categories icon size:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_category_icon_size->units
 #. 3.2->settings-schema.json->pref_search_box_padding_top->units
-#. 3.2->settings-schema.json->pref_search_entry_padding_right->units
-#. 3.2->settings-schema.json->pref_search_entry_padding_bottom->units
-#. 3.2->settings-schema.json->pref_search_entry_padding_left->units
-#. 3.2->settings-schema.json->pref_search_box_padding_bottom->units
-#. 3.2->settings-schema.json->pref_max_fav_icon_size->units
-#. 3.2->settings-schema.json->pref_custom_width_for_searchbox->units
-#. 3.2->settings-schema.json->pref_custom_command_box_padding_left->units
-#. 3.2->settings-schema.json->pref_custom_command_box_padding_right->units
-#. 3.2->settings-schema.json->pref_info_box_padding_right->units
-#. 3.2->settings-schema.json->pref_categories_box_padding_top->units
-#. 3.2->settings-schema.json->pref_application_icon_size->units
-#. 3.2->settings-schema.json->pref_categories_box_padding_left->units
-#. 3.2->settings-schema.json->pref_custom_command_box_padding_top->units
-#. 3.2->settings-schema.json->pref_info_box_padding_left->units
-#. 3.2->settings-schema.json->pref_search_box_padding_left->units
-#. 3.2->settings-schema.json->pref_search_box_padding_right->units
+#. 3.2->settings-schema.json->pref_search_entry_padding_top->units
 #. 3.2->settings-schema.json->pref_user_picture_size->units
 #. 3.2->settings-schema.json->pref_categories_box_padding_bottom->units
+#. 3.2->settings-schema.json->pref_category_icon_size->units
+#. 3.2->settings-schema.json->pref_search_entry_padding_right->units
+#. 3.2->settings-schema.json->pref_custom_width_for_searchbox->units
+#. 3.2->settings-schema.json->pref_custom_command_box_padding_top->units
+#. 3.2->settings-schema.json->pref_custom_command_box_padding_right->units
+#. 3.2->settings-schema.json->pref_application_icon_size->units
+#. 3.2->settings-schema.json->pref_search_entry_padding_left->units
 #. 3.2->settings-schema.json->pref_custom_command_box_padding_bottom->units
+#. 3.2->settings-schema.json->pref_search_box_padding_left->units
+#. 3.2->settings-schema.json->pref_max_fav_icon_size->units
+#. 3.2->settings-schema.json->pref_search_box_padding_right->units
+#. 3.2->settings-schema.json->pref_categories_box_padding_top->units
+#. 3.2->settings-schema.json->pref_info_box_padding_left->units
+#. 3.2->settings-schema.json->pref_categories_box_padding_left->units
+#. 3.2->settings-schema.json->pref_custom_command_box_padding_left->units
 #. 3.2->settings-schema.json->pref_categories_box_padding_right->units
 #. 3.2->settings-schema.json->pref_separator_heigth->units
-#. 3.2->settings-schema.json->pref_search_entry_padding_top->units
+#. 3.2->settings-schema.json->pref_search_entry_padding_bottom->units
+#. 3.2->settings-schema.json->pref_info_box_padding_right->units
+#. 3.2->settings-schema.json->pref_search_box_padding_bottom->units
 #. 3.2->settings-schema.json->pref_custom_command_icon_size->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_category_icon_size->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_left->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_width_for_searchbox->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_right->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_fav_icon_size->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_application_icon_size->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_top->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_top->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_left->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_bottom->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_left->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_right->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_separator_heigth->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_bottom->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_bottom->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_icon_size->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_padding_right->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_top->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_left->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_right->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_padding_left->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_top->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_right->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_bottom->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_padding_right->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_right->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_bottom->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_icon_size->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_top->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_size->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_top->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_right->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_width_for_searchbox->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_left->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_right->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_fav_icon_size->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_left->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_category_icon_size->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_application_icon_size->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_bottom->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_top->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_separator_heigth->units
 msgid "pixels"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_search_box_padding_top->description
+#. 3.2->settings-schema.json->pref_search_entry_padding_top->description
+#. 3.2->settings-schema.json->pref_custom_command_box_padding_top->description
+#. 3.2->settings-schema.json->pref_categories_box_padding_top->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_top->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_top->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_top->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_top->description
+msgid "Box top padding:"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_command_4_command->description
+#. 3.2->settings-schema.json->pref_command_3_command->description
+#. 3.2->settings-schema.json->pref_command_1_command->description
+#. 3.2->settings-schema.json->pref_command_9_command->description
+#. 3.2->settings-schema.json->pref_command_10_command->description
+#. 3.2->settings-schema.json->pref_command_2_command->description
+#. 3.2->settings-schema.json->pref_command_7_command->description
+#. 3.2->settings-schema.json->pref_command_5_command->description
+#. 3.2->settings-schema.json->pref_command_6_command->description
+#. 3.2->settings-schema.json->pref_command_8_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6_command->description
+msgid "*Command or path to file:"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_recent_apps_ignore_favorites->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recent_apps_ignore_favorites->tooltip
+msgid "If enabled, applications set as Favorite will not be stored in the \"Recent Applications\" category."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_recent_apps_ignore_favorites->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recent_apps_ignore_favorites->description
+msgid "Ignore Favorites"
+msgstr ""
+
+#. 3.2->settings-schema.json->custom_launchers_label->description
+msgid ""
+"Fields marked with asterisks (*) are mandatory. Otherwise, the button will not appear on the menu.\n"
+"Icons can be any icon name or path to an icon file (symbolic or full color).\n"
+"Commands can be any command (as entered in a terminal) or a path to a file.\n"
+"If the file is an executable script, an attempt to execute it will be made.\n"
+"Otherwise, the file will be opened with the systems handler for that file type."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_set_search_box_padding->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_search_box_padding->description
+msgid "Set a custom padding for the search box"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_info_box_title_font_size->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_title_font_size->description
+msgid "Applications info box title font size:"
 msgstr ""
 
 #. 3.2->settings-schema.json->pref_display_category_icons->tooltip
@@ -694,29 +633,62 @@ msgstr ""
 msgid "Show category icons"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_user_picture_placement->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->tooltip
-msgid "This option allows to display the user picture on the menu. Clicking on the picture will open \"Account details\". For the image to be shown, the applications info box also has to be displayed."
+#. 3.2->settings-schema.json->pref_display_favorites_as_category_menu->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_favorites_as_category_menu->description
+msgid "Display \"Favorites\" as a category menu"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_user_picture_placement->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->description
-msgid "User picture placement"
+#. 3.2->settings-schema.json->pref_max_recently_used_apps->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_recently_used_apps->units
+msgid "applications"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_user_picture_placement->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->options
-msgid "Right of applications info box"
+#. 3.2->settings-schema.json->pref_max_recently_used_apps->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_recently_used_apps->description
+msgid "Max recently used apps:"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_user_picture_placement->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->options
-msgid "Do not show"
+#. 3.2->settings-schema.json->pref_command_1_description->description
+#. 3.2->settings-schema.json->pref_command_4_description->description
+#. 3.2->settings-schema.json->pref_command_10_description->description
+#. 3.2->settings-schema.json->pref_command_9_description->description
+#. 3.2->settings-schema.json->pref_command_6_description->description
+#. 3.2->settings-schema.json->pref_command_7_description->description
+#. 3.2->settings-schema.json->pref_command_2_description->description
+#. 3.2->settings-schema.json->pref_command_8_description->description
+#. 3.2->settings-schema.json->pref_command_5_description->description
+#. 3.2->settings-schema.json->pref_command_3_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3_description->description
+msgid "Description:"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_user_picture_placement->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->options
-msgid "Left of applications info box"
+#. 3.2->settings-schema.json->pref_user_picture_size->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_size->description
+msgid "User picture size:"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_swap_categories_box->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_swap_categories_box->tooltip
+msgid "By default, the categories box is to the left of the applications list. With this option enabled, the categories box will be placed to the right of the applications list."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_swap_categories_box->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_swap_categories_box->description
+msgid "Swap categories box"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_set_categories_padding->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_categories_padding->description
+msgid "Set a custom padding for the Categories box"
 msgstr ""
 
 #. 3.2->settings-schema.json->pref_cat_select_on_hover->tooltip
@@ -729,38 +701,32 @@ msgstr ""
 msgid "Select categories on hover (EXPERIMENTAL)"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_search_box_padding_top->description
-#. 3.2->settings-schema.json->pref_categories_box_padding_top->description
-#. 3.2->settings-schema.json->pref_custom_command_box_padding_top->description
-#. 3.2->settings-schema.json->pref_search_entry_padding_top->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_top->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_top->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_top->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_top->description
-msgid "Box top padding:"
+#. 3.2->settings-schema.json->pref_command_5_icon->description
+#. 3.2->settings-schema.json->pref_command_9_icon->description
+#. 3.2->settings-schema.json->pref_command_10_icon->description
+#. 3.2->settings-schema.json->pref_command_3_icon->description
+#. 3.2->settings-schema.json->pref_command_7_icon->description
+#. 3.2->settings-schema.json->pref_command_2_icon->description
+#. 3.2->settings-schema.json->pref_command_6_icon->description
+#. 3.2->settings-schema.json->pref_command_8_icon->description
+#. 3.2->settings-schema.json->pref_command_1_icon->description
+#. 3.2->settings-schema.json->pref_command_4_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8_icon->description
+msgid "*Icon:"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_search_entry_padding_right->description
-#. 3.2->settings-schema.json->pref_custom_command_box_padding_right->description
-#. 3.2->settings-schema.json->pref_info_box_padding_right->description
-#. 3.2->settings-schema.json->pref_search_box_padding_right->description
-#. 3.2->settings-schema.json->pref_categories_box_padding_right->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_right->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_right->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_padding_right->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_right->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_right->description
-msgid "Box right padding:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_show_desktop_file_folder_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_desktop_file_folder_on_context->description
-msgid "Show \"Open .desktop file folder\" on context"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_cat_hover_delay->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_cat_hover_delay->description
-msgid "Category selection delay:"
+#. 3.2->settings-schema.json->pref_cat_hover_delay->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_cat_hover_delay->tooltip
+msgid "Delay between switching categories."
 msgstr ""
 
 #. 3.2->settings-schema.json->pref_cat_hover_delay->units
@@ -770,20 +736,50 @@ msgstr ""
 msgid "milliseconds"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_cat_hover_delay->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_cat_hover_delay->tooltip
-msgid "Delay between switching categories."
+#. 3.2->settings-schema.json->pref_cat_hover_delay->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_cat_hover_delay->description
+msgid "Category selection delay:"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_search_entry_padding_bottom->description
-#. 3.2->settings-schema.json->pref_search_box_padding_bottom->description
+#. 3.2->settings-schema.json->pref_show_logout_button->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_logout_button->description
+msgid "Show \"Logout\" button"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_info_box_description_font_size->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_description_font_size->description
+msgid "Applications info box description font size:"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_apps_info_box_alignment_to_the_left->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_apps_info_box_alignment_to_the_left->description
+msgid "Align application info box text to the left"
+msgstr ""
+
 #. 3.2->settings-schema.json->pref_categories_box_padding_bottom->description
 #. 3.2->settings-schema.json->pref_custom_command_box_padding_bottom->description
+#. 3.2->settings-schema.json->pref_search_entry_padding_bottom->description
+#. 3.2->settings-schema.json->pref_search_box_padding_bottom->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_bottom->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_bottom->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_bottom->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_bottom->description
 msgid "Box bottom padding:"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_category_icon_size->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_category_icon_size->description
+msgid "Categories icon size:"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_set_search_entry_padding->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_search_entry_padding->description
+msgid "Set a custom padding for the search entry box"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_show_bumblebee_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_bumblebee_on_context->description
+msgid "Show \"Run with NVIDIA GPU\" on context"
 msgstr ""
 
 #. 3.2->settings-schema.json->pref_fuzzy_search_enabled->tooltip
@@ -796,34 +792,60 @@ msgstr ""
 msgid "Enable fuzzy search (EXPERIMENTAL)"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_display_application_icons->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_application_icons->tooltip
-msgid "Choose whether or not to show icons on applications."
+#. 3.2->settings-schema.json->pref_search_entry_padding_right->description
+#. 3.2->settings-schema.json->pref_custom_command_box_padding_right->description
+#. 3.2->settings-schema.json->pref_search_box_padding_right->description
+#. 3.2->settings-schema.json->pref_categories_box_padding_right->description
+#. 3.2->settings-schema.json->pref_info_box_padding_right->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_right->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_padding_right->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_right->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_right->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_right->description
+msgid "Box right padding:"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_display_application_icons->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_application_icons->description
-msgid "Show application icons"
+#. 3.2->settings-schema.json->pref_custom_width_for_searchbox->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_width_for_searchbox->tooltip
+msgid "Set to 0 (zero) for not setting a width."
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_hide_allapps_category->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_hide_allapps_category->description
-msgid "Hide \"All Applications\" category"
+#. 3.2->settings-schema.json->pref_custom_width_for_searchbox->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_width_for_searchbox->description
+msgid "Custom width for search box:"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_autofit_searchbox_width->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_autofit_searchbox_width->tooltip
-msgid "If enabled, Custom width for search box will be ignored. Also, this option is ignored if the custom launchers box is placed at either side of the searchbox."
+#. 3.2->settings-schema.json->pref_command_5_label->description
+#. 3.2->settings-schema.json->pref_command_7_label->description
+#. 3.2->settings-schema.json->pref_command_9_label->description
+#. 3.2->settings-schema.json->pref_command_2_label->description
+#. 3.2->settings-schema.json->pref_command_8_label->description
+#. 3.2->settings-schema.json->pref_command_10_label->description
+#. 3.2->settings-schema.json->pref_command_6_label->description
+#. 3.2->settings-schema.json->pref_command_3_label->description
+#. 3.2->settings-schema.json->pref_command_4_label->description
+#. 3.2->settings-schema.json->pref_command_1_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4_label->description
+msgid "Label:"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_autofit_searchbox_width->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_autofit_searchbox_width->description
-msgid "Auto-fit the width of the search box with the menu width"
+#. 3.2->settings-schema.json->pref_menu_hover_delay->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_hover_delay->tooltip
+msgid "Delay before the menu is opened on entering the applet."
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_show_add_to_panel_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_add_to_panel_on_context->description
-msgid "Show \"Add to panel\" on context"
+#. 3.2->settings-schema.json->pref_menu_hover_delay->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_hover_delay->description
+msgid "Menu hover delay:"
 msgstr ""
 
 #. 3.2->settings-schema.json->pref_recently_used_apps_invert_order->tooltip
@@ -836,77 +858,93 @@ msgstr ""
 msgid "Invert recently used applications order"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_remember_recently_used_apps->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_remember_recently_used_apps->tooltip
+#. 3.2->settings-schema.json->pref_show_desktop_file_folder_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_desktop_file_folder_on_context->description
+msgid "Show \"Open .desktop file folder\" on context"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_custom_label_for_applet->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_label_for_applet->tooltip
+msgid "Enter custom text to show in the panel."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_custom_label_for_applet->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_label_for_applet->description
+msgid "Custom label"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_overlay_key->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_overlay_key->description
+msgid "Keyboard shortcut to open and close the menu"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_lock_button_custom_icon->tooltip
+#. 3.2->settings-schema.json->pref_shutdown_button_custom_icon->tooltip
+#. 3.2->settings-schema.json->pref_logout_button_custom_icon->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_shutdown_button_custom_icon->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_logout_button_custom_icon->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_lock_button_custom_icon->tooltip
 msgid ""
-"From the moment this option is enabled, every application launched from the menu will be stored and displayed in the \"Recent Applications\" category.\n"
-"Every time this option is disabled, the list of recently used applications will be cleared."
+"Only valid if the System buttons box is placed next to the Custom launchers box.\n"
+"Leave blank to use default."
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_remember_recently_used_apps->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_remember_recently_used_apps->description
-msgid "Show \"Recent Applications\" category"
+#. 3.2->settings-schema.json->pref_lock_button_custom_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_lock_button_custom_icon->description
+msgid "Custom icon for \"Lock screen\" button:"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_command_9_label->description
-#. 3.2->settings-schema.json->pref_command_10_label->description
-#. 3.2->settings-schema.json->pref_command_3_label->description
-#. 3.2->settings-schema.json->pref_command_4_label->description
-#. 3.2->settings-schema.json->pref_command_7_label->description
-#. 3.2->settings-schema.json->pref_command_8_label->description
-#. 3.2->settings-schema.json->pref_command_1_label->description
-#. 3.2->settings-schema.json->pref_command_5_label->description
-#. 3.2->settings-schema.json->pref_command_2_label->description
-#. 3.2->settings-schema.json->pref_command_6_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10_label->description
-msgid "Label:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_max_recently_used_apps->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_recently_used_apps->description
-msgid "Max recently used apps:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_max_recently_used_apps->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_recently_used_apps->units
-msgid "applications"
+#. 3.2->settings-schema.json->pref_application_icon_size->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_application_icon_size->description
+msgid "Applications icon size:"
 msgstr ""
 
 #. 3.2->settings-schema.json->pref_search_entry_padding_left->description
-#. 3.2->settings-schema.json->pref_custom_command_box_padding_left->description
-#. 3.2->settings-schema.json->pref_categories_box_padding_left->description
-#. 3.2->settings-schema.json->pref_info_box_padding_left->description
 #. 3.2->settings-schema.json->pref_search_box_padding_left->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_left->description
+#. 3.2->settings-schema.json->pref_info_box_padding_left->description
+#. 3.2->settings-schema.json->pref_categories_box_padding_left->description
+#. 3.2->settings-schema.json->pref_custom_command_box_padding_left->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_left->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_left->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_left->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_padding_left->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_left->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_left->description
 msgid "Box left padding:"
 msgstr ""
 
-#. 3.2->settings-schema.json->save_settings_button->description
-#. 3.2->settings-schema.json->section_save_button_minimal->title
-msgid "Save settings"
+#. 3.2->settings-schema.json->pref_user_picture_stylized->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_stylized->tooltip
+msgid "With this option enabled, the box containing the user picture will have the same style as the Favorites box."
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_show_logout_button->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_logout_button->description
-msgid "Show \"Logout\" button"
+#. 3.2->settings-schema.json->pref_user_picture_stylized->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_stylized->description
+msgid "Stylize the user image"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_set_search_entry_padding->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_search_entry_padding->description
-msgid "Set a custom padding for the search entry box"
+#. 3.2->settings-schema.json->pref_custom_commands_box_placement->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_placement->options
+msgid "On its own"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_custom_commands_box_placement->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_placement->options
+msgid "Right of search box"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_custom_commands_box_placement->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_placement->options
+msgid "Left of search box"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_custom_commands_box_placement->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_placement->description
+msgid "Custom launchers box placement"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_show_run_from_terminal_as_root_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_run_from_terminal_as_root_on_context->description
+msgid "Show \"Run from terminal as root\" on context"
 msgstr ""
 
 #. 3.2->settings-schema.json->pref_max_fav_icon_size->description
@@ -914,18 +952,103 @@ msgstr ""
 msgid "Favorites icon size:"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_info_box_title_font_size->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_title_font_size->description
-msgid "Applications info box title font size:"
+#. 3.2->settings-schema.json->pref_set_custom_box_padding->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_custom_box_padding->description
+msgid "Set a custom padding for the Custom launchers box"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_info_box_title_font_size->units
-#. 3.2->settings-schema.json->pref_max_width_for_buttons->units
-#. 3.2->settings-schema.json->pref_info_box_description_font_size->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_title_font_size->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_width_for_buttons->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_description_font_size->units
-msgid "ems"
+#. 3.2->settings-schema.json->pref_set_info_box_padding->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_info_box_padding->description
+msgid "Set a custom padding for the Applications info box"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_autofit_searchbox_width->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_autofit_searchbox_width->tooltip
+msgid "If enabled, Custom width for search box will be ignored. Also, this option is ignored if the custom launchers box is placed at either side of the searchbox."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_autofit_searchbox_width->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_autofit_searchbox_width->description
+msgid "Auto-fit the width of the search box with the menu width"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_shutdown_button_custom_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_shutdown_button_custom_icon->description
+msgid "Custom icon for \"Shutdown\" button:"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_first_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
+msgid "Applications/Categories boxes"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_first_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
+msgid "Custom Launchers box"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_first_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance3->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
+msgid "Applications info box"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
+#. 3.2->settings-schema.json->section_appearance_search_box->title
+#. 3.2->settings-schema.json->pref_menu_layout_first_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head4->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance4->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
+msgid "Search box"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
+#. 3.2->settings-schema.json->pref_appinfo_display_method->options
+#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_appinfo_display_method->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
+msgid "None"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_menu_layout_second_place->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->description
+msgid "Second place element"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_show_shutdown_button->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_shutdown_button->description
+msgid "Show \"Shutdown\" button"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_menu_layout_third_place->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->description
+msgid "Third place element"
 msgstr ""
 
 #. 3.2->settings-schema.json->pref_recently_used_apps_separator->tooltip
@@ -940,518 +1063,14 @@ msgstr ""
 msgid "Display separator after \"Recent Applications\" category (WARNING)"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_show_add_to_desktop_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_add_to_desktop_on_context->description
-msgid "Show \"Add to desktop\" on context"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_menu_hover_delay->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_hover_delay->description
-msgid "Menu hover delay:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_menu_hover_delay->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_hover_delay->tooltip
-msgid "Delay before the menu is opened on entering the applet."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_custom_width_for_searchbox->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_width_for_searchbox->description
-msgid "Custom width for search box:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_custom_width_for_searchbox->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_width_for_searchbox->tooltip
-msgid "Set to 0 (zero) for not setting a width."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_set_custom_box_padding->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_custom_box_padding->description
-msgid "Set a custom padding for the Custom launchers box"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_search_filesystem->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_filesystem->tooltip
-msgid "Allows path entry in the menu search box."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_search_filesystem->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_filesystem->description
-msgid "Enable file system path entry in search box"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_appinfo_display_method->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_appinfo_display_method->description
-msgid "Display method for information about applications:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_appinfo_display_method->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_appinfo_display_method->options
-msgid "Info box"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_appinfo_display_method->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_appinfo_display_method->options
-msgid "Tooltips"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_show_shutdown_button->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_shutdown_button->description
-msgid "Show \"Shutdown\" button"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_display_favorites_as_category_menu->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_favorites_as_category_menu->description
-msgid "Display \"Favorites\" as a category menu"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_animate_menu->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_animate_menu->description
-msgid "Animate open/close menu"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_show_add_remove_favorite_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_add_remove_favorite_on_context->description
-msgid "Show \"Add/Remove to/from favorites\" on context"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_application_icon_size->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_application_icon_size->description
-msgid "Applications icon size:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_max_recent_files->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_recent_files->description
-msgid "Max recent documents:"
-msgstr ""
-
 #. 3.2->settings-schema.json->pref_max_recent_files->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_recent_files->units
 msgid "documents"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_terminal_emulator->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_terminal_emulator->tooltip
-msgid ""
-"Choose the terminal emulator used by all launch from terminal options.\n"
-"IMPORTANT!!! The terminal emulator has to support the -e argument."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_terminal_emulator->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_terminal_emulator->description
-msgid "Terminal emulator:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_swap_categories_box->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_swap_categories_box->tooltip
-msgid "By default, the categories box is to the left of the applications list. With this option enabled, the categories box will be placed to the right of the applications list."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_swap_categories_box->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_swap_categories_box->description
-msgid "Swap categories box"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_show_run_from_terminal_as_root_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_run_from_terminal_as_root_on_context->description
-msgid "Show \"Run from terminal as root\" on context"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_use_a_custom_icon_for_applet->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_a_custom_icon_for_applet->tooltip
-msgid "Unchecking this allows the theme to set the icon"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_use_a_custom_icon_for_applet->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_a_custom_icon_for_applet->description
-msgid "Use a custom icon"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_show_places->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_places->tooltip
-msgid "Choose whether or not to show bookmarks and places in the menu."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_show_places->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_places->description
-msgid "Show bookmarks and places"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_shutdown_button_custom_icon->tooltip
-#. 3.2->settings-schema.json->pref_logout_button_custom_icon->tooltip
-#. 3.2->settings-schema.json->pref_lock_button_custom_icon->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_lock_button_custom_icon->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_shutdown_button_custom_icon->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_logout_button_custom_icon->tooltip
-msgid ""
-"Only valid if the System buttons box is placed next to the Custom launchers box.\n"
-"Leave blank to use default."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_shutdown_button_custom_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_shutdown_button_custom_icon->description
-msgid "Custom icon for \"Shutdown\" button:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_logout_button_custom_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_logout_button_custom_icon->description
-msgid "Custom icon for \"Logout\" button:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_max_width_for_buttons->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_width_for_buttons->description
-msgid "Maximum button width:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_max_width_for_buttons->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_width_for_buttons->tooltip
-msgid "Define the maximum width of menu items inside the applications box."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->description
-msgid "Fourth place element"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_show_run_as_root_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_run_as_root_on_context->description
-msgid "Show \"Run as root\" on context"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_show_icons_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_icons_on_context->description
-msgid "Show icons on context menu"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_menu_layout_second_place->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->description
-msgid "Second place element"
-msgstr ""
-
-#. 3.2->settings-schema.json->custom_padding_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance7->description
-msgid ""
-"Note: Most themes stylesheets come with hardcoded sizes for certain elemets.\n"
-"This section is for overriding those stylesheets."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_show_recents_button->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_recents_button->tooltip
-msgid "For people who want the \"Recent documents\" category hidden without disabling recent documents globally."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_show_recents_button->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_recents_button->description
-msgid "Show \"Recent documents\" category"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_custom_icon_for_applet->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_icon_for_applet->description
-msgid "Icon"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_custom_icon_for_applet->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_icon_for_applet->tooltip
-msgid "Select an icon to show in the panel."
-msgstr ""
-
-#. 3.2->settings-schema.json->custom_launchers_label->description
-msgid ""
-"Fields marked with asterisks (*) are mandatory. Otherwise, the button will not appear on the menu.\n"
-"Icons can be any icon name or path to an icon file (symbolic or full color).\n"
-"Commands can be any command (as entered in a terminal) or a path to a file.\n"
-"If the file is an executable script, an attempt to execute it will be made.\n"
-"Otherwise, the file will be opened with the systems handler for that file type."
-msgstr ""
-
-#. 3.2->settings-schema.json->section_save_button_full->title
-msgid ""
-"Most settings are not automatically saved when modified.\n"
-"Press any of the \"Save settings\" buttons for the settings to take effect."
-msgstr ""
-
-#. 3.2->settings-schema.json->section_appearance_favorites_box->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance5->description
-msgid "Favorites box"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_custom_launchers_008->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8->description
-msgid "Custom launcher 8"
-msgstr ""
-
-#. 3.2->settings-schema.json->page_layout->title
-msgid "Layout"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_context_menus_settings->title
-msgid "Context menus settings"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_custom_launchers_006->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6->description
-msgid "Custom launcher 6"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_appearance_applicatons_box->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance6->description
-msgid "Applications box"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_quit_buttons_settings->title
-msgid "Quit buttons settings"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_applet_settings->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head0->description
-msgid "Applet settings"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_custom_launchers_005->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5->description
-msgid "Custom launcher 5"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_layout_002->title
-msgid "Placement on main elements on menu"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_appearance_icons_display->title
-msgid "Icons display"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_appearance_info_box->title
-msgid "Application info box"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_recently_used_applications_settings->title
-msgid "Recently used applications settings"
-msgstr ""
-
-#. 3.2->settings-schema.json->page_appearance->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance1->description
-msgid "Appearance"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_menu_settings->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head1->description
-msgid "Menu settings"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_custom_launchers_009->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9->description
-msgid "Custom launcher 9"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_custom_launchers_004->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4->description
-msgid "Custom launcher 4"
-msgstr ""
-
-#. 3.2->settings-schema.json->page_custom_launchers->title
-msgid "Custom Launchers"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_appearance_icon_sizes->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance2->description
-msgid "Icon sizes"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_custom_launchers_000_bis->title
-msgid "Custom launchers notes"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_search_box_settings->title
-msgid "Search box settings"
-msgstr ""
-
-#. 3.2->settings-schema.json->page_extras->title
-msgid "Extras"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_custom_launchers_003->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3->description
-msgid "Custom launcher 3"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_layout_001->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head2->description
-msgid "Menu layout"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_custom_launchers_007->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7->description
-msgid "Custom launcher 7"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_appearance_boxes_padding->title
-msgid "Theme overrides"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_custom_launchers_001->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1->description
-msgid "Custom launcher 1"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_custom_launchers_002->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2->description
-msgid "Custom launcher 2"
-msgstr ""
-
-#. 3.2->settings-schema.json->page_applet->title
-msgid "Applet"
-msgstr ""
-
-#. 3.2->settings-schema.json->section_custom_launchers_010->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10->description
-msgid "Custom launcher 10"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_custom_label_for_applet->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_label_for_applet->tooltip
-msgid "Enter custom text to show in the panel."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_custom_label_for_applet->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_label_for_applet->description
-msgid "Custom label"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_privilege_elevator->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_privilege_elevator->tooltip
-msgid ""
-"The graphical front-end to use to run applications as root.\n"
-"This is used by the \"Open as Root\" context menu and the option \"Gain privileges of not owned files\"."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_privilege_elevator->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_privilege_elevator->description
-msgid "Privileges elevator:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_privilege_elevator->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_privilege_elevator->options
-msgid "gksu"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_privilege_elevator->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_privilege_elevator->options
-msgid "gksudo"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_set_categories_padding->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_categories_padding->description
-msgid "Set a custom padding for the Categories box"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_custom_commands_box_placement->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_placement->description
-msgid "Custom launchers box placement"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_custom_commands_box_placement->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_placement->options
-msgid "Left of search box"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_custom_commands_box_placement->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_placement->options
-msgid "Right of search box"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_custom_commands_box_placement->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_placement->options
-msgid "On its own"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_show_run_from_terminal_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_run_from_terminal_on_context->description
-msgid "Show \"Run from terminal\" on context"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_recent_apps_ignore_favorites->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recent_apps_ignore_favorites->tooltip
-msgid "If enabled, applications set as Favorite will not be stored in the \"Recent Applications\" category."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_recent_apps_ignore_favorites->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recent_apps_ignore_favorites->description
-msgid "Ignore Favorites"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_set_search_box_padding->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_search_box_padding->description
-msgid "Set a custom padding for the search box"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_hide_applications_list_scrollbar->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_hide_applications_list_scrollbar->description
-msgid "Hide applications list scrollbar"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_open_menu_on_hover->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_open_menu_on_hover->tooltip
-msgid "Enable opening the menu when the mouse enters the applet."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_open_menu_on_hover->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_open_menu_on_hover->description
-msgid "Open the menu on mouse over"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_info_box_description_font_size->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_description_font_size->description
-msgid "Applications info box description font size:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_disable_new_apps_highlighting->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_disable_new_apps_highlighting->description
-msgid "Disable newly installed applications highlighting"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_user_picture_size->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_size->description
-msgid "User picture size:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_use_alternate_vector_box->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_alternate_vector_box->tooltip
-msgid "With this option enabled, an alternate method to select categories will be used. This method can improve the performance of the menu and is extracted from the applet called Configurable Menu by lestcape."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_use_alternate_vector_box->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_alternate_vector_box->description
-msgid "Use alternate category selection method (EXPERIMENTAL)"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_enable_autoscroll->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_enable_autoscroll->tooltip
-msgid "Choose whether or not to enable smooth auto-scrolling in the application list."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_enable_autoscroll->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_enable_autoscroll->description
-msgid "Enable auto-scrolling in application list"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_separator_heigth->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_separator_heigth->description
-msgid "Favorites box separator height:"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_separator_heigth->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_separator_heigth->tooltip
-msgid "Size of separator between \"Favorites\" box and \"Quit\" box."
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_overlay_key->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_overlay_key->description
-msgid "Keyboard shortcut to open and close the menu"
-msgstr ""
-
-#. 3.2->settings-schema.json->pref_set_info_box_padding->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_info_box_padding->description
-msgid "Set a custom padding for the Applications info box"
+#. 3.2->settings-schema.json->pref_max_recent_files->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_recent_files->description
+msgid "Max recent documents:"
 msgstr ""
 
 #. 3.2->settings-schema.json->pref_display_fav_box->tooltip
@@ -1464,39 +1083,297 @@ msgstr ""
 msgid "Show favorites and quit options"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_show_bumblebee_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_bumblebee_on_context->description
-msgid "Show \"Run with NVIDIA GPU\" on context"
+#. 3.2->settings-schema.json->pref_privilege_elevator->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_privilege_elevator->tooltip
+msgid ""
+"The graphical front-end to use to run applications as root.\n"
+"This is used by the \"Open as Root\" context menu and the option \"Gain privileges of not owned files\"."
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_system_buttons_display->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_system_buttons_display->description
-msgid "Quit buttons placement"
+#. 3.2->settings-schema.json->pref_privilege_elevator->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_privilege_elevator->options
+msgid "gksu"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_system_buttons_display->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_system_buttons_display->options
-msgid "Next to \"Custom launchers\" box"
+#. 3.2->settings-schema.json->pref_privilege_elevator->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_privilege_elevator->options
+msgid "gksudo"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_system_buttons_display->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_system_buttons_display->options
-msgid "Hide all"
+#. 3.2->settings-schema.json->pref_privilege_elevator->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_privilege_elevator->description
+msgid "Privileges elevator:"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_system_buttons_display->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_system_buttons_display->options
-msgid "Inside \"Favorites\" box"
+#. 3.2->settings-schema.json->pref_show_uninstall_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_uninstall_on_context->description
+msgid "Show \"Uninstall\" on context"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_show_edit_desktop_file_on_context->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_edit_desktop_file_on_context->tooltip
-msgid "It adds to the applications context menu an entry that will allow you to open the current selected application's .desktop file in a text editor."
+#. 3.2->settings-schema.json->pref_show_recents_button->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_recents_button->tooltip
+msgid "For people who want the \"Recent documents\" category hidden without disabling recent documents globally."
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_show_edit_desktop_file_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_edit_desktop_file_on_context->description
-msgid "Show \"Edit .desktop file\" on context"
+#. 3.2->settings-schema.json->pref_show_recents_button->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_recents_button->description
+msgid "Show \"Recent documents\" category"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_logout_button_custom_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_logout_button_custom_icon->description
+msgid "Custom icon for \"Logout\" button:"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_remember_recently_used_apps->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_remember_recently_used_apps->tooltip
+msgid ""
+"From the moment this option is enabled, every application launched from the menu will be stored and displayed in the \"Recent Applications\" category.\n"
+"Every time this option is disabled, the list of recently used applications will be cleared."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_remember_recently_used_apps->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_remember_recently_used_apps->description
+msgid "Show \"Recent Applications\" category"
+msgstr ""
+
+#. 3.2->settings-schema.json->save_settings_button->description
+#. 3.2->settings-schema.json->section_save_button_minimal->title
+msgid "Save settings"
+msgstr ""
+
+#. 3.2->settings-schema.json->custom_padding_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance7->description
+msgid ""
+"Note: Most themes stylesheets come with hardcoded sizes for certain elemets.\n"
+"This section is for overriding those stylesheets."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_use_hover_feedback->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_hover_feedback->tooltip
+msgid "If enabled, and the user picture is shown, every time an application/favorite/place/recent file is hovered or selected with keyboard navigation, its icon will be displayed where the user picture is located."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_use_hover_feedback->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_hover_feedback->description
+msgid "Use hover feedback"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_custom_icon_for_applet->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_icon_for_applet->tooltip
+msgid "Select an icon to show in the panel."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_custom_icon_for_applet->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_icon_for_applet->description
+msgid "Icon"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_recently_used_apps_custom_icon->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recently_used_apps_custom_icon->tooltip
+msgid ""
+"Enter custom icon for the \"Recent Applications\" category.\n"
+"Only icon names are allowed."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_recently_used_apps_custom_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recently_used_apps_custom_icon->description
+msgid "Custom icon for category"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_open_menu_on_hover->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_open_menu_on_hover->tooltip
+msgid "Enable opening the menu when the mouse enters the applet."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_open_menu_on_hover->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_open_menu_on_hover->description
+msgid "Open the menu on mouse over"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_custom_editor_for_edit_desktop_file_on_context->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_editor_for_edit_desktop_file_on_context->tooltip
+msgid ""
+"Set a custom text editor to open .desktop files (just the name of the text editor executable or the path to it).\n"
+"Leave it blank to let the system decide."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_custom_editor_for_edit_desktop_file_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_editor_for_edit_desktop_file_on_context->description
+msgid "Custom text editor:"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_appinfo_display_method->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_appinfo_display_method->options
+msgid "Info box"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_appinfo_display_method->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_appinfo_display_method->options
+msgid "Tooltips"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_appinfo_display_method->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_appinfo_display_method->description
+msgid "Display method for information about applications:"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_custom_launchers_005->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5->description
+msgid "Custom launcher 5"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_layout_001->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head2->description
+msgid "Menu layout"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_custom_launchers_006->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6->description
+msgid "Custom launcher 6"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_custom_launchers_002->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2->description
+msgid "Custom launcher 2"
+msgstr ""
+
+#. 3.2->settings-schema.json->page_layout->title
+msgid "Layout"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_applet_settings->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head0->description
+msgid "Applet settings"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_custom_launchers_008->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8->description
+msgid "Custom launcher 8"
+msgstr ""
+
+#. 3.2->settings-schema.json->page_applet->title
+msgid "Applet"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_custom_launchers_004->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4->description
+msgid "Custom launcher 4"
+msgstr ""
+
+#. 3.2->settings-schema.json->page_custom_launchers->title
+msgid "Custom Launchers"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_recently_used_applications_settings->title
+msgid "Recently used applications settings"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_context_menus_settings->title
+msgid "Context menus settings"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_custom_launchers_001->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1->description
+msgid "Custom launcher 1"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_search_box_settings->title
+msgid "Search box settings"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_appearance_boxes_padding->title
+msgid "Theme overrides"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_quit_buttons_settings->title
+msgid "Quit buttons settings"
+msgstr ""
+
+#. 3.2->settings-schema.json->page_extras->title
+msgid "Extras"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_custom_launchers_003->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3->description
+msgid "Custom launcher 3"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_appearance_icon_sizes->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance2->description
+msgid "Icon sizes"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_custom_launchers_009->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9->description
+msgid "Custom launcher 9"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_layout_002->title
+msgid "Placement on main elements on menu"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_appearance_applicatons_box->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance6->description
+msgid "Applications box"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_appearance_favorites_box->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance5->description
+msgid "Favorites box"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_menu_settings->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head1->description
+msgid "Menu settings"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_custom_launchers_010->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10->description
+msgid "Custom launcher 10"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_appearance_icons_display->title
+msgid "Icons display"
+msgstr ""
+
+#. 3.2->settings-schema.json->page_appearance->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance1->description
+msgid "Appearance"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_custom_launchers_007->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7->description
+msgid "Custom launcher 7"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_custom_launchers_000_bis->title
+msgid "Custom launchers notes"
+msgstr ""
+
+#. 3.2->settings-schema.json->section_save_button_full->title
+msgid ""
+"Most settings are not automatically saved when modified.\n"
+"Press any of the \"Save settings\" buttons for the settings to take effect."
+msgstr ""
+
+#. 3.2->settings-schema.json->section_appearance_info_box->title
+msgid "Application info box"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_use_a_custom_icon_for_applet->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_a_custom_icon_for_applet->tooltip
+msgid "Unchecking this allows the theme to set the icon"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_use_a_custom_icon_for_applet->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_a_custom_icon_for_applet->description
+msgid "Use a custom icon"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_show_icons_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_icons_on_context->description
+msgid "Show icons on context menu"
 msgstr ""
 
 #. 3.2->settings-schema.json->pref_gain_privileges_on_context->tooltip
@@ -1512,63 +1389,126 @@ msgstr ""
 msgid "Gain privileges of not owned files"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_user_picture_stylized->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_stylized->tooltip
-msgid "With this option enabled, the box containing the user picture will have the same style as the Favorites box."
+#. 3.2->settings-schema.json->pref_user_picture_placement->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->tooltip
+msgid "This option allows to display the user picture on the menu. Clicking on the picture will open \"Account details\". For the image to be shown, the applications info box also has to be displayed."
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_user_picture_stylized->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_stylized->description
-msgid "Stylize the user image"
+#. 3.2->settings-schema.json->pref_user_picture_placement->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->options
+msgid "Right of applications info box"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_show_uninstall_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_uninstall_on_context->description
-msgid "Show \"Uninstall\" on context"
+#. 3.2->settings-schema.json->pref_user_picture_placement->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->options
+msgid "Left of applications info box"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_recently_used_apps_custom_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recently_used_apps_custom_icon->description
-msgid "Custom icon for category"
+#. 3.2->settings-schema.json->pref_user_picture_placement->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->options
+msgid "Do not show"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_recently_used_apps_custom_icon->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recently_used_apps_custom_icon->tooltip
+#. 3.2->settings-schema.json->pref_user_picture_placement->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->description
+msgid "User picture placement"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_show_add_to_desktop_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_add_to_desktop_on_context->description
+msgid "Show \"Add to desktop\" on context"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_show_run_from_terminal_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_run_from_terminal_on_context->description
+msgid "Show \"Run from terminal\" on context"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_show_add_remove_favorite_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_add_remove_favorite_on_context->description
+msgid "Show \"Add/Remove to/from favorites\" on context"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_show_lock_button->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_lock_button->description
+msgid "Show \"Lock screen\" button"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_system_buttons_display->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_system_buttons_display->options
+msgid "Hide all"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_system_buttons_display->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_system_buttons_display->options
+msgid "Inside \"Favorites\" box"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_system_buttons_display->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_system_buttons_display->options
+msgid "Next to \"Custom launchers\" box"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_system_buttons_display->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_system_buttons_display->description
+msgid "Quit buttons placement"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_show_edit_desktop_file_on_context->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_edit_desktop_file_on_context->tooltip
+msgid "It adds to the applications context menu an entry that will allow you to open the current selected application's .desktop file in a text editor."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_show_edit_desktop_file_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_edit_desktop_file_on_context->description
+msgid "Show \"Edit .desktop file\" on context"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_terminal_emulator->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_terminal_emulator->tooltip
 msgid ""
-"Enter custom icon for the \"Recent Applications\" category.\n"
-"Only icon names are allowed."
+"Choose the terminal emulator used by all launch from terminal options.\n"
+"IMPORTANT!!! The terminal emulator has to support the -e argument."
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_use_hover_feedback->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_hover_feedback->tooltip
-msgid "If enabled, and the user picture is shown, every time an application/favorite/place/recent file is hovered or selected with keyboard navigation, its icon will be displayed where the user picture is located."
+#. 3.2->settings-schema.json->pref_terminal_emulator->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_terminal_emulator->description
+msgid "Terminal emulator:"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_use_hover_feedback->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_hover_feedback->description
-msgid "Use hover feedback"
+#. 3.2->settings-schema.json->pref_menu_layout_first_place->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->description
+msgid "First place element"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_custom_editor_for_edit_desktop_file_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_editor_for_edit_desktop_file_on_context->description
-msgid "Custom text editor:"
+#. 3.2->settings-schema.json->pref_show_add_to_panel_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_add_to_panel_on_context->description
+msgid "Show \"Add to panel\" on context"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_custom_editor_for_edit_desktop_file_on_context->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_editor_for_edit_desktop_file_on_context->tooltip
-msgid ""
-"Set a custom text editor to open .desktop files (just the name of the text editor executable or the path to it).\n"
-"Leave it blank to let the system decide."
+#. 3.2->settings-schema.json->pref_show_places->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_places->tooltip
+msgid "Choose whether or not to show bookmarks and places in the menu."
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_custom_commands_box_alignment->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_alignment->description
-msgid "Custom launchers buttons alignment"
+#. 3.2->settings-schema.json->pref_show_places->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_places->description
+msgid "Show bookmarks and places"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_custom_commands_box_alignment->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_alignment->options
-msgid "Left"
+#. 3.2->settings-schema.json->pref_animate_menu->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_animate_menu->description
+msgid "Animate open/close menu"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_use_alternate_vector_box->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_alternate_vector_box->tooltip
+msgid "With this option enabled, an alternate method to select categories will be used. This method can improve the performance of the menu and is extracted from the applet called Configurable Menu by lestcape."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_use_alternate_vector_box->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_alternate_vector_box->description
+msgid "Use alternate category selection method (EXPERIMENTAL)"
 msgstr ""
 
 #. 3.2->settings-schema.json->pref_custom_commands_box_alignment->options
@@ -1578,27 +1518,95 @@ msgstr ""
 
 #. 3.2->settings-schema.json->pref_custom_commands_box_alignment->options
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_alignment->options
+msgid "Left"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_custom_commands_box_alignment->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_alignment->options
 msgid "Right"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_lock_button_custom_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_lock_button_custom_icon->description
-msgid "Custom icon for \"Lock screen\" button:"
+#. 3.2->settings-schema.json->pref_custom_commands_box_alignment->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_alignment->description
+msgid "Custom launchers buttons alignment"
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_apps_info_box_alignment_to_the_left->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_apps_info_box_alignment_to_the_left->description
-msgid "Align application info box text to the left"
+#. 3.2->settings-schema.json->pref_separator_heigth->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_separator_heigth->tooltip
+msgid "Size of separator between \"Favorites\" box and \"Quit\" box."
 msgstr ""
 
-#. 3.2->settings-schema.json->pref_menu_layout_first_place->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->description
-msgid "First place element"
+#. 3.2->settings-schema.json->pref_separator_heigth->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_separator_heigth->description
+msgid "Favorites box separator height:"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_hide_allapps_category->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_hide_allapps_category->description
+msgid "Hide \"All Applications\" category"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_show_run_as_root_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_run_as_root_on_context->description
+msgid "Show \"Run as root\" on context"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_enable_autoscroll->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_enable_autoscroll->tooltip
+msgid "Choose whether or not to enable smooth auto-scrolling in the application list."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_enable_autoscroll->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_enable_autoscroll->description
+msgid "Enable auto-scrolling in application list"
 msgstr ""
 
 #. 3.2->settings-schema.json->pref_custom_command_icon_size->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_icon_size->description
 msgid "Custom launchers icon size:"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_search_filesystem->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_filesystem->tooltip
+msgid "Allows path entry in the menu search box."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_search_filesystem->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_filesystem->description
+msgid "Enable file system path entry in search box"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_display_application_icons->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_application_icons->tooltip
+msgid "Choose whether or not to show icons on applications."
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_display_application_icons->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_application_icons->description
+msgid "Show application icons"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_disable_new_apps_highlighting->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_disable_new_apps_highlighting->description
+msgid "Disable newly installed applications highlighting"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_hide_applications_list_scrollbar->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_hide_applications_list_scrollbar->description
+msgid "Hide applications list scrollbar"
+msgstr ""
+
+#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->description
+msgid "Fourth place element"
+msgstr ""
+
+#. 0dyseus@CustomCinnamonMenu->metadata.json->contributors
+msgid "See this xlet help file."
+msgstr ""
+
+#. 0dyseus@CustomCinnamonMenu->metadata.json->comments
+msgid "Bug reports, feature requests and contributions should be done on this xlet's repository linked below."
 msgstr ""
 
 #. 0dyseus@CustomCinnamonMenu->metadata.json->description
@@ -1609,22 +1617,10 @@ msgstr ""
 msgid "Custom Cinnamon Menu"
 msgstr ""
 
-#. 0dyseus@CustomCinnamonMenu->metadata.json->comments
-msgid "Bug reports, feature requests and contributions should be done on this xlet's repository linked below."
-msgstr ""
-
-#. 0dyseus@CustomCinnamonMenu->metadata.json->contributors
-msgid "See this xlet help file."
-msgstr ""
-
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head7->description
-msgid "Custom launchers"
-msgstr ""
-
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->button2->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->button4->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->button1->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->button3->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->button1->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->button4->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->button0->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->button5->description
 msgid "Click here to save settings"
@@ -1640,14 +1636,16 @@ msgid ""
 "Otherwise, the file will be opened with the systems handler for that file type."
 msgstr ""
 
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head5->description
-msgid "Applications context menu extras"
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head7->description
+msgid "Custom launchers"
 msgstr ""
 
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head->description
-msgid ""
-"Most settings are not automatically saved when modified.\n"
-"Press any of the \"Click here to save settings\" buttons for the settings to take effect."
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head6->description
+msgid "Recently used applications"
+msgstr ""
+
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head5->description
+msgid "Applications context menu extras"
 msgstr ""
 
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->head3->description
@@ -1658,6 +1656,8 @@ msgstr ""
 msgid "Placement of main elements on menu"
 msgstr ""
 
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head6->description
-msgid "Recently used applications"
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head->description
+msgid ""
+"Most settings are not automatically saved when modified.\n"
+"Press any of the \"Click here to save settings\" buttons for the settings to take effect."
 msgstr ""

--- a/0dyseus@CustomCinnamonMenu/files/0dyseus@CustomCinnamonMenu/po/cs.po
+++ b/0dyseus@CustomCinnamonMenu/files/0dyseus@CustomCinnamonMenu/po/cs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.22\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-27 12:27+0200\n"
-"PO-Revision-Date: 2017-05-27 12:40+0200\n"
+"POT-Creation-Date: 2017-06-08 05:56+0200\n"
+"PO-Revision-Date: 2017-06-08 05:57+0200\n"
 "Last-Translator: Radek Otáhal <radek.otahal@email.cz>\n"
 "Language-Team: \n"
 "Language: cs\n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: ../../create_localized_help.py:63
+#: ../../create_localized_help.py:64
 msgid "Keyboard navigation"
 msgstr "Navigace klávesnicí"
 
-#: ../../create_localized_help.py:65
+#: ../../create_localized_help.py:66
 msgid ""
 "Almost all keyboard shortcuts on this menu are the same as the original "
 "menu. There are just a couple of differences that I was forced to add to my "
@@ -33,16 +33,16 @@ msgstr ""
 "některé z jeho funkcí fungovaly. "
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:65
+#: ../../create_localized_help.py:66
 msgid "Note:"
 msgstr "Poznámka:"
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:68
+#: ../../create_localized_help.py:69
 msgid "[[Left Arrow]] and [[Right Arrow]] keys:"
 msgstr "Klávesy [[Šipka vlevo]] a [[Šipka vpravo]]:"
 
-#: ../../create_localized_help.py:70
+#: ../../create_localized_help.py:71
 msgid ""
 "Cycles through the favorites box, applications box and categories box if the "
 "focus is in one of these boxes."
@@ -50,7 +50,7 @@ msgstr ""
 "Cyklicky přepíná mezi oblíbenými položkami, aplikacemi a kategoriemi, pokud "
 "je zaměřena některá z těchto částí."
 
-#: ../../create_localized_help.py:72
+#: ../../create_localized_help.py:73
 msgid ""
 "If the focus is on the custom launchers box, these keys will cycle through "
 "this box buttons."
@@ -59,11 +59,11 @@ msgstr ""
 "procházet tlačítky v tomto boxu."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:74
+#: ../../create_localized_help.py:75
 msgid "[[Tab]] key:"
 msgstr "Klávesa [[Tab]]:"
 
-#: ../../create_localized_help.py:77
+#: ../../create_localized_help.py:78
 msgid ""
 "If the favorites box, applications box or categories box are currently "
 "focused, the [[Tab]] key will switch the focus to the custom launchers box."
@@ -71,7 +71,7 @@ msgstr ""
 "Pokud je zaměřena oblast oblíbených položek, aplikací nebo kategorií, "
 "klávesa [[Tab]] změní zaostření na oblast uživatelských spouštěčů."
 
-#: ../../create_localized_help.py:79 ../../create_localized_help.py:87
+#: ../../create_localized_help.py:80 ../../create_localized_help.py:88
 msgid ""
 "If the focus is on the custom launchers box, the focus will go back to the "
 "categories box."
@@ -79,22 +79,22 @@ msgstr ""
 "Pokud je zaměřena oblast uživatelských spouštěčů, zaostření se vrátí zpět na "
 "oblast kategorií."
 
-#: ../../create_localized_help.py:82
+#: ../../create_localized_help.py:83
 msgid ""
 "If the custom launchers box isn't part of the menu, the [[Tab]] key alone or "
 "[[Ctrl]]/[[Shift]] + [[Tab]] key are pressed, it will cycle through the "
 "favorites box, applications box and categories box."
 msgstr ""
 "Není-li oblast uživatelských spouštěčů součástí menu, stiskem klávesy "
-"[[Tab]] nebo kláves [[Ctrl]] / [[Shift]] + [[Tab]] se bude cyklicky přepínat "
+"[[Tab]] nebo kláves [[Ctrl]] / [[Shift]] + [[Tab] se bude cyklicky přepínat "
 "mezi oblíbenými položkami, aplikacemi a kategoriemi. "
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:84
-msgid "[[Up Arrow]] and [[Down Arrow]] keys:"
-msgstr "Klávesy [[Šipka nahoru]] a [[Šipka dolů]]:"
-
 #: ../../create_localized_help.py:85
+msgid "[[Up Arrow]] and [[Down Arrow]] keys:"
+msgstr "Klávesy [[Šipka nahoru] a [[Šipka dolů]]:"
+
+#: ../../create_localized_help.py:86
 msgid ""
 "If the favorites box, applications box or categories box are currently "
 "focused, these keys will cycle through the items in the currently "
@@ -104,7 +104,7 @@ msgstr ""
 "tyto klávesy procházet položky v aktuálně zvýrazněném poli."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:89
+#: ../../create_localized_help.py:90
 msgid ""
 "[[Page Up]] and [[Page Down]] keys: Jumps to the first and last item of the "
 "currently selected box. This doesn't affect the custom launchers."
@@ -113,7 +113,7 @@ msgstr ""
 "aktuálně vybraného pole. Nemá vliv na uživatelské spouštěče. "
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:91
+#: ../../create_localized_help.py:92
 msgid ""
 "[[Menu]] or [[Alt]] + [[Enter]] keys: Opens and closes the context menu (if "
 "any) of the currently highlighted item."
@@ -122,12 +122,12 @@ msgstr ""
 "(pokud existuje) aktuálně zvýrazněné položky."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:93
+#: ../../create_localized_help.py:94
 msgid "[[Enter]] key: Executes the currently highlighted item."
 msgstr "Klávesa [[Enter]]: Spustí aktuálně zvýrazněnou položku."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:95
+#: ../../create_localized_help.py:96
 msgid ""
 "[[Escape]] key: It closes the main menu. If a context menu is open, it will "
 "close the context menu instead and a second tap of this key will close the "
@@ -137,7 +137,7 @@ msgstr ""
 "zavře kontextovou nabídku a druhým stiskem tohoto tlačítka se zavře hlavní "
 "menu. "
 
-#: ../../create_localized_help.py:98
+#: ../../create_localized_help.py:99
 msgid ""
 "[[Shift]] + [[Enter]]: Executes the application as root. This doesn't affect "
 "the custom launchers."
@@ -146,7 +146,7 @@ msgstr ""
 "spouštěče."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:100
+#: ../../create_localized_help.py:101
 msgid ""
 "[[Ctrl]] + [[Enter]]: Open a terminal and run application from there. This "
 "doesn't affect the custom launchers."
@@ -155,7 +155,7 @@ msgstr ""
 "uživatelské spouštěče."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:102
+#: ../../create_localized_help.py:103
 msgid ""
 "[[Ctrl]] + [[Shift]] + [[Enter]]: Open a terminal and run application from "
 "there, but the application is executed as root. This doesn't affect the "
@@ -164,11 +164,11 @@ msgstr ""
 "[[Ctrl]] + [[Shift]] + [[Enter]]: Otevře terminál a spustí aplikaci odtud, "
 "ale aplikace bude spuštěna jako root. Nemá vliv na uživatelské spouštěče."
 
-#: ../../create_localized_help.py:105
+#: ../../create_localized_help.py:106
 msgid "Applications left click extra actions"
 msgstr "Extra akce pro kliknutí na levé tlačítko při spouštění aplikací"
 
-#: ../../create_localized_help.py:106
+#: ../../create_localized_help.py:107
 msgid ""
 "When left clicking an application on the menu, certain key modifiers can be "
 "pressed to execute an application in a special way."
@@ -177,19 +177,19 @@ msgstr ""
 "klávesové modifikátory, tak aby se aplikace spustila speciálním způsobem."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:108
+#: ../../create_localized_help.py:109
 msgid "[[Shift]] + **Left click**: Executes application as root."
 msgstr "[[Shift]] + ** Levé tlačítko **: Spustí aplikaci jako root."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:110
+#: ../../create_localized_help.py:111
 msgid ""
 "[[Ctrl]] + **Left click**: Open a terminal and run application from there."
 msgstr ""
 "[[Ctrl]] + ** Levé tlačítko **: Otevře terminál a spustí aplikaci odtud."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:112
+#: ../../create_localized_help.py:113
 msgid ""
 "[[Ctrl]] + [[Shift]] + **Left click**: Open a terminal and run application "
 "from there, but the application is executed as root."
@@ -197,11 +197,11 @@ msgstr ""
 "[[Ctrl]] + [[Shift]] + ** Levé tlačítko **: Otevře terminál a spustí "
 "aplikaci odtud, ale aplikace bude spuštěna jako root."
 
-#: ../../create_localized_help.py:114
+#: ../../create_localized_help.py:115
 msgid "About \"Run from terminal\" options"
 msgstr "Informace o možnosti \"Spustit v terminálu\" "
 
-#: ../../create_localized_help.py:115
+#: ../../create_localized_help.py:116
 msgid ""
 "These options are meant for debugging purposes (to see the console output "
 "after opening/closing a program to detect possible errors, for example). "
@@ -220,7 +220,7 @@ msgstr ""
 "apletu. "
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:118
+#: ../../create_localized_help.py:119
 msgid ""
 "By default, these options will use the system's default terminal emulator "
 "(**x-terminal-emulator** on Debian based distributions). Any other terminal "
@@ -237,12 +237,12 @@ msgstr ""
 "argumenty by mohly být předány emulátoru terminálu, ale nejsou mnou "
 "podporovány. "
 
-#: ../../create_localized_help.py:120
+#: ../../create_localized_help.py:121
 msgid "Favorites handling"
 msgstr "Obsluha oblíbených položek"
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:122
+#: ../../create_localized_help.py:123
 msgid ""
 "If the favorites box is **displayed**, favorites can be added/removed from "
 "the context menu for applications and by dragging and dropping applications "
@@ -253,7 +253,7 @@ msgstr ""
 "aplikací do nebo z pole oblíbených položek."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:125
+#: ../../create_localized_help.py:126
 msgid ""
 "**Note:** To remove a favorite, drag a favorite outside the favorites box "
 "into any part of the menu."
@@ -262,7 +262,7 @@ msgstr ""
 "oblíbenou položku mimo pole s oblíbenými položkami do kterékoli části menu."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:127
+#: ../../create_localized_help.py:128
 msgid ""
 "If the favorites box is **hidden** and the favorites category is enabled, "
 "favorites can be added/removed from the context menu for applications and by "
@@ -280,7 +280,7 @@ msgstr ""
 "aplikace přidána do oblíbených položek. "
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:129
+#: ../../create_localized_help.py:130
 msgid ""
 "**Note:** The favorites category will update its content after changing to "
 "another category and going back to the favorites category."
@@ -288,20 +288,20 @@ msgstr ""
 "** Poznámka: ** Kategorie oblíbených položek aktualizuje svůj obsah po "
 "přechodu na jinou kategorii a návratu zpět do kategorie oblíbených položek."
 
-#: ../../create_localized_help.py:131
+#: ../../create_localized_help.py:132
 msgid "Troubleshooting/extra information"
 msgstr "Odstraňování problémů / další informace"
 
-#: ../../create_localized_help.py:132
+#: ../../create_localized_help.py:133
 msgid "Run from terminal."
 msgstr "Spustit v terminálu"
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:134
+#: ../../create_localized_help.py:135
 msgid "Debian based distributions:"
 msgstr "Distribuce založené na Debianu:"
 
-#: ../../create_localized_help.py:135
+#: ../../create_localized_help.py:136
 msgid ""
 "If the command **x-terminal-emulator** doesn't run the terminal emulator "
 "that one wants to be the default, run the following command to set a "
@@ -311,15 +311,15 @@ msgstr ""
 "být výchozí, spusťte následující příkaz a nastavte jiný výchozí emulátor "
 "terminálu."
 
-#: ../../create_localized_help.py:138
+#: ../../create_localized_help.py:139
 msgid "Type in the number of the selection and hit enter."
 msgstr "Zadejte číslo výběru a stiskněte klávesu enter."
 
-#: ../../create_localized_help.py:140
+#: ../../create_localized_help.py:141
 msgid "For other distributions:"
 msgstr "Pro ostatní distribuce:"
 
-#: ../../create_localized_help.py:141
+#: ../../create_localized_help.py:142
 msgid ""
 "Just set the terminal executable of your choice on this applet settings "
 "window."
@@ -328,7 +328,7 @@ msgstr ""
 "nastavení tohoto apletu."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:143
+#: ../../create_localized_help.py:144
 msgid ""
 "There is a file inside this applet directory called **run_from_terminal."
 "sh**. ***Do not remove, rename or edit this file***. Otherwise, all of the "
@@ -339,7 +339,7 @@ msgstr ""
 "případě nebudou všechny možnosti * Spustit z terminálu * funkční. "
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:145
+#: ../../create_localized_help.py:146
 msgid ""
 "There is a folder named **icons** inside this applet directory. It contains "
 "several symbolic icons (most of them are from the Faenza icon theme) and "
@@ -349,28 +349,44 @@ msgstr ""
 "symbolických ikon (většina z nich je z tématu ikon Faenza) a každá ikona "
 "může být použita přímo jménem (například u Uživatelského spouštěče). "
 
+#: ../../create_localized_help.py:168
+msgid "The following two sections are available only in English."
+msgstr "Následující dvě části jsou k dispozici pouze v angličtině."
+
 #. TO TRANSLATORS: This is a placeholder.
 #. Here goes your language name in your own language (a.k.a. endonym).
-#: ../../create_localized_help.py:172 ../../create_localized_help.py:241
+#: ../../create_localized_help.py:193 ../../create_localized_help.py:265
 msgid "language-name"
 msgstr "Česky"
 
-#: ../../create_localized_help.py:244
+#: ../../create_localized_help.py:268 applet.js:3254
+msgid "Help"
+msgstr "Nápověda"
+
+#: ../../create_localized_help.py:269
+msgid "Contributors"
+msgstr "Přispěvatelé"
+
+#: ../../create_localized_help.py:270
+msgid "Changelog"
+msgstr "Changelog"
+
+#: ../../create_localized_help.py:271
 msgid "Choose language"
 msgstr "Zvolte jazyk"
 
 #. TO TRANSLATORS: Full sentence:
 #. "Help for <xlet_name>"
-#: ../../create_localized_help.py:245 ../../create_localized_help.py:252
+#: ../../create_localized_help.py:272 ../../create_localized_help.py:279
 #, python-format
 msgid "Help for %s"
 msgstr "Nápověda pro %s"
 
-#: ../../create_localized_help.py:253
+#: ../../create_localized_help.py:280
 msgid "IMPORTANT!!!"
 msgstr "DŮLEŽITÉ!!!"
 
-#: ../../create_localized_help.py:254
+#: ../../create_localized_help.py:281
 msgid ""
 "Never delete any of the files found inside this xlet folder. It might break "
 "this xlet functionality."
@@ -378,7 +394,7 @@ msgstr ""
 "Nikdy neodstraňujte soubory ze složky tohoto xletu. Mohlo by to narušit "
 "funkčnost xletu. "
 
-#: ../../create_localized_help.py:255
+#: ../../create_localized_help.py:282
 msgid ""
 "Bug reports, feature requests and contributions should be done on this "
 "xlet's repository linked next."
@@ -386,11 +402,11 @@ msgstr ""
 "Zprávy o chybách, požadavky na funkce a příspěvky by měly být prováděny v "
 "repozitáři tohoto xletu, na který je odkaz dále."
 
-#: ../../create_localized_help.py:261
+#: ../../create_localized_help.py:288
 msgid "Applets/Desklets/Extensions (a.k.a. xlets) localization"
 msgstr "Lokalizace apletů/deskletů/rozšíření (a.k.a. xlety)"
 
-#: ../../create_localized_help.py:262
+#: ../../create_localized_help.py:289
 msgid ""
 "If this xlet was installed from Cinnamon Settings, all of this xlet's "
 "localizations were automatically installed."
@@ -399,7 +415,7 @@ msgstr ""
 "všechny tyto lokalizace xletu automaticky nainstalovány."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:264
+#: ../../create_localized_help.py:291
 msgid ""
 "If this xlet was installed manually and not trough Cinnamon Settings, "
 "localizations can be installed by executing the script called "
@@ -409,7 +425,7 @@ msgstr ""
 "Cinnamonu, mohou být lokalizace instalovány spuštěním skriptu nazvaného ** "
 "localizations.sh ** z terminálu otevřeného uvnitř složky xletu."
 
-#: ../../create_localized_help.py:265
+#: ../../create_localized_help.py:292
 msgid ""
 "If this xlet has no locale available for your language, you could create it "
 "by following the following instructions."
@@ -643,145 +659,242 @@ msgstr "Vyhledávejte psaním..."
 msgid "Open the menu editor"
 msgstr "Otevřít menu editor"
 
-#: applet.js:3254
-msgid "Help"
-msgstr "Nápověda"
+#. 3.2->settings-schema.json->pref_command_9_icon->description
+#. 3.2->settings-schema.json->pref_command_2_icon->description
+#. 3.2->settings-schema.json->pref_command_10_icon->description
+#. 3.2->settings-schema.json->pref_command_7_icon->description
+#. 3.2->settings-schema.json->pref_command_1_icon->description
+#. 3.2->settings-schema.json->pref_command_8_icon->description
+#. 3.2->settings-schema.json->pref_command_3_icon->description
+#. 3.2->settings-schema.json->pref_command_5_icon->description
+#. 3.2->settings-schema.json->pref_command_6_icon->description
+#. 3.2->settings-schema.json->pref_command_4_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10_icon->description
+msgid "*Icon:"
+msgstr "*Ikona:"
 
-#. 3.2->settings-schema.json->pref_command_6_description->description
-#. 3.2->settings-schema.json->pref_command_8_description->description
-#. 3.2->settings-schema.json->pref_command_5_description->description
-#. 3.2->settings-schema.json->pref_command_10_description->description
-#. 3.2->settings-schema.json->pref_command_1_description->description
-#. 3.2->settings-schema.json->pref_command_9_description->description
-#. 3.2->settings-schema.json->pref_command_3_description->description
-#. 3.2->settings-schema.json->pref_command_2_description->description
+#. 3.2->settings-schema.json->pref_command_5_command->description
+#. 3.2->settings-schema.json->pref_command_3_command->description
+#. 3.2->settings-schema.json->pref_command_4_command->description
+#. 3.2->settings-schema.json->pref_command_8_command->description
+#. 3.2->settings-schema.json->pref_command_1_command->description
+#. 3.2->settings-schema.json->pref_command_7_command->description
+#. 3.2->settings-schema.json->pref_command_2_command->description
+#. 3.2->settings-schema.json->pref_command_6_command->description
+#. 3.2->settings-schema.json->pref_command_9_command->description
+#. 3.2->settings-schema.json->pref_command_10_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7_command->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9_command->description
+msgid "*Command or path to file:"
+msgstr "*Příkaz nebo cesta k souboru:"
+
+#. 3.2->settings-schema.json->pref_show_lock_button->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_lock_button->description
+msgid "Show \"Lock screen\" button"
+msgstr "Zobrazit tlačítko \"Zamknout obrazovku\""
+
 #. 3.2->settings-schema.json->pref_command_7_description->description
+#. 3.2->settings-schema.json->pref_command_8_description->description
 #. 3.2->settings-schema.json->pref_command_4_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9_description->description
+#. 3.2->settings-schema.json->pref_command_2_description->description
+#. 3.2->settings-schema.json->pref_command_3_description->description
+#. 3.2->settings-schema.json->pref_command_1_description->description
+#. 3.2->settings-schema.json->pref_command_6_description->description
+#. 3.2->settings-schema.json->pref_command_10_description->description
+#. 3.2->settings-schema.json->pref_command_5_description->description
+#. 3.2->settings-schema.json->pref_command_9_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2_description->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8_description->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3_description->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7_description->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4_description->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9_description->description
 msgid "Description:"
 msgstr "Popis:"
 
-#. 3.2->settings-schema.json->pref_apps_info_box_alignment_to_the_left->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_apps_info_box_alignment_to_the_left->description
-msgid "Align application info box text to the left"
-msgstr "Zarovnat text v info boxu o aplikaci doleva."
+#. 3.2->settings-schema.json->pref_menu_layout_third_place->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->description
+msgid "Third place element"
+msgstr "Třetí součást menu"
 
-#. 3.2->settings-schema.json->pref_application_icon_size->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_application_icon_size->description
-msgid "Applications icon size:"
-msgstr "Velikost ikon aplikací:"
+#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
+#. 3.2->settings-schema.json->section_appearance_search_box->title
+#. 3.2->settings-schema.json->pref_menu_layout_first_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head4->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance4->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
+msgid "Search box"
+msgstr "Vyhledávací pole"
 
-#. 3.2->settings-schema.json->pref_application_icon_size->units
-#. 3.2->settings-schema.json->pref_categories_box_padding_bottom->units
-#. 3.2->settings-schema.json->pref_max_fav_icon_size->units
-#. 3.2->settings-schema.json->pref_custom_command_box_padding_top->units
-#. 3.2->settings-schema.json->pref_search_entry_padding_right->units
-#. 3.2->settings-schema.json->pref_custom_command_box_padding_left->units
-#. 3.2->settings-schema.json->pref_categories_box_padding_right->units
-#. 3.2->settings-schema.json->pref_search_entry_padding_top->units
-#. 3.2->settings-schema.json->pref_custom_command_icon_size->units
-#. 3.2->settings-schema.json->pref_separator_heigth->units
-#. 3.2->settings-schema.json->pref_search_box_padding_left->units
-#. 3.2->settings-schema.json->pref_custom_command_box_padding_right->units
-#. 3.2->settings-schema.json->pref_user_picture_size->units
-#. 3.2->settings-schema.json->pref_search_box_padding_top->units
-#. 3.2->settings-schema.json->pref_custom_width_for_searchbox->units
-#. 3.2->settings-schema.json->pref_search_box_padding_bottom->units
-#. 3.2->settings-schema.json->pref_custom_command_box_padding_bottom->units
+#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
+#. 3.2->settings-schema.json->pref_appinfo_display_method->options
+#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_appinfo_display_method->options
+msgid "None"
+msgstr "Žádná"
+
+#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_first_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
+msgid "Applications/Categories boxes"
+msgstr "Aplikace/Kategorie"
+
+#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_first_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance3->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
+msgid "Applications info box"
+msgstr "Info box o aplikaci"
+
+#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
+#. 3.2->settings-schema.json->pref_menu_layout_first_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
+msgid "Custom Launchers box"
+msgstr "Uživatelské spouštěče"
+
+#. 3.2->settings-schema.json->pref_category_icon_size->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_category_icon_size->description
+msgid "Categories icon size:"
+msgstr "Velikost ikon kategorií:"
+
 #. 3.2->settings-schema.json->pref_category_icon_size->units
-#. 3.2->settings-schema.json->pref_categories_box_padding_top->units
+#. 3.2->settings-schema.json->pref_search_box_padding_top->units
+#. 3.2->settings-schema.json->pref_search_entry_padding_right->units
 #. 3.2->settings-schema.json->pref_search_entry_padding_bottom->units
 #. 3.2->settings-schema.json->pref_search_entry_padding_left->units
-#. 3.2->settings-schema.json->pref_info_box_padding_left->units
-#. 3.2->settings-schema.json->pref_search_box_padding_right->units
+#. 3.2->settings-schema.json->pref_search_box_padding_bottom->units
+#. 3.2->settings-schema.json->pref_max_fav_icon_size->units
+#. 3.2->settings-schema.json->pref_custom_width_for_searchbox->units
+#. 3.2->settings-schema.json->pref_custom_command_box_padding_left->units
+#. 3.2->settings-schema.json->pref_custom_command_box_padding_right->units
 #. 3.2->settings-schema.json->pref_info_box_padding_right->units
+#. 3.2->settings-schema.json->pref_categories_box_padding_top->units
+#. 3.2->settings-schema.json->pref_application_icon_size->units
 #. 3.2->settings-schema.json->pref_categories_box_padding_left->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_top->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_application_icon_size->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_right->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_top->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_width_for_searchbox->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_left->units
+#. 3.2->settings-schema.json->pref_custom_command_box_padding_top->units
+#. 3.2->settings-schema.json->pref_info_box_padding_left->units
+#. 3.2->settings-schema.json->pref_search_box_padding_left->units
+#. 3.2->settings-schema.json->pref_search_box_padding_right->units
+#. 3.2->settings-schema.json->pref_user_picture_size->units
+#. 3.2->settings-schema.json->pref_categories_box_padding_bottom->units
+#. 3.2->settings-schema.json->pref_custom_command_box_padding_bottom->units
+#. 3.2->settings-schema.json->pref_categories_box_padding_right->units
+#. 3.2->settings-schema.json->pref_separator_heigth->units
+#. 3.2->settings-schema.json->pref_search_entry_padding_top->units
+#. 3.2->settings-schema.json->pref_custom_command_icon_size->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_category_icon_size->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_top->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_left->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_bottom->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_left->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_size->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_left->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_fav_icon_size->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_right->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_bottom->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_bottom->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_width_for_searchbox->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_right->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_icon_size->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_fav_icon_size->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_application_icon_size->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_top->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_separator_heigth->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_left->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_bottom->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_left->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_right->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_separator_heigth->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_bottom->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_bottom->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_icon_size->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_padding_right->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_top->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_left->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_right->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_padding_left->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_top->units
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_right->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_bottom->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_size->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_top->units
 msgid "pixels"
 msgstr "pixelů"
 
-#. 3.2->settings-schema.json->pref_show_icons_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_icons_on_context->description
-msgid "Show icons on context menu"
-msgstr "Zobrazit ikony v kontextovém menu"
+#. 3.2->settings-schema.json->pref_display_category_icons->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_category_icons->tooltip
+msgid "Choose whether or not to show icons on categories."
+msgstr "Zaškrtněte pro zobrazení ikon kategorií."
 
-#. 3.2->settings-schema.json->pref_command_6_label->description
-#. 3.2->settings-schema.json->pref_command_9_label->description
-#. 3.2->settings-schema.json->pref_command_1_label->description
-#. 3.2->settings-schema.json->pref_command_4_label->description
-#. 3.2->settings-schema.json->pref_command_10_label->description
-#. 3.2->settings-schema.json->pref_command_7_label->description
-#. 3.2->settings-schema.json->pref_command_8_label->description
-#. 3.2->settings-schema.json->pref_command_2_label->description
-#. 3.2->settings-schema.json->pref_command_5_label->description
-#. 3.2->settings-schema.json->pref_command_3_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8_label->description
-msgid "Label:"
-msgstr "Název:"
+#. 3.2->settings-schema.json->pref_display_category_icons->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_category_icons->description
+msgid "Show category icons"
+msgstr "Zobrazit ikony kategorií"
 
-#. 3.2->settings-schema.json->pref_use_hover_feedback->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_hover_feedback->description
-msgid "Use hover feedback"
-msgstr "Zobrazit ikonu po najetí"
-
-#. 3.2->settings-schema.json->pref_use_hover_feedback->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_hover_feedback->tooltip
+#. 3.2->settings-schema.json->pref_user_picture_placement->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->tooltip
 msgid ""
-"If enabled, and the user picture is shown, every time an application/"
-"favorite/place/recent file is hovered or selected with keyboard navigation, "
-"its icon will be displayed where the user picture is located."
+"This option allows to display the user picture on the menu. Clicking on the "
+"picture will open \"Account details\". For the image to be shown, the "
+"applications info box also has to be displayed."
 msgstr ""
-"Je-li volba povolena a zároveň je povoleno zobrazení obrázku uživatele, tak "
-"pokaždé po výběru klávesou nebo při najetí myší na aplikaci/oblíbenou "
-"položku/místo/poslední otevřený soubor, bude jeho ikona zobrazena na místě "
-"obrázku uživatele."
+"Tato volba umožňuje zobrazení obrázku uživatele v menu. Po kliknutí na "
+"obrázek se otevře \"Podrobnosti o účtu\". Pro zobrazení obrázku, musí být "
+"také zobrazen info box o aplikaci."
 
-#. 3.2->settings-schema.json->pref_cat_select_on_hover->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_cat_select_on_hover->description
-msgid "Select categories on hover (EXPERIMENTAL)"
-msgstr "Vybrat kategorie najetím myši (EXPERIMENTÁLNÍ)"
+#. 3.2->settings-schema.json->pref_user_picture_placement->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->description
+msgid "User picture placement"
+msgstr "Umístění obrázku uživatele"
+
+#. 3.2->settings-schema.json->pref_user_picture_placement->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->options
+msgid "Right of applications info box"
+msgstr "Vpravo od info boxu o aplikaci"
+
+#. 3.2->settings-schema.json->pref_user_picture_placement->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->options
+msgid "Do not show"
+msgstr "Nezobrazovat"
+
+#. 3.2->settings-schema.json->pref_user_picture_placement->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->options
+msgid "Left of applications info box"
+msgstr "Vlevo od info boxu o aplikaci"
 
 #. 3.2->settings-schema.json->pref_cat_select_on_hover->tooltip
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_cat_select_on_hover->tooltip
@@ -792,164 +905,98 @@ msgstr ""
 "Je-li volba povolena, může být kategorie vybrána pouhým najetím myši. \n"
 "Není-li povolena, může být kategorie vybrána kliknutím."
 
-#. 3.2->settings-schema.json->pref_command_10_command->description
-#. 3.2->settings-schema.json->pref_command_3_command->description
-#. 3.2->settings-schema.json->pref_command_8_command->description
-#. 3.2->settings-schema.json->pref_command_2_command->description
-#. 3.2->settings-schema.json->pref_command_5_command->description
-#. 3.2->settings-schema.json->pref_command_7_command->description
-#. 3.2->settings-schema.json->pref_command_1_command->description
-#. 3.2->settings-schema.json->pref_command_4_command->description
-#. 3.2->settings-schema.json->pref_command_6_command->description
-#. 3.2->settings-schema.json->pref_command_9_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7_command->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9_command->description
-msgid "*Command or path to file:"
-msgstr "*Příkaz nebo cesta k souboru:"
+#. 3.2->settings-schema.json->pref_cat_select_on_hover->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_cat_select_on_hover->description
+msgid "Select categories on hover (EXPERIMENTAL)"
+msgstr "Vybrat kategorie najetím myši (EXPERIMENTÁLNÍ)"
 
-#. 3.2->settings-schema.json->pref_categories_box_padding_bottom->description
-#. 3.2->settings-schema.json->pref_search_box_padding_bottom->description
-#. 3.2->settings-schema.json->pref_custom_command_box_padding_bottom->description
-#. 3.2->settings-schema.json->pref_search_entry_padding_bottom->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_bottom->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_bottom->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_bottom->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_bottom->description
-msgid "Box bottom padding:"
-msgstr "Odsazení dole:"
-
-#. 3.2->settings-schema.json->pref_max_fav_icon_size->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_fav_icon_size->description
-msgid "Favorites icon size:"
-msgstr "Velikost ikon pro oblíbené položky:"
-
-#. 3.2->settings-schema.json->custom_padding_label->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance7->description
-msgid ""
-"Note: Most themes stylesheets come with hardcoded sizes for certain "
-"elemets.\n"
-"This section is for overriding those stylesheets."
-msgstr ""
-"Poznámka: Většina motivů má ve svých stylech nastavené pevné velikosti pro "
-"určité prvky.\n"
-"Tato sekce umožňuje přepsání těchto stylů."
-
-#. 3.2->settings-schema.json->pref_custom_command_box_padding_top->description
-#. 3.2->settings-schema.json->pref_search_entry_padding_top->description
 #. 3.2->settings-schema.json->pref_search_box_padding_top->description
 #. 3.2->settings-schema.json->pref_categories_box_padding_top->description
+#. 3.2->settings-schema.json->pref_custom_command_box_padding_top->description
+#. 3.2->settings-schema.json->pref_search_entry_padding_top->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_top->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_top->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_top->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_top->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_top->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_top->description
 msgid "Box top padding:"
 msgstr "Odsazení nahoře:"
 
-#. 3.2->settings-schema.json->pref_show_run_as_root_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_run_as_root_on_context->description
-msgid "Show \"Run as root\" on context"
-msgstr "Zobrazit \"Spustit jako root\" v kontextovém menu"
-
 #. 3.2->settings-schema.json->pref_search_entry_padding_right->description
-#. 3.2->settings-schema.json->pref_categories_box_padding_right->description
 #. 3.2->settings-schema.json->pref_custom_command_box_padding_right->description
-#. 3.2->settings-schema.json->pref_search_box_padding_right->description
 #. 3.2->settings-schema.json->pref_info_box_padding_right->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_right->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_right->description
+#. 3.2->settings-schema.json->pref_search_box_padding_right->description
+#. 3.2->settings-schema.json->pref_categories_box_padding_right->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_right->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_right->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_padding_right->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_right->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_right->description
 msgid "Box right padding:"
 msgstr "Odsazení vpravo:"
 
-#. 3.2->settings-schema.json->save_settings_button->description
-#. 3.2->settings-schema.json->section_save_button_minimal->title
-msgid "Save settings"
-msgstr "Uložit nastavení"
+#. 3.2->settings-schema.json->pref_show_desktop_file_folder_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_desktop_file_folder_on_context->description
+msgid "Show \"Open .desktop file folder\" on context"
+msgstr "Zobrazit \"Otevřít složku s .desktop souborem\" v kontextovém menu"
 
-#. 3.2->settings-schema.json->pref_swap_categories_box->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_swap_categories_box->description
-msgid "Swap categories box"
-msgstr "Změnit umístění seznamu kategorií"
+#. 3.2->settings-schema.json->pref_cat_hover_delay->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_cat_hover_delay->description
+msgid "Category selection delay:"
+msgstr "Zpoždění při výběru kategorie:"
 
-#. 3.2->settings-schema.json->pref_swap_categories_box->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_swap_categories_box->tooltip
+#. 3.2->settings-schema.json->pref_cat_hover_delay->units
+#. 3.2->settings-schema.json->pref_menu_hover_delay->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_hover_delay->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_cat_hover_delay->units
+msgid "milliseconds"
+msgstr "milisekund"
+
+#. 3.2->settings-schema.json->pref_cat_hover_delay->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_cat_hover_delay->tooltip
+msgid "Delay between switching categories."
+msgstr "Zpoždění mezi přepnutím kategorií."
+
+#. 3.2->settings-schema.json->pref_search_entry_padding_bottom->description
+#. 3.2->settings-schema.json->pref_search_box_padding_bottom->description
+#. 3.2->settings-schema.json->pref_categories_box_padding_bottom->description
+#. 3.2->settings-schema.json->pref_custom_command_box_padding_bottom->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_bottom->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_bottom->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_bottom->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_bottom->description
+msgid "Box bottom padding:"
+msgstr "Odsazení dole:"
+
+#. 3.2->settings-schema.json->pref_fuzzy_search_enabled->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_fuzzy_search_enabled->tooltip
 msgid ""
-"By default, the categories box is to the left of the applications list. With "
-"this option enabled, the categories box will be placed to the right of the "
-"applications list."
+"This option enables an infinitelly better sorting of search results. It's "
+"marked as experimental because it has a huge impact on performance every "
+"time the search box is cleared."
 msgstr ""
-"Ve výchozím nastavení se zobrazuje seznam kategorií vlevo od seznamu "
-"aplikací. Je-li tato volba zapnuta, bude seznam kategorií umístěn napravo od "
-"seznamu aplikací."
+"Tato volba umožňuje nesrovnatelně lepší třídění výsledků vyhledávání. Je to "
+"označeno jako experimentální, protože má obrovský dopad na výkon pokaždé, "
+"když je vymazán obsah vyhledávacího pole."
 
-#. 3.2->settings-schema.json->pref_command_2_icon->description
-#. 3.2->settings-schema.json->pref_command_10_icon->description
-#. 3.2->settings-schema.json->pref_command_3_icon->description
-#. 3.2->settings-schema.json->pref_command_6_icon->description
-#. 3.2->settings-schema.json->pref_command_4_icon->description
-#. 3.2->settings-schema.json->pref_command_5_icon->description
-#. 3.2->settings-schema.json->pref_command_1_icon->description
-#. 3.2->settings-schema.json->pref_command_8_icon->description
-#. 3.2->settings-schema.json->pref_command_9_icon->description
-#. 3.2->settings-schema.json->pref_command_7_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9_icon->description
-msgid "*Icon:"
-msgstr "*Ikona:"
+#. 3.2->settings-schema.json->pref_fuzzy_search_enabled->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_fuzzy_search_enabled->description
+msgid "Enable fuzzy search (EXPERIMENTAL)"
+msgstr "Povolit fuzzy vyhledávání (EXPERIMENTÁLNÍ)"
 
-#. 3.2->settings-schema.json->pref_overlay_key->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_overlay_key->description
-msgid "Keyboard shortcut to open and close the menu"
-msgstr "Klávesová zkratka pro otevírání a zavírání menu"
+#. 3.2->settings-schema.json->pref_display_application_icons->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_application_icons->tooltip
+msgid "Choose whether or not to show icons on applications."
+msgstr "Zaškrtněte pro zobrazení ikon aplikací."
 
-#. 3.2->settings-schema.json->pref_privilege_elevator->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_privilege_elevator->description
-msgid "Privileges elevator:"
-msgstr "Způsob povýšení oprávnění:"
+#. 3.2->settings-schema.json->pref_display_application_icons->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_application_icons->description
+msgid "Show application icons"
+msgstr "Zobrazit ikony aplikací"
 
-#. 3.2->settings-schema.json->pref_privilege_elevator->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_privilege_elevator->options
-msgid "gksudo"
-msgstr "gksudo"
-
-#. 3.2->settings-schema.json->pref_privilege_elevator->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_privilege_elevator->options
-msgid "gksu"
-msgstr "gksu"
-
-#. 3.2->settings-schema.json->pref_privilege_elevator->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_privilege_elevator->tooltip
-msgid ""
-"The graphical front-end to use to run applications as root.\n"
-"This is used by the \"Open as Root\" context menu and the option \"Gain "
-"privileges of not owned files\"."
-msgstr ""
-"Grafický front-end použitý ke spouštění aplikací jako root.\n"
-"Používá se pro kontextové menu \"Spustit jako root\" a volbu \"Získat "
-"oprávnění k souborům, jichž nejste vlastníkem\"."
-
-#. 3.2->settings-schema.json->pref_autofit_searchbox_width->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_autofit_searchbox_width->description
-msgid "Auto-fit the width of the search box with the menu width"
-msgstr "Automaticky přizpůsobit šířku vyhledávacího pole šířce menu"
+#. 3.2->settings-schema.json->pref_hide_allapps_category->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_hide_allapps_category->description
+msgid "Hide \"All Applications\" category"
+msgstr "Skrýt kategorii \"Všechny aplikace\""
 
 #. 3.2->settings-schema.json->pref_autofit_searchbox_width->tooltip
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_autofit_searchbox_width->tooltip
@@ -962,10 +1009,15 @@ msgstr ""
 "Tato možnost je rovněž ignorována, pokud jsou uživatelské spouštěče umístěny "
 "vedle vyhledávacího pole."
 
-#. 3.2->settings-schema.json->pref_recently_used_apps_invert_order->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recently_used_apps_invert_order->description
-msgid "Invert recently used applications order"
-msgstr "Obrátí pořadí naposledy použitých aplikací"
+#. 3.2->settings-schema.json->pref_autofit_searchbox_width->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_autofit_searchbox_width->description
+msgid "Auto-fit the width of the search box with the menu width"
+msgstr "Automaticky přizpůsobit šířku vyhledávacího pole šířce menu"
+
+#. 3.2->settings-schema.json->pref_show_add_to_panel_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_add_to_panel_on_context->description
+msgid "Show \"Add to panel\" on context"
+msgstr "Zobrazit \"Přidat na panel\" v kontextovém menu"
 
 #. 3.2->settings-schema.json->pref_recently_used_apps_invert_order->tooltip
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recently_used_apps_invert_order->tooltip
@@ -978,88 +1030,10 @@ msgstr ""
 "Je-li tato možnost povolena budou naposledy použité aplikace ve spodní části "
 "seznamu."
 
-#. 3.2->settings-schema.json->pref_custom_command_box_padding_left->description
-#. 3.2->settings-schema.json->pref_search_box_padding_left->description
-#. 3.2->settings-schema.json->pref_search_entry_padding_left->description
-#. 3.2->settings-schema.json->pref_info_box_padding_left->description
-#. 3.2->settings-schema.json->pref_categories_box_padding_left->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_left->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_left->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_left->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_left->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_padding_left->description
-msgid "Box left padding:"
-msgstr "Odsazení vlevo:"
-
-#. 3.2->settings-schema.json->pref_show_logout_button->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_logout_button->description
-msgid "Show \"Logout\" button"
-msgstr "Zobrazit tlačítko \"Odhlásit\""
-
-#. 3.2->settings-schema.json->pref_display_favorites_as_category_menu->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_favorites_as_category_menu->description
-msgid "Display \"Favorites\" as a category menu"
-msgstr "Zobrazit \"Oblíbené\" jako kategorii"
-
-#. 3.2->settings-schema.json->pref_use_a_custom_icon_for_applet->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_a_custom_icon_for_applet->description
-msgid "Use a custom icon"
-msgstr "Použít vlastní ikonu"
-
-#. 3.2->settings-schema.json->pref_use_a_custom_icon_for_applet->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_a_custom_icon_for_applet->tooltip
-msgid "Unchecking this allows the theme to set the icon"
-msgstr "Odškrtnutí tohoto umožní tématu nastavit ikonu"
-
-#. 3.2->settings-schema.json->pref_custom_command_icon_size->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_icon_size->description
-msgid "Custom launchers icon size:"
-msgstr "Velikost ikon pro uživatelské spouštěče:"
-
-#. 3.2->settings-schema.json->pref_use_alternate_vector_box->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_alternate_vector_box->description
-msgid "Use alternate category selection method (EXPERIMENTAL)"
-msgstr "Použít alternativní metodu pro výběr kategorie (EXPERIMENTÁLNÍ)"
-
-#. 3.2->settings-schema.json->pref_use_alternate_vector_box->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_alternate_vector_box->tooltip
-msgid ""
-"With this option enabled, an alternate method to select categories will be "
-"used. This method can improve the performance of the menu and is extracted "
-"from the applet called Configurable Menu by lestcape."
-msgstr ""
-"Je-li tato volba povolena, bude pro výběr kategorie použita alternativní "
-"metoda. Tato metoda může zlepšit výkon menu a je převzata z apletu "
-"Configurable Menu od autora lestcape."
-
-#. 3.2->settings-schema.json->pref_separator_heigth->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_separator_heigth->description
-msgid "Favorites box separator height:"
-msgstr "Výška oddělovače:"
-
-#. 3.2->settings-schema.json->pref_separator_heigth->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_separator_heigth->tooltip
-msgid "Size of separator between \"Favorites\" box and \"Quit\" box."
-msgstr "Velikost oddělovače mezi polem \"Oblíbené\" a \"Ukončit\"."
-
-#. 3.2->settings-schema.json->pref_recent_apps_ignore_favorites->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recent_apps_ignore_favorites->description
-msgid "Ignore Favorites"
-msgstr "Ignorovat Oblíbené"
-
-#. 3.2->settings-schema.json->pref_recent_apps_ignore_favorites->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recent_apps_ignore_favorites->tooltip
-msgid ""
-"If enabled, applications set as Favorite will not be stored in the \"Recent "
-"Applications\" category."
-msgstr ""
-"Je-li volba povolena, aplikace nastavené jako oblíbené položky nebudou "
-"uloženy v kategorii \"Nedávné aplikace\"."
-
-#. 3.2->settings-schema.json->pref_remember_recently_used_apps->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_remember_recently_used_apps->description
-msgid "Show \"Recent Applications\" category"
-msgstr "Zobrazit kategorii \"Nedávné aplikace\""
+#. 3.2->settings-schema.json->pref_recently_used_apps_invert_order->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recently_used_apps_invert_order->description
+msgid "Invert recently used applications order"
+msgstr "Obrátí pořadí naposledy použitých aplikací"
 
 #. 3.2->settings-schema.json->pref_remember_recently_used_apps->tooltip
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_remember_recently_used_apps->tooltip
@@ -1074,115 +1048,198 @@ msgstr ""
 "Pokaždé, když je tato volba vypnuta, bude vymazán seznam nedávno použitých "
 "aplikací."
 
-#. 3.2->settings-schema.json->pref_menu_layout_first_place->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->description
-msgid "First place element"
-msgstr "První součást menu"
+#. 3.2->settings-schema.json->pref_remember_recently_used_apps->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_remember_recently_used_apps->description
+msgid "Show \"Recent Applications\" category"
+msgstr "Zobrazit kategorii \"Nedávné aplikace\""
 
-#. 3.2->settings-schema.json->pref_menu_layout_first_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
-msgid "Custom Launchers box"
-msgstr "Uživatelské spouštěče"
+#. 3.2->settings-schema.json->pref_command_9_label->description
+#. 3.2->settings-schema.json->pref_command_10_label->description
+#. 3.2->settings-schema.json->pref_command_3_label->description
+#. 3.2->settings-schema.json->pref_command_4_label->description
+#. 3.2->settings-schema.json->pref_command_7_label->description
+#. 3.2->settings-schema.json->pref_command_8_label->description
+#. 3.2->settings-schema.json->pref_command_1_label->description
+#. 3.2->settings-schema.json->pref_command_5_label->description
+#. 3.2->settings-schema.json->pref_command_2_label->description
+#. 3.2->settings-schema.json->pref_command_6_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10_label->description
+msgid "Label:"
+msgstr "Název:"
 
-#. 3.2->settings-schema.json->pref_menu_layout_first_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance3->description
-msgid "Applications info box"
-msgstr "Info box o aplikaci"
+#. 3.2->settings-schema.json->pref_max_recently_used_apps->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_recently_used_apps->description
+msgid "Max recently used apps:"
+msgstr "Maximum nedávno otevřených aplikací:"
 
-#. 3.2->settings-schema.json->pref_menu_layout_first_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
-msgid "Applications/Categories boxes"
-msgstr "Aplikace/Kategorie"
+#. 3.2->settings-schema.json->pref_max_recently_used_apps->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_recently_used_apps->units
+msgid "applications"
+msgstr "aplikace"
 
-#. 3.2->settings-schema.json->pref_menu_layout_first_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
-#. 3.2->settings-schema.json->section_appearance_search_box->title
-#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head4->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance4->description
-msgid "Search box"
-msgstr "Vyhledávací pole"
+#. 3.2->settings-schema.json->pref_search_entry_padding_left->description
+#. 3.2->settings-schema.json->pref_custom_command_box_padding_left->description
+#. 3.2->settings-schema.json->pref_categories_box_padding_left->description
+#. 3.2->settings-schema.json->pref_info_box_padding_left->description
+#. 3.2->settings-schema.json->pref_search_box_padding_left->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_box_padding_left->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_entry_padding_left->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_box_padding_left->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_categories_box_padding_left->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_padding_left->description
+msgid "Box left padding:"
+msgstr "Odsazení vlevo:"
 
-#. 3.2->settings-schema.json->pref_search_filesystem->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_filesystem->description
-msgid "Enable file system path entry in search box"
-msgstr "Povolit ve vyhledávacím boxu zadávání cesty v souborovém systému"
+#. 3.2->settings-schema.json->save_settings_button->description
+#. 3.2->settings-schema.json->section_save_button_minimal->title
+msgid "Save settings"
+msgstr "Uložit nastavení"
+
+#. 3.2->settings-schema.json->pref_show_logout_button->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_logout_button->description
+msgid "Show \"Logout\" button"
+msgstr "Zobrazit tlačítko \"Odhlásit\""
+
+#. 3.2->settings-schema.json->pref_set_search_entry_padding->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_search_entry_padding->description
+msgid "Set a custom padding for the search entry box"
+msgstr "Nastavit vlastní odsazení pro vnitřní vyhledávací pole"
+
+#. 3.2->settings-schema.json->pref_max_fav_icon_size->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_fav_icon_size->description
+msgid "Favorites icon size:"
+msgstr "Velikost ikon pro oblíbené položky:"
+
+#. 3.2->settings-schema.json->pref_info_box_title_font_size->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_title_font_size->description
+msgid "Applications info box title font size:"
+msgstr "Velikost fontu názvu aplikace:"
+
+#. 3.2->settings-schema.json->pref_info_box_title_font_size->units
+#. 3.2->settings-schema.json->pref_max_width_for_buttons->units
+#. 3.2->settings-schema.json->pref_info_box_description_font_size->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_title_font_size->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_width_for_buttons->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_description_font_size->units
+msgid "ems"
+msgstr "ems"
+
+#. 3.2->settings-schema.json->pref_recently_used_apps_separator->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recently_used_apps_separator->tooltip
+msgid ""
+"This option, when enabled, will break the menu keyboard navigation. Only "
+"enable this option if you will never use the keyboard to navigate the menu.\n"
+"This message is only temporary until I figure out how to fix this."
+msgstr ""
+"Je-li tato volba povolena, nebude funkční navigace v menu pomocí klávesnice. "
+"Tuto možnost povolte pouze v případě, že nikdy nepoužíváte klávesnici k "
+"navigaci v menu.\n"
+"Tato zpráva je pouze dočasná do doby opravení problému."
+
+#. 3.2->settings-schema.json->pref_recently_used_apps_separator->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recently_used_apps_separator->description
+msgid "Display separator after \"Recent Applications\" category (WARNING)"
+msgstr ""
+"Zobrazit oddělovač za kategorií \"Nedávno spuštěné aplikace\" (UPOZORNĚNÍ)"
+
+#. 3.2->settings-schema.json->pref_show_add_to_desktop_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_add_to_desktop_on_context->description
+msgid "Show \"Add to desktop\" on context"
+msgstr "Zobrazit \"Přidat na plochu\" v kontextovém menu"
+
+#. 3.2->settings-schema.json->pref_menu_hover_delay->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_hover_delay->description
+msgid "Menu hover delay:"
+msgstr "Zpoždění menu při najetí:"
+
+#. 3.2->settings-schema.json->pref_menu_hover_delay->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_hover_delay->tooltip
+msgid "Delay before the menu is opened on entering the applet."
+msgstr "Zpoždění před otevřením menu při najetí."
+
+#. 3.2->settings-schema.json->pref_custom_width_for_searchbox->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_width_for_searchbox->description
+msgid "Custom width for search box:"
+msgstr "Uživatelská šířka vyhledávacího pole:"
+
+#. 3.2->settings-schema.json->pref_custom_width_for_searchbox->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_width_for_searchbox->tooltip
+msgid "Set to 0 (zero) for not setting a width."
+msgstr "Nastavte 0 (nula) pokud nechcete nastavit šířku."
+
+#. 3.2->settings-schema.json->pref_set_custom_box_padding->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_custom_box_padding->description
+msgid "Set a custom padding for the Custom launchers box"
+msgstr "Nastavit vlastní odsazení pro pole uživatelských spouštěčů"
 
 #. 3.2->settings-schema.json->pref_search_filesystem->tooltip
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_filesystem->tooltip
 msgid "Allows path entry in the menu search box."
 msgstr "Povolit zadání cesty ve vyhledávání."
 
-#. 3.2->settings-schema.json->pref_menu_layout_second_place->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->description
-msgid "Second place element"
-msgstr "Druhá součást menu"
+#. 3.2->settings-schema.json->pref_search_filesystem->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_search_filesystem->description
+msgid "Enable file system path entry in search box"
+msgstr "Povolit ve vyhledávacím boxu zadávání cesty v souborovém systému"
 
-#. 3.2->settings-schema.json->pref_menu_layout_second_place->options
+#. 3.2->settings-schema.json->pref_appinfo_display_method->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_appinfo_display_method->description
+msgid "Display method for information about applications:"
+msgstr "Způsob zobrazení informací o aplikacích:"
+
 #. 3.2->settings-schema.json->pref_appinfo_display_method->options
-#. 3.2->settings-schema.json->pref_menu_layout_third_place->options
-#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->options
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_appinfo_display_method->options
-msgid "None"
-msgstr "Žádná"
+msgid "Info box"
+msgstr "Info box"
 
-#. 3.2->settings-schema.json->pref_custom_editor_for_edit_desktop_file_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_editor_for_edit_desktop_file_on_context->description
-msgid "Custom text editor:"
-msgstr "Vlastní textový editor:"
+#. 3.2->settings-schema.json->pref_appinfo_display_method->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_appinfo_display_method->options
+msgid "Tooltips"
+msgstr "Bublinová nápověda"
 
-#. 3.2->settings-schema.json->pref_custom_editor_for_edit_desktop_file_on_context->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_editor_for_edit_desktop_file_on_context->tooltip
-msgid ""
-"Set a custom text editor to open .desktop files (just the name of the text "
-"editor executable or the path to it).\n"
-"Leave it blank to let the system decide."
-msgstr ""
-"Nastavte vlastní textový editor pro otevření .desktop souborů (pouze název "
-"textového editoru nebo cesta).\n"
-"Ponechte nevyplněné pro výběr systémového editoru."
+#. 3.2->settings-schema.json->pref_show_shutdown_button->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_shutdown_button->description
+msgid "Show \"Shutdown\" button"
+msgstr "Zobrazit tlačítko \"Vypnout\""
 
-#. 3.2->settings-schema.json->pref_open_menu_on_hover->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_open_menu_on_hover->description
-msgid "Open the menu on mouse over"
-msgstr "Otevřít menu najetím myši na ikonu"
+#. 3.2->settings-schema.json->pref_display_favorites_as_category_menu->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_favorites_as_category_menu->description
+msgid "Display \"Favorites\" as a category menu"
+msgstr "Zobrazit \"Oblíbené\" jako kategorii"
 
-#. 3.2->settings-schema.json->pref_open_menu_on_hover->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_open_menu_on_hover->tooltip
-msgid "Enable opening the menu when the mouse enters the applet."
-msgstr "Otevře menu při najetí myší na applet."
+#. 3.2->settings-schema.json->pref_animate_menu->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_animate_menu->description
+msgid "Animate open/close menu"
+msgstr "Povolit animace menu při otevírání a zavírání"
 
-#. 3.2->settings-schema.json->pref_terminal_emulator->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_terminal_emulator->description
-msgid "Terminal emulator:"
-msgstr "Emulátor terminálu:"
+#. 3.2->settings-schema.json->pref_show_add_remove_favorite_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_add_remove_favorite_on_context->description
+msgid "Show \"Add/Remove to/from favorites\" on context"
+msgstr "Zobrazit \"Přidat/odebrat do/z oblíbených\" v kontextovém menu"
+
+#. 3.2->settings-schema.json->pref_application_icon_size->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_application_icon_size->description
+msgid "Applications icon size:"
+msgstr "Velikost ikon aplikací:"
+
+#. 3.2->settings-schema.json->pref_max_recent_files->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_recent_files->description
+msgid "Max recent documents:"
+msgstr "Maximum nedávno otevřených dokumentů:"
+
+#. 3.2->settings-schema.json->pref_max_recent_files->units
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_recent_files->units
+msgid "documents"
+msgstr "dokumenty"
 
 #. 3.2->settings-schema.json->pref_terminal_emulator->tooltip
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_terminal_emulator->tooltip
@@ -1193,30 +1250,141 @@ msgstr ""
 "Vyberte emulátor terminálu, který bude používán při požadavku na spuštění.\n"
 "DŮLEŽITÉ!!! Emulátor terminálu musí podporovat -e argument."
 
-#. 3.2->settings-schema.json->pref_display_category_icons->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_category_icons->description
-msgid "Show category icons"
-msgstr "Zobrazit ikony kategorií"
+#. 3.2->settings-schema.json->pref_terminal_emulator->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_terminal_emulator->description
+msgid "Terminal emulator:"
+msgstr "Emulátor terminálu:"
 
-#. 3.2->settings-schema.json->pref_display_category_icons->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_category_icons->tooltip
-msgid "Choose whether or not to show icons on categories."
-msgstr "Zaškrtněte pro zobrazení ikon kategorií."
+#. 3.2->settings-schema.json->pref_swap_categories_box->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_swap_categories_box->tooltip
+msgid ""
+"By default, the categories box is to the left of the applications list. With "
+"this option enabled, the categories box will be placed to the right of the "
+"applications list."
+msgstr ""
+"Ve výchozím nastavení se zobrazuje seznam kategorií vlevo od seznamu "
+"aplikací. Je-li tato volba zapnuta, bude seznam kategorií umístěn napravo od "
+"seznamu aplikací."
 
-#. 3.2->settings-schema.json->pref_set_info_box_padding->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_info_box_padding->description
-msgid "Set a custom padding for the Applications info box"
-msgstr "Nastavit vlastní odsazení pro info box o aplikaci"
+#. 3.2->settings-schema.json->pref_swap_categories_box->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_swap_categories_box->description
+msgid "Swap categories box"
+msgstr "Změnit umístění seznamu kategorií"
 
-#. 3.2->settings-schema.json->pref_show_bumblebee_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_bumblebee_on_context->description
-msgid "Show \"Run with NVIDIA GPU\" on context"
-msgstr "Zobrazit \"Spustit s GPU NVIDIA\" v kontextovém menu"
+#. 3.2->settings-schema.json->pref_show_run_from_terminal_as_root_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_run_from_terminal_as_root_on_context->description
+msgid "Show \"Run from terminal as root\" on context"
+msgstr "Zobrazit \"Spustit v terminálu jako root\" v kontextovém menu"
 
-#. 3.2->settings-schema.json->pref_set_search_box_padding->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_search_box_padding->description
-msgid "Set a custom padding for the search box"
-msgstr "Nastavit vlastní odsazení pro vnější vyhledávací pole"
+#. 3.2->settings-schema.json->pref_use_a_custom_icon_for_applet->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_a_custom_icon_for_applet->tooltip
+msgid "Unchecking this allows the theme to set the icon"
+msgstr "Odškrtnutí tohoto umožní tématu nastavit ikonu"
+
+#. 3.2->settings-schema.json->pref_use_a_custom_icon_for_applet->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_a_custom_icon_for_applet->description
+msgid "Use a custom icon"
+msgstr "Použít vlastní ikonu"
+
+#. 3.2->settings-schema.json->pref_show_places->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_places->tooltip
+msgid "Choose whether or not to show bookmarks and places in the menu."
+msgstr "Zaškrtněte pro zobrazení míst a záložek v menu"
+
+#. 3.2->settings-schema.json->pref_show_places->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_places->description
+msgid "Show bookmarks and places"
+msgstr "Zobrazit záložky a místa"
+
+#. 3.2->settings-schema.json->pref_shutdown_button_custom_icon->tooltip
+#. 3.2->settings-schema.json->pref_logout_button_custom_icon->tooltip
+#. 3.2->settings-schema.json->pref_lock_button_custom_icon->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_lock_button_custom_icon->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_shutdown_button_custom_icon->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_logout_button_custom_icon->tooltip
+msgid ""
+"Only valid if the System buttons box is placed next to the Custom launchers "
+"box.\n"
+"Leave blank to use default."
+msgstr ""
+"Platné pouze pokud jsou tlačítka pro ukončení umístěna vedle uživatelských "
+"spouštěčů.\n"
+"Ponechte prázdné, pokud chcete použít výchozí ikony."
+
+#. 3.2->settings-schema.json->pref_shutdown_button_custom_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_shutdown_button_custom_icon->description
+msgid "Custom icon for \"Shutdown\" button:"
+msgstr "Vlastní ikona pro tlačítko \"Vypnout\":"
+
+#. 3.2->settings-schema.json->pref_logout_button_custom_icon->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_logout_button_custom_icon->description
+msgid "Custom icon for \"Logout\" button:"
+msgstr "Vlastní ikona pro tlačítko \"Odhlásit\":"
+
+#. 3.2->settings-schema.json->pref_max_width_for_buttons->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_width_for_buttons->description
+msgid "Maximum button width:"
+msgstr "Maximální šířka tlačítka:"
+
+#. 3.2->settings-schema.json->pref_max_width_for_buttons->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_width_for_buttons->tooltip
+msgid "Define the maximum width of menu items inside the applications box."
+msgstr "Definuje maximální šířku položek menu uvnitř pole pro aplikace."
+
+#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->description
+msgid "Fourth place element"
+msgstr "Čtvrtá součást menu"
+
+#. 3.2->settings-schema.json->pref_show_run_as_root_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_run_as_root_on_context->description
+msgid "Show \"Run as root\" on context"
+msgstr "Zobrazit \"Spustit jako root\" v kontextovém menu"
+
+#. 3.2->settings-schema.json->pref_show_icons_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_icons_on_context->description
+msgid "Show icons on context menu"
+msgstr "Zobrazit ikony v kontextovém menu"
+
+#. 3.2->settings-schema.json->pref_menu_layout_second_place->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_second_place->description
+msgid "Second place element"
+msgstr "Druhá součást menu"
+
+#. 3.2->settings-schema.json->custom_padding_label->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance7->description
+msgid ""
+"Note: Most themes stylesheets come with hardcoded sizes for certain "
+"elemets.\n"
+"This section is for overriding those stylesheets."
+msgstr ""
+"Poznámka: Většina motivů má ve svých stylech nastavené pevné velikosti pro "
+"určité prvky.\n"
+"Tato sekce umožňuje přepsání těchto stylů."
+
+#. 3.2->settings-schema.json->pref_show_recents_button->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_recents_button->tooltip
+msgid ""
+"For people who want the \"Recent documents\" category hidden without "
+"disabling recent documents globally."
+msgstr ""
+"Pro uživatele, kteří chtějí skrýt kategorii \"Nedávné dokumenty\" bez "
+"globálního zakázání zobrazení posledních dokumentů."
+
+#. 3.2->settings-schema.json->pref_show_recents_button->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_recents_button->description
+msgid "Show \"Recent documents\" category"
+msgstr "Zobrazit kategorii \"Nedávné dokumenty\""
+
+#. 3.2->settings-schema.json->pref_custom_icon_for_applet->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_icon_for_applet->description
+msgid "Icon"
+msgstr "Ikona"
+
+#. 3.2->settings-schema.json->pref_custom_icon_for_applet->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_icon_for_applet->tooltip
+msgid "Select an icon to show in the panel."
+msgstr "Zvolte ikonu, která se zobrazí na panelu."
 
 #. 3.2->settings-schema.json->custom_launchers_label->description
 msgid ""
@@ -1239,10 +1407,191 @@ msgstr ""
 "Jinak bude soubor otevřen aplikací asociovanou v systému pro tento typ "
 "souboru."
 
-#. 3.2->settings-schema.json->pref_user_picture_size->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_size->description
-msgid "User picture size:"
-msgstr "Velikost obrázku uživatele:"
+#. 3.2->settings-schema.json->section_save_button_full->title
+msgid ""
+"Most settings are not automatically saved when modified.\n"
+"Press any of the \"Save settings\" buttons for the settings to take effect."
+msgstr ""
+"Většina změn nastavení se neukládá automaticky.\n"
+"Stiskněte tlačítko \"Uložit nastavení\" pro aktivaci změn."
+
+#. 3.2->settings-schema.json->section_appearance_favorites_box->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance5->description
+msgid "Favorites box"
+msgstr "Oblíbené"
+
+#. 3.2->settings-schema.json->section_custom_launchers_008->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8->description
+msgid "Custom launcher 8"
+msgstr "Uživatelský spouštěč 8"
+
+#. 3.2->settings-schema.json->page_layout->title
+msgid "Layout"
+msgstr "Rozložení"
+
+#. 3.2->settings-schema.json->section_context_menus_settings->title
+msgid "Context menus settings"
+msgstr "Nastavení kontextového menu"
+
+#. 3.2->settings-schema.json->section_custom_launchers_006->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6->description
+msgid "Custom launcher 6"
+msgstr "Uživatelský spouštěč 6"
+
+#. 3.2->settings-schema.json->section_appearance_applicatons_box->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance6->description
+msgid "Applications box"
+msgstr "Aplikace"
+
+#. 3.2->settings-schema.json->section_quit_buttons_settings->title
+msgid "Quit buttons settings"
+msgstr "Nastavení tlačítek ukončení"
+
+#. 3.2->settings-schema.json->section_applet_settings->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head0->description
+msgid "Applet settings"
+msgstr "Nastavení apletu"
+
+#. 3.2->settings-schema.json->section_custom_launchers_005->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5->description
+msgid "Custom launcher 5"
+msgstr "Uživatelský spouštěč 5"
+
+#. 3.2->settings-schema.json->section_layout_002->title
+msgid "Placement on main elements on menu"
+msgstr "Rozmístění hlavních prvků menu"
+
+#. 3.2->settings-schema.json->section_appearance_icons_display->title
+msgid "Icons display"
+msgstr "Zobrazení ikon"
+
+#. 3.2->settings-schema.json->section_appearance_info_box->title
+msgid "Application info box"
+msgstr "Info box o aplikaci"
+
+#. 3.2->settings-schema.json->section_recently_used_applications_settings->title
+msgid "Recently used applications settings"
+msgstr "Nastavení pro nedávno spuštěné aplikace"
+
+#. 3.2->settings-schema.json->page_appearance->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance1->description
+msgid "Appearance"
+msgstr "Vzhled"
+
+#. 3.2->settings-schema.json->section_menu_settings->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head1->description
+msgid "Menu settings"
+msgstr "Nastavení menu"
+
+#. 3.2->settings-schema.json->section_custom_launchers_009->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9->description
+msgid "Custom launcher 9"
+msgstr "Uživatelský spouštěč 9"
+
+#. 3.2->settings-schema.json->section_custom_launchers_004->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4->description
+msgid "Custom launcher 4"
+msgstr "Uživatelský spouštěč 4"
+
+#. 3.2->settings-schema.json->page_custom_launchers->title
+msgid "Custom Launchers"
+msgstr "Uživatelské spouštěče"
+
+#. 3.2->settings-schema.json->section_appearance_icon_sizes->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance2->description
+msgid "Icon sizes"
+msgstr "Velikosti ikon"
+
+#. 3.2->settings-schema.json->section_custom_launchers_000_bis->title
+msgid "Custom launchers notes"
+msgstr "Poznámky pro uživatelské spouštěče"
+
+#. 3.2->settings-schema.json->section_search_box_settings->title
+msgid "Search box settings"
+msgstr "Nastavení vyhledávacího pole"
+
+#. 3.2->settings-schema.json->page_extras->title
+msgid "Extras"
+msgstr "Extra funkce"
+
+#. 3.2->settings-schema.json->section_custom_launchers_003->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3->description
+msgid "Custom launcher 3"
+msgstr "Uživatelský spouštěč 3"
+
+#. 3.2->settings-schema.json->section_layout_001->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head2->description
+msgid "Menu layout"
+msgstr "Uspořádání menu"
+
+#. 3.2->settings-schema.json->section_custom_launchers_007->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7->description
+msgid "Custom launcher 7"
+msgstr "Uživatelský spouštěč 7"
+
+#. 3.2->settings-schema.json->section_appearance_boxes_padding->title
+msgid "Theme overrides"
+msgstr "Přepsání motivu"
+
+#. 3.2->settings-schema.json->section_custom_launchers_001->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1->description
+msgid "Custom launcher 1"
+msgstr "Uživatelský spouštěč 1"
+
+#. 3.2->settings-schema.json->section_custom_launchers_002->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2->description
+msgid "Custom launcher 2"
+msgstr "Uživatelský spouštěč 2"
+
+#. 3.2->settings-schema.json->page_applet->title
+msgid "Applet"
+msgstr "Aplet"
+
+#. 3.2->settings-schema.json->section_custom_launchers_010->title
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10->description
+msgid "Custom launcher 10"
+msgstr "Uživatelský spouštěč 10"
+
+#. 3.2->settings-schema.json->pref_custom_label_for_applet->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_label_for_applet->tooltip
+msgid "Enter custom text to show in the panel."
+msgstr "Vložte text, který se zobrazí na panelu."
+
+#. 3.2->settings-schema.json->pref_custom_label_for_applet->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_label_for_applet->description
+msgid "Custom label"
+msgstr "Uživatelský název"
+
+#. 3.2->settings-schema.json->pref_privilege_elevator->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_privilege_elevator->tooltip
+msgid ""
+"The graphical front-end to use to run applications as root.\n"
+"This is used by the \"Open as Root\" context menu and the option \"Gain "
+"privileges of not owned files\"."
+msgstr ""
+"Grafický front-end použitý ke spouštění aplikací jako root.\n"
+"Používá se pro kontextové menu \"Spustit jako root\" a volbu \"Získat "
+"oprávnění k souborům, jichž nejste vlastníkem\"."
+
+#. 3.2->settings-schema.json->pref_privilege_elevator->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_privilege_elevator->description
+msgid "Privileges elevator:"
+msgstr "Způsob povýšení oprávnění:"
+
+#. 3.2->settings-schema.json->pref_privilege_elevator->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_privilege_elevator->options
+msgid "gksu"
+msgstr "gksu"
+
+#. 3.2->settings-schema.json->pref_privilege_elevator->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_privilege_elevator->options
+msgid "gksudo"
+msgstr "gksudo"
+
+#. 3.2->settings-schema.json->pref_set_categories_padding->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_categories_padding->description
+msgid "Set a custom padding for the Categories box"
+msgstr "Nastavit vlastní odsazení pro pole kategorií"
 
 #. 3.2->settings-schema.json->pref_custom_commands_box_placement->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_placement->description
@@ -1251,63 +1600,169 @@ msgstr "Umístění uživatelských spouštěčů"
 
 #. 3.2->settings-schema.json->pref_custom_commands_box_placement->options
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_placement->options
-msgid "Right of search box"
-msgstr "Vpravo od vyhledávacího pole"
+msgid "Left of search box"
+msgstr "Vlevo od vyhledávacího pole"
 
 #. 3.2->settings-schema.json->pref_custom_commands_box_placement->options
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_placement->options
-msgid "Left of search box"
-msgstr "Vlevo od vyhledávacího pole"
+msgid "Right of search box"
+msgstr "Vpravo od vyhledávacího pole"
 
 #. 3.2->settings-schema.json->pref_custom_commands_box_placement->options
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_placement->options
 msgid "On its own"
 msgstr "Samostatně"
 
-#. 3.2->settings-schema.json->pref_custom_width_for_searchbox->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_width_for_searchbox->description
-msgid "Custom width for search box:"
-msgstr "Uživatelská šířka vyhledávacího pole:"
+#. 3.2->settings-schema.json->pref_show_run_from_terminal_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_run_from_terminal_on_context->description
+msgid "Show \"Run from terminal\" on context"
+msgstr "Zobrazit \"Spustit v terminálu\" v kontextovém menu"
 
-#. 3.2->settings-schema.json->pref_custom_width_for_searchbox->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_width_for_searchbox->tooltip
-msgid "Set to 0 (zero) for not setting a width."
-msgstr "Nastavte 0 (nula) pokud nechcete nastavit šířku."
+#. 3.2->settings-schema.json->pref_recent_apps_ignore_favorites->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recent_apps_ignore_favorites->tooltip
+msgid ""
+"If enabled, applications set as Favorite will not be stored in the \"Recent "
+"Applications\" category."
+msgstr ""
+"Je-li volba povolena, aplikace nastavené jako oblíbené položky nebudou "
+"uloženy v kategorii \"Nedávné aplikace\"."
 
-#. 3.2->settings-schema.json->pref_custom_commands_box_alignment->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_alignment->description
-msgid "Custom launchers buttons alignment"
-msgstr "Zarovnání uživatelských spouštěčů"
+#. 3.2->settings-schema.json->pref_recent_apps_ignore_favorites->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recent_apps_ignore_favorites->description
+msgid "Ignore Favorites"
+msgstr "Ignorovat Oblíbené"
 
-#. 3.2->settings-schema.json->pref_custom_commands_box_alignment->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_alignment->options
-msgid "Right"
-msgstr "Vpravo"
+#. 3.2->settings-schema.json->pref_set_search_box_padding->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_search_box_padding->description
+msgid "Set a custom padding for the search box"
+msgstr "Nastavit vlastní odsazení pro vnější vyhledávací pole"
 
-#. 3.2->settings-schema.json->pref_custom_commands_box_alignment->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_alignment->options
-msgid "Left"
-msgstr "Vlevo"
+#. 3.2->settings-schema.json->pref_hide_applications_list_scrollbar->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_hide_applications_list_scrollbar->description
+msgid "Hide applications list scrollbar"
+msgstr "Skrýt posuvník v seznamu aplikací"
 
-#. 3.2->settings-schema.json->pref_custom_commands_box_alignment->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_alignment->options
-msgid "Middle"
-msgstr "Uprostřed"
+#. 3.2->settings-schema.json->pref_open_menu_on_hover->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_open_menu_on_hover->tooltip
+msgid "Enable opening the menu when the mouse enters the applet."
+msgstr "Otevře menu při najetí myší na applet."
 
-#. 3.2->settings-schema.json->pref_show_lock_button->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_lock_button->description
-msgid "Show \"Lock screen\" button"
-msgstr "Zobrazit tlačítko \"Zamknout obrazovku\""
+#. 3.2->settings-schema.json->pref_open_menu_on_hover->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_open_menu_on_hover->description
+msgid "Open the menu on mouse over"
+msgstr "Otevřít menu najetím myši na ikonu"
 
-#. 3.2->settings-schema.json->pref_show_add_to_panel_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_add_to_panel_on_context->description
-msgid "Show \"Add to panel\" on context"
-msgstr "Zobrazit \"Přidat na panel\" v kontextovém menu"
+#. 3.2->settings-schema.json->pref_info_box_description_font_size->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_description_font_size->description
+msgid "Applications info box description font size:"
+msgstr "Velikost fontu popisu aplikace:"
 
-#. 3.2->settings-schema.json->pref_gain_privileges_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_gain_privileges_on_context->description
-msgid "Gain privileges of not owned files"
-msgstr "Získat oprávnění k souborům, jichž nejste vlastníkem"
+#. 3.2->settings-schema.json->pref_disable_new_apps_highlighting->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_disable_new_apps_highlighting->description
+msgid "Disable newly installed applications highlighting"
+msgstr "Zakázat zvýraznění nově nainstalovaných aplikací"
+
+#. 3.2->settings-schema.json->pref_user_picture_size->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_size->description
+msgid "User picture size:"
+msgstr "Velikost obrázku uživatele:"
+
+#. 3.2->settings-schema.json->pref_use_alternate_vector_box->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_alternate_vector_box->tooltip
+msgid ""
+"With this option enabled, an alternate method to select categories will be "
+"used. This method can improve the performance of the menu and is extracted "
+"from the applet called Configurable Menu by lestcape."
+msgstr ""
+"Je-li tato volba povolena, bude pro výběr kategorie použita alternativní "
+"metoda. Tato metoda může zlepšit výkon menu a je převzata z apletu "
+"Configurable Menu od autora lestcape."
+
+#. 3.2->settings-schema.json->pref_use_alternate_vector_box->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_alternate_vector_box->description
+msgid "Use alternate category selection method (EXPERIMENTAL)"
+msgstr "Použít alternativní metodu pro výběr kategorie (EXPERIMENTÁLNÍ)"
+
+#. 3.2->settings-schema.json->pref_enable_autoscroll->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_enable_autoscroll->tooltip
+msgid ""
+"Choose whether or not to enable smooth auto-scrolling in the application "
+"list."
+msgstr "Zaškrtněte pro automatický posun v seznamu aplikací."
+
+#. 3.2->settings-schema.json->pref_enable_autoscroll->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_enable_autoscroll->description
+msgid "Enable auto-scrolling in application list"
+msgstr "Povolit automatický posun v seznamu aplikací"
+
+#. 3.2->settings-schema.json->pref_separator_heigth->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_separator_heigth->description
+msgid "Favorites box separator height:"
+msgstr "Výška oddělovače:"
+
+#. 3.2->settings-schema.json->pref_separator_heigth->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_separator_heigth->tooltip
+msgid "Size of separator between \"Favorites\" box and \"Quit\" box."
+msgstr "Velikost oddělovače mezi polem \"Oblíbené\" a \"Ukončit\"."
+
+#. 3.2->settings-schema.json->pref_overlay_key->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_overlay_key->description
+msgid "Keyboard shortcut to open and close the menu"
+msgstr "Klávesová zkratka pro otevírání a zavírání menu"
+
+#. 3.2->settings-schema.json->pref_set_info_box_padding->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_info_box_padding->description
+msgid "Set a custom padding for the Applications info box"
+msgstr "Nastavit vlastní odsazení pro info box o aplikaci"
+
+#. 3.2->settings-schema.json->pref_display_fav_box->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_fav_box->tooltip
+msgid "Choose whether or not to show the left pane of the menu."
+msgstr "Zaškrtněte pro zobrazení levého panelu v menu."
+
+#. 3.2->settings-schema.json->pref_display_fav_box->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_fav_box->description
+msgid "Show favorites and quit options"
+msgstr "Zobrazit oblíbené a možnosti ukončení"
+
+#. 3.2->settings-schema.json->pref_show_bumblebee_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_bumblebee_on_context->description
+msgid "Show \"Run with NVIDIA GPU\" on context"
+msgstr "Zobrazit \"Spustit s GPU NVIDIA\" v kontextovém menu"
+
+#. 3.2->settings-schema.json->pref_system_buttons_display->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_system_buttons_display->description
+msgid "Quit buttons placement"
+msgstr "Umístění tlačítek ukončení"
+
+#. 3.2->settings-schema.json->pref_system_buttons_display->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_system_buttons_display->options
+msgid "Next to \"Custom launchers\" box"
+msgstr "Vedle boxu \"Uživatelské spouštěče\""
+
+#. 3.2->settings-schema.json->pref_system_buttons_display->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_system_buttons_display->options
+msgid "Hide all"
+msgstr "Skrýt vše"
+
+#. 3.2->settings-schema.json->pref_system_buttons_display->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_system_buttons_display->options
+msgid "Inside \"Favorites\" box"
+msgstr "Uvnitř boxu \"Oblíbené\""
+
+#. 3.2->settings-schema.json->pref_show_edit_desktop_file_on_context->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_edit_desktop_file_on_context->tooltip
+msgid ""
+"It adds to the applications context menu an entry that will allow you to "
+"open the current selected application's .desktop file in a text editor."
+msgstr ""
+"Přidá do kontextové nabídky aplikace položku, která vám umožní otevřít ."
+"desktop soubor aktuální vybrané aplikace v textovém editoru."
+
+#. 3.2->settings-schema.json->pref_show_edit_desktop_file_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_edit_desktop_file_on_context->description
+msgid "Show \"Edit .desktop file\" on context"
+msgstr "Zobrazit \"Upravit .desktop soubor\" v kontextovém menu"
 
 #. 3.2->settings-schema.json->pref_gain_privileges_on_context->tooltip
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_gain_privileges_on_context->tooltip
@@ -1326,328 +1781,29 @@ msgstr ""
 "umožní otevřít a upravit nevlastní soubory a požádá o heslo uživatele root v "
 "okamžiku uložení změn."
 
-#. 3.2->settings-schema.json->pref_set_custom_box_padding->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_custom_box_padding->description
-msgid "Set a custom padding for the Custom launchers box"
-msgstr "Nastavit vlastní odsazení pro pole uživatelských spouštěčů"
+#. 3.2->settings-schema.json->pref_gain_privileges_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_gain_privileges_on_context->description
+msgid "Gain privileges of not owned files"
+msgstr "Získat oprávnění k souborům, jichž nejste vlastníkem"
 
-#. 3.2->settings-schema.json->pref_logout_button_custom_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_logout_button_custom_icon->description
-msgid "Custom icon for \"Logout\" button:"
-msgstr "Vlastní ikona pro tlačítko \"Odhlásit\":"
-
-#. 3.2->settings-schema.json->pref_logout_button_custom_icon->tooltip
-#. 3.2->settings-schema.json->pref_lock_button_custom_icon->tooltip
-#. 3.2->settings-schema.json->pref_shutdown_button_custom_icon->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_shutdown_button_custom_icon->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_logout_button_custom_icon->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_lock_button_custom_icon->tooltip
+#. 3.2->settings-schema.json->pref_user_picture_stylized->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_stylized->tooltip
 msgid ""
-"Only valid if the System buttons box is placed next to the Custom launchers "
-"box.\n"
-"Leave blank to use default."
+"With this option enabled, the box containing the user picture will have the "
+"same style as the Favorites box."
 msgstr ""
-"Platné pouze pokud jsou tlačítka pro ukončení umístěna vedle uživatelských "
-"spouštěčů.\n"
-"Ponechte prázdné, pokud chcete použít výchozí ikony."
+"Je-li tato volba povolena, bude mít pole obsahující obrázek uživatele stejný "
+"styl jako pole pro oblíbené položky."
 
-#. 3.2->settings-schema.json->pref_appinfo_display_method->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_appinfo_display_method->description
-msgid "Display method for information about applications:"
-msgstr "Způsob zobrazení informací o aplikacích:"
+#. 3.2->settings-schema.json->pref_user_picture_stylized->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_stylized->description
+msgid "Stylize the user image"
+msgstr "Stylizace obrázku uživatele"
 
-#. 3.2->settings-schema.json->pref_appinfo_display_method->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_appinfo_display_method->options
-msgid "Tooltips"
-msgstr "Bublinová nápověda"
-
-#. 3.2->settings-schema.json->pref_appinfo_display_method->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_appinfo_display_method->options
-msgid "Info box"
-msgstr "Info box"
-
-#. 3.2->settings-schema.json->pref_show_add_remove_favorite_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_add_remove_favorite_on_context->description
-msgid "Show \"Add/Remove to/from favorites\" on context"
-msgstr "Zobrazit \"Přidat/odebrat do/z oblíbených\" v kontextovém menu"
-
-#. 3.2->settings-schema.json->pref_animate_menu->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_animate_menu->description
-msgid "Animate open/close menu"
-msgstr "Povolit animace menu při otevírání a zavírání"
-
-#. 3.2->settings-schema.json->pref_show_places->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_places->description
-msgid "Show bookmarks and places"
-msgstr "Zobrazit záložky a místa"
-
-#. 3.2->settings-schema.json->pref_show_places->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_places->tooltip
-msgid "Choose whether or not to show bookmarks and places in the menu."
-msgstr "Zaškrtněte pro zobrazení míst a záložek v menu"
-
-#. 3.2->settings-schema.json->pref_fuzzy_search_enabled->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_fuzzy_search_enabled->description
-msgid "Enable fuzzy search (EXPERIMENTAL)"
-msgstr "Povolit fuzzy vyhledávání (EXPERIMENTÁLNÍ)"
-
-#. 3.2->settings-schema.json->pref_fuzzy_search_enabled->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_fuzzy_search_enabled->tooltip
-msgid ""
-"This option enables an infinitelly better sorting of search results. It's "
-"marked as experimental because it has a huge impact on performance every "
-"time the search box is cleared."
-msgstr ""
-"Tato volba umožňuje nesrovnatelně lepší třídění výsledků vyhledávání. Je to "
-"označeno jako experimentální, protože má obrovský dopad na výkon pokaždé, "
-"když je vymazán obsah vyhledávacího pole."
-
-#. 3.2->settings-schema.json->pref_category_icon_size->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_category_icon_size->description
-msgid "Categories icon size:"
-msgstr "Velikost ikon kategorií:"
-
-#. 3.2->settings-schema.json->pref_show_recents_button->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_recents_button->description
-msgid "Show \"Recent documents\" category"
-msgstr "Zobrazit kategorii \"Nedávné dokumenty\""
-
-#. 3.2->settings-schema.json->pref_show_recents_button->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_recents_button->tooltip
-msgid ""
-"For people who want the \"Recent documents\" category hidden without "
-"disabling recent documents globally."
-msgstr ""
-"Pro uživatele, kteří chtějí skrýt kategorii \"Nedávné dokumenty\" bez "
-"globálního zakázání zobrazení posledních dokumentů."
-
-#. 3.2->settings-schema.json->pref_hide_applications_list_scrollbar->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_hide_applications_list_scrollbar->description
-msgid "Hide applications list scrollbar"
-msgstr "Skrýt posuvník v seznamu aplikací"
-
-#. 3.2->settings-schema.json->pref_max_recent_files->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_recent_files->description
-msgid "Max recent documents:"
-msgstr "Maximum nedávno otevřených dokumentů:"
-
-#. 3.2->settings-schema.json->pref_max_recent_files->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_recent_files->units
-msgid "documents"
-msgstr "dokumenty"
-
-#. 3.2->settings-schema.json->pref_enable_autoscroll->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_enable_autoscroll->description
-msgid "Enable auto-scrolling in application list"
-msgstr "Povolit automatický posun v seznamu aplikací"
-
-#. 3.2->settings-schema.json->pref_enable_autoscroll->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_enable_autoscroll->tooltip
-msgid ""
-"Choose whether or not to enable smooth auto-scrolling in the application "
-"list."
-msgstr "Zaškrtněte pro automatický posun v seznamu aplikací."
-
-#. 3.2->settings-schema.json->pref_system_buttons_display->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_system_buttons_display->description
-msgid "Quit buttons placement"
-msgstr "Umístění tlačítek ukončení"
-
-#. 3.2->settings-schema.json->pref_system_buttons_display->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_system_buttons_display->options
-msgid "Next to \"Custom launchers\" box"
-msgstr "Vedle boxu \"Uživatelské spouštěče\""
-
-#. 3.2->settings-schema.json->pref_system_buttons_display->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_system_buttons_display->options
-msgid "Inside \"Favorites\" box"
-msgstr "Uvnitř boxu \"Oblíbené\""
-
-#. 3.2->settings-schema.json->pref_system_buttons_display->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_system_buttons_display->options
-msgid "Hide all"
-msgstr "Skrýt vše"
-
-#. 3.2->settings-schema.json->pref_user_picture_placement->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->description
-msgid "User picture placement"
-msgstr "Umístění obrázku uživatele"
-
-#. 3.2->settings-schema.json->pref_user_picture_placement->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->options
-msgid "Right of applications info box"
-msgstr "Vpravo od info boxu o aplikaci"
-
-#. 3.2->settings-schema.json->pref_user_picture_placement->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->options
-msgid "Left of applications info box"
-msgstr "Vlevo od info boxu o aplikaci"
-
-#. 3.2->settings-schema.json->pref_user_picture_placement->options
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->options
-msgid "Do not show"
-msgstr "Nezobrazovat"
-
-#. 3.2->settings-schema.json->pref_user_picture_placement->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_placement->tooltip
-msgid ""
-"This option allows to display the user picture on the menu. Clicking on the "
-"picture will open \"Account details\". For the image to be shown, the "
-"applications info box also has to be displayed."
-msgstr ""
-"Tato volba umožňuje zobrazení obrázku uživatele v menu. Po kliknutí na "
-"obrázek se otevře \"Podrobnosti o účtu\". Pro zobrazení obrázku, musí být "
-"také zobrazen info box o aplikaci."
-
-#. 3.2->settings-schema.json->pref_show_run_from_terminal_as_root_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_run_from_terminal_as_root_on_context->description
-msgid "Show \"Run from terminal as root\" on context"
-msgstr "Zobrazit \"Spustit v terminálu jako root\" v kontextovém menu"
-
-#. 3.2->settings-schema.json->section_custom_launchers_007->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_7->description
-msgid "Custom launcher 7"
-msgstr "Uživatelský spouštěč 7"
-
-#. 3.2->settings-schema.json->section_custom_launchers_001->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_1->description
-msgid "Custom launcher 1"
-msgstr "Uživatelský spouštěč 1"
-
-#. 3.2->settings-schema.json->section_layout_001->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head2->description
-msgid "Menu layout"
-msgstr "Uspořádání menu"
-
-#. 3.2->settings-schema.json->section_quit_buttons_settings->title
-msgid "Quit buttons settings"
-msgstr "Nastavení tlačítek ukončení"
-
-#. 3.2->settings-schema.json->section_custom_launchers_005->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_5->description
-msgid "Custom launcher 5"
-msgstr "Uživatelský spouštěč 5"
-
-#. 3.2->settings-schema.json->section_appearance_icons_display->title
-msgid "Icons display"
-msgstr "Zobrazení ikon"
-
-#. 3.2->settings-schema.json->section_layout_002->title
-msgid "Placement on main elements on menu"
-msgstr "Rozmístění hlavních prvků menu"
-
-#. 3.2->settings-schema.json->section_custom_launchers_009->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_9->description
-msgid "Custom launcher 9"
-msgstr "Uživatelský spouštěč 9"
-
-#. 3.2->settings-schema.json->section_appearance_favorites_box->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance5->description
-msgid "Favorites box"
-msgstr "Oblíbené"
-
-#. 3.2->settings-schema.json->section_appearance_applicatons_box->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance6->description
-msgid "Applications box"
-msgstr "Aplikace"
-
-#. 3.2->settings-schema.json->section_context_menus_settings->title
-msgid "Context menus settings"
-msgstr "Nastavení kontextového menu"
-
-#. 3.2->settings-schema.json->section_custom_launchers_003->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_3->description
-msgid "Custom launcher 3"
-msgstr "Uživatelský spouštěč 3"
-
-#. 3.2->settings-schema.json->section_save_button_full->title
-msgid ""
-"Most settings are not automatically saved when modified.\n"
-"Press any of the \"Save settings\" buttons for the settings to take effect."
-msgstr ""
-"Většina změn nastavení se neukládá automaticky.\n"
-"Stiskněte tlačítko \"Uložit nastavení\" pro aktivaci změn."
-
-#. 3.2->settings-schema.json->section_custom_launchers_008->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_8->description
-msgid "Custom launcher 8"
-msgstr "Uživatelský spouštěč 8"
-
-#. 3.2->settings-schema.json->section_custom_launchers_004->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_4->description
-msgid "Custom launcher 4"
-msgstr "Uživatelský spouštěč 4"
-
-#. 3.2->settings-schema.json->section_appearance_boxes_padding->title
-msgid "Theme overrides"
-msgstr "Přepsání motivu"
-
-#. 3.2->settings-schema.json->section_menu_settings->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head1->description
-msgid "Menu settings"
-msgstr "Nastavení menu"
-
-#. 3.2->settings-schema.json->section_applet_settings->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head0->description
-msgid "Applet settings"
-msgstr "Nastavení apletu"
-
-#. 3.2->settings-schema.json->section_custom_launchers_006->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_6->description
-msgid "Custom launcher 6"
-msgstr "Uživatelský spouštěč 6"
-
-#. 3.2->settings-schema.json->section_custom_launchers_010->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_10->description
-msgid "Custom launcher 10"
-msgstr "Uživatelský spouštěč 10"
-
-#. 3.2->settings-schema.json->section_custom_launchers_000_bis->title
-msgid "Custom launchers notes"
-msgstr "Poznámky pro uživatelské spouštěče"
-
-#. 3.2->settings-schema.json->page_applet->title
-msgid "Applet"
-msgstr "Aplet"
-
-#. 3.2->settings-schema.json->section_recently_used_applications_settings->title
-msgid "Recently used applications settings"
-msgstr "Nastavení pro nedávno spuštěné aplikace"
-
-#. 3.2->settings-schema.json->page_custom_launchers->title
-msgid "Custom Launchers"
-msgstr "Uživatelské spouštěče"
-
-#. 3.2->settings-schema.json->page_appearance->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance1->description
-msgid "Appearance"
-msgstr "Vzhled"
-
-#. 3.2->settings-schema.json->page_extras->title
-msgid "Extras"
-msgstr "Extra funkce"
-
-#. 3.2->settings-schema.json->section_appearance_info_box->title
-msgid "Application info box"
-msgstr "Info box o aplikaci"
-
-#. 3.2->settings-schema.json->section_search_box_settings->title
-msgid "Search box settings"
-msgstr "Nastavení vyhledávacího pole"
-
-#. 3.2->settings-schema.json->section_custom_launchers_002->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_command_2->description
-msgid "Custom launcher 2"
-msgstr "Uživatelský spouštěč 2"
-
-#. 3.2->settings-schema.json->page_layout->title
-msgid "Layout"
-msgstr "Rozložení"
-
-#. 3.2->settings-schema.json->section_appearance_icon_sizes->title
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->appearance2->description
-msgid "Icon sizes"
-msgstr "Velikosti ikon"
+#. 3.2->settings-schema.json->pref_show_uninstall_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_uninstall_on_context->description
+msgid "Show \"Uninstall\" on context"
+msgstr "Zobrazit \"Odinstalovat\" v kontextovém menu"
 
 #. 3.2->settings-schema.json->pref_recently_used_apps_custom_icon->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recently_used_apps_custom_icon->description
@@ -1663,222 +1819,78 @@ msgstr ""
 "Zadejte vlastní ikonu pro kategorii \"Nedávné aplikace\".\n"
 "Je možné zadat pouze název ikony."
 
-#. 3.2->settings-schema.json->pref_max_recently_used_apps->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_recently_used_apps->description
-msgid "Max recently used apps:"
-msgstr "Maximum nedávno otevřených aplikací:"
-
-#. 3.2->settings-schema.json->pref_max_recently_used_apps->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_recently_used_apps->units
-msgid "applications"
-msgstr "aplikace"
-
-#. 3.2->settings-schema.json->pref_custom_icon_for_applet->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_icon_for_applet->description
-msgid "Icon"
-msgstr "Ikona"
-
-#. 3.2->settings-schema.json->pref_custom_icon_for_applet->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_icon_for_applet->tooltip
-msgid "Select an icon to show in the panel."
-msgstr "Zvolte ikonu, která se zobrazí na panelu."
-
-#. 3.2->settings-schema.json->pref_set_categories_padding->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_categories_padding->description
-msgid "Set a custom padding for the Categories box"
-msgstr "Nastavit vlastní odsazení pro pole kategorií"
-
-#. 3.2->settings-schema.json->pref_show_run_from_terminal_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_run_from_terminal_on_context->description
-msgid "Show \"Run from terminal\" on context"
-msgstr "Zobrazit \"Spustit v terminálu\" v kontextovém menu"
-
-#. 3.2->settings-schema.json->pref_set_search_entry_padding->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_set_search_entry_padding->description
-msgid "Set a custom padding for the search entry box"
-msgstr "Nastavit vlastní odsazení pro vnitřní vyhledávací pole"
-
-#. 3.2->settings-schema.json->pref_recently_used_apps_separator->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recently_used_apps_separator->description
-msgid "Display separator after \"Recent Applications\" category (WARNING)"
-msgstr ""
-"Zobrazit oddělovač za kategorií \"Nedávno spuštěné aplikace\" (UPOZORNĚNÍ)"
-
-#. 3.2->settings-schema.json->pref_recently_used_apps_separator->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_recently_used_apps_separator->tooltip
+#. 3.2->settings-schema.json->pref_use_hover_feedback->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_hover_feedback->tooltip
 msgid ""
-"This option, when enabled, will break the menu keyboard navigation. Only "
-"enable this option if you will never use the keyboard to navigate the menu.\n"
-"This message is only temporary until I figure out how to fix this."
+"If enabled, and the user picture is shown, every time an application/"
+"favorite/place/recent file is hovered or selected with keyboard navigation, "
+"its icon will be displayed where the user picture is located."
 msgstr ""
-"Je-li tato volba povolena, nebude funkční navigace v menu pomocí klávesnice. "
-"Tuto možnost povolte pouze v případě, že nikdy nepoužíváte klávesnici k "
-"navigaci v menu.\n"
-"Tato zpráva je pouze dočasná do doby opravení problému."
+"Je-li volba povolena a zároveň je povoleno zobrazení obrázku uživatele, tak "
+"pokaždé po výběru klávesou nebo při najetí myší na aplikaci/oblíbenou "
+"položku/místo/poslední otevřený soubor, bude jeho ikona zobrazena na místě "
+"obrázku uživatele."
 
-#. 3.2->settings-schema.json->pref_disable_new_apps_highlighting->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_disable_new_apps_highlighting->description
-msgid "Disable newly installed applications highlighting"
-msgstr "Zakázat zvýraznění nově nainstalovaných aplikací"
+#. 3.2->settings-schema.json->pref_use_hover_feedback->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_use_hover_feedback->description
+msgid "Use hover feedback"
+msgstr "Zobrazit ikonu po najetí"
+
+#. 3.2->settings-schema.json->pref_custom_editor_for_edit_desktop_file_on_context->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_editor_for_edit_desktop_file_on_context->description
+msgid "Custom text editor:"
+msgstr "Vlastní textový editor:"
+
+#. 3.2->settings-schema.json->pref_custom_editor_for_edit_desktop_file_on_context->tooltip
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_editor_for_edit_desktop_file_on_context->tooltip
+msgid ""
+"Set a custom text editor to open .desktop files (just the name of the text "
+"editor executable or the path to it).\n"
+"Leave it blank to let the system decide."
+msgstr ""
+"Nastavte vlastní textový editor pro otevření .desktop souborů (pouze název "
+"textového editoru nebo cesta).\n"
+"Ponechte nevyplněné pro výběr systémového editoru."
+
+#. 3.2->settings-schema.json->pref_custom_commands_box_alignment->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_alignment->description
+msgid "Custom launchers buttons alignment"
+msgstr "Zarovnání uživatelských spouštěčů"
+
+#. 3.2->settings-schema.json->pref_custom_commands_box_alignment->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_alignment->options
+msgid "Left"
+msgstr "Vlevo"
+
+#. 3.2->settings-schema.json->pref_custom_commands_box_alignment->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_alignment->options
+msgid "Middle"
+msgstr "Uprostřed"
+
+#. 3.2->settings-schema.json->pref_custom_commands_box_alignment->options
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_commands_box_alignment->options
+msgid "Right"
+msgstr "Vpravo"
 
 #. 3.2->settings-schema.json->pref_lock_button_custom_icon->description
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_lock_button_custom_icon->description
 msgid "Custom icon for \"Lock screen\" button:"
 msgstr "Vlastní ikona pro tlačítko \"Zamknout obrazovku\":"
 
-#. 3.2->settings-schema.json->pref_info_box_title_font_size->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_title_font_size->description
-msgid "Applications info box title font size:"
-msgstr "Velikost fontu názvu aplikace:"
+#. 3.2->settings-schema.json->pref_apps_info_box_alignment_to_the_left->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_apps_info_box_alignment_to_the_left->description
+msgid "Align application info box text to the left"
+msgstr "Zarovnat text v info boxu o aplikaci doleva."
 
-#. 3.2->settings-schema.json->pref_info_box_title_font_size->units
-#. 3.2->settings-schema.json->pref_max_width_for_buttons->units
-#. 3.2->settings-schema.json->pref_info_box_description_font_size->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_width_for_buttons->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_title_font_size->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_description_font_size->units
-msgid "ems"
-msgstr "ems"
+#. 3.2->settings-schema.json->pref_menu_layout_first_place->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_first_place->description
+msgid "First place element"
+msgstr "První součást menu"
 
-#. 3.2->settings-schema.json->pref_show_edit_desktop_file_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_edit_desktop_file_on_context->description
-msgid "Show \"Edit .desktop file\" on context"
-msgstr "Zobrazit \"Upravit .desktop soubor\" v kontextovém menu"
-
-#. 3.2->settings-schema.json->pref_show_edit_desktop_file_on_context->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_edit_desktop_file_on_context->tooltip
-msgid ""
-"It adds to the applications context menu an entry that will allow you to "
-"open the current selected application's .desktop file in a text editor."
-msgstr ""
-"Přidá do kontextové nabídky aplikace položku, která vám umožní otevřít ."
-"desktop soubor aktuální vybrané aplikace v textovém editoru."
-
-#. 3.2->settings-schema.json->pref_show_uninstall_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_uninstall_on_context->description
-msgid "Show \"Uninstall\" on context"
-msgstr "Zobrazit \"Odinstalovat\" v kontextovém menu"
-
-#. 3.2->settings-schema.json->pref_cat_hover_delay->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_cat_hover_delay->description
-msgid "Category selection delay:"
-msgstr "Zpoždění při výběru kategorie:"
-
-#. 3.2->settings-schema.json->pref_cat_hover_delay->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_cat_hover_delay->tooltip
-msgid "Delay between switching categories."
-msgstr "Zpoždění mezi přepnutím kategorií."
-
-#. 3.2->settings-schema.json->pref_cat_hover_delay->units
-#. 3.2->settings-schema.json->pref_menu_hover_delay->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_cat_hover_delay->units
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_hover_delay->units
-msgid "milliseconds"
-msgstr "milisekund"
-
-#. 3.2->settings-schema.json->pref_display_fav_box->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_fav_box->description
-msgid "Show favorites and quit options"
-msgstr "Zobrazit oblíbené a možnosti ukončení"
-
-#. 3.2->settings-schema.json->pref_display_fav_box->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_fav_box->tooltip
-msgid "Choose whether or not to show the left pane of the menu."
-msgstr "Zaškrtněte pro zobrazení levého panelu v menu."
-
-#. 3.2->settings-schema.json->pref_user_picture_stylized->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_stylized->description
-msgid "Stylize the user image"
-msgstr "Stylizace obrázku uživatele"
-
-#. 3.2->settings-schema.json->pref_user_picture_stylized->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_user_picture_stylized->tooltip
-msgid ""
-"With this option enabled, the box containing the user picture will have the "
-"same style as the Favorites box."
-msgstr ""
-"Je-li tato volba povolena, bude mít pole obsahující obrázek uživatele stejný "
-"styl jako pole pro oblíbené položky."
-
-#. 3.2->settings-schema.json->pref_display_application_icons->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_application_icons->description
-msgid "Show application icons"
-msgstr "Zobrazit ikony aplikací"
-
-#. 3.2->settings-schema.json->pref_display_application_icons->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_display_application_icons->tooltip
-msgid "Choose whether or not to show icons on applications."
-msgstr "Zaškrtněte pro zobrazení ikon aplikací."
-
-#. 3.2->settings-schema.json->pref_hide_allapps_category->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_hide_allapps_category->description
-msgid "Hide \"All Applications\" category"
-msgstr "Skrýt kategorii \"Všechny aplikace\""
-
-#. 3.2->settings-schema.json->pref_show_add_to_desktop_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_add_to_desktop_on_context->description
-msgid "Show \"Add to desktop\" on context"
-msgstr "Zobrazit \"Přidat na plochu\" v kontextovém menu"
-
-#. 3.2->settings-schema.json->pref_max_width_for_buttons->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_width_for_buttons->description
-msgid "Maximum button width:"
-msgstr "Maximální šířka tlačítka:"
-
-#. 3.2->settings-schema.json->pref_max_width_for_buttons->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_max_width_for_buttons->tooltip
-msgid "Define the maximum width of menu items inside the applications box."
-msgstr "Definuje maximální šířku položek menu uvnitř pole pro aplikace."
-
-#. 3.2->settings-schema.json->pref_shutdown_button_custom_icon->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_shutdown_button_custom_icon->description
-msgid "Custom icon for \"Shutdown\" button:"
-msgstr "Vlastní ikona pro tlačítko \"Vypnout\":"
-
-#. 3.2->settings-schema.json->pref_info_box_description_font_size->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_info_box_description_font_size->description
-msgid "Applications info box description font size:"
-msgstr "Velikost fontu popisu aplikace:"
-
-#. 3.2->settings-schema.json->pref_show_desktop_file_folder_on_context->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_desktop_file_folder_on_context->description
-msgid "Show \"Open .desktop file folder\" on context"
-msgstr "Zobrazit \"Otevřít složku s .desktop souborem\" v kontextovém menu"
-
-#. 3.2->settings-schema.json->pref_custom_label_for_applet->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_label_for_applet->description
-msgid "Custom label"
-msgstr "Uživatelský název"
-
-#. 3.2->settings-schema.json->pref_custom_label_for_applet->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_label_for_applet->tooltip
-msgid "Enter custom text to show in the panel."
-msgstr "Vložte text, který se zobrazí na panelu."
-
-#. 3.2->settings-schema.json->pref_menu_hover_delay->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_hover_delay->description
-msgid "Menu hover delay:"
-msgstr "Zpoždění menu při najetí:"
-
-#. 3.2->settings-schema.json->pref_menu_hover_delay->tooltip
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_hover_delay->tooltip
-msgid "Delay before the menu is opened on entering the applet."
-msgstr "Zpoždění před otevřením menu při najetí."
-
-#. 3.2->settings-schema.json->pref_show_shutdown_button->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_show_shutdown_button->description
-msgid "Show \"Shutdown\" button"
-msgstr "Zobrazit tlačítko \"Vypnout\""
-
-#. 3.2->settings-schema.json->pref_menu_layout_third_place->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_third_place->description
-msgid "Third place element"
-msgstr "Třetí součást menu"
-
-#. 3.2->settings-schema.json->pref_menu_layout_fourth_place->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_menu_layout_fourth_place->description
-msgid "Fourth place element"
-msgstr "Čtvrtá součást menu"
+#. 3.2->settings-schema.json->pref_custom_command_icon_size->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->pref_custom_command_icon_size->description
+msgid "Custom launchers icon size:"
+msgstr "Velikost ikon pro uživatelské spouštěče:"
 
 #. 0dyseus@CustomCinnamonMenu->metadata.json->description
 msgid ""
@@ -1886,6 +1898,10 @@ msgid ""
 "customizable."
 msgstr ""
 "Vlastní verze výchozího apletu Cinnamon menu, ale mnohem přizpůsobitelnější."
+
+#. 0dyseus@CustomCinnamonMenu->metadata.json->name
+msgid "Custom Cinnamon Menu"
+msgstr "Nastavitelné Cinnamon menu"
 
 #. 0dyseus@CustomCinnamonMenu->metadata.json->comments
 msgid ""
@@ -1896,46 +1912,21 @@ msgstr ""
 "repozitáři tohoto xletu, na který je odkaz níže."
 
 #. 0dyseus@CustomCinnamonMenu->metadata.json->contributors
-msgid "NikoKrause: Bug fixes and German localization."
-msgstr "NikoKrause: Německá lokalizace a opravy chyb."
+msgid "See this xlet help file."
+msgstr "Viz soubor s nápovědou tohoto xletu."
 
-#. 0dyseus@CustomCinnamonMenu->metadata.json->contributors
-msgid "Radek71: Czech localization."
-msgstr "Radek71: Česká lokalizace."
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head7->description
+msgid "Custom launchers"
+msgstr "Uživatelské spouštěče"
 
-#. 0dyseus@CustomCinnamonMenu->metadata.json->contributors
-msgid "muzena: Croatian localization."
-msgstr "muzena: Chorvatská lokalizace."
-
-#. 0dyseus@CustomCinnamonMenu->metadata.json->contributors
-msgid "giwhub: Chinese localization."
-msgstr "giwhub: Čínská lokalizace."
-
-#. 0dyseus@CustomCinnamonMenu->metadata.json->contributors
-msgid "lestcape: Author of some advanced features used by this applet."
-msgstr ""
-"lestcape: Autor některých pokročilých vlastností použitých tímto apletem."
-
-#. 0dyseus@CustomCinnamonMenu->metadata.json->contributors
-msgid "nooulaif: Fuzzy search feature based on his Sane Menu applet."
-msgstr "nooulaif: Fuzzy vyhledávání založené na jeho Sane Menu apletu."
-
-#. 0dyseus@CustomCinnamonMenu->metadata.json->contributors
-msgid "Daniel Bruce: Some icons used by this menu are from www.entypo.com."
-msgstr ""
-"Daniel Bruce: Některé ikony použité v tomto menu jsou z www.entypo.com."
-
-#. 0dyseus@CustomCinnamonMenu->metadata.json->contributors
-msgid "eson57: Swedish localization."
-msgstr "eson57: Švédská lokalizace."
-
-#. 0dyseus@CustomCinnamonMenu->metadata.json->name
-msgid "Custom Cinnamon Menu"
-msgstr "Nastavitelné Cinnamon menu"
-
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head6->description
-msgid "Recently used applications"
-msgstr "Nedávno použité aplikace"
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->button2->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->button4->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->button1->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->button3->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->button0->description
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->button5->description
+msgid "Click here to save settings"
+msgstr "Klikněte zde pro uložení nastavení"
 
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->head8->description
 msgid ""
@@ -1960,30 +1951,9 @@ msgstr ""
 "Jinak bude soubor otevřen aplikací asociovanou v systému pro tento typ "
 "souboru."
 
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head7->description
-msgid "Custom launchers"
-msgstr "Uživatelské spouštěče"
-
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->button3->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->button2->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->button0->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->button1->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->button5->description
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->button4->description
-msgid "Click here to save settings"
-msgstr "Klikněte zde pro uložení nastavení"
-
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->head5->description
 msgid "Applications context menu extras"
 msgstr "Extra položky pro kontextové menu aplikací"
-
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head3->description
-msgid "Quit buttons"
-msgstr "Tlačítka ukončení"
-
-#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head22->description
-msgid "Placement of main elements on menu"
-msgstr "Rozmístění hlavních prvků menu"
 
 #. 0dyseus@CustomCinnamonMenu->settings-schema.json->head->description
 msgid ""
@@ -1993,6 +1963,44 @@ msgid ""
 msgstr ""
 "Většina změn nastavení se neukládá automaticky.\n"
 "Stiskněte tlačítko \"Klikněte zde pro uložení nastavení\" pro aktivaci změn."
+
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head3->description
+msgid "Quit buttons"
+msgstr "Tlačítka ukončení"
+
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head22->description
+msgid "Placement of main elements on menu"
+msgstr "Rozmístění hlavních prvků menu"
+
+#. 0dyseus@CustomCinnamonMenu->settings-schema.json->head6->description
+msgid "Recently used applications"
+msgstr "Nedávno použité aplikace"
+
+#~ msgid "NikoKrause: Bug fixes and German localization."
+#~ msgstr "NikoKrause: Německá lokalizace a opravy chyb."
+
+#~ msgid "Radek71: Czech localization."
+#~ msgstr "Radek71: Česká lokalizace."
+
+#~ msgid "muzena: Croatian localization."
+#~ msgstr "muzena: Chorvatská lokalizace."
+
+#~ msgid "giwhub: Chinese localization."
+#~ msgstr "giwhub: Čínská lokalizace."
+
+#~ msgid "lestcape: Author of some advanced features used by this applet."
+#~ msgstr ""
+#~ "lestcape: Autor některých pokročilých vlastností použitých tímto apletem."
+
+#~ msgid "nooulaif: Fuzzy search feature based on his Sane Menu applet."
+#~ msgstr "nooulaif: Fuzzy vyhledávání založené na jeho Sane Menu apletu."
+
+#~ msgid "Daniel Bruce: Some icons used by this menu are from www.entypo.com."
+#~ msgstr ""
+#~ "Daniel Bruce: Některé ikony použité v tomto menu jsou z www.entypo.com."
+
+#~ msgid "eson57: Swedish localization."
+#~ msgstr "eson57: Švédská lokalizace."
 
 #~ msgid "Customizable Main Cinnamon menu."
 #~ msgstr "Nastavitelné hlavní Cinnamon menu."


### PR DESCRIPTION
- Redesigned the creation of the help file to be "on-line friendly".
- Finally fixed the annoyance of having titles on the help files hidden behind the top navigation bar when clicking the navigation links (Help/Contributors/Changelog).
- Fixed the display of a translated sentence on the help files that was being displayed untranslated.
- Added smooth scrolling for the links on the navigation bar of the help files.
- Updated localization template, localizations and help file due to changes to the *help file creator* script.
- Added to the xlet README file links to the localized help file.
- Better handling of **Settings.BindingDirection**. Just to avoid surprises when that constant is removed on future versions of Cinnamon.