### PR TITLE
printers@linux-man: Better default printer detection

### DIFF
--- a/printers@linux-man/files/printers@linux-man/applet.js
+++ b/printers@linux-man/files/printers@linux-man/applet.js
@@ -137,7 +137,7 @@ MyApplet.prototype = {
     Util.spawn_async(['python', APPLET_PATH + '/lpstat-a.py'], Lang.bind(this, function(out) {
       this.printers = [];
       Util.spawn_async(['/usr/bin/lpstat', '-d'], Lang.bind(this, function(out2) {//To check default printer
-        if(out2.substring(0, 2) != 'no') out2 = out2.split(': ')[1].trim();
+        if(out2.split(': ')[1] != undefined) out2 = out2.split(': ')[1].trim();
         else out2 = 'no default';
         out = out.split('\n');
         this.printersCount = out.length - 2;


### PR DESCRIPTION
Trying to fix a rare issue: out2.split(...)[1] is undefined.