### PR TITLE
feeds applet: fix some warnings in .xsession-errors

### DIFF
--- a/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/applet.js
+++ b/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/applet.js
@@ -250,11 +250,11 @@ FeedApplet.prototype = {
         let i = 0;
 
         // Find the feeds for the selected instance_name and populate those feeds.
-        for (key in data['instances']) {
+        for (let key in data['instances']) {
             if (data['instances'][key]['name'].trim() === this.instance_name) {
                 let iinterval = data['instances'][key]['interval']; // Not currently used
                 
-                for (fkey in data['instances'][key]['feeds']) {
+                for (let fkey in data['instances'][key]['feeds']) {
                     try {
                         if (data['instances'][key]['feeds'][fkey]['enabled']) {
                             this.feeds[i] = new FeedDisplayMenuItem(
@@ -411,7 +411,7 @@ FeedApplet.prototype = {
             this.feed_to_show = feed_to_show;
             this.feed_to_show.open_menu();
         } else {
-            for (i in this.feeds) {
+            for (let i in this.feeds) {
                 if (this.feeds[i].unread_count > 0) {
                     this.logger.debug("Opening Menu: " + this.feeds[i]);
                     this.feeds[i].open_menu();
@@ -753,7 +753,7 @@ FeedDisplayMenuItem.prototype = {
             this.menuItemCount++;
         }
 
-        let cnt = (this.max_Items > this.unread_count) ? this.max_items : this.unread_count;
+        let cnt = (this.max_items < this.unread_count) ? this.max_items : this.unread_count;
         if(cnt > 0){
             menu_item = new ApplicationContextMenuItem(this, _("Mark Next ") + cnt + _(" Posts Read"), "mark_next_read");
             this.menu.addMenuItem(menu_item, 0);


### PR DESCRIPTION
@jake1164 The last one looks like it was a typo, but it also required me to reverse the logic of the conditional for it to work right (I think it worked before - imperfectly - because it was comparing undefined with whatever this.unread_count is, which will always evaluate to false, causing the unread count to be used no matter what). You know the code better than I do. Could you look this over and make sure I got everything right?