### PR TITLE
[windowlist@cobinja.de] Update to version 2.0

### DIFF
--- a/windowlist@cobinja.de/CHANGELOG.md
+++ b/windowlist@cobinja.de/CHANGELOG.md
@@ -1,0 +1,21 @@
+Changelog
+
+2.0
+==
+
+New Features
+--
+- Added pinning per workspace
+- Add ability to only show windows that are present on the same monitor as the applet
+- Shrink thumbnails when too many windows are open
+
+Bugfixes
+--
+- Fix after StBoxLayout was switched to ClutterBoxLayout (Necessary on future versions of Cinnamon, won't break on Cinnamon 3.2)
+- Fix some windows like Spotify not showing (Fixes #1230)
+
+Various
+--
+- Update pot-file and German translation
+- Added tooltips to some settings
+- Use the new handleDragOut method to delete the drag placeholder (Will only work on future versions of Cinnamon, won't break on Cinnamon 3.2)

--- a/windowlist@cobinja.de/README.md
+++ b/windowlist@cobinja.de/README.md
@@ -12,7 +12,7 @@ Some of the key features are:
 
  - App grouping: this groups window of each program into one button
  - Previews: When hovering over a button, a menu will show previews of all windows managed by that button
- - Pinning programs: You can pin your favorite programs to the applet
+ - Pinning programs: You can pin your favorite programs to workspaces
  - Drag'n'Drop: You can reorder your programs
  - Drop from menu and panel launchers: You can drag menu items from Cinnamon's menu and panel launcher applet to this applet, the program will then be pinned
  - Various actions are available from the buttons' context menus

--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/3.2/applet.js
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/3.2/applet.js
@@ -91,7 +91,7 @@ function _hasFocus(metaWindow) {
   return transientHasFocus;
 }
 
-function compareArray(x, y) {
+function compareObject(x, y) {
   // mimic non-extisting logical xor
   // to determine if one of the
   // parameters is undefined and the other one is not
@@ -101,47 +101,33 @@ function compareArray(x, y) {
   if (x === y) {
     return true;
   }
-  if (x.length != y.length) {
+  
+  if (!(x instanceof Object) || !(y instanceof Object)) {
     return false;
   }
-  for (let key in x) {
-    let xHasKey = x.hasOwnProperty(key);
-    let yHasKey = y.hasOwnProperty(key);
-    if (!xHasKey) {
-      continue;
-    }
-    if(!xHasKey != !yHasKey) {
+  
+  if (Object.getPrototypeOf(x) !== Object.getPrototypeOf(y)) {
+    return false;
+  }
+  
+  let keysX = Object.keys(x);
+  let keysY = Object.keys(y);
+  
+  if (keysX.length != keysY.length) {
+    return false;
+  }
+  
+  for (let i = 0; i < keysX.length; i++) {
+    let key = keysX[i];
+    if (!y.hasOwnProperty(key)) {
       return false;
     }
-    // recursive call in case of a nested array
-    if (!compareArray(x[key], y[key])) {
+    if (!compareObject(x[key], y[key])) {
       return false;
     }
   }
+  
   return true;
-}
-
-function mergeArrays(x, y) {
-  let result = [];
-  if (x && y) {
-    for (let i = 0; i < x.length; i++) {
-      let a = x[i]
-      if (y.indexOf(a) == -1) {
-        result.push(a);
-      }
-    }
-    result = [...new Set([...result, ...y])];
-  }
-  else if (x) {
-    result = x;
-  }
-  else if (y) {
-    result = y;
-  }
-  else {
-    result = [];
-  }
-  return result;
 }
 
 function sign(p1, p2, p3) {
@@ -190,7 +176,7 @@ CobiWindowListSettings.prototype = {
       key_not_found_error(key, this.uuid);
       return;
     }
-    if (!compareArray(this.settingsData[key].value, value)) {
+    if (!compareObject(this.settingsData[key].value, value)) {
       this._setValue(value, key);
     }
   },
@@ -219,7 +205,7 @@ CobiPopupMenuItem.prototype = {
     this.addActor(this._box);
     
     this._iconSize = 20 * global.ui_scale;
-    let descSize = 30 * global.ui_scale;
+    this.descSize = 30 * global.ui_scale;
     this._icon = this._appButton._app ?
                   this._appButton._app.create_icon_texture(this._iconSize) :
                   new St.Icon({ icon_name: "application-default-icon",
@@ -230,7 +216,7 @@ CobiPopupMenuItem.prototype = {
     this._icon.set_width(-1);
     this._icon.set_height(-1);
     let windowActor = metaWindow.get_compositor_private();
-    let monitor = Main.layoutManager.findMonitorForActor(windowActor);
+    let monitor = this._appButton._applet._monitor;
     let width = monitor.width;
     let height = monitor.height;
     let aspectRatio = width / height;
@@ -240,7 +226,7 @@ CobiPopupMenuItem.prototype = {
     this._descBox = new St.BoxLayout({natural_width: width});
     this._box.add_actor(this._descBox);
     
-    this._iconBin = new St.Bin({natural_width: descSize, natural_height: descSize});
+    this._iconBin = new St.Bin({natural_width: this.descSize, natural_height: this.descSize});
     this._descBox.add_actor(this._iconBin);
     this._iconBin.set_child(this._icon);
     
@@ -261,7 +247,7 @@ CobiPopupMenuItem.prototype = {
     this._spacer = new St.Widget();
     this._descBox.add(this._spacer, {expand: true});
     
-    this._closeBin = new St.Bin({natural_width: descSize, natural_height: descSize, reactive: true});
+    this._closeBin = new St.Bin({natural_width: this.descSize, natural_height: this.descSize, reactive: true});
     this._closeIcon = new St.Bin({style_class: "window-close", natural_width: this._iconSize, height: this._iconSize});
     this._descBox.add_actor(this._closeBin);
     this._closeBin.set_child(this._closeIcon);
@@ -272,17 +258,74 @@ CobiPopupMenuItem.prototype = {
       this._box.add_actor(this._cloneBin);
       this._cloneBox = new St.Widget();
       this._cloneBin.add_actor(this._cloneBox);
-      let clones = WindowUtils.createWindowClone(this._metaWindow, width, height, true, true);
-      for (let i = 0; i < clones.length; i++) {
-        let clone = clones[i];
-        this._cloneBox.add_actor(clone.actor);
-        clone.actor.set_position(clone.x, clone.y);
-      }
+      //this.doSize();
     }
     this._signalManager.connect(this.actor, "enter-event", this._onEnterEvent);
     this._signalManager.connect(this.actor, "leave-event", this._onLeaveEvent);
     //this._signalManager.connect(this.actor, "button-release-event", this._onButtonReleaseEvent);
     this._signalManager.connect(this, "activate", this._onActivate);
+  },
+  
+  doSize: function(availWidth, availHeight) {
+    if (Main.software_rendering || !this._settings.getValue("hover-preview")) {
+      return;
+    }
+    let monitor = this._appButton._applet._monitor;
+    let width = monitor.width;
+    let height = monitor.height;
+    let aspectRatio = width / height;
+    
+    let numItems = this._menu.numMenuItems;
+    let themeNode = this.actor.get_theme_node();
+    
+    let overheadWidth = themeNode.get_padding(St.Side.LEFT);
+    overheadWidth += themeNode.get_padding(St.Side.RIGHT);
+    overheadWidth += themeNode.get_border_width(St.Side.LEFT);
+    overheadWidth += themeNode.get_border_width(St.Side.RIGHT);
+    
+    let overheadHeight = themeNode.get_padding(St.Side.TOP);
+    overheadHeight += themeNode.get_padding(St.Side.BOTTOM);
+    overheadHeight += themeNode.get_border_width(St.Side.TOP);
+    overheadHeight += themeNode.get_border_width(St.Side.BOTTOM);
+    overheadHeight += this.descSize;
+    
+    // margin is only supported since Cinnamon 3.4
+    if (themeNode.get_margin !== undefined) {
+      overheadWidth += themeNode.get_margin(St.Side.LEFT);
+      overheadWidth += themeNode.get_margin(St.Side.RIGHT);
+      overheadHeight += themeNode.get_margin(St.Side.TOP);
+      overheadHeight += themeNode.get_margin(St.Side.BOTTOM);
+    }
+    
+    let spacing = Math.round(this._menu.box.get_theme_node().get_length("spacing"));
+    
+    if (this._menu.box.get_vertical()) {
+      height = (availHeight / (Math.max(numItems, 8))) - overheadHeight;
+      //height = Math.round(height / (Math.max(numItems, 10)));
+      
+      width = Math.round(height * aspectRatio);
+    }
+    else {
+      width = (availWidth / (Math.max(numItems, 8))) - overheadWidth;
+      //width = Math.round(width / (Math.max(numItems, 10)));
+      
+      height = Math.round(width / aspectRatio);
+    }
+    
+    //height = Math.round(height / 10);
+    //width = Math.round(height * aspectRatio);
+    
+    this._descBox.natural_width = width;
+    
+    this._cloneBox.remove_all_children();
+    this._cloneBin.natural_width = width;
+    
+    let clones = WindowUtils.createWindowClone(this._metaWindow, width, height, true, true);
+    for (let i = 0; i < clones.length; i++) {
+      let clone = clones[i];
+      this._cloneBox.add_actor(clone.actor);
+      clone.actor.set_position(clone.x, clone.y);
+    }
   },
   
   _onEnterEvent: function() {
@@ -384,8 +427,6 @@ CobiPopupMenu.prototype = {
     this._settings = this._appButton._settings;
     this._signalManager = new SignalManager.SignalManager(this);
     
-    this._windows = [];
-    
     global.focus_manager.add_group(this.actor);
     this.actor.reactive = true;
     Main.layoutManager.addChrome(this.actor);
@@ -457,11 +498,13 @@ CobiPopupMenu.prototype = {
       return;
     }
     this._updateOrientation();
-    let windows = this._appButton.getWindowsOnCurrentWorkspace();
+    let windows = this._appButton._windows;
     for (let i = 0; i < windows.length; i++) {
       let window = windows[i];
-      this.addMenuItem(new CobiPopupMenuItem(this, this._appButton, window));
+      this.addWindow(window);
     }
+    this.recalcItemSizes();
+    
     this._appButton._computeMousePos();
     PopupMenu.PopupMenu.prototype.open.call(this, false);
   },
@@ -473,12 +516,13 @@ CobiPopupMenu.prototype = {
     this.removeDelay();
     PopupMenu.PopupMenu.prototype.close.call(this, false);
     this.removeAll();
-    this._windows = [];
   },
   
-  addWindow: function(metaWindow) {
-    if (this._findMenuItemForWindow(metaWindow) == null) {
-      this.addMenuItem(new CobiPopupMenuItem(this, this._appButton, metaWindow));
+  addWindow: function(window) {
+    if (this._findMenuItemForWindow(window) == null) {
+      let menuItem = new CobiPopupMenuItem(this, this._appButton, window);
+      this.addMenuItem(menuItem);
+      this.recalcItemSizes();
     }
   },
   
@@ -486,6 +530,37 @@ CobiPopupMenu.prototype = {
     let item = this._findMenuItemForWindow(metaWindow);
     if (item && this.numMenuItems > 1) {
       item.hide();
+    }
+  },
+  
+  recalcItemSizes: function() {
+    let themeNode = this.actor.get_theme_node();
+    
+    let overheadWidth = themeNode.get_padding(St.Side.LEFT);
+    overheadWidth += themeNode.get_padding(St.Side.RIGHT);
+    overheadWidth += themeNode.get_border_width(St.Side.LEFT);
+    overheadWidth += themeNode.get_border_width(St.Side.RIGHT);
+    
+    let overheadHeight = themeNode.get_padding(St.Side.TOP);
+    overheadHeight += themeNode.get_padding(St.Side.BOTTOM);
+    overheadHeight += themeNode.get_border_width(St.Side.TOP);
+    overheadHeight += themeNode.get_border_width(St.Side.BOTTOM);
+    
+    // margin is only supported since Cinnamon 3.4
+    if (themeNode.get_margin !== undefined) {
+      overheadWidth += themeNode.get_margin(St.Side.LEFT);
+      overheadWidth += themeNode.get_margin(St.Side.RIGHT);
+      overheadHeight += themeNode.get_margin(St.Side.TOP);
+      overheadHeight += themeNode.get_margin(St.Side.BOTTOM);
+    }
+    
+    let monitor = this._appButton._applet._monitor;
+    let availWidth = monitor.width - overheadWidth;
+    let availHeight = monitor.height - overheadHeight;
+    
+    let items = this._getMenuItems();
+    for (let i = 0; i < items.length; i++) {
+      items[i].doSize(availWidth, availHeight);
     }
   },
   
@@ -611,12 +686,13 @@ CobiMenuManager.prototype = {
   }
 }
 
-function CobiAppButton(applet, app) {
-  this._init(applet, app);
+function CobiAppButton(workspace, applet, app) {
+  this._init(workspace, applet, app);
 }
 
 CobiAppButton.prototype = {
-  _init: function(applet, app) {
+  _init: function(workspace, applet, app) {
+    this._workspace = workspace;
     this._applet = applet;
     this._app = app;
     this._settings = this._applet._settings;
@@ -631,7 +707,7 @@ CobiAppButton.prototype = {
     });
     
     this._label = new St.Label();
-    this._labelBox = new St.Bin({natural_width: 0,
+    this._labelBox = new St.Bin({natural_width: 0, min_width: 0,
                                  x_align: St.Align.START});
     this._labelBox.add_actor(this._label);
     
@@ -708,7 +784,7 @@ CobiAppButton.prototype = {
   
   _onDragEnd: function() {
     this.actor.set_track_hover(true);
-    this._applet._clearDragPlaceholder();
+    this._workspace._clearDragPlaceholder();
     this._updateVisibility();
     this._updateTooltip();
   },
@@ -743,18 +819,20 @@ CobiAppButton.prototype = {
   },
   
   getPinnedIndex: function() {
-    let pinSetting = this._settings.getValue("pinned-apps");
+    let pinSetting = this._settings.getValue("pinned-apps")[this._workspace._wsNum];
     return this._pinned ? pinSetting.indexOf(this._app.get_id()) : -1;
   },
   
   _onWmClassChanged: function(metaWindow) {
-    this._applet._windowRemoved(metaWindow.get_workspace(), metaWindow);
-    this._applet._windowAdded(metaWindow.get_workspace(), metaWindow);
+    let workspace = this._workspace;
+    workspace._windowRemoved(metaWindow);
+    workspace._windowAdded(metaWindow);
   },
   
   _onGtkApplicationChanged: function(metaWindow) {
-    this._applet._windowRemoved(metaWindow.get_workspace(), metaWindow);
-    this._applet._windowAdded(metaWindow.get_workspace(), metaWindow);
+    let workspace = this._workspace;
+    workspace._windowRemoved(metaWindow);
+    workspace._windowAdded(metaWindow);
   },
   
   addWindow: function(metaWindow) {
@@ -772,12 +850,12 @@ CobiAppButton.prototype = {
     this._signalManager.connect(metaWindow, "notify::demands-attention", this._updateUrgentState);
     this._signalManager.connect(metaWindow, "notify::gtk-application-id", this._onGtkApplicationChanged);
     this._signalManager.connect(metaWindow, "notify::wm-class", this._onWmClassChanged);
+    this._signalManager.connect(metaWindow, "workspace-changed", this._onWindowWorkspaceChanged);
     
     this.actor.remove_style_pseudo_class("neutral");
     this._updateTooltip();
-    let wsWindows = this.getWindowsOnCurrentWorkspace();
-    if (wsWindows.length == 1) {
-      this._applet.menuManager.addMenu(this.menu);
+    if (this._windows.length == 1) {
+      this._workspace.menuManager.addMenu(this.menu);
     }
   },
   
@@ -802,7 +880,7 @@ CobiAppButton.prototype = {
         this.actor.remove_style_pseudo_class("focus");
         this.actor.remove_style_pseudo_class("active");
         this.actor.add_style_pseudo_class("neutral");
-        this._applet.menuManager.removeMenu(this.menu);
+        this._workspace.menuManager.removeMenu(this.menu);
       }
     }
     this._updateTooltip();
@@ -811,42 +889,25 @@ CobiAppButton.prototype = {
     this._updateVisibility();
   },
   
-  getWindowsOnCurrentWorkspace: function() {
-    let workspaceIndex = global.screen.get_active_workspace_index();
-    return this.getWindowsOnWorkspace(workspaceIndex);
-  },
-  
-  getWindowsOnWorkspace: function(workspaceIndex) {
-    let wsWindows = global.screen.get_workspace_by_index(workspaceIndex).list_windows();
-    let windows = this._windows.filter(Lang.bind(this, function(win) {
-      return wsWindows.indexOf(win) >= 0;
-    }));
-    return windows;
-  },
-  
-  hasWindowsOnCurrentWorkspace: function() {
-    return this.getWindowsOnCurrentWorkspace().length > 0;
-  },
-  
-  hasWindowsOnWorkspace: function(workspaceIndex) {
-    return this.getWindowsOnWorkspace(workspaceIndex).length > 0;
-  },
-  
   _updateCurrentWindow: function() {
-    let wsWindows = this.getWindowsOnCurrentWorkspace();
-    if (wsWindows.length > 1) {
-      wsWindows = wsWindows.sort(function(a, b) {
+    let windows = this._windows.slice();
+    if (windows.length > 1) {
+      windows = windows.sort(function(a, b) {
         return b.user_time - a.user_time;
       });
     }
-    this._currentWindow = wsWindows.length > 0 ? wsWindows[0] : null;
+    this._currentWindow = windows.length > 0 ? windows[0] : null;
     if (this._currentWindow) {
       this._updateLabel();
     }
   },
   
+  _onWindowWorkspaceChanged: function(window, wsNum) {
+    this._applet.windowWorkspaceChanged(window, wsNum);
+  },
+  
   _updateTooltip: function() {
-    this._tooltip.preventShow = this.getWindowsOnCurrentWorkspace().length > 0;
+    this._tooltip.preventShow = this._windows.length > 0;
   },
   
   updateIcon: function() {
@@ -858,11 +919,25 @@ CobiAppButton.prototype = {
       this.iconSize = ((panelHeight - 4) > DEFAULT_ICON_SIZE) ? DEFAULT_ICON_SIZE : MINIMUM_ICON_SIZE;
     }
     
-    let icon = this._app ?
-            this._app.create_icon_texture(this.iconSize) :
-            new St.Icon({ icon_name: "application-default-icon",
-                icon_type: St.IconType.FULLCOLOR,
-                icon_size: this.iconSize });
+    let icon = null;
+    
+    if (this._app) {
+      let appInfo = this._app.get_app_info();
+      if (appInfo) {
+        let infoIcon = appInfo.get_icon();
+        icon = new St.Icon({ gicon: infoIcon,
+                             icon_size: this.iconSize
+                           });
+      }
+      else {
+        icon = this._app.create_icon_texture(this.iconSize);
+      }
+    }
+    else {
+      icon = new St.Icon({ icon_name: "application-default-icon",
+                           icon_type: St.IconType.FULLCOLOR,
+                           icon_size: this.iconSize });
+    }
     
     this._icon = icon;
     this._iconBin.set_child(this._icon);
@@ -888,7 +963,7 @@ CobiAppButton.prototype = {
   _updateNumber: function() {
     let setting = this._settings.getValue("display-number");
     let text = "";
-    let number = this.getWindowsOnCurrentWorkspace().length;
+    let number = this._windows.length;
     if (((setting == CobiDisplayNumber.All && number >= 1)    ||
          (setting == CobiDisplayNumber.Smart && number >= 2)) &&
         this._settings.getValue("group-windows")) {
@@ -1007,8 +1082,7 @@ CobiAppButton.prototype = {
   },
   
   _updateUrgentState: function() {
-    let wsWindows = this.getWindowsOnCurrentWorkspace();
-    let state = wsWindows.some(function(win) {
+    let state = this._windows.some(function(win) {
       return win.urgent || win.demands_attention;
     });
     
@@ -1021,9 +1095,8 @@ CobiAppButton.prototype = {
   },
   
   _updateFocus: function() {
-    let wsWindows = this.getWindowsOnCurrentWorkspace();
-    for (let i = 0; i < wsWindows.length; i++) {
-      let metaWindow = wsWindows[i];
+    for (let i = 0; i < this._windows.length; i++) {
+      let metaWindow = this._windows[i];
       if (_hasFocus(metaWindow) && !metaWindow.minimized) {
         this.actor.add_style_pseudo_class("focus");
         this._currentWindow = metaWindow;
@@ -1039,7 +1112,7 @@ CobiAppButton.prototype = {
   },
   
   _updateVisibility: function() {
-    if (this.hasWindowsOnCurrentWorkspace()) {
+    if (this._windows.length) {
       this.actor.show();
     }
     else if (this._pinned) {
@@ -1065,30 +1138,13 @@ CobiAppButton.prototype = {
   
   destroy: function() {
     this._signalManager.disconnectAllSignals();
-    this._labelNumber.destroy();
-    this._labelNumber = null;
-    this._labelBox.destroy();
-    this._labelBox = null;
-    this._label.destroy();
-    this._label = null;
-    this._icon.destroy();
-    this._icon = null;
-    this._iconBin.destroy();
-    this._iconBin = null;
     this._tooltip.hide();
     this._tooltip.destroy();
-    this._tooltip = null;
-    this._app = null;
+    this._workspace.menuManager.removeMenu(this.menu);
     this.menu.destroy();
-    this._applet.menuManager.removeMenu(this.menu);
-    this.menu = null;
-    this._contextMenu.destroy();
     this._contextMenuManager.removeMenu(this._contextMenu);
-    this._contextMenu = null;
-    this._applet = null;
-    this._settings = null;
+    this._contextMenu.destroy();
     this.actor.destroy();
-    this.actor = null;
   },
   
   _onButtonRelease: function(actor, event) {
@@ -1102,9 +1158,8 @@ CobiAppButton.prototype = {
     // left mouse button
     if (event.get_state() & Clutter.ModifierType.BUTTON1_MASK) {
       if (this._currentWindow) {
-        if (this.hasWindowsOnCurrentWorkspace()) {
-          let wsWindows = this.getWindowsOnCurrentWorkspace();
-          if (wsWindows.length == 1) {
+        if (this._windows.length > 0) {
+          if (this._windows.length == 1) {
             if (_hasFocus(this._currentWindow)) {
               this._currentWindow.minimize();
             }
@@ -1160,21 +1215,20 @@ CobiAppButton.prototype = {
   },
   
   _onEnterEvent: function() {
-    let wsWindows = this.getWindowsOnCurrentWorkspace();
-    let state = wsWindows.some(function(win) {
+    let state = this._windows.some(function(win) {
       return win.urgent || win.demands_attention;
     });
     if (state) {
       this.actor.set_track_hover(false);
       this.actor.set_hover(false);
     }
-    if (this.getWindowsOnCurrentWorkspace().length > 0) {
+    if (this._windows.length > 0) {
       this.menu.openDelay();
     }
   },
   
   _onLeaveEvent: function() {
-    if (this.getWindowsOnCurrentWorkspace().length > 0) {
+    if (this._windows.length > 0) {
       this.menu.closeDelay();
     }
     this.actor.set_track_hover(true);
@@ -1207,10 +1261,8 @@ CobiAppButton.prototype = {
   },
   
   _hasFocus: function() {
-    let windows = this.getWindowsOnCurrentWorkspace();
-    for (let i = 0; i < windows.length; i++) {
-      let window = windows[i];
-      if (_hasFocus(window)) {
+    for (let i = 0; i < this._windows.length; i++) {
+      if (_hasFocus(this._windows[i])) {
         return true;
       }
     }
@@ -1220,7 +1272,6 @@ CobiAppButton.prototype = {
   _populateContextMenu: function() {
     this._contextMenu.removeAll();
     let item;
-    let length;
     
     // applet-wide
     let subMenu = new PopupMenu.PopupSubMenuMenuItem(_("Preferences"));
@@ -1249,18 +1300,45 @@ CobiAppButton.prototype = {
     this._contextMenu.addMenuItem(item);
     
     if (this._settings.getValue("display-pinned") && !this._app.is_window_backed()) {
-      if (this._pinned) {
-        item = new PopupMenu.PopupIconMenuItem(_("Unpin app from window list"), "starred", St.IconType.SYMBOLIC);
-        item.connect("activate", Lang.bind(this, function() {
-          this._applet.unpinAppButton(this);
-        }));
-        this._contextMenu.addMenuItem(item);
-      }
-      else {
-        item = new PopupMenu.PopupIconMenuItem(_("Pin app to window list"), "non-starred", St.IconType.SYMBOLIC);
-        item.connect("activate", Lang.bind(this, function() {
-          this._applet.pinAppButton(this);
-        }));
+      let iconName = this._pinned ? "starred" : "non-starred";
+      item = new PopupMenu.PopupSwitchIconMenuItem(_("Pin to this workspace"), this._pinned, iconName, St.IconType.SYMBOLIC);
+      item.connect("toggled", Lang.bind(this, function(menuItem, state) {
+        if (state) {
+          this._workspace.pinAppButton(this);
+          menuItem.setIconSymbolicName("starred");
+        }
+        else {
+          this._workspace.unpinAppButton(this);
+          menuItem.setIconSymbolicName("non-starred");
+        }
+      }));
+      this._contextMenu.addMenuItem(item);
+      
+      if (global.screen.n_workspaces > 1) {
+        item = new PopupMenu.PopupSubMenuMenuItem(_("Pin to other workspaces"));
+        let pinSettings = this._settings.getValue("pinned-apps");
+        let appId = this._app.get_id();
+        for (let i = 0; i < global.screen.n_workspaces; i++) {
+          if (i == this._workspace._wsNum) {
+            continue;
+          }
+          let name = Main.getWorkspaceName(i);
+          let pinned = pinSettings[i].indexOf(appId) >= 0;
+          let iconName = pinned ? "starred" : "non-starred";
+          let ws = new PopupMenu.PopupSwitchIconMenuItem(name, pinned, iconName, St.IconType.SYMBOLIC);
+          let j = i;
+          ws.connect("toggled", Lang.bind(this, function(menuItem, state) {
+            if (state) {
+              this._applet._workspaces[j].pinAppId(appId);
+              menuItem.setIconSymbolicName("starred");
+            }
+            else {
+              this._applet._workspaces[j].unpinAppId(appId);
+              menuItem.setIconSymbolicName("non-starred");
+            }
+          }));
+          item.menu.addMenuItem(ws);
+        }
         this._contextMenu.addMenuItem(item);
       }
     }
@@ -1273,25 +1351,41 @@ CobiAppButton.prototype = {
       }
       else {
         this._contextMenu.addAction(_("Visible on all workspaces"), Lang.bind(this, function() {this._currentWindow.stick()}));
-        let workspace = this._currentWindow.get_workspace();
-        length = global.screen.n_workspaces;
-        if (length > 1) {
+        if (this._applet._workspaces.length > 1) {
           item = new PopupMenu.PopupSubMenuMenuItem(_("Move to another workspace"));
           this._contextMenu.addMenuItem(item);
-
-          let curr_index = this._currentWindow.get_workspace().index();
-          for (let i = 0; i < length; i++) {
-            if (i != curr_index) {
+          
+          for (let i = 0; i < this._applet._workspaces.length; i++) {
+            if (i != this._workspace._wsNum) {
               // Make the index a local variable to pass to function
               let j = i;
               let name = Main.workspace_names[i] ? Main.workspace_names[i] : Main._makeDefaultWorkspaceName(i);
               let ws = new PopupMenu.PopupMenuItem(name);
-              ws.connect('activate', Lang.bind(this, function() {
-                 this._currentWindow.change_workspace(global.screen.get_workspace_by_index(j));
+              ws.connect("activate", Lang.bind(this, function() {
+                 this._currentWindow.change_workspace_by_index(j, false, 0);
               }));
               item.menu.addMenuItem(ws);
             }
           }
+        }
+      }
+      
+      let nMonitors = Main.layoutManager.monitors.length;
+      if (nMonitors > 1) {
+        item = new PopupMenu.PopupSubMenuMenuItem(_("Move to another monitor"));
+        this._contextMenu.addMenuItem(item);
+        
+        for (let i = 0; i < nMonitors; i++) {
+          if (i == this._applet._monitor.index) {
+            continue;
+          }
+          let j = i;
+          let name = _("Monitor") + " " + j;
+          let mon = new PopupMenu.PopupMenuItem(name);
+          mon.connect("activate", Lang.bind(this, function() {
+            this._currentWindow.move_to_monitor(j);
+          }));
+          item.menu.addMenuItem(mon);
         }
       }
       
@@ -1315,47 +1409,52 @@ CobiAppButton.prototype = {
       }
       
       this._contextMenu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-      let wsWindows = this.getWindowsOnCurrentWorkspace();
-      if (wsWindows.length > 1) {
+      if (this._windows.length > 1) {
         item = new PopupMenu.PopupIconMenuItem(_("Close others"), "application-exit", St.IconType.SYMBOLIC);
-        item.connect("activate", function() {
-          for (let i = wsWindows.length - 1; i > 0; i--) {
-            wsWindows[i].delete(global.get_current_time());
+        item.connect("activate", Lang.bind(this, function() {
+          let curIdx = this._windows.indexOf(this._currentWindow);
+          this._windows.splice(curIdx, 1);
+          this._windows.push(this._currentWindow);
+          for (let i = this._windows.length - 2; i >= 0; i--) {
+            this._windows[i].delete(global.get_current_time());
           }
-        });
+        }));
         this._contextMenu.addMenuItem(item);
         
         item = new PopupMenu.PopupIconMenuItem(_("Close all"), "window-close", St.IconType.SYMBOLIC);
-        item.connect("activate", function() {
-          for (let i = wsWindows.length - 1; i >= 0; i--) {
-            wsWindows[i].delete(global.get_current_time());
+        item.connect("activate", Lang.bind(this, function() {
+          for (let i = this._windows.length - 1; i >= 0; i--) {
+            this._windows[i].delete(global.get_current_time());
           }
-        });
+        }));
         this._contextMenu.addMenuItem(item);
       }
       
       item = new PopupMenu.PopupIconMenuItem(_("Close"), "edit-delete", St.IconType.SYMBOLIC);
-      item.connect('activate', Lang.bind(this, function() {this._currentWindow.delete(global.get_current_time())}));
+      item.connect('activate', Lang.bind(this, function() {
+        this._currentWindow.delete(global.get_current_time());
+      }));
       this._contextMenu.addMenuItem(item);
     }
   }
 }
 
-function CobiWindowList(orientation, panelHeight, instanceId) {
-  this._init(orientation, panelHeight, instanceId);
+function CobiWorkspace(applet, wsNum) {
+  this._init(applet, wsNum);
 }
 
-CobiWindowList.prototype = {
-  __proto__: Applet.Applet.prototype,
-  
-  _init: function(orientation, panelHeight, instanceId) {
-    Applet.Applet.prototype._init.call(this, orientation, panelHeight, instanceId);
-    this.setAllowedLayout(Applet.AllowedLayout.BOTH);
+CobiWorkspace.prototype = {
+  _init: function(applet, wsNum) {
+    this._applet = applet;
+    this._wsNum = wsNum;
+    this._settings = this._applet._settings;
+    this._signalManager = new SignalManager.SignalManager(this);
     
+    this.actor = new St.BoxLayout();
+    this.actor._delegate = this;
     this.actor.set_hover(false);
     this.actor.set_track_hover(false);
     this.actor.add_style_class_name("window-list-box");
-    this.orientation = orientation;
     
     this.dragInProgress = false;
     
@@ -1365,52 +1464,47 @@ CobiWindowList.prototype = {
     this.menuManager = new CobiMenuManager(this);
     
     this._appButtons = [];
-    this._settings = new CobiWindowListSettings(instanceId);
-    this._signalManager = new SignalManager.SignalManager(this);
+    this._settings = this._applet._settings;
     
-    this.on_orientation_changed(orientation);
-    
-    this._workspaces = [];
-  },
-  
-  _onDragBegin: function() {
-    Applet.Applet.prototype._onDragBegin.call(this);
-    let children = this.actor.get_children();
-    for (let i = 0; i < children.length; i++) {
-      let appButton = children[i]._delegate;
-      if (appButton instanceof CobiAppButton) {
-        appButton.menu.close();
-      }
+    let pinSetting = this._settings.getValue("pinned-apps");
+    if (pinSetting.length < wsNum) {
+      let newSetting = pinSetting.slice();
+      newSetting.push([]);
+      this._settings.setValue("pinned-apps", newSetting);
     }
+    
+    this._signalManager = new SignalManager.SignalManager(this);
   },
   
-  _onButtonReleaseEvent: function (actor, event) {
-    // override applet's default context menu toggling
-  },
-  
-  _onButtonPressEvent: function() {
-    // override applet's default context menu toggling
-  },
-  
-  on_applet_added_to_panel: function() {
+  onAddedToPanel: function() {
     if (this._settings.getValue("display-pinned")) {
       this._updatePinnedApps();
     }
-    this._onWorkspacesChanged();
-    this.emit("connect-signals");
     
-    this._signalManager.connect(global.window_manager, "switch-workspace", this._onWorkspaceSwitched);
-    this._signalManager.connect(global.settings, "changed::panel-edit-mode", this._onPanelEditModeChanged);
-    this._signalManager.connect(global.screen, "notify::n-workspaces", this._onWorkspacesChanged);
+    this._updateAllWindowsForMonitor();
+    
+    this.onOrientationChanged(this._applet.orientation);
+    
     this._signalManager.connect(this._windowTracker, "notify::focus-app", this._updateFocus);
+    this._signalManager.connect(global.settings, "changed::panel-edit-mode", this._onPanelEditModeChanged);
     this._signalManager.connect(this._settings, "changed::pinned-apps", this._updatePinnedApps);
-    this._signalManager.connect(this._settings, "changed::display-pinned", this._onDisplayPinnedChanged);
-    this._signalManager.connect(this._settings, "changed::group-windows", this._onGroupingChanged);
+    this._signalManager.connect(this._settings, "changed::show-windows-for-current-monitor", this._updateAllWindowsForMonitor);
   },
   
-  on_applet_removed_from_panel: function() {
-    this._signalManager.disconnectAllSignals();
-    this.emit("disconnect-signals");
+  onOrientationChanged: function(orientation) {
+    if (orientation == St.Side.TOP || orientation == St.Side.BOTTOM) {
+      this.actor.set_vertical(false);
+      this.actor.remove_style_class_name("vertical");
+      this.actor.set_style("margin-bottom: 0px; padding-bottom: 0px; margin-top: 0px; padding-top: 0px;");
+    }
+    else {
+      this.actor.set_vertical(true);
+      this.actor.add_style_class_name("vertical");
+      this.actor.set_style("margin-right: 0px; padding-right: 0px; padding-left: 0px; margin-left: 0px;");
+    }
+    for (let i = 0; i < this._appButtons.length; i++) {
+      this._appButtons[i]._updateOrientation();
+    }
   },
   
   _onPanelEditModeChanged: function () {
@@ -1428,27 +1522,19 @@ CobiWindowList.prototype = {
     }
   },
   
-  on_panel_height_changed: function() {
-    for (let i in this._appButtons) {
-      this._appButtons[i].updateIcon();
+  _onDragBegin: function() {
+    let children = this.actor.get_children();
+    for (let i = 0; i < children.length; i++) {
+      let appButton = children[i]._delegate;
+      if (appButton instanceof CobiAppButton) {
+        appButton.menu.close();
+      }
     }
   },
   
-  on_orientation_changed: function(orientation) {
-    this.orientation = orientation;
-    if (orientation == St.Side.TOP || orientation == St.Side.BOTTOM) {
-      this.actor.set_vertical(false);
-      this.actor.remove_style_class_name("vertical");
-      this.actor.set_style("margin-bottom: 0px; padding-bottom: 0px; margin-top: 0px; padding-top: 0px;");
-    }
-    else {
-      this.actor.set_vertical(true);
-      this.actor.add_style_class_name("vertical");
-      this.actor.set_style("margin-right: 0px; padding-right: 0px; padding-left: 0px; margin-left: 0px;");
-    }
-    for (let i = 0; i < this._appButtons.length; i++) {
-      let appButton = this._appButtons[i];
-      appButton._updateOrientation();
+  onPanelHeightChanged: function() {
+    for (let i in this._appButtons) {
+      this._appButtons[i].updateIcon();
     }
   },
   
@@ -1456,7 +1542,7 @@ CobiWindowList.prototype = {
     if (!app) {
       return undefined;
     }
-    let appButton = new CobiAppButton(this, app);
+    let appButton = new CobiAppButton(this, this._applet, app);
     this._appButtons.push(appButton);
     this.actor.add_actor(appButton.actor);
     appButton.updateIcon();
@@ -1491,45 +1577,27 @@ CobiWindowList.prototype = {
     return appButtons.length > 0 ? appButtons[0] : undefined;
   },
   
-  _onWorkspacesChanged: function() {
-    for (let i in this._workspaces) {
-      let ws = this._workspaces[i];
-      ws.disconnect(ws._cobiWindowAddedId);
-      ws.disconnect(ws._cobiWindowRemovedId);
+  _windowAdded: function(metaWindow) {
+    if (this._settings.getValue("show-windows-for-current-monitor") &&
+        this._applet._monitor.index != metaWindow.get_monitor()) {
+      return;
     }
     
-    this._workspaces = [];
-    for (let i = 0; i < global.screen.n_workspaces; i++ ) {
-      let ws = global.screen.get_workspace_by_index(i);
-      this._workspaces[i] = ws;
-      let windows = ws.list_windows();
-      for (let j = 0; j < windows.length; j++) {
-        let metaWindow = windows[j];
-        if (!this._lookupAppButtonForWindow(metaWindow)) {
-          this._windowAdded(ws, metaWindow);
-        }
-      }
-      ws._cobiWindowAddedId = ws.connect("window-added",
-                                     Lang.bind(this, this._windowAdded));
-      ws._cobiWindowRemovedId = ws.connect("window-removed",
-                                       Lang.bind(this, this._windowRemoved));
-    }
-  },
-  
-  _onWorkspaceSwitched: function() {
-    this._updateAppButtonVisibility();
-  },
-  
-  _windowAdded: function(metaWorkspace, metaWindow) {
     if (!Main.isInteresting(metaWindow)) {
       return;
     }
+    
+    if (this._lookupAppButtonForWindow(metaWindow)) {
+      return;
+    }
+    
+    if (metaWindow.get_workspace().index() != this._wsNum && !metaWindow.is_on_all_workspaces()) {
+      return;
+    }
+    
     let app = this._windowTracker.get_window_app(metaWindow);
     if (!app) {
       app = this._windowTracker.get_app_from_pid(metaWindow.get_pid());
-    }
-    if (this._lookupAppButtonForWindow(metaWindow)) {
-      return;
     }
     let appButton;
     if (this._settings.getValue("group-windows")) {
@@ -1548,14 +1616,14 @@ CobiWindowList.prototype = {
     if (!appButton) {
       appButton = this._addAppButton(app);
     }
-    else if (!this._settings.getValue("group-windows") && appButton.hasWindowsOnWorkspace(metaWorkspace.index())) {
+    else if (!this._settings.getValue("group-windows") && appButton._windows.length > 0) {
       appButton = this._addAppButton(app);
     }
     appButton.addWindow(metaWindow);
     this._updateAppButtonVisibility();
   },
   
-  _windowRemoved: function(metaWorkspace, metaWindow) {
+  _windowRemoved: function(metaWindow) {
     let appButton = this._lookupAppButtonForWindow(metaWindow);
     if (appButton) {
       let remove = true;
@@ -1565,6 +1633,22 @@ CobiWindowList.prototype = {
       }
       if (remove) {
         this._removeAppButton(appButton);
+      }
+    }
+  },
+  
+  _updateAllWindowsForMonitor: function() {
+    let ws = global.screen.get_workspace_by_index(this._wsNum);
+    let windows = ws.list_windows();
+    let setting = this._settings.getValue("show-windows-for-current-monitor");
+    
+    for (let i = 0; i < windows.length; i++) {
+      let metaWindow = windows[i];
+      if (!setting) {
+        this._windowAdded(metaWindow);
+      }
+      else if (metaWindow.get_monitor() != this._applet._monitor.index) {
+        this._windowRemoved(metaWindow);
       }
     }
   },
@@ -1583,7 +1667,7 @@ CobiWindowList.prototype = {
   _updatePinnedApps: function() {
     // find new pinned apps
     if (this._settings.getValue("display-pinned")) {
-      let pinnedApps = this._settings.getValue("pinned-apps");
+      let pinnedApps = this._settings.getValue("pinned-apps")[this._wsNum];
       for (let i = 0; i < pinnedApps.length; i++) {
         let pinnedAppId = pinnedApps[i];
         let app = this._lookupApp(pinnedAppId);
@@ -1614,7 +1698,7 @@ CobiWindowList.prototype = {
     
     for (let i = this._appButtons.length - 1; i >= 0; i--) {
       let appButton = this._appButtons[i];
-      if (!(appButton._pinned) && appButton._windows.length == 0) {
+      if ((appButton.getPinnedIndex() < 0) && appButton._windows.length == 0) {
         this._removeAppButton(appButton);
       }
     }
@@ -1637,12 +1721,14 @@ CobiWindowList.prototype = {
   
   _updatePinSettings: function() {
     let appButtons = this.actor.get_children().map(x => x._delegate);
-    let setting = [];
+    let newSetting = [];
     let pinnedBtns = appButtons.filter(x => { return (x._pinned && !x._app.get_id().startsWith("window:")) });
     for (let i = 0; i < pinnedBtns.length; i++) {
-      setting.push(pinnedBtns[i]._app.get_id());
+      newSetting.push(pinnedBtns[i]._app.get_id());
     }
-    this._settings.setValue("pinned-apps", setting);
+    let pinSetting = this._settings.getValue("pinned-apps").slice();
+    pinSetting[this._wsNum] = newSetting;
+    this._settings.setValue("pinned-apps", pinSetting);
   },
   
   pinAppId: function(appId, actorPos) {
@@ -1653,17 +1739,32 @@ CobiWindowList.prototype = {
     let appButton = this._lookupAppButtonForApp(app);
     if (!appButton) {
       appButton = this._addAppButton(app);
+      let actIdx = this.actor.get_children().indexOf(appButton.actor);
+      if (actorPos !== undefined && actorPos - actIdx > 0) {
+        actorPos--;
+      }
     }
-    
-    let actIdx = this.actor.get_children().indexOf(appButton.actor);
-    
-    if (actorPos - actIdx > 0) {
-      actorPos--;
+    if (actorPos !== undefined) {
+      this.actor.move_child(appButton.actor, actorPos);
     }
-    
-    this.actor.move_child(appButton.actor, actorPos);
     this.pinAppButton(appButton);
     return true;
+  },
+  
+  unpinAppId: function(appId) {
+    let app = this._lookupApp(appId);
+    if (!app) {
+      return false;
+    }
+    let appButtons = this._lookupAllAppButtonsForApp(app);
+    for (let i = 0; i < appButtons.length; i++) {
+      let appButton = appButtons[i];
+      if (appButton._pinned) {
+        this.unpinAppButton(appButton);
+        return true;
+      }
+    }
+    return false;
   },
   
   pinAppButton: function(appButton) {
@@ -1708,8 +1809,8 @@ CobiWindowList.prototype = {
         let btn = allButtons[j];
         for (let k = 0; k < btn._windows.length; k++) {
           let window = btn._windows[k];
-          this._windowRemoved(null, window);
-          this._windowAdded(window.get_workspace(), window);
+          this._windowRemoved(window);
+          this._windowAdded(window);
         }
         this._removeAppButton(btn);
       }
@@ -1728,7 +1829,7 @@ CobiWindowList.prototype = {
         let window = appButton._windows[j];
         if (window != appButton._currentWindow) {
           appButton.removeWindow(window);
-          this._windowAdded(window.get_workspace(), window);
+          this._windowAdded(window);
         }
       }
       appButton.updateView();
@@ -1769,7 +1870,7 @@ CobiWindowList.prototype = {
     
     let pos = children.length;
 
-    if (this.orientation == St.Side.TOP || this.orientation == St.Side.BOTTOM) {
+    if (this._applet.orientation == St.Side.TOP || this._applet.orientation == St.Side.BOTTOM) {
       while (--pos && x < children[pos].get_allocation_box().x1);
     }
     else {
@@ -1795,6 +1896,10 @@ CobiWindowList.prototype = {
     else {
       return DND.DragMotionResult.COPY_DROP;
     }
+  },
+  
+  handleDragOut: function() {
+    this._clearDragPlaceholder();
   },
   
   acceptDrop: function(source, actor, x, y, time) {
@@ -1833,6 +1938,233 @@ CobiWindowList.prototype = {
       this._dragPlaceholder.actor.destroy();
       this._dragPlaceholder = undefined;
       this._dragPlaceholderPos = undefined;
+    }
+  },
+  
+  destroy: function() {
+    this._signalManager.disconnectAllSignals();
+    
+    let pinSetting = this._settings.getValue("pinned-apps").slice();
+    pinSetting.splice(this._wsNum, 1);
+    this._settings.setValue("pinned-apps", pinSetting);
+    
+    for (let i = this._appButtons.length - 1; i >= 0; i--) {
+      this._appButtons[i].destroy();
+    }
+    this._appButtons = null;
+    this.actor.destroy();
+  }
+}
+
+Signals.addSignalMethods(CobiWorkspace.prototype);
+
+function CobiWindowList(orientation, panelHeight, instanceId) {
+  this._init(orientation, panelHeight, instanceId);
+}
+
+CobiWindowList.prototype = {
+  __proto__: Applet.Applet.prototype,
+  
+  _init: function(orientation, panelHeight, instanceId) {
+    Applet.Applet.prototype._init.call(this, orientation, panelHeight, instanceId);
+    this.setAllowedLayout(Applet.AllowedLayout.BOTH);
+    
+    this.actor.set_hover(false);
+    this.actor.set_track_hover(false);
+    this.orientation = orientation;
+    
+    this._settings = new CobiWindowListSettings(instanceId);
+    this._signalManager = new SignalManager.SignalManager(this);
+    
+    this._workspaces = [];
+    
+    this.on_orientation_changed(orientation);
+  },
+  
+  _onDragBegin: function() {
+    Applet.Applet.prototype._onDragBegin.call(this);
+    let children = this.actor.get_children();
+    for (let i = 0; i < children.length; i++) {
+      let appButton = children[i]._delegate;
+      if (appButton instanceof CobiWorkspace) {
+        appButton._onDragBegin();
+      }
+    }
+  },
+  
+  _onButtonReleaseEvent: function (actor, event) {
+    // override applet's default context menu toggling
+  },
+  
+  _onButtonPressEvent: function() {
+    // override applet's default context menu toggling
+  },
+  
+  on_applet_added_to_panel: function() {
+    let nWorkspaces = global.screen.get_n_workspaces();
+    
+    // upgrade pinned-apps
+    let pinSetting = this._settings.getValue("pinned-apps");
+    let newSetting = [];
+    let changed = false;
+    if (pinSetting.length > 0 && pinSetting[0] instanceof Array) {
+      if (pinSetting.length > nWorkspaces) {
+        newSetting = pinSetting.slice(0, nWorkspaces);
+        changed = true;
+      }
+    }
+    else {
+      let nWorkspaces = global.screen.get_n_workspaces();
+      for (let i = 0; i < nWorkspaces; i++) {
+        newSetting.push(pinSetting.slice());
+      }
+      changed = true;
+    }
+    
+    if (changed) {
+      this._settings.setValue("pinned-apps", newSetting);
+    }
+    
+    for (let i = 0; i < nWorkspaces; i++) {
+      this._onWorkspaceAdded(global.screen, i);
+    }
+    
+    this._updateMonitor();
+    
+    this.emit("connect-signals");
+    this._signalManager.connect(global.window_manager, "switch-workspace", this._updateCurrentWorkspace);
+    this._signalManager.connect(global.screen, "workspace-added", this._onWorkspaceAdded);
+    this._signalManager.connect(global.screen, "workspace-removed", this._onWorkspaceRemoved);
+    this._signalManager.connect(global.screen, "window-added", this._windowAdded);
+    this._signalManager.connect(global.screen, "window-removed", this._windowRemoved);
+    this._signalManager.connect(global.screen, "window-monitor-changed", this.windowMonitorChanged);
+    this._signalManager.connect(Main.layoutManager, "monitors-changed", this._updateMonitor);
+  },
+  
+  on_applet_removed_from_panel: function() {
+    this._signalManager.disconnectAllSignals();
+    this.emit("disconnect-signals");
+  },
+  
+  on_panel_height_changed: function() {
+    for (let i = 0; i < this._workspaces.length; i++) {
+      this._workspaces[i].onPanelHeightChanged();
+    }
+  },
+  
+  on_orientation_changed: function(orientation) {
+    this.orientation = orientation;
+    if (orientation == St.Side.TOP || orientation == St.Side.BOTTOM) {
+      this.actor.set_vertical(false);
+      this.actor.remove_style_class_name("vertical");
+      this.actor.set_style("margin-bottom: 0px; padding-bottom: 0px; margin-top: 0px; padding-top: 0px;");
+    }
+    else {
+      this.actor.set_vertical(true);
+      this.actor.add_style_class_name("vertical");
+      this.actor.set_style("margin-right: 0px; padding-right: 0px; padding-left: 0px; margin-left: 0px;");
+    }
+    // TODO: update orientation for workspaces
+    for (let i = 0; i < this._workspaces.length; i++) {
+      this._workspaces[i].onOrientationChanged(orientation);
+    }
+  },
+  
+  _updateMonitor: function() {
+    this._monitor = Main.layoutManager.findMonitorForActor(this.actor);
+  },
+  
+  _onWorkspaceAdded: function(screen, wsNum) {
+    if (this._workspaces.length <= wsNum) {
+      let workspace = new CobiWorkspace(this, wsNum);
+      this._workspaces[wsNum] = workspace;
+      let pinSettings = this._settings.getValue("pinned-apps");
+      if (wsNum >= pinSettings.length) {
+        pinSettings = pinSettings.slice();
+        pinSettings.push([]);
+        this._settings.setValue("pinned-apps", pinSettings);
+      }
+      this.actor.add_child(workspace.actor);
+      this._updateCurrentWorkspace();
+      workspace.onAddedToPanel();
+    }
+  },
+  
+  _onWorkspaceRemoved: function(screen, wsNum) {
+    if (this._workspaces.length > wsNum) {
+      let workspace = this._workspaces[wsNum];
+      this._workspaces.splice(wsNum, 1);
+      
+      for (let i = 0; i < this._workspaces.length; i++) {
+        this._workspaces[i]._wsNum = i;
+      }
+      
+      workspace.destroy();
+    }
+  },
+  
+  _updateCurrentWorkspace: function() {
+    let currentWs = global.screen.get_active_workspace_index();
+    for (let i = 0; i < this._workspaces.length; i++) {
+      let ws = this._workspaces[i];
+      if (ws._wsNum == currentWs) {
+        ws.actor.show();
+        ws._updateAppButtonVisibility();
+      }
+      else {
+        ws.actor.hide();
+      }
+    }
+  },
+  
+  _windowAdded: function(screen, metaWindow, monitor) {
+    if (this._settings.getValue("show-windows-for-current-monitor") &&
+        monitor != this._monitor.index) {
+      return;
+    }
+    for (let i = 0; i < this._workspaces.length; i++) {
+      let workspace = this._workspaces[i];
+      workspace._windowAdded(metaWindow);
+    }
+  },
+  
+  _windowRemoved: function(screen, metaWindow, monitor) {
+    for (let i = 0; i < this._workspaces.length; i++) {
+      let workspace = this._workspaces[i];
+      workspace._windowRemoved(metaWindow);
+    }
+  },
+  
+  windowWorkspaceChanged: function(window, wsNumOld) {
+    let stuck = window.is_on_all_workspaces();
+    let wsWindow = window.get_workspace();
+    let wsNumNew = wsWindow.index();
+    for (let i = 0; i < this._workspaces.length; i++) {
+      let workspace = this._workspaces[i];
+      let wsIdx = workspace._wsNum;
+      if (stuck) {
+        workspace._windowAdded(window);
+      }
+      else {
+        if (wsNumNew == wsIdx) {
+          workspace._windowAdded(window);
+        }
+        else {
+          workspace._windowRemoved(window);
+        }
+      }
+    }
+  },
+  
+  windowMonitorChanged: function(screen, window, monitor) {
+    if (!this._settings.getValue("show-windows-for-current-monitor")) {
+      return;
+    }
+    if (monitor == this._monitor.index) {
+      this._windowAdded(screen, window, monitor);
+    }
+    else {
+      this._windowRemoved(screen, window, monitor);
     }
   }
 }

--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/3.2/applet.js
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/3.2/applet.js
@@ -1647,8 +1647,13 @@ CobiWorkspace.prototype = {
       if (!setting) {
         this._windowAdded(metaWindow);
       }
-      else if (metaWindow.get_monitor() != this._applet._monitor.index) {
-        this._windowRemoved(metaWindow);
+      else {
+        if (metaWindow.get_monitor() != this._applet._monitor.index) {
+          this._windowRemoved(metaWindow);
+        }
+        else {
+          this._windowAdded(metaWindow);
+        }
       }
     }
   },
@@ -2001,6 +2006,7 @@ CobiWindowList.prototype = {
   },
   
   on_applet_added_to_panel: function() {
+    this._updateMonitor();
     let nWorkspaces = global.screen.get_n_workspaces();
     
     // upgrade pinned-apps
@@ -2028,8 +2034,6 @@ CobiWindowList.prototype = {
     for (let i = 0; i < nWorkspaces; i++) {
       this._onWorkspaceAdded(global.screen, i);
     }
-    
-    this._updateMonitor();
     
     this.emit("connect-signals");
     this._signalManager.connect(global.window_manager, "switch-workspace", this._updateCurrentWorkspace);

--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/3.2/settings-schema.json
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/3.2/settings-schema.json
@@ -30,7 +30,8 @@
     "max": 1000,
     "units": "pixels",
     "step": 1,
-    "description": "Label width"
+    "description": "Label width",
+    "toolip": "This defines the width of the button label"
   },
   "label-animation": {
     "type": "switch",
@@ -50,9 +51,9 @@
     "type": "combobox",
     "default": 1,
     "options": {
-      "None": 0,
-      "All": 1,
-      "Smart": 2
+      "Never": 0,
+      "Always": 1,
+      "2 or more windows": 2
     },
     "description": "Display Number"
   },
@@ -63,7 +64,8 @@
   "group-windows": {
     "type": "switch",
     "default": true,
-    "description": "Group Windows"
+    "description": "Group Windows",
+    "tooltip": "If windows are grouped, all windows from an application are managed by the same button,\nif not grouped, all windows get an own button"
   },
   "display-pinned": {
     "type": "switch",
@@ -77,7 +79,14 @@
     "max": 10000,
     "units": "milliseconds",
     "step": 1,
-    "description": "Animation Time"
+    "description": "Animation Time",
+    "tooltip": "The flashing time when a new window is opened via a button"
+  },
+  "show-windows-for-current-monitor": {
+    "type": "switch",
+    "default": true,
+    "description": "Only show windows on the same monitor",
+    "tooltip": "If enabled, this applet instance only manages windows\nthat are displayed on the same monitor"
   },
   "section3": {
     "type": "section",
@@ -86,7 +95,8 @@
   "hover-preview": {
     "type": "switch",
     "default": true,
-    "description": "Show on Hover"
+    "description": "Show on Hover",
+    "tooltip": "If enabled, the popup menu will show window previews\n(Always disabled when running Cinnamon in Software Rendering Mode)"
   },
   "preview-timeout-show": {
     "type": "spinbutton",
@@ -95,7 +105,8 @@
     "max": 10000,
     "units": "milliseconds",
     "step": 1,
-    "description": "Timeout Show"
+    "description": "Timeout Show",
+    "tooltip": "The waiting time for the popup menu to show, when hovering a button\n(Not used when moving directly to a different button in the list)"
   },
   "preview-timeout-hide": {
     "type": "spinbutton",
@@ -104,7 +115,8 @@
     "max": 10000,
     "units": "milliseconds",
     "step": 1,
-    "description": "Timeout Hide"
+    "description": "Timeout Hide",
+    "tooltip": "The waiting time for the popup menu to hide, when leaving a button\n(Not used when moving directly to a different button in the list)"
   },
   "preview-close-on-middle-click": {
     "type": "switch",
@@ -113,6 +125,8 @@
   },
   "pinned-apps": {
     "type": "generic",
-    "default": ["nemo.desktop", "firefox.desktop"]
+    "default": [
+      ["nemo.desktop", "firefox.desktop"]
+    ]
   }
 }

--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/3.2/settings-schema.json
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/3.2/settings-schema.json
@@ -84,7 +84,7 @@
   },
   "show-windows-for-current-monitor": {
     "type": "switch",
-    "default": true,
+    "default": false,
     "description": "Only show windows on the same monitor",
     "tooltip": "If enabled, this applet instance only manages windows\nthat are displayed on the same monitor"
   },

--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/po/de.po
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/po/de.po
@@ -83,14 +83,38 @@ msgstr "Verzögerung Anzeigen"
 msgid "Timeout Hide"
 msgstr "Verzögerung Verbergen"
 
-msgid "Pin app to window list"
-msgstr "An Fensterleiste anheften"
+msgid "Pin to this workspace"
+msgstr "An diese Arbeitsfläche anheften"
 
-msgid "Unpin app from window list"
-msgstr "Von Fensterleiste lösen"
+msgid "Pin to other workspaces"
+msgstr "An andere Arbeitsflächen anheften"
 
 msgid "Unmaximize"
 msgstr "De-Maximieren"
 
 msgid "Close window on mouse-wheel click"
 msgstr "Schließe Fenster mit Mausrad-Klick"
+
+msgid "If windows are grouped, all windows from an application are managed by the same button,\nif not grouped, all windows get an own button"
+msgstr "Wenn Fenster gruppiert werden, werden alle Fenster dieser Anwendung von der selben Schaltfläche verwaltet\nFalls nicht gruppiert wird, bekommt jedes Fenster eine eigene Schaltfläche"
+
+msgid "The flashing time when a new window is opened via a button"
+msgstr "Die Animationszeit beim Öffnen eines neuen Fensters von der Schaltfläche aus"
+
+msgid "If enabled, the popup menu will show window previews\n(Always disabled when running Cinnamon in Software Rendering Mode)"
+msgstr "Wenn aktiviert, zeigt das Menü Vorschauen der Fenster an\n(Immer deaktiviert, wenn Cinnamon im Software Rendering Modus läuft)"
+
+msgid "The waiting time for the popup menu to show, when hovering a button\n(Not used when moving directly to a different button in the list)"
+msgstr "Die Wartezeit, bis das Menü gezeigt wird, wenn die Maus über der Schaltfläche ist\n(Wird nicht benutzt, wenn direkt zu einer anderen Schaltfläche gewechselt wird)"
+
+msgid "The waiting time for the popup menu to hide, when leaving a button\n(Not used when moving directly to a different button in the list)"
+msgstr "Die Wartezeit, bis das Menü ausgeblendet wird, wenn die Maus eine Schaltfläche verlässt\n(Wird nicht benutzt, wenn direkt zu einer anderen Schaltfläche gewechselt wird)"
+
+msgid "Only show windows on the same monitor"
+msgstr "Nur Fenster auf dem gleichen Bildschirm zeigen"
+
+msgid "If enabled, this applet instance only manages windows\nthat are displayed on the same monitor"
+msgstr "Wenn aktiviert, werden nur Fenster angezeigt,\ndie auf dem gleichen Bildschirm angezeigt werden"
+
+msgid "Move to another monitor"
+msgstr "Auf anderen Bildschirm verschieben"

--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/po/windowlist@cobinja.de.pot
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/po/windowlist@cobinja.de.pot
@@ -83,14 +83,38 @@ msgstr ""
 msgid "Timeout Hide"
 msgstr ""
 
-msgid "Pin app to window list"
+msgid "Pin to this workspace"
 msgstr ""
 
-msgid "Unpin app from window list"
+msgid "Pin to other workspaces"
 msgstr ""
 
 msgid "Unmaximize"
 msgstr ""
 
 msgid "Close window on mouse-wheel click"
+msgstr ""
+
+msgid "If windows are grouped, all windows from an application are managed by the same button,\nif not grouped, all windows get an own button"
+msgstr ""
+
+msgid "The flashing time when a new window is opened via a button"
+msgstr ""
+
+msgid "If enabled, the popup menu will show window previews\n(Always disabled when running Cinnamon in Software Rendering Mode)"
+msgstr ""
+
+msgid "The waiting time for the popup menu to show, when hovering a button\n(Not used when moving directly to a different button in the list)"
+msgstr ""
+
+msgid "The waiting time for the popup menu to hide, when leaving a button\n(Not used when moving directly to a different button in the list)"
+msgstr ""
+
+msgid "Only show windows on the current monitor"
+msgstr ""
+
+msgid "If enabled, this applet instance only manages windows\nthat are displayed on the same monitor"
+msgstr ""
+
+msgid "Move to another monitor"
 msgstr ""


### PR DESCRIPTION
New Features
--
- Added pinning per workspace
- Add ability to only show windows that are present on the same monitor as the applet
- Shrink thumbnails when too many windows are open

Bugfixes
--
- Fix after StBoxLayout was switched to ClutterBoxLayout (Necessary on future versions of Cinnamon, won't break on Cinnamon 3.2)
- Fix some windows like Spotify not showing (Fixes #1230)

Various
--
- Update pot-file and German translation
- Added tooltips to some settings
- Use the new handleDragOut method to delete the drag placeholder (Will only work on future versions of Cinnamon, won't break on Cinnamon 3.2)