### PR TITLE
[[Feature]] Add Ability to Assign Key Command to Activate Applet Click Behavior – calendar@simonwiles.net

### DIFF
--- a/calendar@simonwiles.net/files/calendar@simonwiles.net/applet.js
+++ b/calendar@simonwiles.net/files/calendar@simonwiles.net/applet.js
@@ -13,6 +13,7 @@ const APPLET_DIR = imports.ui.appletManager.appletMeta[EXTENSION_UUID].path;
 const Gettext = imports.gettext;
 const Applet = imports.ui.applet;
 const Lang = imports.lang;
+const Main = imports.ui.main;
 const Mainloop = imports.mainloop;
 const Clutter = imports.gi.Clutter;
 const St = imports.gi.St;
@@ -133,6 +134,8 @@ MyApplet.prototype = {
 
             this.settings.bindProperty(Settings.BindingDirection.IN, "use-custom-format", "use_custom_format", this.on_settings_changed, null);
             this.settings.bindProperty(Settings.BindingDirection.IN, "custom-format", "custom_format", this.on_settings_changed, null);
+            this.settings.bindProperty(Settings.BindingDirection.IN, "keybinding", "keybinding", this._onKeySettingsUpdated, null);
+            Main.keybindingManager.addHotKey(EXTENSION_UUID, this.keybinding, Lang.bind(this, this.on_applet_clicked));
 
             // Track changes to world-clock settings
             this.settings.bindProperty(Settings.BindingDirection.IN, "worldclocks", "worldclocks", addWorldClocks, null);
@@ -158,7 +161,14 @@ MyApplet.prototype = {
         }
     },
 
-    on_applet_clicked: function(event) {
+    _onKeySettingsUpdated: function() {
+        if (this.keybinding != null)
+            Main.keybindingManager.addHotKey(EXTENSION_UUID, this.keybinding, Lang.bind(this, this.on_applet_clicked));
+
+        this.on_applet_clicked;
+    },
+
+    on_applet_clicked: function() {
         this.menu.toggle();
     },
 

--- a/calendar@simonwiles.net/files/calendar@simonwiles.net/settings-schema.json
+++ b/calendar@simonwiles.net/files/calendar@simonwiles.net/settings-schema.json
@@ -27,6 +27,18 @@
     "callback" : "on_custom_format_button_pressed",
     "tooltip" : "Click this button to know more about the syntax for date formats."
  },
+ "separator0" : {
+    "type" : "separator"
+ },
+ "keybindings": {
+    "type":        "header",
+    "description": "Keybindings"
+ },
+ "keybinding": {
+    "type": "keybinding",
+    "description": "Set the keybinding to call the menu",
+    "default": "<Super><Shift>c"
+ },
  "separator" : {
     "type" : "separator"
  },


### PR DESCRIPTION
Add to applet's setting the ability to assign a key command for drawing up the Applet via the keyboard:
![image](https://user-images.githubusercontent.com/10533934/33461317-7dff7a6a-d5f7-11e7-99c8-379c2c5a7f62.png)

Calling said key command will draw up the applet as if clicking on it.

@simonwiles