### PR TITLE
nvidiaprime@pdcurtis Update to Version 3.3.1

### DIFF
--- a/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/CHANGELOG.md
+++ b/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog for recent versions
 
+### 3.3.1
+
+ * Add checks that Nvidia drivers and nvidia-settings are loaded
+ * Allow GPU temperature to be displayed in vertical panels but shorten (by removing the degree symbol) if over 100 degrees on vertical panels.
+ * Update nvidiaprime.pot to identify changes which need to be translated.
+
 ### 3.3.0
 
 Major changes to support vertical panels and to use icons instead of text to harmonise with other cinnamon applets such as nvidia-prime

--- a/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/README.md
+++ b/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/README.md
@@ -8,37 +8,37 @@ The preferred method of switching with the latest kernels and nVidia drivers no 
 
 ## Rationale
 
-It is useful to have continuous indication of whether the Discrete Graphics Processor Unit is in use and its temperature which is a concern on some laptops. It can be used in place of the nVidia Prime system applet if panel space is at a premium. 
+It is useful to have continuous indication of whether the Discrete Graphics Processor Unit is in use and its temperature which is a concern on some laptops. 
 
 ## Features
 
-The latest versions 3.3.0 and higher work with horizontal and vertical panels.  The indication of which GPU is active has changed to be an icon making it consistent with then nvidia-prime system applet. The GPU temperature display is beside the icon on horizontal panels and inhibited on vertical panels. The temperature display in the panel can now be inhibited in horizontal panels to save space if required.  One can also configure the update rate of the applet in settings.
+The latest versions 3.3.0 and higher work with horizontal and vertical panels.  The indication of which GPU is active has changed to be an icon making it consistent with the nvidia-prime system applet. The GPU temperature display is beside the icon on horizontal panels and inhibited on vertical panels. The temperature display in the panel can now be inhibited in horizontal panels to save space if required.  One can also configure the update rate of the applet in settings.
 
-Clicking the applet opens nvidia-settings which allows one to change GPU in the same way as the built in NVIDIA Prime applet which it can replace if panel space is at a premium.
+Clicking the applet opens nvidia-settings which allows one to change GPU in the same way as the built in NVIDIA Prime applet.
 
 The right click context menu also gives the ability to run the nVidia Settings program as well as the System Monitor and Power Statistics, all useful for monitoring and controlling power consumption which is paramount when using a laptop on batteries.
 
-There is error checking to ensure the switching program bbswith is loaded and does not fill the error logs with messages when that is not the the case. It displays a message of ERROR if it is not found.
+There is error checking to ensure the nvidia drivers, nvidia-settings and bbswith are loaded. It displays a message of Err if these are not found.
 
 ## Requirements
 
-The applet requires at least Cinnamon 2.0 to access the configuration from within the applet. Mint versions with less than Cinnamon 2.0 have now passed their end of life so all current version are supported.
+The applet requires at least Cinnamon 2.0 to access the configuration from within the applet. Mint versions with less than Cinnamon 2.2 have now passed their end of life so all current version are supported.
 
-the nVidia graphics packages obviously need to be installed but no other packages are essential. Cinnamon 3.2 or higher is required to support a vertical panel but not to support other features of the applet.
+the nVidia graphics packages must be installed  and working before installing this applet but no other packages are essential. Cinnamon 3.2 or higher is required to support a vertical panel but not to support other features of the applet.
 
-The latest version has a tick box option on the configuration screen to access enhanced functionality through the Right Click Context Menu. This needs a Cinnamon Restart or log out/in before the change is visible. Currently this adds the glxspheres64 Graphics Processor Test to the menu.
+There is a tick box option on the configuration screen to access enhanced functionality through the Right Click Context Menu. This needs a Cinnamon Restart or log out/in before the change is visible. Currently this adds the glxspheres64 Graphics Processor Test to the menu.
 
-glxsheres64 only needs to be installed if you want to use the applet to test the relative performances of the Intel and nVidia graphics processors. glxsheres64 is part of the VirtualGL package which needs to be installed from  http://sourceforge.net/projects/virtualgl/files/VirtualGL/ - download the latest version and install using gdebi (should be the default for a right click on the downloaded file). It should run about five times faster when the nVidia GPU is active and is a very good test as to how good your cooling is for both the CPU and nVidia GPU when it is active.
+glxsheres64 only needs to be installed if you want to use the applet to test the relative performances of the Intel and nVidia graphics processors. glxsheres64 is part of the VirtualGL package which needs to be installed from  http://sourceforge.net/projects/virtualgl/files/VirtualGL/ - download the latest version and install using gdebi (should be the default for a right click on the downloaded file). It should run about five times faster when the nVidia GPU is active and is a very good test as to how good your cooling is for both the CPU and nVidia GPU.
 
 ## Translations and other Contributions
 
