### PR TITLE
IcingTaskManager@json: 6.2.0

### DIFF
--- a/IcingTaskManager@json/.eslintrc.json
+++ b/IcingTaskManager@json/.eslintrc.json
@@ -6,15 +6,15 @@
         "node": true
     },
     "extends": "eslint:recommended",
+    "parser": "babel-eslint",
     "parserOptions": {
         "ecmaFeatures": {
+            "classes": true,
             "ecmaVersion": "2017",
-            "experimentalObjectRestSpread": true
+            "experimentalObjectRestSpread": true,
+            "jsx": true
         },
         "sourceType": "module"
-    },
-    "global": {
-        "window": 0
     },
     "rules": {
         "comma-dangle": 0,
@@ -27,7 +27,7 @@
         "no-dupe-keys": 2,
         "no-duplicate-case": 1,
         "no-empty-character-class": 0,
-        "no-empty": 2,
+        "no-empty": 0,
         "no-ex-assign": 0,
         "no-extra-boolean-cast": 1,
         "no-extra-parens": 0,
@@ -110,7 +110,7 @@
         "no-undef": 0,
         "no-undefined": 0,
         "no-unused-vars": 1,
-        "no-use-before-define": [1,"nofunc"],
+        "no-use-before-define": [1, "nofunc"],
         "callback-return": 0,
         "handle-callback-err": 0,
         "no-mixed-requires": 0,
@@ -150,7 +150,7 @@
         "no-ternary": 0,
         "no-trailing-spaces": 0,
         "no-underscore-dangle": 0,
-        "no-unneeded-ternary": 0,
+        "no-unneeded-ternary": 1,
         "object-curly-spacing": 0,
         "one-var": 0,
         "operator-assignment": 0,
@@ -160,7 +160,7 @@
         "quotes": 0,
         "id-match": 0,
         "semi-spacing": 0,
-        "semi": 1,
+        "semi": 0,
         "sort-vars": 0,
         "space-after-keywords": 0,
         "space-before-blocks": 0,
@@ -190,6 +190,11 @@
         "max-params": 0,
         "max-statements": 0,
         "no-bitwise": 0,
-        "no-plusplus": 0
+        "no-plusplus": 0,
+        "multiline-ternary": 0,
+        "keyword-spacing": 1,
+        "jsx-quotes": [2, "prefer-double"],
+        "block-spacing": [1, "never"],
+        "func-call-spacing": [1, "never"]
     }
 }

--- a/IcingTaskManager@json/CHANGELOG.md
+++ b/IcingTaskManager@json/CHANGELOG.md
@@ -1,5 +1,19 @@
 Changelog
 
+### 6.2.0
+
+  * Fixed windows from all workspaces showing, and added an option to show all workspaces.
+    - Also properly handles sticky windows that are marked as visible on all workspaces.
+  * Fixed per-monitor window mode not working correctly on the primary monitor.
+    - When toggling this setting, it will now take effect on all ITM instances.
+  * Fixed  pinning/unpinning apps in ungrouped app mode.
+  * Added an option to disable icons in the thumbnail menu.
+  * Added an option to scroll windows while hovering over an app's thumbnail menu.
+  * Added a transition duration override option for app buttons, and the option to a assign the checked pseudo class as an override.
+  * Added an option to show a "New Window" context menu item.
+  * Improved theme compatibility for the closed pinned app styling.
+  * Fixed multiple app buttons receiving focus styling in some scenarios (6.1 regression).
+
 ### 6.1.0
 
   * Fixed dragging pinned apps not working correctly when uninstalled apps are in the list.

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/appGroup.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/appGroup.js
@@ -213,6 +213,7 @@ AppGroup.prototype = {
     this.signals.connect(this.hoverMenu.actor, 'enter-event', Lang.bind(this.hoverMenu, this.hoverMenu._onMenuEnter));
     this.signals.connect(this.hoverMenu.actor, 'leave-event', Lang.bind(this.hoverMenu, this.hoverMenu._onMenuLeave));
     this.signals.connect(this.hoverMenu.actor, 'key-release-event', Lang.bind(this.hoverMenu, this.hoverMenu._onKeyRelease));
+    this.signals.connect(this.hoverMenu.actor, 'scroll-event', (c, e) => this.state.trigger('cycleWindows', e, this.actor._delegate));
     this.signals.connect(this.hoverMenu.box, 'key-press-event', Lang.bind(this.hoverMenu, this.hoverMenu._onKeyPress));
     this.signals.connect(this._container, 'get-preferred-width', Lang.bind(this, this._getPreferredWidth));
     this.signals.connect(this._container, 'get-preferred-height', Lang.bind(this, this._getPreferredHeight));
@@ -734,7 +735,7 @@ AppGroup.prototype = {
         return;
       }
       if (this.state.settings.leftClickAction === 3) {
-        this.state.trigger('cycleWindows', this.actor._delegate);
+        this.state.trigger('cycleWindows', null, this.actor._delegate);
         return;
       }
       this.hoverMenu.shouldOpen = false;

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/appGroup.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/appGroup.js
@@ -542,22 +542,15 @@ AppGroup.prototype = {
       return false;
     }
     let hoverPseudoClass = getPseudoClass(this.state.settings.hoverPseudoClass);
-    let focusPseudoClass = getPseudoClass(this.state.settings.focusPseudoClass);
-    let activePseudoClass = getPseudoClass(this.state.settings.activePseudoClass);
 
-    this.pseudoClassStash = [];
-    if (this.actor.has_style_pseudo_class(focusPseudoClass)) {
-      this.pseudoClassStash.push(focusPseudoClass);
-    }
-    if (this.actor.has_style_pseudo_class(activePseudoClass)) {
-      this.pseudoClassStash.push(activePseudoClass);
-    }
     if (this.actor.has_style_pseudo_class('closed')) {
-      this.pseudoClassStash.push('closed');
+      this.hadClosedPseudoClass = true;
       this.actor.remove_style_pseudo_class('closed');
     }
 
-    this.actor.add_style_pseudo_class(hoverPseudoClass);
+    if (!this.actor.has_style_pseudo_class(hoverPseudoClass)) {
+      this.actor.add_style_pseudo_class(hoverPseudoClass);
+    }
 
     this.hoverMenu._onMenuEnter();
   },
