### PR TITLE
bumblebee@pdcurtis Update to Version 3.2.2

### DIFF
--- a/bumblebee@pdcurtis/files/bumblebee@pdcurtis/CHANGELOG.md
+++ b/bumblebee@pdcurtis/files/bumblebee@pdcurtis/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog for recent versions
 
+### 3.2.2
+
+ * Allow GPU temperature to be displayed in vertical panels but shorten (by removing the degree symbol) if over 100 degrees on vertical panels.
+ * Update bumblebee.pot to identify changes which need to be translated
+
 ### 3.2.1
 
  * Use CHANGELOG.md instead of changelog.txt in context menu

--- a/bumblebee@pdcurtis/files/bumblebee@pdcurtis/README.md
+++ b/bumblebee@pdcurtis/files/bumblebee@pdcurtis/README.md
@@ -16,7 +16,9 @@ I have recently reloaded Bumblebee using the instructions at http://www.webupd8.
  
 ## Features
 
-The latest versions 3.2.0 and higher work with horizontal and vertical panels.  The indication of which GPU is active has changed to be an icon making it consistent with the nvidia-prime system applet. The GPU temperature display is beside the icon on horizontal panels and inhibited on vertical panels. The temperature display in the panel can now be inhibited in horizontal panels to save space if required.  One can also configure the update rate of the applet in settings.
+The latest versions 3.2.0 and higher work with horizontal and vertical panels.  The indication of which GPU is active has changed to be an icon. The GPU temperature display is beside the icon on horizontal panels and below on vertical panels.  The display is shortened (by removing the degree symbol) if over 100 degrees on vertical panels because of width restrictions.
+
+The temperature display in the panel can now be inhibited to save space if required in settings.  One can also configure the update rate of the applet in settings.
 
 The Right Click (Context menu) gives the ability to easily run the nVidia Settings program without use of the terminal and also the System Monitor and Power Statistics, all useful for monitoring Bumblebee and Power consumption which is paramount when using a laptop on batteries.
 

--- a/bumblebee@pdcurtis/files/bumblebee@pdcurtis/changelog.txt
+++ b/bumblebee@pdcurtis/files/bumblebee@pdcurtis/changelog.txt
@@ -1,4 +1,4 @@
-Version 3.2.1
+Version 3.2.2
 v20_0.9.0 Beta 12-12-2013
 v20_0.9.1 Added System Monitor and Power Statistics to right click menu
 v20_0.9.2 Added Left Click Menu with 5 Program Launch Items with configuration in Settings - Release Candidate 14-12-2013 
@@ -44,4 +44,6 @@ v30_3.1.0  Changed help file from help.txt to README.md
  * Use CHANGELOG.md instead of changelog.txt in context menu
  * Add symbolic link from UUID folder to applet folder so it is displayed on latest spices web site.
  * Add check that bumblebee daemon is installed.
-
+### 3.2.2
+ * Allow GPU temperature to be displayed in vertical panels but shorten (by removing the degree symbol) if over 100 degrees on vertical panels.
+ * Update bumblebee.pot to identify changes which need to be translated

--- a/bumblebee@pdcurtis/files/bumblebee@pdcurtis/metadata.json
+++ b/bumblebee@pdcurtis/files/bumblebee@pdcurtis/metadata.json
@@ -2,6 +2,6 @@
     "description": "Displays Status of Bumblebee and nVidia GPU Temperature with associated support functions including starting selected programs with optirun or primusrun", 
     "max-instances": "1", 
     "name": "Bumblebee Status with NVidia Temperature Display", 
-    "version": "3.2.1", 
+    "version": "3.2.2", 
     "uuid": "bumblebee@pdcurtis"
 }

--- a/bumblebee@pdcurtis/files/bumblebee@pdcurtis/po/bumblebee.pot
+++ b/bumblebee@pdcurtis/files/bumblebee@pdcurtis/po/bumblebee.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-14 03:44+0100\n"
+"POT-Creation-Date: 2017-06-14 01:13+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,60 +17,64 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: \n"
 
-#: applet.js:154
+#: applet.js:172
 msgid "Waiting for Bumblebee"
 msgstr ""
 
-#: applet.js:210
+#: applet.js:232
 msgid "Open nVidia Settings Program"
 msgstr ""
 
-#: applet.js:216
+#: applet.js:238
 msgid "Open Power Statistics"
 msgstr ""
 
-#: applet.js:224
+#: applet.js:244
 msgid "Open System Monitor"
 msgstr ""
 
-#: applet.js:233
+#: applet.js:253
 msgid "Housekeeping and System Sub Menu"
 msgstr ""
 
-#: applet.js:236
+#: applet.js:256
 msgid "View the Changelog"
 msgstr ""
 
-#: applet.js:242
+#: applet.js:262
 msgid "Open the Help file"
 msgstr ""
 
-#: applet.js:258
+#: applet.js:278
 msgid "Launch programs using the nVidia Graphics Processor"
 msgstr ""
 
-#: applet.js:331
-msgid "ERROR"
-msgstr ""
-
-#: applet.js:332
-msgid "Bumblebee is not installed so applet willl not work"
-msgstr ""
-
-#: applet.js:337
+#: applet.js:358
 msgid "NVidia based GPU is Off"
 msgstr ""
 
-#: applet.js:352
+#: applet.js:381
 msgid "NVidia based GPU is On and Core Temperature is"
 msgstr ""
 
+#: applet.js:389
+msgid "Err"
+msgstr ""
+
+#: applet.js:390
+msgid ""
+"Bumblebee is not set up correctly - are bbswitch, bumblebee and nvidia "
+"drivers installed?"
+msgstr ""
+
 #. bumblebee@pdcurtis->settings-schema.json->showGpuTemp->description
-msgid "Show GPU Temperature in Horizontal Panels"
+msgid "Show GPU Temperature as well as icon"
 msgstr ""
 
 #. bumblebee@pdcurtis->settings-schema.json->showGpuTemp->tooltip
-msgid "Not available in Vertical Panels"
+msgid ""
+"Available in Horizontal and Vertical Panels. Display is in Degrees "
+"Centigrade."
 msgstr ""
 
 #. bumblebee@pdcurtis->settings-schema.json->head2->description

--- a/bumblebee@pdcurtis/files/bumblebee@pdcurtis/settings-schema.json
+++ b/bumblebee@pdcurtis/files/bumblebee@pdcurtis/settings-schema.json
@@ -17,8 +17,8 @@
     "showGpuTemp": {
         "type": "checkbox",
         "default": true,
-        "description": "Show GPU Temperature in Horizontal Panels",
-        "tooltip": "Not available in Vertical Panels"
+        "description": "Show GPU Temperature as well as icon",
+        "tooltip": "Available in Horizontal and Vertical Panels. Display is in Degrees Centigrade."
     },
 
 


### PR DESCRIPTION
 * Allow GPU temperature to be displayed in vertical panels but shorten (by removing the degree symbol) if over 100 degrees on vertical panels.
 * Update bumblebee.pot to identify changes which need to be translated