### PR TITLE
multicore-sys-monitor@ccadeptic23: 1.7.2

### DIFF
--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/DataProviders.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/DataProviders.js
@@ -236,12 +236,12 @@ NetDataProvider.prototype = {
     this.disabledDevices = disabledDevicesList;
   },
   getNetDevices: function(init = false) {
-    let nmClient = NMClient.Client.new();
-    let devices = nmClient.get_devices();
+    let nmClient;
+    let devices = GTop.glibtop_get_netlist(new GTop.glibtop_netlist());
     let removedDeviceIndexes = [];
     if (!devices) {
-      nmClient = undefined;
-      devices = GTop.glibtop_get_netlist(new GTop.glibtop_netlist());
+      nmClient = NMClient.Client.new();
+      devices = nmClient.get_devices();
     }
     for (let i = 0, len = devices.length; i < len; i++) {
       let deviceConnected = true;

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/DataProviders.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/DataProviders.js
@@ -276,8 +276,14 @@ NetDataProvider.prototype = {
     this.getData();
     let toolTipString = _('------- Networks -------') + '\n';
     for (let i = 0, len = this.currentReadings.length; i < len; i++) {
-      let down = formatBytes(this.currentReadings[i].tooltipUp, 2);
-      let up = formatBytes(this.currentReadings[i].tooltipDown, 2);
+      if (!this.currentReadings[i].tooltipDown) {
+        this.currentReadings[i].tooltipDown = 0;
+      }
+      if (!this.currentReadings[i].tooltipUp) {
+        this.currentReadings[i].tooltipUp = 0;
+      }
+      let down = formatBytes(this.currentReadings[i].tooltipDown, 2);
+      let up = formatBytes(this.currentReadings[i].tooltipUp, 2);
       toolTipString += this.currentReadings[i].id.padEnd(22) + '\n';
       toolTipString += indent + _('Down:') + '' + down.padStart(spaces) + rate + '\n';
       toolTipString += indent  + _('Up:') + '   ' + up.padStart(spaces) + rate + '\n';

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/Graphs.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/Graphs.js
@@ -245,6 +245,9 @@ GraphLineChart.prototype = {
       this.maxvalue = 1.0;
       for (let i = 0; i < this.dataPointsList.length; i++) {
         for (let j = 0; j < datapoints.length; j++) {
+          if (!this.dataPointsList[i][j]) {
+            continue;
+          }
           if (this.dataPointsList[i][j] >= this.maxvalue && this.dataPointsList[i][j] > this.minMaxValue) {
             this.maxvalue = this.dataPointsList[i][j];
             this.maxvalueloc = i;

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
@@ -1,7 +1,7 @@
 {
     "uuid": "multicore-sys-monitor@ccadeptic23",
     "name": "Multi-Core System Monitor",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "icon": "utilities-system-monitor",
     "description": "Displays in realtime the cpu usage for each core/cpu and overall memory usage.",
     "multiversion": true,


### PR DESCRIPTION
Thanks to Pavel S for emailing the patch in af1175f, which fixes glibtop flooding the log with warnings.

- Fixed the network activity
- Fixed Spidermonkey warnings on network device change