### PR TITLE
batterymonitor@pdcurtis Update to Version 1.3.1

### DIFF
--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/CHANGELOG.md
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 1.3.1
+
+Bug Fix for use with early versions of Cinnamon
+ * Inhibited use of hide_applet_label() to Cinnamon version 3.2 or higher in vertical panels.
+
 ### 1.3.0
 
 Major update - now includes support for Vertical Panels, Battery icons and 5 Display Modes

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/applet.js
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/applet.js
@@ -279,7 +279,7 @@ MyApplet.prototype = {
             });
             this.menu.addMenuItem(this.menuitemHead1);
 
-            this.menuitemInfo2 = new PopupMenu.PopupMenuItem("     " + _("Note: Alerts not enabled in Settings"), {
+            this.menuitemInfo2 = new PopupMenu.PopupMenuItem("     " + _("Waiting for battery information"), {
                 reactive: false
             });
             this.menu.addMenuItem(this.menuitemInfo2);
@@ -424,16 +424,19 @@ if (this.batteryPercentage < 60  && this.batteryPercentage >= Math.floor(this.al
     this.batteryMessage = ""
              }
 
-             if ( this.displayType == "icon" ) {
-                 this.hide_applet_label(true); 
-             } else {
-                 this.hide_applet_label(false);
-             }
+
 
              if (this.batteryPercentage == 100 && !this.isHorizontal ) { 
                 this.set_applet_label(this.batteryMessage + this.batteryPercentage + "");
              } else {
                 this.set_applet_label(this.batteryMessage + this.batteryPercentage + "%");
+             }
+
+             if ( this.displayType == "icon" ) {
+                 this.set_applet_label("");
+                 if (!this.isHorizontal) { this.hide_applet_label(true) }; 
+             } else {
+                 if (!this.isHorizontal) { this.hide_applet_label(false) };
              }
 
             // Set left click menu item 'label' for slider 
@@ -540,5 +543,9 @@ Now includes support for Vertical Panels, Battery icons and 5 display modes
  * Code comments improved and some commented out code removed.
  * Update README.md, CHANGELOG.md and metadata.json
  * Recreate batterymonitor.pot to allow translation support to be updated.
+### 1.3.1
+Bug Fix for use with early versions of Cinnamon
+ * Inhibited use of hide_applet_label() to Cinnamon version 3.2 or higher in vertical panels.
+ * Corrected Icon Only display mode
 */
 

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/changelog.txt
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/changelog.txt
@@ -68,3 +68,8 @@ Major update - now includes support for Vertical Panels, Battery icons and 5 Dis
  * Code comments improved and some commented out code removed.
  * Update README.md, CHANGELOG.md and metadata.json
  * Recreate batterymonitor.pot to allow translation support to be updated.
+### 1.3.1
+Bug Fix for use with early versions of Cinnamon
+ * Inhibited use of hide_applet_label() to Cinnamon version 3.2 or higher in vertical panels.
+ * Corrected Icon Only display mode
+

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/metadata.json
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/metadata.json
@@ -2,7 +2,7 @@
     "max-instances": "1",  
     "description": "Displays Charge as Percentage and allows Alerts and Actions", 
     "name": "Battery  Applet with Monitoring and Shutdown (BAMS)",
-    "version": "1.3.0", 
+    "version": "1.3.1", 
     "uuid": "batterymonitor@pdcurtis"
 }
 


### PR DESCRIPTION
Bug Fix for use with early versions of Cinnamon
 * Inhibited use of hide_applet_label() to Cinnamon version 3.2 or higher in vertical panels.
 * Corrected 'Icon Only' display mode