### PR TITLE
axos88@countdown-timer: Fix re-assignment of const AppOptions

### DIFF
--- a/axos88@countdown-timer/files/axos88@countdown-timer/applet.js
+++ b/axos88@countdown-timer/files/axos88@countdown-timer/applet.js
@@ -18,7 +18,7 @@ const UUID = "axos88@countdown-timer";
 const AppletMeta = imports.ui.appletManager.applets[UUID];
 const AssetDir = imports.ui.appletManager.appletMeta[UUID].path + "/assets";
 const ConfigFile = GLib.build_filenamev([global.userdatadir, 'applets/' + UUID + '/config.js']);
-const AppOptions = AppletMeta.config.Options;
+let AppOptions = AppletMeta.config.Options;
 const OpenFileCmd = "xdg-open";
 
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale")


### PR DESCRIPTION
```AppOptions``` is re-assigned on [line 297](https://github.com/jaszhix/applets/blob/ec78fdf16ac29d276746b1be2e992c0543aa45d4/axos88%40countdown-timer/files/axos88%40countdown-timer/applet.js#L297), this is a no-op in strict mode.

@axos88 

Closes #927 