### PR TITLE
redshift@marvel4u: Ensure the icon size is 24px

### DIFF
--- a/redshift@marvel4u/files/redshift@marvel4u/applet.js
+++ b/redshift@marvel4u/files/redshift@marvel4u/applet.js
@@ -56,6 +56,7 @@ MyApplet.prototype = {
 
         try {
 			this.set_applet_icon_symbolic_path(ICON_OFF);
+            this._applet_icon.set_icon_size(24);
             this.set_applet_tooltip(_("Brightness")); // applet tooltip
 
             this.menuManager = new PopupMenu.PopupMenuManager(this);


### PR DESCRIPTION
@Marvel4U @Martin1887 

Following up on discussion in #1149, this sets the icon size to 24px due to a change in behavior on SVG symbolic icons in Cinnamon 3.6.