@@ -566,23 +559,18 @@ AppGroup.prototype = {
     if (this.state.panelEditMode) {
       return false;
     }
+    let hoverPseudoClass = getPseudoClass(this.state.settings.hoverPseudoClass);
+
     if (this.listState.lastFocusedApp !== this.groupState.appId) {
-      this.actor.remove_style_pseudo_class(getPseudoClass(this.state.settings.hoverPseudoClass));
+      this.actor.remove_style_pseudo_class(hoverPseudoClass);
+    }
+    if (this.hadClosedPseudoClass && this.groupState.metaWindows.length === 0) {
+      this.hadClosedPseudoClass = false;
+      this.actor.add_style_pseudo_class('closed');
     }
 
     this._setFavoriteAttributes();
-    this.popPseudoClassStash();
-
     this.hoverMenu._onMenuLeave();
-  },
-
-  popPseudoClassStash: function() {
-    if (this.pseudoClassStash.length > 0) {
-      for (let i = 0; i < this.pseudoClassStash.length; i++) {
-        this.actor.add_style_pseudo_class(this.pseudoClassStash[i]);
-      }
-      this.pseudoClassStash = [];
-    }
   },
 
   setActiveStatus: function(windows){

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/appGroup.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/appGroup.js
@@ -127,7 +127,8 @@ AppGroup.prototype = {
 
     this.groupState.connect({
       isFavoriteApp: () => this.handleFavorite(true),
-      getActor: () => this.actor
+      getActor: () => this.actor,
+      launchNewInstance: () => this.launchNewInstance()
     });
 
     this.signals = new SignalManager.SignalManager({});
@@ -686,9 +687,14 @@ AppGroup.prototype = {
     return this.actor;
   },
 
-  showOrderLabel: function (number){
+  showOrderLabel: function (number) {
     this._numLabel.text = (number + 1).toString();
     this._numLabel.show();
+  },
+
+  launchNewInstance: function() {
+    this.groupState.app.open_new_window(-1);
+    this._animate();
   },
 
   _onAppButtonRelease: function(actor, event) {
@@ -701,8 +707,7 @@ AppGroup.prototype = {
     let shouldEndInstance = button === 2 && this.state.settings.middleClickAction === 3 && this.groupState.lastFocused;
 
     if (shouldStartInstance) {
-      this.groupState.app.open_new_window(-1);
-      this._animate();
+      this.launchNewInstance();
       return;
     }
 
@@ -778,8 +783,7 @@ AppGroup.prototype = {
 
   _onAppKeyPress: function () {
     if (this.groupState.isFavoriteApp && this.groupState.metaWindows.length === 0) {
-      this.groupState.app.open_new_window(-1);
-      this._animate();
+      this.launchNewInstance();
     } else {
       if (this.groupState.metaWindows.length > 1) {
         this.hoverMenu.open(true);
@@ -788,11 +792,6 @@ AppGroup.prototype = {
       }
       this._windowHandle(false);
     }
-  },
-
-  _onNewAppKeyPress: function () {
-    this.groupState.app.open_new_window(-1);
-    this._animate();
   },
 
   _windowHandle: function () {

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/appGroup.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/appGroup.js
@@ -273,6 +273,7 @@ AppGroup.prototype = {
     this._updateIconBoxClip();
     this.setIconPadding();
     this.setMargin();
+    this.setTransitionDuration();
   },
 
   setIconPadding: function () {
@@ -289,6 +290,14 @@ AppGroup.prototype = {
     let direction = this.state.isHorizontal ? 'right' : 'bottom';
     let existingStyle = this.actor.style ? this.actor.style : '';
     this.actor.style = existingStyle + 'margin-' + direction + ': ' + this.state.settings.iconSpacing + 'px;';
+  },
+
+  setTransitionDuration: function() {
+    if (!this.state.settings.appButtonTransitionDuration) {
+      return;
+    }
+    let existingStyle = this.actor.style ? this.actor.style : '';
+    this.actor.style = existingStyle + 'transition-duration: ' + this.state.settings.appButtonTransitionDuration + ';';
   },
 
   _onIconBoxStyleChanged: function() {

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/appList.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/appList.js
@@ -130,7 +130,7 @@ AppList.prototype = {
     if (number > this.appList.length) {
       return;
     }
-    this.appList[number - 1]._onNewAppKeyPress(number);
+    this.appList[number - 1].launchNewInstance();
   },
 
   _showAppsOrder: function(){

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/appList.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/appList.js
@@ -3,12 +3,13 @@ const Gio = imports.gi.Gio;
 const Lang = imports.lang;
 const SignalManager = imports.misc.signalManager;
 
-let each, findIndex, find, isEqual, AppGroup, setTimeout, unref, store;
+let each, findIndex, find, filter, isEqual, AppGroup, setTimeout, unref, store;
 if (typeof require !== 'undefined') {
   const utils = require('./utils');
   each = utils.each;
   findIndex = utils.findIndex;
   find = utils.find;
+  filter = utils.filter;
   isEqual = utils.isEqual;
   setTimeout = utils.setTimeout;
   unref = utils.unref;
@@ -19,6 +20,7 @@ if (typeof require !== 'undefined') {
   each = AppletDir.utils.each;
   findIndex = AppletDir.utils.findIndex;
   find = AppletDir.utils.find;
+  filter = AppletDir.utils.filter;
   isEqual = AppletDir.utils.isEqual;
   setTimeout = AppletDir.utils.setTimeout;
   unref = AppletDir.utils.unref;
@@ -330,16 +332,15 @@ AppList.prototype = {
     if (refApp === -1) {
       let _appWindows = app.get_windows();
       let appWindows = [];
-      if (this.state.settings.showAllWorkspaces) {
-        appWindows = _appWindows;
-      } else {
-        for (var i = 0; i < _appWindows.length; i++) {
-          if (_appWindows[i].is_on_all_workspaces()
-            || isEqual(_appWindows[i].get_workspace(), this.metaWorkspace)) {
-            appWindows.push(_appWindows[i]);
-          }
+
+      for (var i = 0; i < _appWindows.length; i++) {
+        if ((this.state.settings.showAllWorkspaces || _appWindows[i].is_on_all_workspaces() || isEqual(_appWindows[i].get_workspace(), this.metaWorkspace))
+          && (this.state.settings.includeAllWindows || this.state.trigger('isWindowInteresting', _appWindows[i]))
+          && (!this.state.settings.listMonitorWindows || this.state.monitorWatchList.indexOf(_appWindows[i].get_monitor()) > -1 )) {
+          appWindows.push(_appWindows[i]);
         }
       }
+
       if (this.state.settings.groupApps) {
         initApp(appWindows);
       } else {

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/applet.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/applet.js
@@ -133,7 +133,7 @@ PinnedFavs.prototype = {
   _onFavoritesChange: function() {
     if (!this.params.state.settings.groupApps) {
       let currentAppList = this.params.state.trigger('getCurrentAppList');
-      currentAppList._refreshList();
+      setTimeout(() => currentAppList._refreshList(), 0);
       return;
     }
     let oldFavoritesIds = [];

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/applet.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/applet.js
@@ -335,7 +335,7 @@ MyApplet.prototype = {
   bindSettings: function() {
     let settingsProps = [
       {key: 'show-pinned', value: 'showPinned', cb: this.refreshCurrentAppList},
-      {key: 'show-active', value: 'showActive', cb: this._updatePseudoClasses},
+      {key: 'show-active', value: 'showActive', cb: this.refreshCurrentAppList},
       {key: 'show-alerts', value: 'showAlerts', cb: this._updateAttentionState},
       {key: 'group-apps', value: 'groupApps', cb: this.refreshCurrentAppList},
       {key: 'enable-app-button-dragging', value: 'enableDragging', cb: null},
@@ -346,9 +346,10 @@ MyApplet.prototype = {
       {key: 'show-apps-order-hotkey', value: 'showAppsOrderHotkey', cb: this._bindAppKeys},
       {key: 'show-apps-order-timeout', value: 'showAppsOrderTimeout', cb: null},
       {key: 'cycleMenusHotkey', value: 'cycleMenusHotkey', cb: this._bindAppKeys},
-      {key: 'hoverPseudoClass', value: 'hoverPseudoClass', cb: this._updatePseudoClasses},
-      {key: 'focusPseudoClass', value: 'focusPseudoClass', cb: this._updatePseudoClasses},
-      {key: 'activePseudoClass', value: 'activePseudoClass', cb: this._updatePseudoClasses},
+      {key: 'hoverPseudoClass', value: 'hoverPseudoClass', cb: this.refreshCurrentAppList},
+      {key: 'focusPseudoClass', value: 'focusPseudoClass', cb: this.refreshCurrentAppList},
+      {key: 'activePseudoClass', value: 'activePseudoClass', cb: this.refreshCurrentAppList},
+      {key: 'app-button-transition-duration', value: 'appButtonTransitionDuration', cb: this.refreshCurrentAppList},
       {key: 'enable-hover-peek', value: 'enablePeek', cb: null},
       {key: 'onclick-thumbnails', value: 'onClickThumbs', cb: null},
       {key: 'hover-peek-opacity', value: 'peekOpacity', cb: null},
@@ -584,16 +585,6 @@ MyApplet.prototype = {
     each(this.appLists, (workspace) => {
       each(workspace.appList, (appGroup) => {
         appGroup.hoverMenu.updateThumbnailCloseButtonSize();
-      });
-    });
-  },
-
-  _updatePseudoClasses: function () {
-    each(this.appLists, (workspace) => {
-      each(workspace.appList, (appGroup) => {
-        appGroup.groupState.trigger('isFavoriteApp');
-        appGroup.setActiveStatus(appGroup.groupState.metaWindows);
-        appGroup._onFocusChange();
       });
     });
   },

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/applet.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/applet.js
@@ -97,9 +97,6 @@ PinnedFavs.prototype = {
   },
 
   triggerUpdate: function (appId, pos, isFavoriteApp) {
-    if (!this.params.state.settings.groupApps) {
-      return;
-    }
     let currentAppList = this.params.state.trigger('getCurrentAppList');
     let refApp = currentAppList.appList.findIndex(appGroup => appGroup.groupState.appId === appId);
     if (refApp > -1) {
@@ -134,6 +131,11 @@ PinnedFavs.prototype = {
   },
 
   _onFavoritesChange: function() {
+    if (!this.params.state.settings.groupApps) {
+      let currentAppList = this.params.state.trigger('getCurrentAppList');
+      currentAppList._refreshList();
+      return;
+    }
     let oldFavoritesIds = [];
     let newFavoritesIds = [];
     for (let i = 0; i < this._favorites.length; i++) {
@@ -193,7 +195,7 @@ PinnedFavs.prototype = {
   },
 
   moveFavoriteToPos: function (opts, oldIndex) {
-    if (!oldIndex) {
+    if (!oldIndex || !this.params.state.settings.groupApps) {
       oldIndex = findIndex(this._favorites, function(favorite) {
         return favorite.id === opts.appId;
       });
@@ -210,6 +212,19 @@ PinnedFavs.prototype = {
     }).filter(function(renderedFavorite) {
       return favoriteIds.indexOf(renderedFavorite.id) > -1
     });
+    if (!this.params.state.settings.groupApps) {
+      let matched = [];
+      each(renderedFavoriteApps, function(favorite) {
+        let refFavorite = findIndex(matched, function(match) {
+          return match.id === favorite.id;
+        });
+        if (refFavorite > -1) {
+          return;
+        }
+        matched.push(favorite);
+      });
+      renderedFavoriteApps = matched;
+    }
     renderedFavoriteApps = renderedFavoriteApps
       .slice(0, opts.pos)
       .concat([{id:  opts.appId, app: opts.app}])

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/applet.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/applet.js
@@ -364,6 +364,7 @@ MyApplet.prototype = {
       {key: 'highlight-last-focused-thumbnail', value: 'highlightLastFocusedThumbnail', cb: this._updateVerticalThumbnailState},
       {key: 'vertical-thumbnails', value: 'verticalThumbs', cb: this._updateVerticalThumbnailState},
       {key: 'show-thumbnails', value: 'showThumbs', cb: this._updateVerticalThumbnailState},
+      {key: 'show-icons', value: 'showIcons', cb: this._updateVerticalThumbnailState},
       {key: 'animate-thumbnails', value: 'animateThumbs', cb: null},
       {key: 'include-all-windows', value: 'includeAllWindows', cb: this.refreshCurrentAppList},
       {key: 'number-display', value: 'numDisplay', cb: this._updateWindowNumberState},

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/applet.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/applet.js
@@ -404,6 +404,7 @@ MyApplet.prototype = {
       {key: 'menuItemType', value: 'menuItemType', cb: null},
       {key: 'firefox-menu', value: 'firefoxMenu', cb: null},
       {key: 'autostart-menu-item', value: 'autoStart', cb: null},
+      {key: 'launch-new-instance-menu-item', value: 'launchNewInstance', cb: null},
       {key: 'monitor-move-all-windows', value: 'monitorMoveAllWindows', cb: null},
       {key: 'enable-app-button-width', value: 'enableAppButtonWidth', cb: this._updateActorAttributes},
       {key: 'app-button-width', value: 'appButtonWidth', cb: this._updateActorAttributes},

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/constants.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/constants.js
@@ -37,6 +37,7 @@ const constants = {
     {id: 3, label: 'active'},
     {id: 4, label: 'outlined'},
     {id: 5, label: 'selected'},
+    {id: 6, label: 'checked'},
   ],
   autoStartStrDir: './.config/autostart'
 };

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/settings-schema.json
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/settings-schema.json
@@ -96,7 +96,8 @@
         "show-active",
         "hoverPseudoClass",
         "focusPseudoClass",
-        "activePseudoClass"
+        "activePseudoClass",
+        "app-button-transition-duration"
       ]
     },
     "iconSection": {
@@ -462,7 +463,8 @@
       "focus": 2,
       "active": 3,
       "outlined": 4,
-      "selected": 5
+      "selected": 5,
+      "checked": 6
     },
     "tooltip": "Overrides the pseudo class for app buttons on hover."
   },
@@ -475,7 +477,8 @@
       "focus": 2,
       "active": 3,
       "outlined": 4,
-      "selected": 5
+      "selected": 5,
+      "checked": 6
     },
     "tooltip": "Overrides the pseudo class for app button on focus."
   },
@@ -488,9 +491,20 @@
       "focus": 2,
       "active": 3,
       "outlined": 4,
-      "selected": 5
+      "selected": 5,
+      "checked": 6
     },
     "tooltip": "Overrides the pseudo class for app buttons when they are active."
+  },
+  "app-button-transition-duration": {
+    "type": "spinbutton",
+    "default": 0,
+    "min": 0,
+    "max": 4000,
+    "step": 1,
+    "units": "ms",
+    "description": "App button transition duration",
+    "tooltip": "Overrides the theme's animation time for app buttons. If set to zero, the theme's transition duration will be used."
   },
   "mintYPreset": {
     "type" : "button",

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/settings-schema.json
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/settings-schema.json
@@ -88,6 +88,7 @@
         "firefox-menu",
         "menuItemType",
         "autostart-menu-item",
+        "launch-new-instance-menu-item",
         "monitor-move-all-windows"
       ]
     },
@@ -396,6 +397,12 @@
     "default": true,
     "description": "Show autostart option",
     "tooltip": "Shows the autostart toggle option in an app's context menu."
+  },
+  "launch-new-instance-menu-item": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show new window option",
+    "tooltip": "Shows the \"New Window\" option in an app's context menu if it doesn't already have one from the app's own action menu items."
   },
   "monitor-move-all-windows": {
     "type": "checkbox",

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/settings-schema.json
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/settings-schema.json
@@ -61,6 +61,7 @@
         "thumbnail-size",
         "thumbnail-close-button-size",
         "thumbnail-padding",
+        "thumbnail-scroll-behavior",
         "show-thumbnails",
         "animate-thumbnails",
         "vertical-thumbnails",
@@ -299,6 +300,12 @@
     "units": "px",
     "description": "Thumbnail padding",
     "tooltip": "Controls how much space will be around the window preview thumbnails."
+  },
+  "thumbnail-scroll-behavior": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Cycle windows on mouse wheel scroll",
+    "tooltip": "Choose whether or not scrolling the mouse wheel cycles windows when hovering over a thumbnail menu."
   },
   "show-thumbnails": {
     "type": "checkbox",

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/settings-schema.json
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/settings-schema.json
@@ -63,6 +63,7 @@
         "thumbnail-padding",
         "thumbnail-scroll-behavior",
         "show-thumbnails",
+        "show-icons",
         "animate-thumbnails",
         "vertical-thumbnails",
         "sort-thumbnails",
@@ -312,6 +313,12 @@
     "default": true,
     "description": "Show thumbnails",
     "tooltip": "Show window thumbnails when hovering over an app button."
+  },
+  "show-icons": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show icons",
+    "tooltip": "Show the window's icon next to the title."
   },
   "animate-thumbnails": {
     "type": "checkbox",

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/settings-schema.json
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/settings-schema.json
@@ -1,11 +1,16 @@
 {
   "layout": {
     "type" : "layout",
-    "pages": ["panelPage", "thumbnailsPage", "contextMenuPage", "themePage"],
+    "pages": ["generalPage", "panelPage", "thumbnailsPage", "contextMenuPage", "themePage"],
+    "generalPage": {
+      "type" : "page",
+      "title" : "General",
+      "sections": ["generalSection", "hotKeysSection"]
+    },
     "panelPage": {
       "type" : "page",
       "title" : "Panel",
-      "sections": ["appButtonsSection", "hotKeysSection"]
+      "sections": ["appButtonsSection"]
     },
     "thumbnailsPage": {
       "type" : "page",
@@ -22,6 +27,20 @@
       "title" : "Theming",
       "sections": ["stylingSection", "iconSection", "presetSection"]
     },
+    "generalSection": {
+      "type" : "section",
+      "title" : "Behavior",
+      "keys": [
+        "group-apps",
+        "scroll-behavior",
+        "left-click-action",
+        "middle-click-action",
+        "system-favorites",
+        "list-monitor-windows",
+        "show-all-workspaces",
+        "include-all-windows"
+      ]
+    },
     "appButtonsSection": {
       "type" : "section",
       "title" : "App Buttons",
@@ -30,18 +49,11 @@
         "app-button-width",
         "number-display",
         "title-display",
-        "scroll-behavior",
-        "left-click-action",
-        "middle-click-action",
         "pinned-apps",
-        "group-apps",
         "show-alerts",
         "show-pinned",
-        "system-favorites",
         "enable-app-button-dragging",
-        "pinOnDrag",
-        "list-monitor-windows",
-        "include-all-windows"
+        "pinOnDrag"
       ]
     },
     "hotKeysSection": {
@@ -400,7 +412,7 @@
   },
   "launch-new-instance-menu-item": {
     "type": "checkbox",
-    "default": true,
+    "default": false,
     "description": "Show new window option",
     "tooltip": "Shows the \"New Window\" option in an app's context menu if it doesn't already have one from the app's own action menu items."
   },

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/settings-schema.json
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/settings-schema.json
@@ -205,6 +205,12 @@
     "description": "Use system favorites for pinned apps",
     "tooltip": "Controls whether or not pinned apps consist of the system favorites list."
   },
+  "show-all-workspaces": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Show windows from all workspaces",
+    "tooltip": "Show windows from all workspaces"
+  },
   "enable-app-button-dragging": {
     "type": "checkbox",
     "default": true,

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/specialMenus.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/specialMenus.js
@@ -729,9 +729,11 @@ AppThumbnailHoverMenu.prototype = {
     if (skipThumbnailIconResize) {
       return;
     }
-    for (let i = 0; i < this.appThumbnails.length; i++) {
-      if (this.appThumbnails[i]) {
-        this.appThumbnails[i].thumbnailIconSize();
+    if (this.state.settings.showIcons) {
+      for (let i = 0; i < this.appThumbnails.length; i++) {
+        if (this.appThumbnails[i]) {
+          this.appThumbnails[i].thumbnailIconSize();
+        }
       }
     }
     if (wasOpen) {
@@ -848,16 +850,26 @@ WindowThumbnail.prototype = {
       y_expand: false
     });
 
-    this.icon = this.groupState.app.create_icon_texture(16);
-    this.themeIcon = new St.BoxLayout({
-      style_class: 'thumbnail-icon'
-    });
-    this.themeIcon.add_actor(this.icon);
-    this._container.add_actor(this.themeIcon);
     this._label = new St.Label({
-      style_class: 'thumbnail-label'
+      style_class: this.icon ? 'thumbnail-label' : 'thumbnail-label-no-icon'
     });
-    this._container.add_actor(this._label);
+
+    if (this.state.settings.showIcons) {
+      this.icon = this.groupState.app.create_icon_texture(16);
+      this.themeIcon = new St.BoxLayout({
+        style_class: 'thumbnail-icon'
+      });
+      this.themeIcon.add_actor(this.icon);
+      this._container.add_actor(this.themeIcon);
+      this._container.add_actor(this._label);
+    } else {
+      this.labelContainer = new St.Bin({
+        y_align: this.icon ? St.Align.START : St.Align.MIDDLE
+      });
+      this.labelContainer.add_actor(this._label);
+      this._container.add_actor(this.labelContainer);
+    }
+
     this.button = new St.BoxLayout({
       reactive: true
     });
@@ -1049,6 +1061,9 @@ WindowThumbnail.prototype = {
         }
 
         // Replace the old thumbnail
+        if (this.labelContainer) {
+          this.labelContainer.set_width(this.thumbnailWidth);
+        }
         this._label.text = this.metaWindow.title;
         this.getThumbnail();
       }

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/specialMenus.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/specialMenus.js
@@ -794,6 +794,13 @@ function WindowThumbnail () {
 WindowThumbnail.prototype = {
   _init: function (params) {
     this.state = params.state;
+    this.stateConnectId = this.state.connect({
+      scrollActive: () => {
+        if (this.state.overlayPreview) {
+          this.destroyOverlayPreview();
+        }
+      }
+    })
     this.groupState = params.groupState;
     this.connectId = this.groupState.connect({
       isFavoriteApp: () => this.handleFavorite(),
@@ -1051,7 +1058,7 @@ WindowThumbnail.prototype = {
   },
 
   _hoverPeek: function (opacity) {
-    if (!this.state.settings.enablePeek || this.state.overlayPreview) {
+    if (!this.state.settings.enablePeek || this.state.overlayPreview || this.state.scrollActive) {
       return;
     }
     if (!this.metaWindowActor) {
@@ -1084,6 +1091,7 @@ WindowThumbnail.prototype = {
     if (!this.groupState) {
       return;
     }
+    this.state.disconnect(this.stateConnectId);
     this.groupState.disconnect(this.connectId);
     this.signals.disconnectAllSignals();
     this._container.destroy();

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/specialMenus.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/specialMenus.js
@@ -112,7 +112,7 @@ AppMenuButtonRightClickMenu.prototype = {
           this.signals.connect(item, 'activate', Lang.bind(this, this.monitorMoveWindows, i));
         };
         for (let i = 0, len = Main.layoutManager.monitors.length; i < len; i++) {
-          if (i === this.groupState.lastFocused.get_monitor()) {
+          if (!this.groupState.lastFocused || i === this.groupState.lastFocused.get_monitor()) {
             continue;
           }
           item = createMenuItem({label: Main.layoutManager.monitors.length === 2 ? _('Move to the other monitor') : _('Move to monitor ') + (i + 1).toString()});

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/specialMenus.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/specialMenus.js
@@ -125,11 +125,17 @@ AppMenuButtonRightClickMenu.prototype = {
       if ((length = global.screen.n_workspaces) > 1) {
         if (this.groupState.lastFocused.is_on_all_workspaces()) {
           item = createMenuItem({label: _('Only on this workspace')});
-          this.signals.connect(item, 'activate', () => this.groupState.lastFocused.unstick());
+          this.signals.connect(item, 'activate', () => {
+            this.groupState.lastFocused.unstick();
+            this.state.trigger('removeWindowFromOtherWorkspaces', this.groupState.lastFocused);
+          });
           this.addMenuItem(item);
         } else {
           item = createMenuItem({label: _('Visible on all workspaces')});
-          this.signals.connect(item, 'activate', () => this.groupState.lastFocused.stick());
+          this.signals.connect(item, 'activate', () => {
+            this.groupState.lastFocused.stick();
+            this.state.trigger('addWindowToAllWorkspaces', this.groupState.lastFocused);
+          });
           this.addMenuItem(item);
 
           item = new PopupMenu.PopupSubMenuMenuItem(_('Move to another workspace'));
@@ -561,7 +567,8 @@ AppThumbnailHoverMenu.prototype = {
   close: function (force) {
     if (!force && (!this.shouldClose
       || (!this.shouldClose && this.state.settings.onClickThumbs))
-      || !this.groupState) {
+      || !this.groupState
+      || !this.groupState.tooltip) {
       return;
     }
     if (!this.groupState.metaWindows || this.groupState.metaWindows.length === 0) {

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/specialMenus.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/specialMenus.js
@@ -11,7 +11,7 @@ const Applet = imports.ui.applet;
 const Util = imports.misc.util;
 const SignalManager = imports.misc.signalManager;
 
-let each, find, findIndex, tryFn, isEqual, constants, getFirefoxHistory, setTimeout, unref, _, store;
+let each, find, findIndex, tryFn, isEqual, constants, getFirefoxHistory, setTimeout, unref, _;
 if (typeof require !== 'undefined') {
   const utils = require('./utils');
   each = utils.each;
@@ -24,7 +24,6 @@ if (typeof require !== 'undefined') {
   setTimeout = utils.setTimeout;
   unref = utils.unref;
   getFirefoxHistory = require('./firefox').getFirefoxHistory;
-  store = require('./store');
 } else {
   const AppletDir = imports.ui.appletManager.applets['IcingTaskManager@json'];
   each = AppletDir.utils.each;
@@ -37,7 +36,6 @@ if (typeof require !== 'undefined') {
   setTimeout = AppletDir.utils.setTimeout;
   unref = AppletDir.utils.unref;
   getFirefoxHistory = AppletDir.firefox.getFirefoxHistory;
-  store = AppletDir.store_mozjs24;
 }
 
 const convertRange = function(value, r1, r2) {
@@ -316,6 +314,7 @@ AppMenuButtonRightClickMenu.prototype = {
         this.addMenuItem(item);
       }
     } else {
+      this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
       item = createMenuItem({label: _('Create Shortcut'), icon: 'list-add'});
       this.signals.connect(item, 'activate', Lang.bind(this, this._createShortcut));
       this.addMenuItem(item);
@@ -803,6 +802,8 @@ AppThumbnailHoverMenu.prototype = {
           this.appThumbnails[w].handleLeaveEvent();
         }
         this.appThumbnails[w].destroy(true);
+        this.appThumbnails[w] = null;
+        this.appThumbnails.splice(w, 1)
       }
     }
     this.removeAll();

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/store.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/store.js
@@ -168,9 +168,6 @@ function init(state = {}, listeners = [], connections = 0) {
     let keys = Object.keys(object);
     let changed = false;
     for (let i = 0; i < keys.length; i++) {
-      if (typeof state[keys[i]] === 'undefined') {
-        throw storeError('set', keys[i], 'Property not found.');
-      }
       if (state[keys[i]] !== object[keys[i]]) {
         changed = true;
         state[keys[i]] = object[keys[i]];

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/stylesheet.css
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/stylesheet.css
@@ -1,46 +1,34 @@
-/* the pseudo are not being overidden so I can't do a hover. that will need to be added to themes */
 .thumbnail-row .thumbnail-alerts {
-	background: rgba(255,52,52,0.3);
-}
-.hide-arrow {
-	-arrow-background-color: rgba(80,80,80,0.0);
-	-arrow-border-color: rgba(150,150,150,0.0);
+  background: rgba(255,52,52,0.3);
 }
 .thumbnail-icon {
-	/* thumbnail icon size */
-	width: 16px;
-	height: 16px;
+  width: 16px;
+  height: 16px;
 }
 .thumbnail-label {
-	padding-left: 4px;
+  padding-left: 4px;
 }
-/*  Careful with the calculation of background position or you will have to much dead space.*/
-.thumbnail-close {
-  background-image: url("close-window.png");
-	background-size: 16px 16px;
-	background-position: 0px -2px;
-	width: 16px;
- 	height: 16px;
+.app-list-item-box {
+  z-index: -9;
 }
-/*App List Padding is set in the the applet settings
-use to override window-list-item-box */
-.app-list-item-box{
-	z-index: -9;
-}
-/* NumLabel */
 .window-icon-list-numlabel {
-	z-index: 99;
+  z-index: 99;
   text-shadow: black 1px 0px 2px
 }
-/* Non grouped container */
 .window-icon-list-buttonbox {
   spacing: 2px;
 }
-.window-list-item-box:closed {
-  background-gradient-direction: vertical;
-  background-gradient-start: rgba(100,100,100,0.0) !important;
-  background-gradient-end: rgba(50,50,50,0.0) !important;
-  box-shadow: inset 0px 0px 0px 1px rgba(80,80,80,0.0) !important;
+.panel-top .window-list-item-box:closed,
+.panel-bottom .window-list-item-box:closed,
+.panel-left .window-list-item-box:closed,
+.panel-right .window-list-item-box:closed {
+  background-gradient-direction: vertical !important;
+  background-gradient-start: rgba(0,0,0,0.0) !important;
+  background-gradient-end: rgba(0,0,0,0.0) !important;
+  border-radius: 0px 0px 0px 0px !important;
+  border-image: none !important;
+  border-color: rgba(0,0,0,0.0) !important;
+  box-shadow: inset 0px 0px 0px 0px rgba(0,0,0,0.0) !important;
 }
 .window-list-item-demands-attention {
 }

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/stylesheet.css
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/stylesheet.css
@@ -8,6 +8,9 @@
 .thumbnail-label {
   padding-left: 4px;
 }
+.thumbnail-label-no-icon {
+  padding-left: 4px;
+}
 .app-list-item-box {
   z-index: -9;
 }

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/utils.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/utils.js
@@ -126,6 +126,21 @@ const filter = function (arr, cb) {
   return result;
 };
 
+const map = function (arr, fn) {
+  if (arr == null) {
+    return [];
+  }
+
+  let len = arr.length;
+  let out = Array(len);
+
+  for (let i = 0; i < len; i++) {
+    out[i] = fn(arr[i], i, arr);
+  }
+
+  return out;
+}
+
 const tryFn = function(fn, errCb) {
   try {
     return fn();

--- a/IcingTaskManager@json/files/IcingTaskManager@json/metadata.json
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/metadata.json
@@ -2,7 +2,7 @@
     "description": "Window list with app grouping and thumbnails",
     "max-instances": -1,
     "name": "Icing Task Manager",
-    "version": "6.1.0",
+    "version": "6.2.0",
     "role": "panellauncher",
     "uuid": "IcingTaskManager@json",
     "multiversion": true,

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/bg.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/bg.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-09 18:56+0200\n"
+"POT-Creation-Date: 2017-12-09 03:01-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Peyu Yovev <spacy00001@gmail.com>\n"
 "Language-Team: \n"
@@ -897,6 +897,74 @@ msgstr "Диспечер на задачи Icing"
 #. IcingTaskManager@json->metadata.json->description
 msgid "Window list with app grouping and thumbnails"
 msgstr "Списък с прозорци с групиране на приложения и миниатюри"
+
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+#, fuzzy
+msgid "App button transition duration"
+msgstr "Ширина на бутона"
+
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr ""
+
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "Без иконки"
+
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr ""
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "Показване на опцията за автоматично пускане"
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#, fuzzy
+msgid "Show windows from all workspaces"
+msgstr "Видимо на всички работни места"
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
+msgid "Cycle windows on mouse wheel scroll"
+msgstr ""
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
+#, fuzzy
+msgid ""
+"Choose whether or not scrolling the mouse wheel cycles windows when hovering "
+"over a thumbnail menu."
+msgstr ""
+"Изберете дали да включите превъртането на работещите приложения с колелцето "
+"на мишката."
 
 #~ msgid "number"
 #~ msgstr "число"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/da.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/da.po
@@ -899,3 +899,68 @@ msgstr "Icing programhåndtering"
 #. IcingTaskManager@json->metadata.json->description
 msgid "Window list with app grouping and thumbnails"
 msgstr "Vinduesliste med miniaturer og gruppering af programmer"
+
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+#, fuzzy
+msgid "App button transition duration"
+msgstr "Programknappens bredde"
+
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr ""
+
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "Ingen ikoner"
+
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr ""
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "Vis til-/fravalg af automatisk opstart"
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#, fuzzy
+msgid "Show windows from all workspaces"
+msgstr "Synlig på alle arbejdsområder"
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
+msgid "Cycle windows on mouse wheel scroll"
+msgstr ""
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
+msgid ""
+"Choose whether or not scrolling the mouse wheel cycles windows when hovering "
+"over a thumbnail menu."
+msgstr ""

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/de.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/de.po
@@ -922,6 +922,71 @@ msgstr "Icing Task Manager"
 msgid "Window list with app grouping and thumbnails"
 msgstr "Fensterliste mit Anwendungsgruppierung und Fenstervorschau"
 
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+#, fuzzy
+msgid "App button transition duration"
+msgstr "Breite der Anwendungsknöpfe"
+
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr ""
+
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "Keine Icons"
+
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr ""
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "Autostart-Option anzeigen"
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#, fuzzy
+msgid "Show windows from all workspaces"
+msgstr "Auf allen Arbeitsflächen anzeigen"
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
+msgid "Cycle windows on mouse wheel scroll"
+msgstr ""
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
+msgid ""
+"Choose whether or not scrolling the mouse wheel cycles windows when hovering "
+"over a thumbnail menu."
+msgstr ""
+
 #~ msgid "number"
 #~ msgstr "Anzahl"
 

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/default.pot
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/default.pot
@@ -861,3 +861,64 @@ msgstr ""
 #. IcingTaskManager@json->metadata.json->description
 msgid "Window list with app grouping and thumbnails"
 msgstr ""
+
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr ""
+
+#. 3.4->settings-schema.json->show-icons->description
+msgid "Show icons"
+msgstr ""
+
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr ""
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+msgid "Show new window option"
+msgstr ""
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+msgid "Show windows from all workspaces"
+msgstr ""
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
+msgid "Cycle windows on mouse wheel scroll"
+msgstr ""
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
+msgid ""
+"Choose whether or not scrolling the mouse wheel cycles windows when hovering"
+" over a thumbnail menu."
+msgstr ""

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/es.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/es.po
@@ -922,6 +922,70 @@ msgid "Window list with app grouping and thumbnails"
 msgstr ""
 "Lista de ventanas con agrupación de aplicaciones y miniaturas de ventanas"
 
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr ""
+
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "Sin iconos"
+
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr ""
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "Mostrar la opción de inicio automático"
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#, fuzzy
+msgid "Show windows from all workspaces"
+msgstr "Mostrar en todas las áreas de trabajo"
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
+msgid "Cycle windows on mouse wheel scroll"
+msgstr ""
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
+msgid ""
+"Choose whether or not scrolling the mouse wheel cycles windows when hovering "
+"over a thumbnail menu."
+msgstr ""
+
 # Should not be set, just leave it blank by setting one white-space character
 #~ msgid "number"
 #~ msgstr " "

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/fr.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/fr.po
@@ -945,6 +945,70 @@ msgstr "Icing Task Manager"
 msgid "Window list with app grouping and thumbnails"
 msgstr "Liste des fenêtres avec regroupement et miniatures des applications"
 
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr ""
+
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "Aucune icône"
+
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr ""
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "Afficher l'option de démarrage automatique"
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#, fuzzy
+msgid "Show windows from all workspaces"
+msgstr "Visible dans tous les espaces de travail"
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
+msgid "Cycle windows on mouse wheel scroll"
+msgstr ""
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
+msgid ""
+"Choose whether or not scrolling the mouse wheel cycles windows when hovering "
+"over a thumbnail menu."
+msgstr ""
+
 # Should not be set, just leave it blank by setting one white-space character
 #~ msgid "number"
 #~ msgstr " "

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/he.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/he.po
@@ -901,6 +901,70 @@ msgid "Window list with app grouping and thumbnails"
 msgstr ""
 "שורת משימות עם קיבוץ אפליקציות והצגת חלונות ממוזערים תכלס - כמו בווינדוס"
 
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr ""
+
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "לא נמצאו סמלים"
+
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr ""
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "אפשרות autostart צג"
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#, fuzzy
+msgid "Show windows from all workspaces"
+msgstr "רק בשולחן העבודה הזה"
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
+msgid "Cycle windows on mouse wheel scroll"
+msgstr ""
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
+msgid ""
+"Choose whether or not scrolling the mouse wheel cycles windows when hovering "
+"over a thumbnail menu."
+msgstr ""
+
 # Should not be set, just leave it blank by setting one white-space character
 #~ msgid "number"
 #~ msgstr " "

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/hr.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/hr.po
@@ -913,6 +913,70 @@ msgstr "Icing upravitelj zadataka"
 msgid "Window list with app grouping and thumbnails"
 msgstr "Popis prozora s grupiranjem aplikacija i minijaturama prozora"
 
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr ""
+
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "Bez ikona"
+
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr ""
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "Prikaži mogućnosti automatskog pokretanja"
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#, fuzzy
+msgid "Show windows from all workspaces"
+msgstr "Vidljivo na svim radnim prostorima"
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
+msgid "Cycle windows on mouse wheel scroll"
+msgstr ""
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
+msgid ""
+"Choose whether or not scrolling the mouse wheel cycles windows when hovering "
+"over a thumbnail menu."
+msgstr ""
+
 #~ msgid "number"
 #~ msgstr "broj"
 

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/pl.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/pl.po
@@ -920,6 +920,70 @@ msgstr "Icing Task Manager"
 msgid "Window list with app grouping and thumbnails"
 msgstr "Lista okien z grupowaniem aplikacji i miniaturkami"
 
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr ""
+
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "Bez ikon"
+
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr ""
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "Pokazuj opcję autostartu"
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#, fuzzy
+msgid "Show windows from all workspaces"
+msgstr "Widoczne na wszystkich obszarach roboczych"
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
+msgid "Cycle windows on mouse wheel scroll"
+msgstr ""
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
+msgid ""
+"Choose whether or not scrolling the mouse wheel cycles windows when hovering "
+"over a thumbnail menu."
+msgstr ""
+
 #~ msgid "number"
 #~ msgstr "numer"
 

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/ru.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/ru.po
@@ -903,6 +903,70 @@ msgstr "Icing Task Manager"
 msgid "Window list with app grouping and thumbnails"
 msgstr "Список окон с группировкой и миниатюрами"
 
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr ""
+
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "Нет иконок"
+
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr ""
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "Отображать параметры автозагрузки"
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#, fuzzy
+msgid "Show windows from all workspaces"
+msgstr "На всех рабочих столах"
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
+msgid "Cycle windows on mouse wheel scroll"
+msgstr ""
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
+msgid ""
+"Choose whether or not scrolling the mouse wheel cycles windows when hovering "
+"over a thumbnail menu."
+msgstr ""
+
 # Should not be set, just leave it blank by setting one white-space character
 #~ msgid "number"
 #~ msgstr " "

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/sv.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/sv.po
@@ -896,6 +896,71 @@ msgstr "Icing Task Manager"
 msgid "Window list with app grouping and thumbnails"
 msgstr "Fönsterlista med programgruppering och miniatyrer"
 
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+#, fuzzy
+msgid "App button transition duration"
+msgstr "Programknappsbredd"
+
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr ""
+
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "Inga ikoner"
+
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr ""
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "Visa autostartalternativ"
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#, fuzzy
+msgid "Show windows from all workspaces"
+msgstr "Synlig på alla arbetsytor"
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
+msgid "Cycle windows on mouse wheel scroll"
+msgstr ""
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
+msgid ""
+"Choose whether or not scrolling the mouse wheel cycles windows when hovering "
+"over a thumbnail menu."
+msgstr ""
+
 #~ msgid "number"
 #~ msgstr "antal"
 

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/tr.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/tr.po
@@ -921,6 +921,70 @@ msgstr "Icing Görev Yöneticisi"
 msgid "Window list with app grouping and thumbnails"
 msgstr "Uygulama gruplama ve pencere ön izleme destekli pencere listesi"
 
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr ""
+
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "Simge yok"
+
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr ""
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "Otomatik başlatma seçeneğini göster"
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#, fuzzy
+msgid "Show windows from all workspaces"
+msgstr "Tüm çalışma alanlarında görünür"
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
+msgid "Cycle windows on mouse wheel scroll"
+msgstr ""
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
+msgid ""
+"Choose whether or not scrolling the mouse wheel cycles windows when hovering "
+"over a thumbnail menu."
+msgstr ""
+
 #~ msgid "number"
 #~ msgstr "sayı"
 

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/zh_CN.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/zh_CN.po
@@ -873,6 +873,71 @@ msgstr "Icing Task Manager"
 msgid "Window list with app grouping and thumbnails"
 msgstr "带应用程序分组和缩略图的窗口列表"
 
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+#, fuzzy
+msgid "App button transition duration"
+msgstr "应用程序按钮宽度"
+
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr ""
+
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "没有图标"
+
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr ""
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "显示自动启动开关"
+
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#, fuzzy
+msgid "Show windows from all workspaces"
+msgstr "在所有工作区可见"
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
+msgid "Cycle windows on mouse wheel scroll"
+msgstr ""
+
+#. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
+msgid ""
+"Choose whether or not scrolling the mouse wheel cycles windows when hovering "
+"over a thumbnail menu."
+msgstr ""
+
 #~ msgid "number"
 #~ msgstr "个数"
 


### PR DESCRIPTION
  * Fixed windows from all workspaces showing, and added an option to show all workspaces.
    - Also properly handles sticky windows that are marked as visible on all workspaces.
  * Fixed per-monitor window mode not working correctly on the primary monitor.
    - When toggling this setting, it will now take effect on all ITM instances.
  * Fixed  pinning/unpinning apps in ungrouped app mode.
  * Added an option to disable icons in the thumbnail menu.
  * Added an option to scroll windows while hovering over an app's thumbnail menu.
  * Added a transition duration override option for app buttons, and the option to a assign the checked pseudo class as an override.
  * Added an option to show a "New Window" context menu item.
  * Improved theme compatibility for the closed pinned app styling.
  * Fixed multiple app buttons receiving focus styling in some scenarios (6.1 regression).