### PR TITLE
netusagemonitor@pdcurtis Update to version 3.2.4.1

### DIFF
--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/README.md
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/README.md
@@ -13,17 +13,24 @@ The Network Usage Monitor Applet (NUMA) enables one to continuously display the 
             ```sudo apt-get install gir1.2-gtop-2.0 vnstat vnstati zenity sox libsox-fmt-mp3``
    * Cinnamon Version 2.2 or higher ie. It can be used with all supported versions of Mint.
 
+## Warning about use on Distributions other than Mint:
+
+   * This Applet was originally designed to be used with Cinnamon running under Mint and has largely been tested under Mint.
+   * It currently assumes the NMClient and NetworkManager libraries are available and in use as is the case in Mint versions up to 18.3 and most other current distro versions.
+   * It  cannot be loaded on Fedora 27 (and possibly future versions of Linux Mint or other distros) due to the move from NMClient and NetworkManager libraries to NM.
+   * Attempting to add this applet on Fedora 27 may cause Cinnamon to continually crash (issue #1647).
+
 ## Features:
 
   * **The Applet:**
-       + Continuosusly displays Upload and Download rate in a fixed width 'steady' display
+       + Continuously displays Upload and Download rate in a fixed width 'steady' display
        + The Applet Background colour is:
           - Black when Current Interface not active
           - Green when Current connection and interface has provided data
           - Orange when the Alert level (as percentage of the Data Limit) has been exceeded
           - Red when the Data Limit for the current connection has been exceeded
    * **Hover over Applet:**
-       + Displays continuously updated Upload and Downoaded data usage for the current connection
+       + Displays continuously updated Upload and Downloaded data usage for the current connection
    * **The Context Menu (Right Click):**
        + Displays all the interfaces managed by the Network Manager Applet
        + Identifies any Active interfaces within Network Manager
@@ -81,13 +88,13 @@ The system program vnstat which provides the option of a graphic history of data
 
 ## Status
 
-The author is committed to maintaining and developing the applet. The applet is based on a well tried core from the netspeed applet and has been tested on various systems initially running under Mint 15 with a variety of themes. The current Version has been tested with Cinnamon 2.2 - 3.4 and Mint 17 - 18.2. 
+The author is committed to maintaining and developing the applet. The applet is based on a well tried core from the netspeed applet and has been tested on various systems initially running under Mint 15 with a variety of themes. The current Version has been tested with Cinnamon 2.2 - 3.6 under Mint 17 - 18.3. But see Warnings above about use under Fedora 27 which have yet to be addressed.
 
 ## Translations and other Contributions
 
 The internal changes required in the applet to allow translations are being implemented but no translations are available at this time. Translations are usually contributed by people fluent in the language and will be very much appreciated. Users please note I am unable to take responsibility for the accuracy of translations!
 
-Although comments and suggestions are always welcome any contributions which are contemplated should follow discussion. Changes can have many unintended consequences and the integrity of the applet is paramount. Unsolicited Pull Requests will never be authorised other than for urgent and critical bug fixes from the Cinnamon Team. 
+Although comments and suggestions are always welcome any contributions which are contemplated should follow discussion. Changes can have many unintended consequences and the integrity of the applet is paramount. Unsolicited Pull Requests will never be authorised other than for urgent and critical bug fixes or from the Cinnamon Team. 
 
 Thanks are given for the very useful contributions from @collinss and @Odyseus to help harmonise the menus with other applets.
 


### PR DESCRIPTION
This is a holding action which adds warnings about issue #1647 to the README.md but makes no changes to the code to address the problem of the move from NMClient and NetworkManager libraries to NM in Fedora 27 at this point in time.

The changes required may take some time as I am going to be away without internet access for over a month. Assistance from those who have contributed to the changes on other applets would be welcome!
