### PR TITLE
Icing Task Manager: Update to 4.6.1

### DIFF
--- a/IcingTaskManager@json/CHANGELOG.md
+++ b/IcingTaskManager@json/CHANGELOG.md
@@ -1,5 +1,10 @@
 Changelog
 
+### 4.6.1
+
+  * Fixed a bug preventing some apps, such as Transmission, from having their app button removed from the panel after they are closed.
+  * Fixed a couple warnings when windows are minimized through ITM.
+
 ### 4.6.0
 
   * Added support for Cinnamon's minimize animation positioning.

--- a/IcingTaskManager@json/files/IcingTaskManager@json/appGroup.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/appGroup.js
@@ -366,12 +366,12 @@ AppGroup.prototype = {
         }
         Main.activateWindow(nextWindow, global.get_current_time());
       } else {
-        this.lastFocused.minimize(global.get_current_time());
+        this.lastFocused.minimize();
         this.actor.remove_style_pseudo_class('focus');
       }
     } else {
       if (this.lastFocused.minimized) {
-        this.lastFocused.unminimize(global.get_current_time());
+        this.lastFocused.unminimize();
       }
       let ws = this.lastFocused.get_workspace().index();
       if (ws != global.screen.get_active_workspace_index()) {

--- a/IcingTaskManager@json/files/IcingTaskManager@json/appList.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/appList.js
@@ -410,7 +410,7 @@ AppList.prototype = {
 
     for (let i = 0, len = windows.length; i < len; i++) {
       let windowWorkspace = windows[i].get_workspace();
-      if (windowWorkspace.index() === workspace.index()) {
+      if (windowWorkspace && windowWorkspace.index() === workspace.index()) {
         ++result;
       }
     }

--- a/IcingTaskManager@json/files/IcingTaskManager@json/metadata.json
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/metadata.json
@@ -2,7 +2,7 @@
     "description": "Window list with app grouping and thumbnails",
     "max-instances": -1,
     "name": "Icing Task Manager",
-    "version": "4.6.0",
+    "version": "4.6.1",
     "role": "panellauncher",
     "uuid": "IcingTaskManager@json",
     "multiversion": true,

--- a/IcingTaskManager@json/files/IcingTaskManager@json/specialMenus.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/specialMenus.js
@@ -331,7 +331,7 @@ AppMenuButtonRightClickMenu.prototype = {
         Miscellaneous
       */
 
-      if (mw.get_compositor_private().opacity != 255) {
+      if (mw.get_compositor_private().opacity !== 255) {
         item = createMenuItem({label: 'Restore to full opacity'});
         item.connect('activate', function() {
           mw.get_compositor_private().set_opacity(255);
@@ -347,7 +347,7 @@ AppMenuButtonRightClickMenu.prototype = {
       } else {
         item = createMenuItem({label: 'Minimize', icon: 'view-sort-ascending'});
         item.connect('activate', function() {
-          mw.minimize(global.get_current_time());
+          mw.minimize();
         });
       }
       this.addMenuItem(item);


### PR DESCRIPTION
  * Fixed a bug preventing some apps, such as Transmission, from having their app button removed from the panel after they are closed.
  * Fixed a couple warnings when windows are minimized through ITM.