### PR TITLE
Extensions Manager (0dyseus@ExtensionsManager) update

### DIFF
--- a/0dyseus@ExtensionsManager/README.md
+++ b/0dyseus@ExtensionsManager/README.md
@@ -22,6 +22,6 @@ This applet creates a menu with a list of all installed extensions in Cinnamon. 
 
 ![Settings window](https://odyseus.github.io/CinnamonTools/lib/img/ExtensionsManager-001.png "Settings window")
 
-[Contributors/Mentions](https://github.com/Odyseus/CinnamonTools/blob/master/applets/0dyseus%40ExtensionsManager/CONTRIBUTORS.md)
-
-[Full change log](https://github.com/Odyseus/CinnamonTools/blob/master/applets/0dyseus%40ExtensionsManager/CHANGELOG.md)
+#### [Localized help](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@ExtensionsManager.html)
+#### [Contributors/Mentions](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@ExtensionsManager.html#xlet-contributors)
+#### [Full change log](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@ExtensionsManager.html#xlet-changelog)

--- a/0dyseus@ExtensionsManager/files/0dyseus@ExtensionsManager/HELP.html
+++ b/0dyseus@ExtensionsManager/files/0dyseus@ExtensionsManager/HELP.html
@@ -12,6 +12,102 @@ exported toggleLocalizationVisibility
 
 /* jshint varstmt: false */
 
+// Source: https://github.com/julienetie/smooth-scroll
+(function(window, document) {
+    var prefixes = ['moz', 'webkit', 'o'],
+        animationFrame;
+
+    // Modern rAF prefixing without setTimeout
+    function requestAnimationFrameNative() {
+        prefixes.map(function(prefix) {
+            if (!window.requestAnimationFrame) {
+                animationFrame = window[prefix + 'RequestAnimationFrame'];
+            } else {
+                animationFrame = requestAnimationFrame;
+            }
+        });
+    }
+    requestAnimationFrameNative();
+
+    function getOffsetTop(el) {
+        if (!el) {
+            return 0;
+        }
+
+        var yOffset = el.offsetTop,
+            parent = el.offsetParent;
+
+        yOffset += getOffsetTop(parent);
+
+        return yOffset;
+    }
+
+    function getScrollTop(scrollable) {
+        return scrollable.scrollTop || document.body.scrollTop || document.documentElement.scrollTop;
+    }
+
+    function scrollTo(scrollable, coords, millisecondsToTake) {
+        var currentY = getScrollTop(scrollable),
+            diffY = coords.y - currentY,
+            startTimestamp = null;
+
+        if (coords.y === currentY || typeof scrollable.scrollTo !== 'function') {
+            return;
+        }
+
+        function doScroll(currentTimestamp) {
+            if (startTimestamp === null) {
+                startTimestamp = currentTimestamp;
+            }
+
+            var progress = currentTimestamp - startTimestamp,
+                fractionDone = (progress / millisecondsToTake),
+                pointOnSineWave = Math.sin(fractionDone * Math.PI / 2);
+            scrollable.scrollTo(0, currentY + (diffY * pointOnSineWave));
+
+            if (progress < millisecondsToTake) {
+                animationFrame(doScroll);
+            } else {
+                // Ensure we're at our destination
+                scrollable.scrollTo(coords.x, coords.y);
+            }
+        }
+
+        animationFrame(doScroll);
+    }
+
+    // Declaire scroll duration, (before script)
+    var speed = window.smoothScrollSpeed || 750;
+
+    function smoothScroll(e) { // no smooth scroll class to ignore links
+        if (e.target.className === 'no-ss') {
+            return;
+        }
+
+        var source = e.target,
+            targetHref = source.hash,
+            target = null;
+
+        if (!source || !targetHref) {
+            return;
+        }
+
+        targetHref = targetHref.substring(1);
+        target = document.getElementById(targetHref);
+        if (!target) {
+            return;
+        }
+
+        scrollTo(window, {
+            x: 0,
+            y: getOffsetTop(target)
+        }, speed);
+    }
+
+    // Uses target's hash for scroll
+    document.addEventListener('click', smoothScroll, false);
+}(window, document));
+
 if (!window.localStorage) {
     /*
     Storage objects are a recent addition to the standard. As such they may not be present
@@ -449,7 +545,7 @@ body {
 <noscript>
 <div class="alert alert-warning">
 <p><strong>Oh snap! This page needs JavaScript enabled to display correctly.</strong></p>
-<p><strong>This page uses JavaScript only to switch between the available languages.</strong></p>
+<p><strong>This page uses JavaScript only to switch between the available languages and/or display images.</strong></p>
 <p><strong>There are no tracking services of any kind and never will be (at least, not from my side).</strong></p>
 </div> <!-- .alert.alert-warning -->
 </noscript>
@@ -458,16 +554,16 @@ body {
     <div class="container-fluid">
     <div class="navbar-header">
         <ul class="nav navbar-nav">
-            <li><a id="nav-xlet-help" class="navbar-brand" href="#xlet-help"></a></li>
-            <li><a id="nav-xlet-contributors" class="navbar-brand" href="#xlet-contributors"></a></li>
-            <li><a id="nav-xlet-changelog" class="navbar-brand" href="#xlet-changelog"></a></li>
+            <li><a id="nav-xlet-help" class="js_smoothScroll navbar-brand" href="#xlet-help"></a></li>
+            <li><a id="nav-xlet-contributors" class="js_smoothScroll navbar-brand" href="#xlet-contributors"></a></li>
+            <li><a id="nav-xlet-changelog" class="js_smoothScroll navbar-brand" href="#xlet-changelog"></a></li>
         </ul>
     </div>
     <form class="navbar-form navbar-collapse collapse navbar-right">
         <div class="form-group">
             <label id="localization-chooser-label" class="control-label" for="localization-switch"></label>
             <select class="form-control input-sm" id="localization-switch" onchange="self.toggleLocalizationVisibility(value, this);">
-                <!-- Česky --><option data-title="Nápověda pro Extensions Manager" data-language-chooser-label="Zvolte jazyk" data-xlet-help="Help" data-xlet-contributors="Contributors" data-xlet-changelog="Changelog" value="cs">Česky</option>
+                <!-- Česky --><option data-title="Nápověda pro Extensions Manager" data-language-chooser-label="Zvolte jazyk" data-xlet-help="Nápověda" data-xlet-contributors="Přispěvatelé" data-xlet-changelog="Changelog" value="cs">Česky</option>
 <!-- English --><option selected data-title="Help for Extensions Manager" data-language-chooser-label="Choose language" data-xlet-help="Help" data-xlet-contributors="Contributors" data-xlet-changelog="Changelog" value="en">English</option>
 <!-- Español --><option data-title="Ayuda para Extensions Manager" data-language-chooser-label="Elegir idioma" data-xlet-help="Ayuda" data-xlet-contributors="Colaboradores" data-xlet-changelog="Registro de cambios" value="es">Español</option>
 <!-- Svenska --><option data-title="Hjälp för Extensions Manager" data-language-chooser-label="Välj språk" data-xlet-help="Hjälp" data-xlet-contributors="Medhjälpare" data-xlet-changelog="Ändringslogg" value="sv">Svenska</option>
@@ -477,7 +573,7 @@ body {
     </form>
     </div>
 </nav>
-<span id="xlet-help">
+<span id="xlet-help" style="padding-top:70px;">
 <div class="container boxed">
 
 <div id="zh_CN" class="localization-content hidden">
@@ -502,6 +598,7 @@ body {
 <li>如果该xlet没有您的语言的本地化，您可以按照以下说明进行创建。 <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">以下两个部分仅使用英语。</div>
 </div> <!-- .localization-content -->
 
 
@@ -527,6 +624,7 @@ body {
 <li>Si este xlet no está disponible en su idioma, la localización puede ser creada siguiendo las siguientes instrucciones. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Las siguientes dos secciones están disponibles sólo en Inglés.</div>
 </div> <!-- .localization-content -->
 
 
@@ -552,6 +650,7 @@ body {
 <li>Pokud tento xlet nemá k dispozici překlad pro váš jazyk, můžete jej vytvořit podle následujících pokynů. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Následující dvě části jsou k dispozici pouze v angličtině.</div>
 </div> <!-- .localization-content -->
 
 
@@ -577,6 +676,7 @@ body {
 <li>Om ditt språk saknas i denna xlet, kan du översätta den med hjälp av följande instruktioner. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Följande två sektioner är endast tillgängliga på Engelska.</div>
 </div> <!-- .localization-content -->
 
 
@@ -602,11 +702,11 @@ body {
 <li>If this xlet has no locale available for your language, you could create it by following the following instructions. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">The following two sections are available only in English.</div>
 </div> <!-- .localization-content -->
 
 </div> <!-- .container.boxed -->
-<div style="font-weight:bold;" class="container alert alert-info">The following two sections are available only in English.</div>
-<span id="xlet-contributors">
+<span id="xlet-contributors" style="padding-top:140px;">
 <div class="container boxed">
 <h2>Contributors/Mentions</h2>
 <ul>
@@ -618,10 +718,29 @@ body {
 
 </div> <!-- .container.boxed -->
 
-<span id="xlet-changelog">
+<span id="xlet-changelog" style="padding-top:70px;">
 <div class="container boxed">
 <h2>Extensions Manager changelog</h2>
 <h4>This change log is only valid for the version of the xlet hosted on <a href="https://github.com/Odyseus/CinnamonTools">its original repository</a></h4>
+<hr>
+<ul>
+<li><strong>Date:</strong> Thu, 8 Jun 2017 01:11:05 -0300</li>
+<li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/2b17363">2b17363</a></li>
+<li><strong>Author:</strong> Odyseus</li>
+</ul>
+<pre><code>Extensions Manager applet
+- Updated Czech localization.
+</code></pre>
+<hr>
+<ul>
+<li><strong>Date:</strong> Tue, 6 Jun 2017 22:29:43 -0300</li>
+<li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/ba83574">ba83574</a></li>
+<li><strong>Author:</strong> Odyseus</li>
+</ul>
+<pre><code>Extensions Manager applet
+- Better handling of **Settings.BindingDirection**. Just to avoid surprises when that constant is
+removed on future versions of Cinnamon.
+</code></pre>
 <hr>
 <ul>
 <li><strong>Date:</strong> Sun, 4 Jun 2017 19:33:13 +0800</li>
@@ -956,6 +1075,8 @@ Python 2 to execute it.
 </div> <!-- .container.boxed -->
 
 </div> <!-- #mainarea -->
-<script type="text/javascript">toggleLocalizationVisibility(null);</script>
+<script type="text/javascript">toggleLocalizationVisibility(null);
+
+</script>
 </body>
 </html>

--- a/0dyseus@ExtensionsManager/files/0dyseus@ExtensionsManager/applet.js
+++ b/0dyseus@ExtensionsManager/files/0dyseus@ExtensionsManager/applet.js
@@ -198,13 +198,19 @@ MyApplet.prototype = {
             ["pref_custom_icon_for_applet", this._updateIconAndLabel],
             ["pref_custom_label_for_applet", this._updateIconAndLabel],
         ];
-        let bindingDirection = Settings.BindingDirection.BIDIRECTIONAL || null;
+        // Needed for retro-compatibility.
+        // Mark for deletion on EOL.
+        let bD = {
+            IN: 1,
+            OUT: 2,
+            BIDIRECTIONAL: 3
+        };
         let bindingType = typeof this.settings.bind === "function";
         for (let [property_name, callback] of settingsArray) {
             if (bindingType)
                 this.settings.bind(property_name, property_name, callback);
             else
-                this.settings.bindProperty(bindingDirection, property_name, property_name, callback, null);
+                this.settings.bindProperty(bD.BIDIRECTIONAL, property_name, property_name, callback, null);
         }
     },
 

--- a/0dyseus@ExtensionsManager/files/0dyseus@ExtensionsManager/metadata.json
+++ b/0dyseus@ExtensionsManager/files/0dyseus@ExtensionsManager/metadata.json
@@ -11,6 +11,6 @@
     "max-instances": -1,
     "uuid": "0dyseus@ExtensionsManager",
     "comments": "Bug reports, feature requests and contributions should be done on this xlet's repository linked below.",
-    "version": "1.07",
+    "version": "1.08",
     "description": "Allows enabling/disabling extensions (and other tasks) from a menu."
 }

--- a/0dyseus@ExtensionsManager/files/0dyseus@ExtensionsManager/po/0dyseus@ExtensionsManager.pot
+++ b/0dyseus@ExtensionsManager/files/0dyseus@ExtensionsManager/po/0dyseus@ExtensionsManager.pot
@@ -5,8 +5,8 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 0dyseus@ExtensionsManager 1.07\n"
-"POT-Creation-Date: 2017-06-02 17:05-0300\n"
+"Project-Id-Version: 0dyseus@ExtensionsManager 1.08\n"
+"POT-Creation-Date: 2017-06-12 22:20-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,65 +15,65 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: make-xlet-pot.py 1.0.32\n"
 
-#: ../../create_localized_help.py:90
-msgid "The following two sections are available only in English."
-msgstr ""
-
 #. TO TRANSLATORS: This is a placeholder.
 #. Here goes your language name in your own language (a.k.a. endonym).
-#: ../../create_localized_help.py:115 ../../create_localized_help.py:187
+#: ../../create_localized_help.py:119 ../../create_localized_help.py:195
 msgid "language-name"
 msgstr ""
 
-#: ../../create_localized_help.py:190 applet.js:155
+#: ../../create_localized_help.py:125
+msgid "The following two sections are available only in English."
+msgstr ""
+
+#: ../../create_localized_help.py:198 applet.js:160
 msgid "Help"
 msgstr ""
 
-#: ../../create_localized_help.py:191
+#: ../../create_localized_help.py:199
 msgid "Contributors"
 msgstr ""
 
-#: ../../create_localized_help.py:192
+#: ../../create_localized_help.py:200
 msgid "Changelog"
 msgstr ""
 
-#: ../../create_localized_help.py:193
+#: ../../create_localized_help.py:201
 msgid "Choose language"
 msgstr ""
 
 #. TO TRANSLATORS: Full sentence:
 #. "Help for <xlet_name>"
-#: ../../create_localized_help.py:194 ../../create_localized_help.py:201
+#: ../../create_localized_help.py:202 ../../create_localized_help.py:209
 #, python-format
 msgid "Help for %s"
 msgstr ""
 
-#: ../../create_localized_help.py:202
+#: ../../create_localized_help.py:210
 msgid "IMPORTANT!!!"
 msgstr ""
 
-#: ../../create_localized_help.py:203
+#: ../../create_localized_help.py:211
 msgid "Never delete any of the files found inside this xlet folder. It might break this xlet functionality."
 msgstr ""
 
-#: ../../create_localized_help.py:204
+#: ../../create_localized_help.py:212
 msgid "Bug reports, feature requests and contributions should be done on this xlet's repository linked next."
 msgstr ""
 
-#: ../../create_localized_help.py:210
+#: ../../create_localized_help.py:218
 msgid "Applets/Desklets/Extensions (a.k.a. xlets) localization"
 msgstr ""
 
-#: ../../create_localized_help.py:211
+#: ../../create_localized_help.py:219
 msgid "If this xlet was installed from Cinnamon Settings, all of this xlet's localizations were automatically installed."
 msgstr ""
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:213
+#: ../../create_localized_help.py:221
 msgid "If this xlet was installed manually and not trough Cinnamon Settings, localizations can be installed by executing the script called **localizations.sh** from a terminal opened inside the xlet's folder."
 msgstr ""
 
-#: ../../create_localized_help.py:214
+#: ../../create_localized_help.py:222
 msgid "If this xlet has no locale available for your language, you could create it by following the following instructions."
 msgstr ""
 
@@ -141,180 +141,74 @@ msgstr ""
 msgid "A detailed error has been logged into ~/.cinnamon/glass.log."
 msgstr ""
 
-#: applet.js:99
+#: applet.js:104
 msgid "Open extensions manager"
 msgstr ""
 
-#: applet.js:112
+#: applet.js:117
 msgid "Disable all extensions"
 msgstr ""
 
-#: applet.js:122
+#: applet.js:127
 msgid "This will disable all active extensions. Are you sure you want to do this?"
 msgstr ""
 
-#: applet.js:130
+#: applet.js:135
 msgid "Refresh extension list"
 msgstr ""
 
-#: applet.js:137
+#: applet.js:142
 msgid "Restart Cinnamon"
 msgstr ""
 
-#: applet.js:146
+#: applet.js:151
 msgid "Debug"
 msgstr ""
 
-#: applet.js:237 applet.js:283
+#: applet.js:248 applet.js:294
 #, javascript-format
 msgid "Source of error: %s"
 msgstr ""
 
-#: applet.js:373
+#: applet.js:384
 msgid "There aren't any extensions installed on your system. Or you may need to refresh the list of extensions from this applet context menu."
 msgstr ""
 
-#: applet.js:442
+#: applet.js:453
 msgid "Enabled extensions"
 msgstr ""
 
-#: applet.js:445
+#: applet.js:456
 msgid "No enabled extensions"
 msgstr ""
 
-#: applet.js:449
+#: applet.js:460
 msgid "Disabled extensions"
 msgstr ""
 
-#: applet.js:451
+#: applet.js:462
 msgid "No disabled extensions"
 msgstr ""
 
-#: applet.js:488
+#: applet.js:499
 #, javascript-format
 msgid "Extension %s is not compatible with current version of cinnamon. Using it may break your system. Load anyway?"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->metadata.json->contributors
-msgid "See this xlet help file."
 msgstr ""
 
 #. 0dyseus@ExtensionsManager->metadata.json->name
 msgid "Extensions Manager"
 msgstr ""
 
-#. 0dyseus@ExtensionsManager->metadata.json->comments
-msgid "Bug reports, feature requests and contributions should be done on this xlet's repository linked below."
+#. 0dyseus@ExtensionsManager->metadata.json->contributors
+msgid "See this xlet help file."
 msgstr ""
 
 #. 0dyseus@ExtensionsManager->metadata.json->description
 msgid "Allows enabling/disabling extensions (and other tasks) from a menu."
 msgstr ""
 
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_enabled_extensions_style->description
-msgid "Style for \"Enabled extensions\" sub-menu"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_max_menu_height->description
-msgid "Max height for menu"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_max_menu_height->units
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_extension_options_icon_size->units
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_extension_icon_size->units
-msgid "pixels"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_keep_enabled_extension_menu_open->tooltip
-msgid "If enabled, every time that the menu is open, the \"Enabled extensions\" sub menu will be open too."
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_keep_enabled_extension_menu_open->description
-msgid "Keep \"Enabled extensions\" menu open"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_disabled_extensions_style->description
-msgid "Style for \"Disabled extensions\" sub-menu"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_open_extension_folder_button->tooltip
-msgid "If enabled, it will display a button in each extension menu item that will open the location where the extension is installed."
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_open_extension_folder_button->description
-msgid "Show \"Open extension folder\" button on extensions menu"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_spices_button->tooltip
-msgid "If enabled, it will display a button in each extension menu item that will open the extension's Spices page (if the extension is published on Spices)."
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_spices_button->description
-msgid "Show \"Spices page\" button on extensions menu"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_keep_only_one_menu_open->description
-msgid "Keep only one menu open at all times"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_config_button->tooltip
-msgid "If enabled, it will display a button in each extension menu item that will open the extension's settings page (if the extension has a configuration mechanism)."
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_config_button->description
-msgid "Show \"Open settings window\" button on extensions menu"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_custom_label_for_applet->tooltip
-msgid "Enter custom text to show in the panel."
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_custom_label_for_applet->description
-msgid "Custom label"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_use_extension_names_as_label->tooltip
-msgid "If disabled, the extension UUID will be used as label for the menu items."
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_use_extension_names_as_label->description
-msgid "Use extension name as label"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_keep_disabled_extension_menu_open->tooltip
-msgid "If enabled, every time that the menu is open, the \"Disabled extensions\" sub menu will be open too."
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_keep_disabled_extension_menu_open->description
-msgid "Keep \"Disabled extensions\" menu open"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_extension_options_icon_size->description
-msgid "Icon size for the extension option buttons"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->head1->description
-msgid "Extensions menu settings"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_set_max_menu_height->description
-msgid "Set max height for the main menu"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_edit_extension_file_button->tooltip
-msgid "If enabled, it will display a button in each extension menu item that will open main extension file (extension.js) with a text editor."
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_edit_extension_file_button->description
-msgid "Show \"Edit extension main file\" button on extensions menu"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_icons_on_menu->description
-msgid "Show icons on menu items"
-msgstr ""
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->head0->description
-msgid "Applet settings"
+#. 0dyseus@ExtensionsManager->metadata.json->comments
+msgid "Bug reports, feature requests and contributions should be done on this xlet's repository linked below."
 msgstr ""
 
 #. 0dyseus@ExtensionsManager->settings-schema.json->pref_max_width_for_menu_items_label->units
@@ -325,14 +219,120 @@ msgstr ""
 msgid "Max width for menu items label"
 msgstr ""
 
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_extension_options_icon_size->units
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_extension_icon_size->units
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_max_menu_height->units
+msgid "pixels"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_extension_options_icon_size->description
+msgid "Icon size for the extension option buttons"
+msgstr ""
+
 #. 0dyseus@ExtensionsManager->settings-schema.json->pref_extension_icon_size->description
 msgid "Icon size for the extension logo"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_enabled_extensions_style->description
+msgid "Style for \"Enabled extensions\" sub-menu"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_custom_icon_for_applet->description
+msgid "Icon"
 msgstr ""
 
 #. 0dyseus@ExtensionsManager->settings-schema.json->pref_custom_icon_for_applet->tooltip
 msgid "Select an icon to show in the panel."
 msgstr ""
 
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_custom_icon_for_applet->description
-msgid "Icon"
+#. 0dyseus@ExtensionsManager->settings-schema.json->head0->description
+msgid "Applet settings"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_keep_disabled_extension_menu_open->description
+msgid "Keep \"Disabled extensions\" menu open"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_keep_disabled_extension_menu_open->tooltip
+msgid "If enabled, every time that the menu is open, the \"Disabled extensions\" sub menu will be open too."
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_set_max_menu_height->description
+msgid "Set max height for the main menu"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_config_button->description
+msgid "Show \"Open settings window\" button on extensions menu"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_config_button->tooltip
+msgid "If enabled, it will display a button in each extension menu item that will open the extension's settings page (if the extension has a configuration mechanism)."
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_keep_only_one_menu_open->description
+msgid "Keep only one menu open at all times"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_spices_button->description
+msgid "Show \"Spices page\" button on extensions menu"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_spices_button->tooltip
+msgid "If enabled, it will display a button in each extension menu item that will open the extension's Spices page (if the extension is published on Spices)."
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->head1->description
+msgid "Extensions menu settings"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_open_extension_folder_button->description
+msgid "Show \"Open extension folder\" button on extensions menu"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_open_extension_folder_button->tooltip
+msgid "If enabled, it will display a button in each extension menu item that will open the location where the extension is installed."
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_custom_label_for_applet->description
+msgid "Custom label"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_custom_label_for_applet->tooltip
+msgid "Enter custom text to show in the panel."
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_icons_on_menu->description
+msgid "Show icons on menu items"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_use_extension_names_as_label->description
+msgid "Use extension name as label"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_use_extension_names_as_label->tooltip
+msgid "If disabled, the extension UUID will be used as label for the menu items."
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_keep_enabled_extension_menu_open->description
+msgid "Keep \"Enabled extensions\" menu open"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_keep_enabled_extension_menu_open->tooltip
+msgid "If enabled, every time that the menu is open, the \"Enabled extensions\" sub menu will be open too."
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_max_menu_height->description
+msgid "Max height for menu"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_disabled_extensions_style->description
+msgid "Style for \"Disabled extensions\" sub-menu"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_edit_extension_file_button->description
+msgid "Show \"Edit extension main file\" button on extensions menu"
+msgstr ""
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_edit_extension_file_button->tooltip
+msgid "If enabled, it will display a button in each extension menu item that will open main extension file (extension.js) with a text editor."
 msgstr ""

--- a/0dyseus@ExtensionsManager/files/0dyseus@ExtensionsManager/po/cs.po
+++ b/0dyseus@ExtensionsManager/files/0dyseus@ExtensionsManager/po/cs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.07\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-29 06:32+0200\n"
-"PO-Revision-Date: 2017-05-29 06:32+0200\n"
+"POT-Creation-Date: 2017-06-08 06:03+0200\n"
+"PO-Revision-Date: 2017-06-08 06:04+0200\n"
 "Last-Translator: Radek Otáhal <radek.otahal@email.cz>\n"
 "Language-Team: \n"
 "Language: cs\n"
@@ -18,28 +18,44 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
+#: ../../create_localized_help.py:90
+msgid "The following two sections are available only in English."
+msgstr "Následující dvě části jsou k dispozici pouze v angličtině."
+
 #. TO TRANSLATORS: This is a placeholder.
 #. Here goes your language name in your own language (a.k.a. endonym).
-#: ../../create_localized_help.py:94 ../../create_localized_help.py:163
+#: ../../create_localized_help.py:115 ../../create_localized_help.py:187
 msgid "language-name"
 msgstr "Česky"
 
-#: ../../create_localized_help.py:166
+#: ../../create_localized_help.py:190 applet.js:155
+msgid "Help"
+msgstr "Nápověda"
+
+#: ../../create_localized_help.py:191
+msgid "Contributors"
+msgstr "Přispěvatelé"
+
+#: ../../create_localized_help.py:192
+msgid "Changelog"
+msgstr "Changelog"
+
+#: ../../create_localized_help.py:193
 msgid "Choose language"
 msgstr "Zvolte jazyk"
 
 #. TO TRANSLATORS: Full sentence:
 #. "Help for <xlet_name>"
-#: ../../create_localized_help.py:167 ../../create_localized_help.py:174
+#: ../../create_localized_help.py:194 ../../create_localized_help.py:201
 #, python-format
 msgid "Help for %s"
 msgstr "Nápověda pro %s"
 
-#: ../../create_localized_help.py:175
+#: ../../create_localized_help.py:202
 msgid "IMPORTANT!!!"
 msgstr "DŮLEŽITÉ!!!"
 
-#: ../../create_localized_help.py:176
+#: ../../create_localized_help.py:203
 msgid ""
 "Never delete any of the files found inside this xlet folder. It might break "
 "this xlet functionality."
@@ -47,7 +63,7 @@ msgstr ""
 "Nikdy neodstraňujte soubory ze složky tohoto xletu. Mohlo by to narušit "
 "funkčnost xletu. "
 
-#: ../../create_localized_help.py:177
+#: ../../create_localized_help.py:204
 msgid ""
 "Bug reports, feature requests and contributions should be done on this "
 "xlet's repository linked next."
@@ -55,11 +71,11 @@ msgstr ""
 "Zprávy o chybách, požadavky na funkce a příspěvky by měly být prováděny v "
 "repozitáři tohoto xletu, na který je odkaz dále."
 
-#: ../../create_localized_help.py:183
+#: ../../create_localized_help.py:210
 msgid "Applets/Desklets/Extensions (a.k.a. xlets) localization"
 msgstr "Lokalizace apletů/deskletů/rozšíření (a.k.a. xlety)"
 
-#: ../../create_localized_help.py:184
+#: ../../create_localized_help.py:211
 msgid ""
 "If this xlet was installed from Cinnamon Settings, all of this xlet's "
 "localizations were automatically installed."
@@ -68,7 +84,7 @@ msgstr ""
 "všechny tyto lokalizace xletu automaticky nainstalovány."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:186
+#: ../../create_localized_help.py:213
 msgid ""
 "If this xlet was installed manually and not trough Cinnamon Settings, "
 "localizations can be installed by executing the script called "
@@ -78,7 +94,7 @@ msgstr ""
 "Cinnamonu, mohou být lokalizace instalovány spuštěním skriptu nazvaného ** "
 "localizations.sh ** z terminálu otevřeného uvnitř složky xletu."
 
-#: ../../create_localized_help.py:187
+#: ../../create_localized_help.py:214
 msgid ""
 "If this xlet has no locale available for your language, you could create it "
 "by following the following instructions."
@@ -154,37 +170,37 @@ msgstr "Chyba parsování JSON řetězce."
 msgid "A detailed error has been logged into ~/.cinnamon/glass.log."
 msgstr "Podrobnosti chyby byly zaznamenány do ~/.cinnamon/glass.log souboru."
 
-#: applet.js:98
+#: applet.js:99
 msgid "Open extensions manager"
 msgstr "Otevřít správce rozšíření"
 
-#: applet.js:111
+#: applet.js:112
 msgid "Disable all extensions"
 msgstr "Zakázat všechna rozšíření"
 
-#: applet.js:121
+#: applet.js:122
 msgid ""
 "This will disable all active extensions. Are you sure you want to do this?"
 msgstr "Tímto vypnete všechna aktivní rozšíření. Chcete opravdu pokračovat?"
 
-#: applet.js:129
+#: applet.js:130
 msgid "Refresh extension list"
 msgstr "Obnovit seznam rozšíření"
 
-#: applet.js:136
+#: applet.js:137
 msgid "Restart Cinnamon"
 msgstr "Restartovat Cinnamon"
 
-#: applet.js:145
+#: applet.js:146
 msgid "Debug"
 msgstr "Ladit"
 
-#: applet.js:226 applet.js:272
+#: applet.js:237 applet.js:283
 #, javascript-format
 msgid "Source of error: %s"
 msgstr "Zdroj chyby: % s"
 
-#: applet.js:362
+#: applet.js:373
 msgid ""
 "There aren't any extensions installed on your system. Or you may need to "
 "refresh the list of extensions from this applet context menu."
@@ -192,23 +208,23 @@ msgstr ""
 "Ve vašem systému nejsou nainstalována žádná rozšíření. Vyzkoušejte obnovit "
 "seznam rozšíření z kontextového menu tohoto appletu."
 
-#: applet.js:431
+#: applet.js:442
 msgid "Enabled extensions"
 msgstr "Povolená rozšíření"
 
-#: applet.js:434
+#: applet.js:445
 msgid "No enabled extensions"
 msgstr "Žádná povolená rozšíření"
 
-#: applet.js:438
+#: applet.js:449
 msgid "Disabled extensions"
 msgstr "Zakázaná rozšíření"
 
-#: applet.js:440
+#: applet.js:451
 msgid "No disabled extensions"
 msgstr "Žádná zakázaná rozšíření"
 
-#: applet.js:477
+#: applet.js:488
 #, javascript-format
 msgid ""
 "Extension %s is not compatible with current version of cinnamon. Using it "
@@ -218,24 +234,12 @@ msgstr ""
 "poškodit váš systém. Přesto pokračovat?"
 
 #. 0dyseus@ExtensionsManager->metadata.json->contributors
-msgid "Radek71: Czech localization."
-msgstr "Radek71: Česká lokalizace."
+msgid "See this xlet help file."
+msgstr "Viz soubor s nápovědou tohoto xletu."
 
-#. 0dyseus@ExtensionsManager->metadata.json->contributors
-msgid "muzena: Croatian localization."
-msgstr "muzena: Chorvatská lokalizace."
-
-#. 0dyseus@ExtensionsManager->metadata.json->contributors
-msgid "giwhub: Chinese localization."
-msgstr "giwhub: Čínská lokalizace."
-
-#. 0dyseus@ExtensionsManager->metadata.json->contributors
-msgid "eson57: Swedish localization."
-msgstr "eson57: Švédská lokalizace."
-
-#. 0dyseus@ExtensionsManager->metadata.json->description
-msgid "Allows enabling/disabling extensions (and other tasks) from a menu."
-msgstr "Umožňuje povolit/zakázat rozšíření (a další činnosti) z menu."
+#. 0dyseus@ExtensionsManager->metadata.json->name
+msgid "Extensions Manager"
+msgstr "Správce rozšíření"
 
 #. 0dyseus@ExtensionsManager->metadata.json->comments
 msgid ""
@@ -245,35 +249,23 @@ msgstr ""
 "Zprávy o chybách, požadavky na funkce a příspěvky by měly být prováděny v "
 "repozitáři tohoto xletu, na který je odkaz níže."
 
-#. 0dyseus@ExtensionsManager->metadata.json->name
-msgid "Extensions Manager"
-msgstr "Správce rozšíření"
+#. 0dyseus@ExtensionsManager->metadata.json->description
+msgid "Allows enabling/disabling extensions (and other tasks) from a menu."
+msgstr "Umožňuje povolit/zakázat rozšíření (a další činnosti) z menu."
 
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_open_extension_folder_button->tooltip
-msgid ""
-"If enabled, it will display a button in each extension menu item that will "
-"open the location where the extension is installed."
-msgstr ""
-"Je-li povoleno, tak zobrazí u každé položky menu rozšíření tlačítko pro "
-"otevření složky ve které je rozšíření nainstalováno."
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_enabled_extensions_style->description
+msgid "Style for \"Enabled extensions\" sub-menu"
+msgstr "Styl pro \"Povolená rozšíření\" sub-menu"
 
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_open_extension_folder_button->description
-msgid "Show \"Open extension folder\" button on extensions menu"
-msgstr "Zobrazit \"Otevřít složku rozšíření\" tlačítko v menu rozšíření"
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_max_menu_height->description
+msgid "Max height for menu"
+msgstr "Maximální výška menu"
 
-#. 0dyseus@ExtensionsManager->settings-schema.json->head0->description
-msgid "Applet settings"
-msgstr "Nastavení Appletu"
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_extension_options_icon_size->units
 #. 0dyseus@ExtensionsManager->settings-schema.json->pref_max_menu_height->units
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_extension_options_icon_size->units
 #. 0dyseus@ExtensionsManager->settings-schema.json->pref_extension_icon_size->units
 msgid "pixels"
 msgstr "pixelů"
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_extension_options_icon_size->description
-msgid "Icon size for the extension option buttons"
-msgstr "Velikost ikon pro tlačítka voleb rozšíření"
 
 #. 0dyseus@ExtensionsManager->settings-schema.json->pref_keep_enabled_extension_menu_open->tooltip
 msgid ""
@@ -287,25 +279,21 @@ msgstr ""
 msgid "Keep \"Enabled extensions\" menu open"
 msgstr "Ponechat menu \"Povolená rozšíření\" otevřené"
 
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_max_menu_height->description
-msgid "Max height for menu"
-msgstr "Maximální výška menu"
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_disabled_extensions_style->description
+msgid "Style for \"Disabled extensions\" sub-menu"
+msgstr "Styl pro \"Zakázaná rozšíření\" sub-menu"
 
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_custom_label_for_applet->tooltip
-msgid "Enter custom text to show in the panel."
-msgstr "Vložte text, který se zobrazí na panelu."
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_open_extension_folder_button->tooltip
+msgid ""
+"If enabled, it will display a button in each extension menu item that will "
+"open the location where the extension is installed."
+msgstr ""
+"Je-li povoleno, tak zobrazí u každé položky menu rozšíření tlačítko pro "
+"otevření složky ve které je rozšíření nainstalováno."
 
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_custom_label_for_applet->description
-msgid "Custom label"
-msgstr "Uživatelský název"
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_custom_icon_for_applet->tooltip
-msgid "Select an icon to show in the panel."
-msgstr "Zvolte ikonu, která se zobrazí na panelu."
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_custom_icon_for_applet->description
-msgid "Icon"
-msgstr "Ikona"
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_open_extension_folder_button->description
+msgid "Show \"Open extension folder\" button on extensions menu"
+msgstr "Zobrazit \"Otevřít složku rozšíření\" tlačítko v menu rozšíření"
 
 #. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_spices_button->tooltip
 msgid ""
@@ -319,46 +307,9 @@ msgstr ""
 msgid "Show \"Spices page\" button on extensions menu"
 msgstr "Zobrazit \"Spices web\" tlačítko v menu rozšíření"
 
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_edit_extension_file_button->tooltip
-msgid ""
-"If enabled, it will display a button in each extension menu item that will "
-"open main extension file (extension.js) with a text editor."
-msgstr ""
-"Je-li povoleno, tak zobrazí u každé položky menu rozšíření tlačítko pro "
-"otevření  hlavního souboru (extension.js) v textovém editoru."
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_edit_extension_file_button->description
-msgid "Show \"Edit extension main file\" button on extensions menu"
-msgstr "Zobrazit \"Upravit hlavní soubor rozšíření\" tlačítko v menu rozšíření"
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_enabled_extensions_style->description
-msgid "Style for \"Enabled extensions\" sub-menu"
-msgstr "Styl pro \"Povolená rozšíření\" sub-menu"
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_use_extension_names_as_label->tooltip
-msgid ""
-"If disabled, the extension UUID will be used as label for the menu items."
-msgstr "Je-li zakázáno, tak bude pro položku menu použito UUID jako jméno."
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_use_extension_names_as_label->description
-msgid "Use extension name as label"
-msgstr "Použít název rozšíření jako jméno"
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_set_max_menu_height->description
-msgid "Set max height for the main menu"
-msgstr "Nastavit maximální výšku pro hlavní menu"
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_disabled_extensions_style->description
-msgid "Style for \"Disabled extensions\" sub-menu"
-msgstr "Styl pro \"Zakázaná rozšíření\" sub-menu"
-
 #. 0dyseus@ExtensionsManager->settings-schema.json->pref_keep_only_one_menu_open->description
 msgid "Keep only one menu open at all times"
 msgstr "Ponechat vždy otevřené pouze jedno menu"
-
-#. 0dyseus@ExtensionsManager->settings-schema.json->head1->description
-msgid "Extensions menu settings"
-msgstr "Nastavení menu rozšíření"
 
 #. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_config_button->tooltip
 msgid ""
@@ -373,13 +324,22 @@ msgstr ""
 msgid "Show \"Open settings window\" button on extensions menu"
 msgstr "Zobrazit \"Otevřít okno nastavení\" tlačítko v menu rozšíření"
 
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_max_width_for_menu_items_label->units
-msgid "ems"
-msgstr "ems"
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_custom_label_for_applet->tooltip
+msgid "Enter custom text to show in the panel."
+msgstr "Vložte text, který se zobrazí na panelu."
 
-#. 0dyseus@ExtensionsManager->settings-schema.json->pref_max_width_for_menu_items_label->description
-msgid "Max width for menu items label"
-msgstr "Maximální šířka pro názvy položek menu"
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_custom_label_for_applet->description
+msgid "Custom label"
+msgstr "Uživatelský název"
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_use_extension_names_as_label->tooltip
+msgid ""
+"If disabled, the extension UUID will be used as label for the menu items."
+msgstr "Je-li zakázáno, tak bude pro položku menu použito UUID jako jméno."
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_use_extension_names_as_label->description
+msgid "Use extension name as label"
+msgstr "Použít název rozšíření jako jméno"
 
 #. 0dyseus@ExtensionsManager->settings-schema.json->pref_keep_disabled_extension_menu_open->tooltip
 msgid ""
@@ -393,13 +353,69 @@ msgstr ""
 msgid "Keep \"Disabled extensions\" menu open"
 msgstr "Ponechat menu \"Zakázaná rozšíření\" otevřené"
 
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_extension_options_icon_size->description
+msgid "Icon size for the extension option buttons"
+msgstr "Velikost ikon pro tlačítka voleb rozšíření"
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->head1->description
+msgid "Extensions menu settings"
+msgstr "Nastavení menu rozšíření"
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_set_max_menu_height->description
+msgid "Set max height for the main menu"
+msgstr "Nastavit maximální výšku pro hlavní menu"
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_edit_extension_file_button->tooltip
+msgid ""
+"If enabled, it will display a button in each extension menu item that will "
+"open main extension file (extension.js) with a text editor."
+msgstr ""
+"Je-li povoleno, tak zobrazí u každé položky menu rozšíření tlačítko pro "
+"otevření  hlavního souboru (extension.js) v textovém editoru."
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_show_edit_extension_file_button->description
+msgid "Show \"Edit extension main file\" button on extensions menu"
+msgstr "Zobrazit \"Upravit hlavní soubor rozšíření\" tlačítko v menu rozšíření"
+
 #. 0dyseus@ExtensionsManager->settings-schema.json->pref_icons_on_menu->description
 msgid "Show icons on menu items"
 msgstr "Zobrazit ikony položek menu"
 
+#. 0dyseus@ExtensionsManager->settings-schema.json->head0->description
+msgid "Applet settings"
+msgstr "Nastavení Appletu"
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_max_width_for_menu_items_label->units
+msgid "ems"
+msgstr "ems"
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_max_width_for_menu_items_label->description
+msgid "Max width for menu items label"
+msgstr "Maximální šířka pro názvy položek menu"
+
 #. 0dyseus@ExtensionsManager->settings-schema.json->pref_extension_icon_size->description
 msgid "Icon size for the extension logo"
 msgstr "Velikost ikony pro logo rozšíření "
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_custom_icon_for_applet->tooltip
+msgid "Select an icon to show in the panel."
+msgstr "Zvolte ikonu, která se zobrazí na panelu."
+
+#. 0dyseus@ExtensionsManager->settings-schema.json->pref_custom_icon_for_applet->description
+msgid "Icon"
+msgstr "Ikona"
+
+#~ msgid "Radek71: Czech localization."
+#~ msgstr "Radek71: Česká lokalizace."
+
+#~ msgid "muzena: Croatian localization."
+#~ msgstr "muzena: Chorvatská lokalizace."
+
+#~ msgid "giwhub: Chinese localization."
+#~ msgstr "giwhub: Čínská lokalizace."
+
+#~ msgid "eson57: Swedish localization."
+#~ msgstr "eson57: Švédská lokalizace."
 
 #~ msgid "Appearance"
 #~ msgstr "Vzhled"


### PR DESCRIPTION
- Redesigned the creation of the help file to be "on-line friendly".
- Finally fixed the annoyance of having titles on the help files hidden behind the top navigation bar when clicking the navigation links (Help/Contributors/Changelog).
- Fixed the display of a translated sentence on the help files that was being displayed untranslated.
- Added smooth scrolling for the links on the navigation bar of the help files.
- Updated localization template, localizations and help file due to changes to the *help file creator* script.
- Added to the xlet README file links to the localized help file.
- Better handling of **Settings.BindingDirection**. Just to avoid surprises when that constant is removed on future versions of Cinnamon.