### PR TITLE
nvidiaprime@pdcurtis Update to Version 3.3.3

### DIFF
--- a/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/CHANGELOG.md
+++ b/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog for recent versions
 
+### 3.3.3
+
+Fix to allow use with early versions of Cinnamon
+ * Inhibit use of hide_applet_label() unless Cinnamon version 3.2 or higher in use.
+
 ### 3.3.2
 
  * Updates to some tooltips and README.md to reflect the latest changes better.

--- a/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/applet.js
+++ b/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/applet.js
@@ -254,7 +254,7 @@ MyApplet.prototype = {
    try {
          if(this.bbst == "OFF") {
                this.set_applet_label(""); 
-               this.hide_applet_label(true);
+               if (!this.isHorizontal) { this.hide_applet_label(true) }; 
                this.set_applet_tooltip(_("NVidia based GPU is Off")); 
                this.set_applet_icon_path(this.intel_icon);
          }
@@ -267,9 +267,9 @@ MyApplet.prototype = {
 
                 if (!this.showGpuTemp ) {
 	                  this.set_applet_label("");
-                      this.hide_applet_label(true);
+                      if (!this.isHorizontal) { this.hide_applet_label(true) }; 
                  } else { 
-                      this.hide_applet_label(false);
+                      if (!this.isHorizontal) { this.hide_applet_label(false) }; 
                       if ( this.nvidiagputemp < 100 || this.isHorizontal )  { 
                            this.set_applet_label(this.nvidiagputemp + "\u1d3c" );
                       } else {
@@ -288,7 +288,7 @@ MyApplet.prototype = {
          if(this.bbst == "ERROR" || this.nvidiaPrimeMissing) {
 	          this.set_applet_label(_("Err" )); 
               this.set_applet_tooltip(_("Nvidia Prime is not set up correctly - are the nvidia drivers and nvidia-prime  installed?")); 
-              this.hide_applet_label(false);       
+              if (!this.isHorizontal) { this.hide_applet_label(false) };        
          }
       } catch (e) {
           global.logError(e);
@@ -370,5 +370,8 @@ Major new version to support vertical panels and to use icons instead of text to
 ### 3.3.2
  * Updates to some tooltips and README.md to reflect the latest changes better.
  * Update nvidiaprime.pot to identify changes which need to be translated.
+### 3.3.3
+Fix to allow use with early versions of Cinnamon
+ * Inhibit use of hide_applet_label() unless Cinnamon version 3.2 or higher in use.
 */
 

--- a/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/changelog.txt
+++ b/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/changelog.txt
@@ -51,3 +51,6 @@ Major new version to support vertical panels and to use icons instead of text to
 ### 3.3.2
  * Updates to some tooltips and README.md to reflect the latest changes better.
  * Update nvidiaprime.pot to identify changes which need to be translated.
+### 3.3.3
+Fix to allow use with early versions of Cinnamon
+ * Inhibit use of hide_applet_label() unless Cinnamon version 3.2 or higher in use.

--- a/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/metadata.json
+++ b/nvidiaprime@pdcurtis/files/nvidiaprime@pdcurtis/metadata.json
@@ -3,6 +3,6 @@
     "description": "Displays which Graphics processor is active and nVidia GPU Temperature when active and in a horizontal panel", 
     "name": "nVidia Prime GPU Display", 
     "uuid": "nvidiaprime@pdcurtis",
-    "version": "3.3.2"
+    "version": "3.3.3"
 }
 


### PR DESCRIPTION
Fix to allow use with early versions of Cinnamon
 * Inhibit use of hide_applet_label() unless Cinnamon version 3.2 or higher in use.