### PR TITLE
color-picker@fmete: Use symbolic icon as default

### DIFF
--- a/color-picker@fmete/files/color-picker@fmete/applet.js
+++ b/color-picker@fmete/files/color-picker@fmete/applet.js
@@ -94,7 +94,7 @@ MyApplet.prototype = {
         else if (Gtk.IconTheme.get_default().has_icon(this.icon_name))
             this.set_applet_icon_name(this.icon_name);
         else
-            this.set_applet_icon_path(this.appletPath + "/icon.png");
+            this.set_applet_icon_symbolic_name("color-select");
      },
 
      on_keybinding_changed: function() {


### PR DESCRIPTION
Closes https://github.com/linuxmint/cinnamon-spices-applets/issues/1578