### PR TITLE
color-picker@fmete: Change default keybinding

### DIFF
--- a/color-picker@fmete/files/color-picker@fmete/settings-schema.json
+++ b/color-picker@fmete/files/color-picker@fmete/settings-schema.json
@@ -37,6 +37,6 @@
   "keybinding-test" : {
     "type" : "keybinding",
     "description" : "Keybinding, which activates the color picker",
-    "default" : "<Primary>p"
+    "default" : "<Primary><Alt>p"
  }
 }


### PR DESCRIPTION
`Ctrl+P` conflicts with printing in many applications. Use `Ctrl+Alt+P` instead.
Fixes https://github.com/linuxmint/cinnamon-spices-applets/issues/1593