### PR TITLE
collapsible-systray@feuerfuchs.eu: Fix issues with Cinnamon 3.4 + AppIndicators

### DIFF
--- a/collapsible-systray@feuerfuchs.eu/files/collapsible-systray@feuerfuchs.eu/applet.js
+++ b/collapsible-systray@feuerfuchs.eu/files/collapsible-systray@feuerfuchs.eu/applet.js
@@ -162,12 +162,6 @@ CollapsibleSystrayApplet.prototype = {
         this._loadAppIconVisibilityList();
         this.collapseBtn.setVertical(this._direction == this.Direction.VERTICAL);
         this.collapseBtn.refreshReactive();
-
-        //
-        // Hover events
-
-        this._signalManager.connect(this.actor, 'enter-event', Lang.bind(this, this._onEnter));
-        this._signalManager.connect(this.actor, 'leave-event', Lang.bind(this, this._onLeave));
     },
 
     /*
@@ -783,6 +777,7 @@ CollapsibleSystrayApplet.prototype = {
             iconActor.actor.csEnable = function() {
                 iconActor.actor.set_reactive(true);
             }
+            iconActor.actor.csEnableAfter = function() { }
             iconActor.actor.connect('destroy', Lang.bind(this, function() {
                 this._unregisterAppIcon(appIndicator.id, iconActor.actor);
             }));
@@ -842,6 +837,12 @@ CollapsibleSystrayApplet.prototype = {
                 this._hideAppIcons(true);
             }
         }));
+
+        //
+        // Hover events
+
+        this._signalManager.connect(this.actor, 'enter-event', Lang.bind(this, this._onEnter));
+        this._signalManager.connect(this.actor, 'leave-event', Lang.bind(this, this._onLeave));
     },
 
     /*

--- a/collapsible-systray@feuerfuchs.eu/files/collapsible-systray@feuerfuchs.eu/metadata.json
+++ b/collapsible-systray@feuerfuchs.eu/files/collapsible-systray@feuerfuchs.eu/metadata.json
@@ -1,6 +1,6 @@
 {
     "website": "https://github.com/Feuerfuchs/Collapsible-Systray-Cinnamon-Applet", 
-    "name": "Collapsible Systray", 
+    "uuid": "collapsible-systray@feuerfuchs.eu", 
     "cinnamon-version": [
         "2.8", 
         "3.0", 
@@ -9,7 +9,7 @@
     ], 
     "max-instances": 1, 
     "description": "A replacement for the abandoned System Tray Collapsible Cinnamon applet", 
-    "uuid": "collapsible-systray@feuerfuchs.eu", 
-    "version": "1.8", 
-    "icon": "indicator-applet"
+    "version": "1.9", 
+    "icon": "indicator-applet", 
+    "name": "Collapsible Systray"
 }


### PR DESCRIPTION
When indicator support was enabled in Cinnamon 3.4, the applet would freeze on expand.