-The internal changes required in the applet to allow translations are being implemented but no translations are available at this time. Translations are usually contributed by people fluent in the language and will be very much appreciated. Users please note I rarely be able to take responsibility for the accuracy of translations!
+The internal changes required in the applet to allow translations are being implemented but no translations are available at this time. Translations are usually contributed by people fluent in the language and will be very much appreciated. Users please note I am rarely able to take responsibility for the accuracy of translations!
 
-Although comments and suggestions are always welcome any contributions which are contemplated must follow discussion. Changes can have many unintended consequences and the integrity of the applet is paramount. Unsolicited Pull Requests will never be authorised other than for urgent and critical bug fixes from the Cinnamon Team. 
+Although comments and suggestions are always welcome any contributions which are contemplated must follow discussion. Changes can have many unintended consequences and the integrity of the applet is paramount. Unsolicited Pull Requests will never be authorised other than for urgent and critical bug fixes from the Cinnamon Team or for translations. 
 
 ## Manual Installation:
   
-   * Make sure the nVidia drivers and nVidia Prime are installed and working
+   * The nVidia drivers and nVidia Prime must be installed and working before installing this applet.
    * Download from the Spices Web Site
    * Unzip and extract folder ```nvidiaprime@pdcurtis``` to ```~/.local/share/cinnamon/applets/```
    * Install glxspheres64 if required.

--- a/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/applet.js
+++ b/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/applet.js
@@ -18,6 +18,7 @@ const Lang = imports.lang; //  ++ Needed for menus
 const GLib = imports.gi.GLib; // ++ Needed for starting programs and translations
 const Mainloop = imports.mainloop; // Needed for timer update loop
 const Gettext = imports.gettext; // ++ Needed for translations
+const Main = imports.ui.main; // ++ Needed for criticalNotify()
 
 // ++ Always needed for localisation/translation support
 // l10n support thanks to ideas from @Odyseus, @lestcape and @NikoKrause
