### PR TITLE
IcingTaskManager@json: 6.0.1

### DIFF
--- a/IcingTaskManager@json/CHANGELOG.md
+++ b/IcingTaskManager@json/CHANGELOG.md
@@ -1,5 +1,14 @@
 Changelog
 
+### 6.0.1
+
+  * Fixed cycling thumbnail menus via the hotkey not working.
+  * Fixed some apps indicating attention when they are first starting up.
+  * Fixed focused title display mode showing all button labels.
+  * Fixed app icon size preferences not being applied when labels are shown on buttons.
+  * Fixed empty thumbnails being added to the hover menu.
+  * Fixed labels not hiding when pinned apps are closed.
+
 ### 6.0.0
 
   * Reorganized and cleaned up a lot of code.

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.2/appGroup.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.2/appGroup.js
@@ -94,6 +94,7 @@ function AppGroup () {
 }
 
 AppGroup.prototype = {
+  __proto__: DND.LauncherDraggable.prototype,
   _init: function (params) {
     if (DND.LauncherDraggable) {
       DND.LauncherDraggable.prototype._init.call(this);
@@ -113,6 +114,7 @@ AppGroup.prototype = {
       willUnmount: false,
       hoverMenuEntered: false,
       tooltip: null,
+      groupReady: false
     });
 
     this.groupState.connect({
@@ -128,7 +130,6 @@ AppGroup.prototype = {
     this.padding = 0;
     this.wasFavapp = false;
     this.time = params.time;
-    this.ungroupedIndex = params.ungroupedIndex;
     this.focusedWindow = false;
     this.title = '';
     this.pseudoClassStash = [];
@@ -166,7 +167,8 @@ AppGroup.prototype = {
     this.setActorAttributes();
     this._label = new St.Label({
       style_class: 'app-button-label',
-      text: ''
+      text: '',
+      show_on_set_parent: false
     });
     if (this.state.settings.titleDisplay === constants.TitleDisplay.Focused) {
       this.hideLabel(false);
@@ -219,10 +221,11 @@ AppGroup.prototype = {
     this.signals.connect(this._draggable, 'drag-end', Lang.bind(this, this._onDragEnd));
     this._calcWindowNumber(this.groupState.metaWindows);
     this.handleFavorite();
-    this.on_orientation_changed(null, true);
+    this.on_orientation_changed(true);
+    setTimeout(() => this.groupState.set({groupReady: true}), 0);
   },
 
-  on_orientation_changed: function(orientation, fromInit) {
+  on_orientation_changed: function(fromInit) {
     this.actor.set_style_class_name('window-list-item-box');
     if (this.state.orientation === St.Side.TOP) {
       this.actor.add_style_class_name('top');
@@ -246,7 +249,7 @@ AppGroup.prototype = {
     // mode, but not currently sure how to unset the fixed width on the actor so it revert to a
     // resizable state without destroying it. Otherwise, buttons with labels don't have enough padding set.
     if (!this.state.isHorizontal
-      ||this.state.settings.titleDisplay === 1
+      || this.state.settings.titleDisplay === 1
       || this.state.settings.titleDisplay === 3 && !this.labelVisible) {
       if (this.state.settings.enableAppButtonWidth) {
         this.actor.width = this.state.settings.appButtonWidth;
@@ -273,7 +276,8 @@ AppGroup.prototype = {
 
   setMargin: function() {
     let direction = this.state.isHorizontal ? 'right' : 'bottom';
-    this.actor.style = this.actor.style + 'margin-' + direction + ': ' + this.state.settings.iconSpacing + 'px;';
+    let existingStyle = this.actor.style ? this.actor.style : '';
+    this.actor.style = existingStyle + 'margin-' + direction + ': ' + this.state.settings.iconSpacing + 'px;';
   },
 
   _onIconBoxStyleChanged: function() {
@@ -300,7 +304,6 @@ AppGroup.prototype = {
   },
 
   setIcon: function () {
-    log(this.state.trigger('getScaleMode'))
     if (this.state.trigger('getScaleMode') && this.labelVisible) {
       this.iconSize = Math.round(this.state.settings.iconSize * ICON_HEIGHT_FACTOR / global.ui_scale);
     } else {
@@ -395,7 +398,6 @@ AppGroup.prototype = {
   },
 
   _allocate: function (actor, box, flags) {
-
     let allocWidth = box.x2 - box.x1;
     let allocHeight = box.y2 - box.y1;
     let childBox = new Clutter.ActorBox();
@@ -585,6 +587,12 @@ AppGroup.prototype = {
   },
 
   _onWindowDemandsAttention: function (window) {
+    // Prevent apps from indicating attention when they are starting up.
+    if (!this.groupState
+      || !this.groupState.groupReady
+      || this.groupState.willUnmount) {
+      return;
+    }
     let windows = this.groupState.app.get_windows();
     for (let i = 0, len = windows.length; i < len; i++) {
       if (isEqual(windows[i], window)) {
@@ -893,10 +901,6 @@ AppGroup.prototype = {
       return;
     }
 
-    if (this.state.settings.titleDisplay === constants.TitleDisplay.Focused) {
-      this.setText(metaWindow.title);
-      this.showLabel(true);
-    }
     if ((metaWindow.lastTitle && metaWindow.lastTitle === metaWindow.title)
       && !refresh) {
       return;
@@ -937,18 +941,15 @@ AppGroup.prototype = {
     }
     this._onFocusChange(hasFocus);
     if (this.state.settings.titleDisplay === constants.TitleDisplay.Focused) {
-      this._updateFocusedStatus(hasFocus);
+      if (hasFocus) {
+        this.setText(metaWindow.title);
+        this.showLabel(true);
+      } else {
+        this.hideLabel(true);
+      }
     }
     if (this.state.settings.sortThumbs) {
       this.hoverMenu.addThumbnail(metaWindow);
-    }
-  },
-
-  _updateFocusedStatus: function (hasFocus) {
-    if (hasFocus) {
-      this.showLabel(true);
-    } else {
-      this.hideLabel(true);
     }
   },
 
@@ -1043,9 +1044,9 @@ AppGroup.prototype = {
     this.listState.trigger('removeChild', this.actor);
     this._container.destroy();
     this.actor.destroy();
-    this.groupState.destroy();
 
     if (!skipRefCleanup) {
+      this.groupState.destroy();
       unref(this);
     }
   }

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.2/appGroup.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.2/appGroup.js
@@ -34,7 +34,6 @@ if (typeof require !== 'undefined') {
   store = AppletDir.store_mozjs24;
 }
 
-const HORIZONTAL_ICON_SIZE = 16;
 const ICON_HEIGHT_FACTOR = 0.64;
 const VERTICAL_ICON_HEIGHT_FACTOR = 0.75;
 
@@ -301,12 +300,11 @@ AppGroup.prototype = {
   },
 
   setIcon: function () {
+    log(this.state.trigger('getScaleMode'))
     if (this.state.trigger('getScaleMode') && this.labelVisible) {
       this.iconSize = Math.round(this.state.settings.iconSize * ICON_HEIGHT_FACTOR / global.ui_scale);
-    } else if (!this.labelVisible) {
-      this.iconSize = Math.round(this.state.settings.iconSize * VERTICAL_ICON_HEIGHT_FACTOR / global.ui_scale);
     } else {
-      this.iconSize = HORIZONTAL_ICON_SIZE;
+      this.iconSize = Math.round(this.state.settings.iconSize * VERTICAL_ICON_HEIGHT_FACTOR / global.ui_scale);
     }
     let icon;
     if (this.groupState.app) {

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.2/appList.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.2/appList.js
@@ -405,6 +405,7 @@ AppList.prototype = {
       this.appList[refApp]._windowRemoved(metaWorkspace, metaWindow, refWindow, (appId, isFavoriteApp)=>{
         if (isFavoriteApp || (isFavoriteApp && !this.state.settings.groupApps && windowCount === 0)) {
           this.appList[refApp].groupState.trigger('isFavoriteApp');
+          this.appList[refApp].hideLabel(true);
           this._refreshApps();
           return;
         }

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.2/appList.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.2/appList.js
@@ -145,7 +145,7 @@ AppList.prototype = {
       this.state.lastCycled = 0;
     }
     this.state.set({lastCycled: this.state.lastCycled});
-    if (this.appList[refApp].groupState.metaWindows.length > 0) {
+    if (refApp > -1 && this.appList[refApp].groupState.metaWindows.length > 0) {
       this.appList[refApp].hoverMenu.open();
     } else {
       this._cycleMenus();
@@ -276,7 +276,6 @@ AppList.prototype = {
     }
 
     let initApp = (metaWindows, window, index)=>{
-      let time = Date.now();
       let appGroup = new AppGroup({
         state: this.state,
         listState: this.listState,
@@ -285,8 +284,6 @@ AppList.prototype = {
         metaWorkspace: metaWorkspace,
         metaWindows: metaWindows,
         metaWindow: metaWindow,
-        timeStamp: time,
-        ungroupedIndex: index,
         appId: appId,
       });
       this.actor.add_actor(appGroup.actor);
@@ -405,8 +402,10 @@ AppList.prototype = {
       this.appList[refApp]._windowRemoved(metaWorkspace, metaWindow, refWindow, (appId, isFavoriteApp)=>{
         if (isFavoriteApp || (isFavoriteApp && !this.state.settings.groupApps && windowCount === 0)) {
           this.appList[refApp].groupState.trigger('isFavoriteApp');
-          this.appList[refApp].hideLabel(true);
-          this._refreshApps();
+          if (this.state.settings.titleDisplay > 1) {
+            this.appList[refApp].hideLabel(true);
+            this.appList[refApp].groupState.set({groupReady: false});
+          }
           return;
         }
         this.appList[refApp].destroy(true);

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.2/applet.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.2/applet.js
@@ -396,7 +396,7 @@ MyApplet.prototype = {
   },
 
   on_applet_instances_changed: function(loaded) {
-    if (!loaded) {
+    if (!loaded || !this.state.appletReady) {
       return;
     }
     this.updateMonitorWatchlist();
@@ -440,7 +440,6 @@ MyApplet.prototype = {
       }
     }
 
-    this.state.destroy();
     unref(this);
   },
 

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.2/specialMenus.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.2/specialMenus.js
@@ -682,7 +682,6 @@ AppThumbnailHoverMenu.prototype = {
       this.appThumbnails[refThumb].refreshThumbnail();
       this.box.set_child_at_index(this.appThumbnails[refThumb].actor, refThumb);
     }
-
   },
 
   addWindowThumbnails: function () {
@@ -963,7 +962,7 @@ WindowThumbnail.prototype = {
     this.stopClick = false;
   },
 
-  getThumbnail: function (deferredRetry = false) {
+  getThumbnail: function () {
     if (!this.state.settings.showThumbs) {
       return null;
     }
@@ -991,8 +990,8 @@ WindowThumbnail.prototype = {
           height: height * scale
         });
       }
-    } else if (!deferredRetry) {
-      setTimeout(() => this.getThumbnail(true), 0);
+    } else {
+      this.destroy();
     }
   },
 

--- a/IcingTaskManager@json/files/IcingTaskManager@json/metadata.json
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/metadata.json
@@ -2,7 +2,7 @@
     "description": "Window list with app grouping and thumbnails",
     "max-instances": -1,
     "name": "Icing Task Manager",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "role": "panellauncher",
     "uuid": "IcingTaskManager@json",
     "multiversion": true,


### PR DESCRIPTION
  * Fixed cycling thumbnail menus via the hotkey not working.
  * Fixed some apps indicating attention when they are first starting up.
  * Fixed focused title display mode showing all button labels.
  * Fixed app icon size preferences not being applied when labels are shown on buttons.
  * Fixed empty thumbnails being added to the hover menu.
  * Fixed labels not hiding when pinned apps are closed.