### PR TITLE
redshift@marv4u: Fix up #1170

### DIFF
--- a/redshift@marvel4u/files/redshift@marvel4u/applet.js
+++ b/redshift@marvel4u/files/redshift@marvel4u/applet.js
@@ -302,6 +302,7 @@ MyApplet.prototype = {
 			// Icon on
 			if (this.changeOnNight) {
 				this.set_applet_icon_symbolic_path(ICON_SUNSET);
+                this._applet_icon.set_icon_size(24);
 				if (this.latitude && this.longitude) {
 					Util.spawnCommandLine('redshift -l ' + this.latitude + ':' + this.longitude
 						+ ' -t ' + this.dayColor + ':' + this.nightColor
@@ -312,11 +313,13 @@ MyApplet.prototype = {
 				}
 			} else {
 				this.set_applet_icon_symbolic_path(ICON_ON);
+                this._applet_icon.set_icon_size(24);
 				Util.spawnCommandLine('redshift -O ' + this.dayColor + ' -b ' + (this.redshiftDayBrightness / 100));
 			}
     	} else {
 			// Icon off
 			this.set_applet_icon_symbolic_path(ICON_OFF);
+            this._applet_icon.set_icon_size(24);
             // reset Redshift configuration
     		Util.spawnCommandLine('redshift -x');
 		}


### PR DESCRIPTION
@Marvel4U @Martin1887 

This corrects #1170. I was only seeing the correct icon size when reloading the applet, but when re-adding it to the panel the issue persisted. The icon size has to be set whenever the icon changes. Tested against 3.4. Sorry!

By the way, I noticed tabs and spaces are getting mixed up in this file, that's why Github shows the indentation being off.