@@ -82,9 +83,9 @@ MyApplet.prototype = {
             this.nvidea_icon = metadata.path + "/icons/nvidia.png"
             this.intel_icon = metadata.path + "/icons/prime-tray-intel.png"
 
-            this.on_orientation_changed(orientation); // Initialise for panel orientation
+            this.on_orientation_changed(orientation); // ++ Initialise for panel orientation
 
-            this.applet_running = true; //** New to allow applet to be fully stopped when removed from panel
+            this.applet_running = true; //** Allow applet to be fully stopped when removed from panel
 
             // Choose Text Editor depending on whether Mint 18 with Cinnamon 3.0 and latter
             // This could be replaced by use of system editor? but "If it ain't broke don't fix it" 
@@ -92,6 +93,17 @@ MyApplet.prototype = {
                this.textEd = "gedit";
             } else { 
                this.textEd = "xed";
+            }
+
+            // Check that Nvidia drivers are installed 
+            if (!GLib.find_program_in_path("nvidia-settings")) {
+                 let icon = new St.Icon({ icon_name: 'error',
+                 icon_type: St.IconType.FULLCOLOR,
+                 icon_size: 36 });
+                 Main.criticalNotify("Nvidia Prime not installed", "You appear to be missing some of the required programs for Nvidia Prime to switch graphics processors using NVIDIA Optimus.\n\nPlease read the help file.", icon);
+                 this.nvidiaPrimeMissing = true;
+            } else {
+                 this.nvidiaPrimeMissing = false;
             }
 
             // ++ Set up left click menu
@@ -232,13 +244,13 @@ MyApplet.prototype = {
          else {
               this.bbst = "OFF";
          }
-      // This catches error if bbswitch  is not loaded                     
-      } catch (e) {
-//          global.logError(e);  // Comment out to avoid filling error log
-          this.bbst = "ERROR"
-	  this.set_applet_label(_("ERROR")); 
-          this.set_applet_tooltip(_("Nvidia Prime is not installed so applet willl not work"));          
-      } 
+      
+      // This catches error if bbswitch is not loaded                     
+   } catch (e) {
+//          global.logError(e);  // Commented out to avoid filling error log
+        this.bbst = "ERROR";
+   }
+ 
    try {
          if(this.bbst == "OFF") {
                this.set_applet_label(""); 
@@ -252,12 +264,18 @@ MyApplet.prototype = {
                 // Check we have a valid temperature returned before updating 
                 // in case of slow response from nvidia-settings which gives null string
                 if(this.nvidiagputemp1.substr(5,2) > 0){ this.nvidiagputemp = this.nvidiagputemp1.substr(5,2)}; 
-                if (!this.showGpuTemp  || !this.isHorizontal) {
+
+                if (!this.showGpuTemp ) {
 	                  this.set_applet_label("");
                       this.hide_applet_label(true);
                  } else { 
                       this.hide_applet_label(false);
-                      this.set_applet_label(this.nvidiagputemp + " \u1d3cC" );
+                      if ( this.nvidiagputemp < 100 || this.isHorizontal )  { 
+                           this.set_applet_label(this.nvidiagputemp + "\u1d3c" );
+                      } else {
+                           this.set_applet_label(this.nvidiagputemp + "" ); // Needs empty string for typing
+                      }
+
                  }
 
                 this.set_applet_tooltip(_("NVidia based GPU is On and Core Temperature is") + " " + this.nvidiagputemp + "\u1d3cC" );
@@ -266,6 +284,12 @@ MyApplet.prototype = {
                 // Get temperatures via asyncronous script ready for next cycle
                 GLib.spawn_command_line_async('sh ' + this.gputempScript );
          } 
+
+         if(this.bbst == "ERROR" || this.nvidiaPrimeMissing) {
+	          this.set_applet_label(_("Err" )); 
+              this.set_applet_tooltip(_("Bumblebee is not set up correctly - are bbswitch, bumblebee and nvidia drivers installed?")); 
+              this.hide_applet_label(false);       
+         }
       } catch (e) {
           global.logError(e);
       }       
@@ -293,7 +317,7 @@ function main(metadata, orientation, panelHeight, instance_id) {
     return myApplet;
 }
 /*
-Version 3.3.0
+Version 3.3.1
 
 v30_3.0.0 Based on Bumblbee v20_0.9.8 but modified to use nVidia Prime.
           Changes to work with Mint 18 and Cinnamon 3.0 -gedit -> xed
@@ -329,7 +353,8 @@ v30_3.2.0 Changed help file from help.txt to README.md -can keep copies of READM
           Create nvidiaprime.pot using cinnamon-json-makepot --js po/nvidiaprime.pot
           Version and changes information update in applet.js and changelog.txt
           Update README.md (2x)
-3.3.0     Major new version to support vertical panels and to use icons instead of text to harmonise with other cinnamon applets such as nvidia-prime
+### 3.3.0     
+Major new version to support vertical panels and to use icons instead of text to harmonise with other cinnamon applets such as nvidia-prime
               - Allow use of vertical as well as horizontal panels after version number check to see if they are supported.
               - Change to TextIcon applet
               - Addition of setting to hide temperatures on Horizontal panel.
@@ -337,5 +362,10 @@ v30_3.2.0 Changed help file from help.txt to README.md -can keep copies of READM
               - New Translation function
               - Changes to improve translation strings
               - Recreate bumblebee.pot
-              Changes to README.md changelog.txt etc 
+              Changes to README.md changelog.txt etc
+### 3.3.1
+ * Add checks that Nvidia drivers and nvidia-settings are loaded
+ * Allow GPU temperature to be displayed in vertical panels but shorten (by removing the degree symbol) if over 100 degrees on vertical panels.
+ * Update nvidiaprime.pot to identify changes which need to be translated
 */
+

--- a/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/changelog.txt
+++ b/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/changelog.txt
@@ -1,4 +1,4 @@
-Version 3.3.0
+Version 3.3.1
 
 v30_3.0.0 Based on Bumblbee v20_0.9.8 but modified to use nVidia Prime.
           Changes to work with Mint 18 and Cinnamon 3.0 -gedit -> xed
@@ -34,7 +34,8 @@ v30_3.2.0 Changed help file from help.txt to README.md -can keep copies of READM
           Create nvidiaprime.pot using cinnamon-json-makepot --js po/nvidiaprime.pot
           Version and changes information update in applet.js and changelog.txt
           Update README.md (2x)
-3.3.0     Major new version to support vertical panels and to use icons instead of text to harmonise with other cinnamon applets such as nvidia-prime
+### 3.3.0     
+Major new version to support vertical panels and to use icons instead of text to harmonise with other cinnamon applets such as nvidia-prime
               - Allow use of vertical as well as horizontal panels after version number check to see if they are supported.
               - Change to TextIcon applet
               - Addition of setting to hide temperatures on Horizontal panel.
@@ -42,4 +43,8 @@ v30_3.2.0 Changed help file from help.txt to README.md -can keep copies of READM
               - New Translation function
               - Changes to improve translation strings
               - Recreate bumblebee.pot
-              Changes to README.md changelog.txt etc 
+              Changes to README.md changelog.txt etc
+### 3.3.1
+ * Add checks that Nvidia drivers and nvidia-settings are loaded
+ * Allow GPU temperature to be displayed in vertical panels but shorten (by removing the degree symbol) if over 100 degrees on vertical panels.
+ * Update nvidiaprime.pot to identify changes which need to be translated

--- a/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/metadata.json
+++ b/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/metadata.json
@@ -3,6 +3,6 @@
     "description": "Displays which Graphics processor is active and nVidia GPU Temperature when active and in a horizontal panel", 
     "name": "nVidia Prime GPU Display", 
     "uuid": "nvidiaprime@pdcurtis",
-    "version": "3.3.0"
+    "version": "3.3.1"
 }
 

--- a/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/po/nvidiaprime.pot
+++ b/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/po/nvidiaprime.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-19 02:25+0100\n"
+"POT-Creation-Date: 2017-06-13 01:52+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,52 +17,56 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: \n"
 
-#: applet.js:111
+#: applet.js:123
 msgid "Waiting for nvidia"
 msgstr ""
 
-#: applet.js:171
+#: applet.js:183
 msgid "Open Power Statistics"
 msgstr ""
 
-#: applet.js:177
+#: applet.js:189
 msgid "Open System Monitor"
 msgstr ""
 
-#: applet.js:195
+#: applet.js:207
 msgid "Housekeeping and System Sub Menu"
 msgstr ""
 
-#: applet.js:198
+#: applet.js:210
 msgid "View the Changelog"
 msgstr ""
 
-#: applet.js:204
+#: applet.js:216
 msgid "Open the Help file"
 msgstr ""
 
-#: applet.js:239
-msgid "ERROR"
-msgstr ""
-
-#: applet.js:240
-msgid "Nvidia Prime is not installed so applet willl not work"
-msgstr ""
-
-#: applet.js:246
+#: applet.js:258
 msgid "NVidia based GPU is Off"
 msgstr ""
 
-#: applet.js:263
+#: applet.js:281
 msgid "NVidia based GPU is On and Core Temperature is"
 msgstr ""
 
+#: applet.js:289
+msgid "Err"
+msgstr ""
+
+#: applet.js:290
+msgid ""
+"Bumblebee is not set up correctly - are bbswitch, bumblebee and nvidia "
+"drivers installed?"
+msgstr ""
+
 #. nvidiaprime@pdcurtis->settings-schema.json->showGpuTemp->description
-msgid "Show GPU Temperature in Horizontal Panels"
+msgid "Show GPU Temperature as well as icon"
 msgstr ""
 
 #. nvidiaprime@pdcurtis->settings-schema.json->showGpuTemp->tooltip
-msgid "Not available in Vertical Panels"
+msgid ""
+"Available in Horizontal and Vertical Panels. Display is in Degrees "
+"Centigrade."
 msgstr ""
 
 #. nvidiaprime@pdcurtis->settings-schema.json->displayExtra->description
@@ -101,7 +105,9 @@ msgid "Additional Functionality"
 msgstr ""
 
 #. nvidiaprime@pdcurtis->metadata.json->description
-msgid "Displays nVidia GPU Temperature when using Prime"
+msgid ""
+"Displays which Graphics processor is active and nVidia GPU Temperature when "
+"active and in a horizontal panel"
 msgstr ""
 
 #. nvidiaprime@pdcurtis->metadata.json->name

--- a/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/settings-schema.json
+++ b/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/settings-schema.json
@@ -17,8 +17,8 @@
     "showGpuTemp": {
         "type": "checkbox",
         "default": true,
-        "description": "Show GPU Temperature in Horizontal Panels",
-        "tooltip": "Not available in Vertical Panels"
+        "description": "Show GPU Temperature as well as icon",
+        "tooltip": "Available in Horizontal and Vertical Panels. Display is in Degrees Centigrade."
     },
 
 


### PR DESCRIPTION
 * Add checks that nvidia drivers and nvidia-settings are loaded
 * Allow GPU temperature to be displayed in vertical panels but shorten (by removing the degree symbol) if over 100 degrees on vertical panels.
 * Update nvidiaprime.pot to identify changes which need to be translated.