### PR TITLE
bumblebee@pdcurtis Update to Version 3.2.3

### DIFF
--- a/bumblebee@pdcurtis/files/bumblebee@pdcurtis/CHANGELOG.md
+++ b/bumblebee@pdcurtis/files/bumblebee@pdcurtis/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog for recent versions
 
+### 3.2.3
+
+ * Change to the check added in 3.2.1 that bumblebee is installed. This solves an issue reported when applet used with LMDE (issue #1136).
+
 ### 3.2.2
 
  * Allow GPU temperature to be displayed in vertical panels but shorten (by removing the degree symbol) if over 100 degrees on vertical panels.
@@ -9,7 +13,7 @@
 
  * Use CHANGELOG.md instead of changelog.txt in context menu
  * Add symbolic link from UUID folder to applet folder so it is displayed on latest spices web site.
- * Add check that bumblebee daemon is installed.
+ * Add initial check that bumblebee daemon is installed.
 
 ### 3.2.0
 

--- a/bumblebee@pdcurtis/files/bumblebee@pdcurtis/applet.js
+++ b/bumblebee@pdcurtis/files/bumblebee@pdcurtis/applet.js
@@ -144,8 +144,8 @@ MyApplet.prototype = {
                this.textEd = "xed";
             }
 
-            // Check that Bumblebee Daemen is installed 
-            if (!GLib.find_program_in_path("bumblebeed")) {
+            // Check that Bumblebee is installed by presence of optirun
+            if (!GLib.find_program_in_path("optirun")) {
                  let icon = new St.Icon({ icon_name: 'error',
                  icon_type: St.IconType.FULLCOLOR,
                  icon_size: 36 });
@@ -466,4 +466,6 @@ v30_3.1.0  Changed help file from help.txt to README.md
 ### 3.2.2
  * Allow GPU temperature to be displayed in vertical panels but shorten (by removing the degree symbol) if over 100 degrees on vertical panels.
  * Update bumblebee.pot to identify changes which need to be translated
+### 3.2.3
+ * Change to the check added in 3.2.1 that bumblebee is installed. This solves an issue reported when applet used with LMDE (issue #1136).
 */

--- a/bumblebee@pdcurtis/files/bumblebee@pdcurtis/changelog.txt
+++ b/bumblebee@pdcurtis/files/bumblebee@pdcurtis/changelog.txt
@@ -43,7 +43,9 @@ v30_3.1.0  Changed help file from help.txt to README.md
 ### 3.2.1
  * Use CHANGELOG.md instead of changelog.txt in context menu
  * Add symbolic link from UUID folder to applet folder so it is displayed on latest spices web site.
- * Add check that bumblebee daemon is installed.
+ * Add an initial check that bumblebee daemon is installed.
 ### 3.2.2
  * Allow GPU temperature to be displayed in vertical panels but shorten (by removing the degree symbol) if over 100 degrees on vertical panels.
  * Update bumblebee.pot to identify changes which need to be translated
+### 3.2.3
+ * Change to the check added in 3.2.1 that bumblebee is installed. This solves an issue reported when applet used with LMDE (issue #1136).

--- a/bumblebee@pdcurtis/files/bumblebee@pdcurtis/metadata.json
+++ b/bumblebee@pdcurtis/files/bumblebee@pdcurtis/metadata.json
@@ -2,6 +2,6 @@
     "description": "Displays Status of Bumblebee and nVidia GPU Temperature with associated support functions including starting selected programs with optirun or primusrun", 
     "max-instances": "1", 
     "name": "Bumblebee Status with NVidia Temperature Display", 
-    "version": "3.2.2", 
+    "version": "3.2.3", 
     "uuid": "bumblebee@pdcurtis"
 }


### PR DESCRIPTION
 * Change to the check that bumblebee is installed to use presence of optirun rather than bumblebeed. 
 * This solves an issue raised by @Kickertom when the applet is used with LMDE (resolves #1136) 