### PR TITLE
batterymonitor@pdcurtis Update to Version 1.3.2

### DIFF
--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/CHANGELOG.md
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 1.3.2
+
+ * Add checks that sox and zenity are installed and warn that full facilities are not available without them.
+ * Update batterymonitor.pot so translations can be updated.
+
 ### 1.3.1
 
 Bug Fix for use with early versions of Cinnamon

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/README.md
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/README.md
@@ -56,7 +56,7 @@ Although comments and suggestions are always welcome any contributions which are
 
 ## Requirements:
 
-Cinnamon Version 1.8 or higher as it make comprehensive use of the new Cinnamon Settings Interface for Applets and Desklets. It has been tested up to Cinnamon 3.2 and Mint 18.1. 
+Cinnamon Version 1.8 or higher as it make comprehensive use of the new Cinnamon Settings Interface for Applets and Desklets. The latest versions been tested from Mint 17 with Cinnamon 2.4 up to Cinnamon 3.4 and Mint 18.2. 
     
 For full facilities including notifications and audible alerts the ```zenity sox``` and ```libsox-fmt-mp3``` libraries must be installed. They can be installed wih the Synaptic Package Manager or using the following terminal command:
  

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/applet.js
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/applet.js
@@ -19,7 +19,7 @@ const GLib = imports.gi.GLib; // ++ Needed for starting programs and translation
 const Mainloop = imports.mainloop; // Needed for timer update loop
 const ModalDialog = imports.ui.modalDialog; // Needed for Modal Dialog used in Alert
 const Gettext = imports.gettext; // ++ Needed for translations
-
+const Main = imports.ui.main; // ++ Needed for criticalNotify()
 
 // ++ Always needed if you want localisation/translation support
 // New l10n support thanks to ideas from @Odyseus, @lestcape and @NikoKrause
@@ -142,8 +142,16 @@ MyApplet.prototype = {
                 this.textEd = "xed";
             }
 
-            // Set up Modal Alert Box - Now moved below 
- //          alertModalDataWarning = new AlertDialog("The Battery Level has fallen to your alert level\n\n either reconnect to a power source\n\or close down your work and suspend or shutdown the machine");
+            // Check that all Dependencies Met by presence of sox and zenity 
+            if (GLib.find_program_in_path("sox") && GLib.find_program_in_path("zenity") ) {
+                 this.dependenciesMet = true;
+            } else {
+                 let icon = new St.Icon({ icon_name: 'error',
+                 icon_type: St.IconType.FULLCOLOR,
+                 icon_size: 36 });
+                 Main.criticalNotify("Some Dependencies not Installed", "You appear to be missing some of the programs required for this applet to have all it's facilities including notifications and audible alerts .\n\nPlease read the help file on how to install them.", icon);
+                 this.dependenciesMet = false;
+            }
 
             // ++ Set up left click menu
             this.menuManager = new PopupMenu.PopupMenuManager(this);
