### PR TITLE
Spices repo: Amend the issue template with a suggestion of adding debugging information

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -5,3 +5,10 @@
 
 [Issue]: <> (Describe your issue below.)
 
+[Tips]: <> For bug reports, it helps the maintainer of the applet you are reporting an issue on when you give them some environmental information for debugging. This can help them figure out what is wrong with it more quickly. Some things you can include in your bug report are the:
+
+ - Distribution
+ - Cinnamon version
+ - Applet version
+ - ~/.cinnamon/glass.log (use pastebin or a small snippet that's relavent to the issue)
+ - ~/.xsession-errors (if you have one)

--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -7,8 +7,8 @@
 
 [Tips]: <> For bug reports, it helps the maintainer of the applet you are reporting an issue on when you give them some environmental information for debugging. This can help them figure out what is wrong with it more quickly. Some things you can include in your bug report are the:
 
- - Distribution
- - Cinnamon version
- - Applet version
- - ~/.cinnamon/glass.log (use pastebin or a small snippet that's relavent to the issue)
- - ~/.xsession-errors (if you have one)
+ - Distribution (In a terminal run "lsb_release -a".)
+ - Cinnamon version (In a terminal run "cinnamon --version".)
+ - Applet version (Right-click the applet, then click "About...", or go to its directory and include the version/last-edited values.)
+ - ~/.cinnamon/glass.log (Use pastebin or a small snippet that's relavent to the issue.)
+ - ~/.xsession-errors (If you have one.)

--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -9,6 +9,6 @@
 
  - Distribution (In a terminal run "lsb_release -a".)
  - Cinnamon version (In a terminal run "cinnamon --version".)
- - Applet version (Right-click the applet, then click "About...", or go to its directory and include the version/last-edited values.)
+ - Applet version (Right-click the applet, then click "About...", or go to its directory and include the version/last-edited values in metadata.json.)
  - ~/.cinnamon/glass.log (Use pastebin or a small snippet that's relavent to the issue.)
  - ~/.xsession-errors (If you have one.)

--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,9 +1,8 @@
-[Have you read the guidelines for contributing?]: <> (Before opening an issue, please read the guidelines for contributing linked above. Else the issue will be closed. Also don't forget to notify the author.)
+Have you read the guidelines for contributing?
 
-[Notify author of applet]: <> (You should mention the author on GitHub by typing @ plus his/her username to trigger a notification and bring his/her attention to an issue or pull request. You find the username of the author on the cinnamon spices website: https://cinnamon-spices.linuxmint.com/)
-@AuthorName
+Before opening an issue, please read the guidelines for contributing linked above. Issues with invalid formats, or issues not mentioning the maintainer of the applet, may not get a response, and eventually will be closed. You can find the author by visiting the applet's page on the Spices website (https://cinnamon-spices.linuxmint.com/), or going to the applet's directory on this repository, and checking the the author field in info.json. If it is set to none in info.json, or there is no author listed on the site, then this step is not necessary.
 
-[Issue]: <> (Describe your issue below.)
+[Notify author of applet]: @<GithubAuthor>
 
 [Tips]: <> For bug reports, it helps the maintainer of the applet you are reporting an issue on when you give them some environmental information for debugging. This can help them figure out what is wrong with it more quickly. Some things you can include in your bug report are the:
 
@@ -12,3 +11,5 @@
  - Applet version (Right-click the applet, then click "About...", or go to its directory and include the version/last-edited values in metadata.json.)
  - ~/.cinnamon/glass.log (Use pastebin or a small snippet that's relavent to the issue.)
  - ~/.xsession-errors (If you have one.)
+
+[Issue]: <> (Describe your issue below.)


### PR DESCRIPTION
This was in my original issue I opened about the issue template in #34. I think it is a basic thing issue templates should have, and makes it much easier to maintain applets. Issues are a chance for users to be a part of the development process, so I think it is fair to encourage including a little more info on Github. 