### PR TITLE
radio@driglu4it: Make sure, MOC-Server is running before playing

### DIFF
--- a/radio@driglu4it/files/radio@driglu4it/applet.js
+++ b/radio@driglu4it/files/radio@driglu4it/applet.js
@@ -44,6 +44,8 @@ MyApplet.prototype = {
     });
   },
   startCM: function(id) {
+    //Make sure that the MOC-Server is running before playing a stream
+    Main.Util.spawnCommandLine("mocp -S")
     Main.Util.spawnCommandLine('mocp -c -a -p ' + id);
   },
   on_applet_clicked: function(event) {


### PR DESCRIPTION
On Linux Mint 18.2 with moc 2.6-alpha1 the command "mocp -c -a -p [stream-url]" doesn't start the MOC-Server by default, it produces the message "FATAL_ERROR: The server is not running!"

Now before playing a stream, the applet will try to start the MOC-Server with "mocp -S"

@Driglu4it 