### PR TITLE
sysmonitor@orcus: Fixed issue with a missing function in some distributions

### DIFF
--- a/sysmonitor@orcus/files/sysmonitor@orcus/metadata.json
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/metadata.json
@@ -2,7 +2,7 @@
     "description": "Displays CPU, memory, swap and network usage and load in graphs", 
     "uuid": "sysmonitor@orcus", 
     "name": "System Monitor", 
-    "version": "1.6", 
+    "version": "1.6.1", 
     "icon": "utilities-system-monitor",
     "max-instances": -1
 }


### PR DESCRIPTION
I have fixed #1008. The applet should now load properly when the function GTop.glibtop.get_netlist is not exposed through GObject introspection or is missing for some other reason.