### PR TITLE
Screenshot+Record Desktop@tech71 - fix icon resizing bug, allow multiple instances & clarify correct package names for dependencies.

### DIFF
--- a/ScreenShot+RecordDesktop@tech71/README.md
+++ b/ScreenShot+RecordDesktop@tech71/README.md
@@ -1,0 +1,11 @@
+### Screenshot & Record Desktop
+
+#### Dependencies
+
+To use this applets recording functionality you must have the following packages installed.
+
+* ffmpeg
+* xdotool
+* x11-utils
+
+To install in Linux Mint open a terminal (Ctrl-Alt-T) and enter the command `apt install ffmpeg xdotool x11-utils`

--- a/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/applet.js
+++ b/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/applet.js
@@ -1,4 +1,4 @@
-//SchreenShot+Record Applet By Infektedpc
+//ScreenShot+Record Applet By Infektedpc
 const Applet = imports.ui.applet;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
@@ -17,8 +17,8 @@ function ConfirmDialog(){
 }
 
 
-function MyApplet(orientation) {
-    this._init(orientation);
+function MyApplet(orientation, panelHeight, instanceId) {
+    this._init(orientation, panelHeight, instanceId);
 }
 
 MyApplet.prototype = {
@@ -99,8 +99,8 @@ MyApplet.prototype = {
         
         this.menu.addMenuItem(this.recordItem);
     },
-    _init: function(orientation) {        
-        Applet.IconApplet.prototype._init.call(this, orientation);
+    _init: function(orientation, panelHeight, instanceId) {        
+        Applet.IconApplet.prototype._init.call(this, orientation, panelHeight, instanceId);
         
         try {        
             this.set_applet_icon_symbolic_name("camera-photo-symbolic");
@@ -145,7 +145,7 @@ MyApplet.prototype = {
     
 };
 
-function main(metadata, orientation) {  
-    let myApplet = new MyApplet(orientation);
+function main(metadata, orientation, panelHeight, instanceId) {  
+    let myApplet = new MyApplet(orientation, panelHeight, instanceId);
     return myApplet;      
 }

--- a/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/metadata.json
+++ b/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/metadata.json
@@ -1,6 +1,7 @@
 {
-    "description": "Take A Snapshot Or Record Your Desktop (require ffmpeg, xwininfo, xdotool, xdpyinfo)",
-    "icon": "applets-screenshooter",
-    "uuid": "ScreenShot+RecordDesktop@tech71",
-    "name": "ScreenShot+Record Desktop"
+    "max-instances": -1,
+    "uuid": "ScreenShot+RecordDesktop@tech71", 
+    "description": "Take A Snapshot Or Record Your Desktop (recording requires the packages ffmpeg, xdotool & x11-utils to be installed)", 
+    "name": "ScreenShot+Record Desktop", 
+    "icon": "applets-screenshooter"
 }


### PR DESCRIPTION
…

Same bug fixed in this applet as reported and fixed for Screenshot@tech71 - #1723 & #1727.

Also amended description slightly to reflect package names of dependencies rather than the command names.