### PR TITLE
[[Feature]] Display World Times in a Non-Bold Font Style – calendar@simonwiles.net

### DIFF
--- a/calendar@simonwiles.net/files/calendar@simonwiles.net/applet.js
+++ b/calendar@simonwiles.net/files/calendar@simonwiles.net/applet.js
@@ -118,9 +118,9 @@ MyApplet.prototype = {
                     this._worldclocks[i][1] = GLib.TimeZone.new(this._worldclocks[i][1]);
 
                     let tz = new St.BoxLayout({vertical: false});
-                    let tz_label = new St.Label({ style_class: "datemenu-date-label", text: _(this._worldclocks[i][0]) });
+                    let tz_label = new St.Label({ style_class: "calendar", text: _(this._worldclocks[i][0]) });
                     tz.add(tz_label, {x_align: St.Align.START, expand: true, x_fill: false});
-                    this._worldclock_labels[i] = new St.Label({ style_class: "datemenu-date-label" });
+                    this._worldclock_labels[i] = new St.Label({ style_class: "calendar" });
                     tz.add(this._worldclock_labels[i], {x_align: St.Align.END, expand: true, x_fill: false});
                     this._worldclocks_box.add(tz);
                 }


### PR DESCRIPTION
It more or less boils down to personal preference but I do think there's reasonable logic for this change:

bolding confuses the displayed times with the same level of importance as the date at the top of the applet and tugs the eyes in multiple directions in terms of where they're supposed to give focus.

Making the world times un-bold makes them stick out since they don't share the same style as the Date at the top and that the rest of the calendar likely doesn't share the same font size as the world times.

@simonwiles