### PR TITLE
hideable-applets@cardsurf: Fix for Cinnamon 3.8

### DIFF
--- a/hideable-applets@cardsurf/files/hideable-applets@cardsurf/applet.js
+++ b/hideable-applets@cardsurf/files/hideable-applets@cardsurf/applet.js
@@ -11,9 +11,18 @@ const GLib = imports.gi.GLib;
 
 const uuid = "hideable-applets@cardsurf";
 const AppletDirectory = imports.ui.appletManager.applets[uuid];
-const AppletGui = AppletDirectory.appletGui;
-const AppletConstants = AppletDirectory.appletConstants;
-const FilesCsv = AppletDirectory.filesCsv;
+
+let AppletGui, AppletConstants, FilesCsv;
+
+if (typeof require !== 'undefined') {
+    AppletGui = require('./appletGui');
+    AppletConstants = require('./appletConstants');
+    FilesCsv = require('./filesCsv');
+} else {
+    AppletGui = AppletDirectory.appletGui;
+    AppletConstants = AppletDirectory.appletConstants;
+    FilesCsv = AppletDirectory.filesCsv;
+}
 
 
 
@@ -989,7 +998,7 @@ MyApplet.prototype = {
     },
 
     get_sorted_indexes: function(array) {
-        indexes = [];
+        let indexes = [];
 
         for(let i = 0; i < array.length; ++i) {
             let item = array[i];

--- a/hideable-applets@cardsurf/files/hideable-applets@cardsurf/appletGui.js
+++ b/hideable-applets@cardsurf/files/hideable-applets@cardsurf/appletGui.js
@@ -318,8 +318,8 @@ HoverMenuIcons.prototype={
 
     _append_semicolon: function(css_style){
         css_style = css_style.trim();
-        last_char = css_style.slice(-1);
-        semicolon = ';';
+        let last_char = css_style.slice(-1);
+        let semicolon = ';';
         if (last_char != semicolon) {
             css_style += semicolon;
         }

--- a/hideable-applets@cardsurf/files/hideable-applets@cardsurf/files.js
+++ b/hideable-applets@cardsurf/files/hideable-applets@cardsurf/files.js
@@ -40,7 +40,7 @@ File.prototype = {
 
     overwrite: function(array_strings) {
         let string = array_strings.join(this.newline);
-        return GLib.file_set_contents(this.path, string, string.length, null);
+        return GLib.file_set_contents(this.path, string);
     },
 
     create: function() {
@@ -127,7 +127,7 @@ Directory.prototype = {
     },
 
     _create: function() {
-        return this.directory.make_directory(null, null);
+        return this.directory.make_directory(null);
     },
 
     removeIfEmpty: function() {


### PR DESCRIPTION
- Fixed strict mode errors
- Fixed Glib warnings
- Switched applet over to new importer so it reloads correctly

@cardsurf 