@@ -307,7 +315,7 @@ MyApplet.prototype = {
             this.batteryPercentage = this.batteryPercentage.trim().substr(5);
             this.batteryPercentage = Math.floor(this.batteryPercentage); 
              // now check we have a genuine number otherwise use last value
-            if ( ! ( this.batteryPercentage > 0 && this.batteryPercentage <= 100 )) {             
+            if ( ! ( this.batteryPercentage >= 0 && this.batteryPercentage <= 100 )) {             
                 this.batteryPercentage = this.lastBatteryPercentage;
             }
 //          Comment out following line when tests are complete
@@ -547,5 +555,10 @@ Now includes support for Vertical Panels, Battery icons and 5 display modes
 Bug Fix for use with early versions of Cinnamon
  * Inhibited use of hide_applet_label() to Cinnamon version 3.2 or higher in vertical panels.
  * Corrected Icon Only display mode
+### 1.3.2
+ * Add checks that sox and zenity are installed and warn that full facilities are not available without them.
+ * Improve handling of completely empty batteries.
+ * Update README.md, CHANGELOG.md and metadata.json
+ * Update batterymonitor.pot so translations can be updated.
 */
 

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/changelog.txt
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/changelog.txt
@@ -72,4 +72,9 @@ Major update - now includes support for Vertical Panels, Battery icons and 5 Dis
 Bug Fix for use with early versions of Cinnamon
  * Inhibited use of hide_applet_label() to Cinnamon version 3.2 or higher in vertical panels.
  * Corrected Icon Only display mode
+### 1.3.2
+ * Add checks that sox and zenity are installed and warn that full facilities are not available without them.
+ * Improve handling of completely empty batteries.
+ * Update README.md, CHANGELOG.md and metadata.json
+ * Update batterymonitor.pot so translations can be updated.
 

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/metadata.json
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/metadata.json
@@ -2,7 +2,7 @@
     "max-instances": "1",  
     "description": "Displays Charge as Percentage and allows Alerts and Actions", 
     "name": "Battery  Applet with Monitoring and Shutdown (BAMS)",
-    "version": "1.3.1", 
+    "version": "1.3.2", 
     "uuid": "batterymonitor@pdcurtis"
 }
 

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/batterymonitor.pot
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/batterymonitor.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-07 10:23+0100\n"
+"POT-Creation-Date: 2017-08-31 15:17+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,48 +21,48 @@ msgstr ""
 msgid "Ok"
 msgstr ""
 
-#: applet.js:165
+#: applet.js:173
 msgid "Waiting"
 msgstr ""
 
-#: applet.js:231
+#: applet.js:239
 msgid "Open Power Statistics"
 msgstr ""
 
-#: applet.js:237
+#: applet.js:245
 msgid "Open System Monitor"
 msgstr ""
 
-#: applet.js:246
+#: applet.js:254
 msgid "Housekeeping and System Sub Menu"
 msgstr ""
 
-#: applet.js:249
+#: applet.js:257
 msgid "View the Changelog"
 msgstr ""
 
-#: applet.js:255
+#: applet.js:263
 msgid "Open the Help file"
 msgstr ""
 
-#: applet.js:261
+#: applet.js:269
 msgid "Open stylesheet.css  (Advanced Function)"
 msgstr ""
 
 #. batterymonitor@pdcurtis->metadata.json->name
-#: applet.js:277
+#: applet.js:285
 msgid "Battery  Applet with Monitoring and Shutdown (BAMS)"
 msgstr ""
 
-#: applet.js:282
-msgid "Note: Alerts not enabled in Settings"
+#: applet.js:290
+msgid "Waiting for battery information"
 msgstr ""
 
-#: applet.js:345
+#: applet.js:353
 msgid "Battery Low - turn off or connect to mains"
 msgstr ""
 
-#: applet.js:350
+#: applet.js:358
 msgid ""
 "The Battery Level has fallen to your alert level\n"
 "\n"
@@ -70,31 +70,31 @@ msgid ""
 "or close down your work and suspend or shutdown the machine"
 msgstr ""
 
-#: applet.js:367
+#: applet.js:375
 msgid "Battery Critical will Suspend unless connected to mains"
 msgstr ""
 
-#: applet.js:385
+#: applet.js:393
 msgid "Charge:"
 msgstr ""
 
-#: applet.js:385
+#: applet.js:393
 msgid "Alert:"
 msgstr ""
 
-#: applet.js:385
+#: applet.js:393
 msgid "Suspend:"
 msgstr ""
 
-#: applet.js:440
+#: applet.js:451
 msgid "Percentage Charge:"
 msgstr ""
 
-#: applet.js:440
+#: applet.js:451
 msgid "Alert at:"
 msgstr ""
 
-#: applet.js:440
+#: applet.js:451
 msgid "Suspend at:"
 msgstr ""
 


### PR DESCRIPTION
 * Add checks that sox and zenity are installed and warn that full facilities are not available without them.
 * Improve handling of completely empty batteries.
 * Update README.md, CHANGELOG.md and metadata.json
 * Update batterymonitor.pot so translations can be updated.