### PR TITLE
temperature@fevimu: Added setting to reduce precision

### DIFF
--- a/temperature@fevimu/files/temperature@fevimu/applet.js
+++ b/temperature@fevimu/files/temperature@fevimu/applet.js
@@ -29,6 +29,7 @@ MyApplet.prototype = {
         this.settings = new Settings.AppletSettings(this, UUID, instance_id);
 
         this.settings.bind("use-fahrenheit", "use_fahrenheit", this._update_temp);
+        this.settings.bind("only-integer-part", "only_integer_part", this._update_temp);
 
         this.lang = {
             'acpi' : 'ACPI Adapter',
@@ -369,7 +370,7 @@ MyApplet.prototype = {
 
 
     _toFahrenheit: function(c){
-        return ((9/5)*c+32).toFixed(1);
+        return ((9/5)*c+32);
     },
 
     _getContent: function(c){
@@ -377,10 +378,12 @@ MyApplet.prototype = {
     },
 
     _formatTemp: function(t) {
+        let precisionDigits;
+        precisionDigits = this.only_integer_part ? 0 : 1;
         if (this.use_fahrenheit)
-            return this._toFahrenheit(t).toString()+" °F";
+            return this._toFahrenheit(t).toFixed(precisionDigits).toString()+" °F";
         else
-            return (Math.round(t*10)/10).toFixed(1).toString()+" °C";
+            return (Math.round(t*10)/10).toFixed(precisionDigits).toString()+" °C";
     }
 
 

--- a/temperature@fevimu/files/temperature@fevimu/applet.js
+++ b/temperature@fevimu/files/temperature@fevimu/applet.js
@@ -45,7 +45,9 @@ MyApplet.prototype = {
 		try {
 
 			// Create the popup menu
-			this.menu = new Applet.AppletPopupMenu(this, orientation);
+			this.menuManager = new PopupMenu.PopupMenuManager(this);
+ 			this.menu = new Applet.AppletPopupMenu(this, orientation);
+			this.menuManager.addMenu(this.menu);
 
         	this.sensorsPath = this._detectSensors();
 

--- a/temperature@fevimu/files/temperature@fevimu/settings-schema.json
+++ b/temperature@fevimu/files/temperature@fevimu/settings-schema.json
@@ -3,5 +3,10 @@
         "type" : "switch",
         "default" : false,
         "description" : "Show temperature in Fahrenheit"
+    },
+    "only-integer-part": {
+        "type" : "switch",
+        "default" : false,
+        "description" : "Show only integer part of temperature"
     }
 }

--- a/temperature@fevimu/files/temperature@fevimu/settings-schema.json
+++ b/temperature@fevimu/files/temperature@fevimu/settings-schema.json
@@ -7,6 +7,6 @@
     "only-integer-part": {
         "type" : "switch",
         "default" : false,
-        "description" : "Show only integer part of temperature"
+        "description" : "Use integer values for temperature"
     }
 }


### PR DESCRIPTION
Hi, I created a setting to reduce the precision of the temperature. In my case, I found the value always changing a bit distractive. With this setting, only the integer part of the value is show for both Celsius and Fahrenheit (28 instead of 28.5).

I labeled the setting as "Show only integer part of temperature". I feel it is a bit geekish for public in general. I'm accepting better suggestions for this if the change is accepted.

@fevimu @NikoKrause 