### PR TITLE
feeds@jonbrettdev.wordpress.com Resolved issue on mint 18.2 

### DIFF
--- a/feeds@jonbrettdev.wordpress.com/CHANGELOG
+++ b/feeds@jonbrettdev.wordpress.com/CHANGELOG
@@ -1,3 +1,7 @@
+0.29
+ ===
+ - Found bug where if data folder is not created the app fails to load.  
+
 0.28
  ===
  - Moved feeds.json file from config folder to data folder to resolve configure button issue.

--- a/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/ConfigFileManager.py
+++ b/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/ConfigFileManager.py
@@ -19,6 +19,7 @@
 '''
 from __future__ import unicode_literals
 import sys
+import os
 import uuid
 import json
 import csv
@@ -302,6 +303,11 @@ class ConfigFileManager:
                     for feed in instance['feeds']:
                         # This unique ID is the identifier for this feed for life
                         feed['id'] = ConfigFileManager.get_new_id()
+            # Create the UUID folder if it does not exist.
+            path = os.path.dirname(file_name)
+            if not os.path.exists(path):
+                os.makedirs(path)
+                
             ConfigFileManager.write(file_name, json_obj)
 
         return json_obj

--- a/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/metadata.json
+++ b/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/metadata.json
@@ -11,6 +11,6 @@
         "mockturtl <mockturtl@users.noreply.github.com>", 
         "Jason Jackson <jake1164@hotmail.com>"
     ], 
-    "version": 0.28, 
+    "version": 0.29, 
     "uuid": "feeds@jonbrettdev.wordpress.com"
 }


### PR DESCRIPTION
Found that on 18.2 the applet will not create the default feeds.json config file if the data folder does not exist.