### PR TITLE
printers@linux-man: Update when closing menu

### DIFF
--- a/printers@linux-man/README.md
+++ b/printers@linux-man/README.md
@@ -18,6 +18,9 @@ French corrections by Christophe Hortemel
 
 ### Changelog
 
+### 0.8
+    Applet also updates when closing menu
+
 ### 0.7
     Applet only updates when receives a Cups signal - faster Menu toggle
     3s timeout between updates

--- a/printers@linux-man/files/printers@linux-man/applet.js
+++ b/printers@linux-man/files/printers@linux-man/applet.js
@@ -55,7 +55,6 @@ MyApplet.prototype = {
     this.printError = false;
     this.printWarning = false;
     this.updating = false;
-    this.outdated = false;
     this.printers = [];
     this.setIcon('printer-printing');
     this.onSettingsChanged();
@@ -87,7 +86,7 @@ MyApplet.prototype = {
   },
 
   onMenuToggled: function() {
-    if(!this.menu.isOpen && this.outdated && !this.printWarning) this.update();
+    if(!this.printWarning) this.update();
   },
 
   onSettingsChanged: function() {
@@ -119,13 +118,8 @@ MyApplet.prototype = {
   },
 
   update: function() {
-    if(this.updating) return;
-    if(this.menu.isOpen) {
-      this.outdated = true;
-      return;
-    }
+    if(this.updating || this.menu.isOpen) return;
     this.updating = true;
-    this.outdated = false;
     this.jobsCount = 0;
     this.printersCount = 0;
     this.menu.removeAll();

--- a/printers@linux-man/files/printers@linux-man/metadata.json
+++ b/printers@linux-man/files/printers@linux-man/metadata.json
@@ -4,7 +4,7 @@
  "contributors": "Caldas Lopes",
  "name": "Printers",
  "description": "Manage Jobs and Printers",
- "version": "0.7",
+ "version": "0.8",
  "icon": "printer",
  "max-instances": "-1"
 }


### PR DESCRIPTION
A low-overhead way to make the applet partially usable at the multiple cases where DBus connection with Cups is lost.