### PR TITLE
netusagemonitor@pdcurtis Update to Version 3.2.3

### DIFF
--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/CHANGELOG.md
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changelog covering recent changes
 
+## 3.2.3
+ * Add check that GTop library is installed using a try and catch(e) technique
+ * Remove duplicate let declarations occurances missed in 3.2.0 which could give difficulties in Cinnamon 3.4
 ## 3.2.2
 Support new facility on Cinnamon Spices Web Site to display a CHANGELOG.md
 

--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/README.md
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/README.md
@@ -6,12 +6,12 @@ The Network Usage Monitor Applet (NUMA) enables one to continuously display the 
 
 ## Special Requirements:
 
-   * For the basic facilities the ```gir1.2-gtop-2.0``` library __must be installed__ or the applet will not load. It can be installed by the synaptic package manager or with the terminal command:
+   * For the basic facilities the ```gir1.2-gtop-2.0``` library __must be installed__ or the applet will not load and a notification will be displayed. It can be installed by the synaptic package manager or with the terminal command:
                       ```sudo apt-get install gir1.2-gtop-2.0```
 
-   * For full facilities including notifications, audible alerts and statistics the ```gir1.2-gtop-2.0 vnstat vnstati zenity sox libsox-fmt-mp3``` libraries must be installed. They can be installed  by the synaptic package manager or with the terminal command:
+   * For full facilities including use of notifications, audible alerts and statistics the ```gir1.2-gtop-2.0 vnstat vnstati zenity sox libsox-fmt-mp3``` libraries must be installed. They can be installed  by the synaptic package manager or with the terminal command:
             ```sudo apt-get install gir1.2-gtop-2.0 vnstat vnstati zenity sox libsox-fmt-mp3``
-   * Cinnamon Version 1.8 or higher as it make comprehensive use of the new Cinnamon Settings Interface for Applets and Desklets.
+   * Cinnamon Version 2.2 or higher ie. It can be used with all supported versions of Mint.
 
 ## Features:
 
@@ -81,7 +81,7 @@ The system program vnstat which provides the option of a graphic history of data
 
 ## Status
 
-The author is committed to maintaining and developing the applet. The applet is based on a well tried core from the netspeed applet and has been tested on various systems initially running Mint 15 with a variety of themes. It is designed to work with Cinammon 1.8 and higher. The current Version has been tested with Cinnamon 2.2 - 3.2 and Mint 16 - 18.1. 
+The author is committed to maintaining and developing the applet. The applet is based on a well tried core from the netspeed applet and has been tested on various systems initially running under Mint 15 with a variety of themes. The current Version has been tested with Cinnamon 2.2 - 3.4 and Mint 17 - 18.2. 
 
 ## Translations and other Contributions
 
@@ -95,14 +95,14 @@ Thanks are given for the very useful contributions from @collinss and @Odyseus t
 
    * Download from Cinnamon Spices
    * Unzip and extract folder netusagemonitor@pdcurtis to ~/.local/share/cinnamon/applets/
-   * Install any additional programs required.
+   * Install the additional programs required.
    * Enable the applet in Cinnamon Settings -> Applets
    * You can also access the Settings Screen from Cinnamon Settings -> Applets
 
 
 ### Version information prior to the changes introduced by the new Cinnamon Spices Web site in January 2017
 
-There is a full change log in the applet folder called changelog.txt which can also be accessed  through the Context (Right Click) menu in the Housekeeping sub-menu. The initial  development was carried out on Github along with my other applets at [github.com/pdcurtis/cinnamon-applets](https://github.com/pdcurtis/cinnamon-applets)
+There is a change log in the applet folder called CHANGELOG.md which can also be accessed through the Context (Right Click) menu in the Housekeeping sub-menu. The initial  development was carried out on Github along with my other applets at [github.com/pdcurtis/cinnamon-applets](https://github.com/pdcurtis/cinnamon-applets)
 
 ### Contact
 

--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/changelog.txt
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/changelog.txt
@@ -157,3 +157,14 @@ Transition to new cinnamon-spices-applets repository from github.com/pdcurtis/ci
           Tidy up comments in applet.js
           Update README.md to remove a couple of references to Ubuntu from early days.
           Usual updates to new version in applet.js, changelog and metadata.json
+3.2.2     Removed unused this.UUID = metadata.uuid 
+          Improved l10n translation support.
+          Added CHANGELOG.md to applet folder and use it instead of changelog.txt in right click menu
+          CHANGELOG.md based on recent entries to changelog.txt with last changes at the top. changelog.txt currently remains in applet folder but is not used.
+          Use symbolic links for README.md and CHANGELOG.md instead of copies from the applet folder to UUID folder for the Cinnamon Web Site to pick up
+## 3.2.3
+ * Add check that GTop library is installed using a try and catch(e) technique
+ * Remove some additional duplicate let declarations occurances which could give difficulties in Cinnamon 3.4
+ * Changes to l10n translation support to bring ahead of GTop test.
+ * Update CHANGELOG.md, README.md, settings-schema.json and metadata.json
+ * Update netusagemonitor.pot so translations can be updated. 

--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/metadata.json
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/metadata.json
@@ -3,6 +3,6 @@
     "uuid": "netusagemonitor@pdcurtis", 
     "name": "Network Data Usage Monitor", 
     "description": "A Comprehensive Data Usage Monitor with alerts and cumulative data functions",
-    "version": "3.2.2"
+    "version": "3.2.3"
 }
 

--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/po/netusagemonitor.pot
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/po/netusagemonitor.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-08 04:19+0100\n"
+"POT-Creation-Date: 2017-09-03 22:17+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,137 +17,148 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: \n"
 
-#: applet.js:43
+#: applet.js:38
+msgid "Some Dependencies not Installed"
+msgstr ""
+
+#: applet.js:38
+msgid ""
+"You appear to be missing some of the programs or libraries required for this applet to run.\n"
+"\n"
+"Please read the help file on how to install them."
+msgstr ""
+
+#: applet.js:59
 msgid "Ok"
 msgstr ""
 
-#: applet.js:294
+#: applet.js:313
 msgid "No Interface being Monitored - right click to select"
 msgstr ""
 
-#: applet.js:420
+#: applet.js:439
 msgid ""
 "ERROR: Please make sure vnstat and vnstati are installed and that the vnstat"
 " daemon is running!"
 msgstr ""
 
-#: applet.js:423
+#: applet.js:442
 msgid ""
 "NOTE: The last time the network traffic statistics were updated by vnStat is"
 " at the top right"
 msgstr ""
 
-#: applet.js:427
+#: applet.js:446
 msgid ""
 "If no Interface is Active, the last available information has been displayed"
 msgstr ""
 
-#: applet.js:439
+#: applet.js:458
 msgid "Cumulative Data Usage Information:"
 msgstr ""
 
-#: applet.js:466
+#: applet.js:485
 msgid "Current Connection and Interface Information"
 msgstr ""
 
-#: applet.js:478
+#: applet.js:497
 msgid "No network monitored. Please select one right-clicking the applet."
 msgstr ""
 
-#: applet.js:485
+#: applet.js:504
 msgid "Note: Alerts not enabled in Settings"
 msgstr ""
 
-#: applet.js:501
+#: applet.js:520
 msgid "Alert level (Orange):"
 msgstr ""
 
-#: applet.js:501
-#, c-format
+#: applet.js:520
+#, javascript-format
 msgid "% of Data Limit of"
 msgstr ""
 
-#: applet.js:506 applet.js:508 applet.js:514 applet.js:516 applet.js:522
+#: applet.js:525 applet.js:527 applet.js:533 applet.js:535 applet.js:541
 msgid "Cumulative Data Use"
 msgstr ""
 
-#: applet.js:506 applet.js:514 applet.js:522
+#: applet.js:525 applet.js:533 applet.js:541
 msgid "with offset of"
 msgstr ""
 
-#: applet.js:545
+#: applet.js:564
 msgid "Select a network manager interface to be monitored:"
 msgstr ""
 
-#: applet.js:558
+#: applet.js:577
 msgid "(Active)"
 msgstr ""
 
-#: applet.js:571
+#: applet.js:590
 msgid "or Select an independent interface to be monitored:"
 msgstr ""
 
-#: applet.js:575
+#: applet.js:594
 msgid "for most USB Mobile Internet Modems)"
 msgstr ""
 
-#: applet.js:587
+#: applet.js:606
 msgid "for Android Bluetooth PAN Connections)"
 msgstr ""
 
-#: applet.js:597
+#: applet.js:616
 msgid "Check for Changes in Devices and Display Options"
 msgstr ""
 
-#: applet.js:605
+#: applet.js:624
 msgid "Toggle Display from ↓ and ↑ to ⇵"
 msgstr ""
 
-#: applet.js:619 applet.js:629 applet.js:639
+#: applet.js:638 applet.js:648 applet.js:658
 msgid "Reset Cumulative Data Usage"
 msgstr ""
 
-#: applet.js:652
+#: applet.js:671
 msgid "Housekeeping and System Sub Menu"
 msgstr ""
 
-#: applet.js:655
+#: applet.js:674
 msgid "Open System Monitor"
 msgstr ""
 
-#: applet.js:661
+#: applet.js:680
 msgid "View the Changelog"
 msgstr ""
 
-#: applet.js:667
+#: applet.js:686
 msgid "View the Help File"
 msgstr ""
 
-#: applet.js:676
+#: applet.js:695
 msgid "Open stylesheet.css  (Advanced Function)"
 msgstr ""
 
-#: applet.js:682
+#: applet.js:701
 msgid "Open alertScript  (Advanced Function)"
 msgstr ""
 
-#: applet.js:688
+#: applet.js:707
 msgid "Open suspendScript  (Advanced Function)"
 msgstr ""
 
-#: applet.js:696
+#: applet.js:715
 msgid "Test alertScript  (Advanced Test Function)"
 msgstr ""
 
-#: applet.js:702
+#: applet.js:721
 msgid "Test suspendScript  (Advanced Test Function)"
 msgstr ""
 
-#: applet.js:708
+#: applet.js:727
 msgid "Test Crisis Management Function (Advanced Test Function)"
 msgstr ""
 
-#: applet.js:777
+#: applet.js:797
 msgid ""
 "THE DATA USAGE LIMIT HAS BEEN EXCEEDED\n"
 "\n"
@@ -156,15 +167,15 @@ msgid ""
 "or disconnect using the Network Manager Applet"
 msgstr ""
 
-#: applet.js:849
+#: applet.js:870
 msgid "Interface:"
 msgstr ""
 
-#: applet.js:849 applet.js:852
+#: applet.js:870 applet.js:873
 msgid "Downloaded:"
 msgstr ""
 
-#: applet.js:849 applet.js:852
+#: applet.js:870 applet.js:873
 msgid "Uploaded:"
 msgstr ""
 
@@ -495,9 +506,7 @@ msgid "Full path and filename of alert sound file"
 msgstr ""
 
 #. netusagemonitor@pdcurtis->settings-schema.json->alertSound->tooltip
-msgid ""
-"Only for built in alerts - hard code into scripts. Must have Sox installed. "
-"Most sound file types supported"
+msgid "Must have Sox installed. Most sound file types supported"
 msgstr ""
 
 #. netusagemonitor@pdcurtis->metadata.json->description

--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/settings-schema.json
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/settings-schema.json
@@ -242,7 +242,7 @@
         "default": "/usr/share/sounds/freedesktop/stereo/alarm-clock-elapsed.oga",
         "dependency": "useAlertSound",
         "description": "Full path and filename of alert sound file",
-        "tooltip": "Only for built in alerts - hard code into scripts. Must have Sox installed. Most sound file types supported"
+        "tooltip": "Must have Sox installed. Most sound file types supported"
     },
     "displayExtraHousekeeping": {
         "type": "checkbox",


### PR DESCRIPTION
 * Add check that GTop library is installed using a try and catch(e) technique
 * Remove some additional duplicate let declarations occurrences which could give difficulties in Cinnamon 3.4
 * Changes to l10n translation support to bring ahead of GTop test.
 * Update CHANGELOG.md, README.md, settings-schema.json and metadata.json
 * Update netusagemonitor.pot so translations can be updated. 
