### PR TITLE
Desktop Handler (0dyseus@DesktopHandler) update

### DIFF
--- a/0dyseus@DesktopHandler/files/0dyseus@DesktopHandler/HELP.html
+++ b/0dyseus@DesktopHandler/files/0dyseus@DesktopHandler/HELP.html
@@ -922,6 +922,16 @@ body {
 <h4>This change log is only valid for the version of the xlet hosted on <a href="https://github.com/Odyseus/CinnamonTools">its original repository</a></h4>
 <hr>
 <ul>
+<li><strong>Date:</strong> Wed, 5 Jul 2017 17:40:41 -0300</li>
+<li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/bf6a86b">bf6a86b</a></li>
+<li><strong>Author:</strong> Odyseus</li>
+</ul>
+<pre><code>Desktop Handler applet
+- Fixed typo that caused the impossibility to open the applet settings window from its context menu.
+Fixes #126
+</code></pre>
+<hr>
+<ul>
 <li><strong>Date:</strong> Tue, 6 Jun 2017 22:29:26 -0300</li>
 <li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/4289024">4289024</a></li>
 <li><strong>Author:</strong> Odyseus</li>

--- a/0dyseus@DesktopHandler/files/0dyseus@DesktopHandler/applet.js
+++ b/0dyseus@DesktopHandler/files/0dyseus@DesktopHandler/applet.js
@@ -508,7 +508,7 @@ MyApplet.prototype = {
                 "system-run",
                 St.IconType.SYMBOLIC);
             this.context_menu_item_configure.connect("activate", Lang.bind(this, function() {
-                Util.spawn_async(["cinnamon-settings applets", this.metadata.uuid,
+                Util.spawn_async(["cinnamon-settings", "applets", this.metadata.uuid,
                     this.instance_id
                 ], null);
             }));


### PR DESCRIPTION
- Fixed typo that caused the impossibility to open the applet settings window from its context menu.