### PR TITLE
Updates multicore-sys-monitor to work on Fedora

### DIFF
--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/DataProviders.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/DataProviders.js
@@ -1,6 +1,6 @@
-const GLib = imports.gi.GLib;
 const GTop = imports.gi.GTop;
 const Gio = imports.gi.Gio;
+const GIRepository = imports.gi.GIRepository;
 
 let _;
 if (typeof require !== 'undefined') {
@@ -11,12 +11,14 @@ if (typeof require !== 'undefined') {
 }
 
 let CONNECTED_STATE, NMClient_new;
-let [_res, _out, _err, exit_code] = GLib.spawn_sync(null, [imports.ui.appletManager.appletMeta['multicore-sys-monitor@ccadeptic23'].path+"/use_old_nm.sh"], null, 0, null);
-if (exit_code != 0) {
+let nm_index = GIRepository.Repository.get_default().get_loaded_namespaces().indexOf('NetworkManager')
+if (nm_index == -1) {
+  // The NetworkManager repository is not currently loaded so load the NM repo
   const NM = imports.gi.NM;
   CONNECTED_STATE = NM.DeviceState.Activated;
   NMClient_new = () => { return NM.Client.new(null); }
 } else {
+  // The NetworkManager repository is current loaded so load it and the NMClient repos
   const NMClient = imports.gi.NMClient;
   const NetworkManager = imports.gi.NetworkManager;
   CONNECTED_STATE = NetworkManager.DeviceState.CONNECTED;

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/DataProviders.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/DataProviders.js
@@ -1,28 +1,27 @@
+const GLib = imports.gi.GLib;
 const GTop = imports.gi.GTop;
 const Gio = imports.gi.Gio;
 
-let _, tryFn;
+let _;
 if (typeof require !== 'undefined') {
-  const utils = require('./utils');
-  _ = utils._;
-  tryFn = utils.tryFn;
+  _ = require('./utils')._;
 } else {
   const AppletDir = imports.ui.appletManager.applets['multicore-sys-monitor@ccadeptic23'];
   _ = AppletDir.utils._;
-  tryFn = AppletDir.utils.tryFn;
 }
 
 let CONNECTED_STATE, NMClient_new;
-tryFn(function() {
+let [_res, _out, _err, exit_code] = GLib.spawn_sync(null, [imports.ui.appletManager.appletMeta['multicore-sys-monitor@ccadeptic23'].path+"/use_old_nm.sh"], null, 0, null);
+if (exit_code != 0) {
   const NM = imports.gi.NM;
   CONNECTED_STATE = NM.DeviceState.Activated;
   NMClient_new = () => { return NM.Client.new(null); }
-}, function(e) {
+} else {
   const NMClient = imports.gi.NMClient;
   const NetworkManager = imports.gi.NetworkManager;
   CONNECTED_STATE = NetworkManager.DeviceState.CONNECTED;
   NMClient_new = () => { return NMClient.Client.new(); }
-});
+}
 
 const formatBytes = (bytes, decimals)=>{
   if (bytes === 0) {

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/use_old_nm.sh
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/use_old_nm.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-lsof -p $PPID | grep -m 1 NetworkManager 2>&1 1>/dev/null

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/use_old_nm.sh
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/use_old_nm.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+lsof -p $PPID | grep -m 1 NetworkManager 2>&1 1>/dev/null


### PR DESCRIPTION
Fixes #1616.

Makes the applet use either the `NetworkManager` and `NMClient` (as required for Linux Mint and older Fedoras) or just the `NM` (as required for newest Fedora) depending on which of those was previously loaded by Cinnamon. Loading both sets causes Cinnamon to crash.

The applets `vnstat@linuxmint.com`, `turbonote@iksws.com.br`, and `netusagemonitor@pdcurtis` will likely also need similar updates to become compatible with the newest Fedora. It is possible that even Linux Mint will move Cinnamon to using the newer `NM` library soon and thus these updates will be required even for Linux Mint.