### PR TITLE
tracker@glebihan: Prepare applet.js for translations, add pot file and de.po

### DIFF
--- a/tracker@glebihan/files/tracker@glebihan/applet.js
+++ b/tracker@glebihan/files/tracker@glebihan/applet.js
@@ -4,7 +4,7 @@ const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
 const Gio = imports.gi.Gio;
 const Util = imports.misc.util;
-const Gettext = imports.gettext.domain('cinnamon-applets');
+const Gettext = imports.gettext;
 const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
 const Mainloop = imports.mainloop;
@@ -12,7 +12,13 @@ const Cinnamon = imports.gi.Cinnamon;
 const Tracker = imports.gi.Tracker;
 const Main = imports.ui.main;
 const Settings = imports.ui.settings;
-const _ = Gettext.gettext;
+
+const UUID = "tracker@glebihan"
+Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale")
+
+function _(str) {
+  return Gettext.dgettext(UUID, str);
+}
 
 const RESULT_TYPES_LABELS = 
 {

--- a/tracker@glebihan/files/tracker@glebihan/po/de.po
+++ b/tracker@glebihan/files/tracker@glebihan/po/de.po
@@ -1,0 +1,67 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-09-28 11:56+0200\n"
+"PO-Revision-Date: 2017-09-28 12:02+0200\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.7.1\n"
+"Last-Translator: Peter Moser <pitiz29a@gmail.com>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: de\n"
+
+#: applet.js:19
+msgid "Software"
+msgstr "Software"
+
+#: applet.js:20
+msgid "Pictures"
+msgstr "Bilder"
+
+#: applet.js:21
+msgid "Videos"
+msgstr "Videos"
+
+#: applet.js:22
+msgid "Music"
+msgstr "Musik"
+
+#: applet.js:23
+msgid "Folders"
+msgstr "Verzeichnisse"
+
+#: applet.js:24
+msgid "Other Files"
+msgstr "Andere Dateien"
+
+#: applet.js:163
+msgid "Indexing Preferences"
+msgstr "Indizierungseinstellungen"
+
+#: applet.js:177
+msgid "Search files using Tracker"
+msgstr "Durchsuche Dateien mit Tracker"
+
+#: applet.js:189
+msgid "Type to search..."
+msgstr "Tippen startet die Suche..."
+
+#. tracker@glebihan->settings-schema.json->launch_shortcut->description
+msgid "Keyboard shortcut to show the search entry"
+msgstr "Tastaturkürzel für das Suchfeld"
+
+#. tracker@glebihan->metadata.json->description
+msgid "Search for files and applications using Tracker"
+msgstr "Durchsuche Dateien und Anwendungen mit Tracker"
+
+#. tracker@glebihan->metadata.json->name
+msgid "Search using Tracker"
+msgstr "Suche mit Tracker"

--- a/tracker@glebihan/files/tracker@glebihan/po/tracker@glebihan.pot
+++ b/tracker@glebihan/files/tracker@glebihan/po/tracker@glebihan.pot
@@ -1,0 +1,66 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-09-28 11:55+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: \n"
+
+#: applet.js:19
+msgid "Software"
+msgstr ""
+
+#: applet.js:20
+msgid "Pictures"
+msgstr ""
+
+#: applet.js:21
+msgid "Videos"
+msgstr ""
+
+#: applet.js:22
+msgid "Music"
+msgstr ""
+
+#: applet.js:23
+msgid "Folders"
+msgstr ""
+
+#: applet.js:24
+msgid "Other Files"
+msgstr ""
+
+#: applet.js:163
+msgid "Indexing Preferences"
+msgstr ""
+
+#: applet.js:177
+msgid "Search files using Tracker"
+msgstr ""
+
+#: applet.js:189
+msgid "Type to search..."
+msgstr ""
+
+#. tracker@glebihan->settings-schema.json->launch_shortcut->description
+msgid "Keyboard shortcut to show the search entry"
+msgstr ""
+
+#. tracker@glebihan->metadata.json->description
+msgid "Search for files and applications using Tracker"
+msgstr ""
+
+#. tracker@glebihan->metadata.json->name
+msgid "Search using Tracker"
+msgstr ""


### PR DESCRIPTION
Could someone test this... Some translation did not show up inside the applet, although I restart cinnamon after installing this translation via `./cinnamon-spices-makepot tracker@glebihan -i`. 