### PR TITLE
places center: fix panel text not shown

### DIFF
--- a/placesCenter@scollins/files/placesCenter@scollins/applet.js
+++ b/placesCenter@scollins/files/placesCenter@scollins/applet.js
@@ -213,11 +213,11 @@ MyApplet.prototype = {
 
     on_orientation_changed: function(orientation) {
         this.orientation = orientation;
-        if (orientation in [St.Side.LEFT, St.Side.RIGHT]) {
-            this.hide_applet_label(false);
+        if (orientation == St.Side.LEFT || orientation == St.Side.RIGHT) {
+            this.hide_applet_label(true);
         }
         else {
-            this.hide_applet_label(true);
+            this.hide_applet_label(false);
         }
     },
 


### PR DESCRIPTION
The in operator doesn't work like what supposed here, for an array, it refers to the index, not the value, also the true/false parameter for hide_applet_label functions were misplaced. This fixes #249
@collinss 