### PR TITLE
vnstat@linuxmint.com Update README.md only

### DIFF
--- a/vnstat@linuxmint.com/README.md
+++ b/vnstat@linuxmint.com/README.md
@@ -22,6 +22,14 @@ Notes: In Linux Mint, you can simply run `apt install vnstati` and that will tak
 
 It is possible to add additional devices, for example a USB Mobile Internet stick. Running `man vnstat` will give some information on how to proceed but beware it is not trivial.
 
-## You're not alone:
 
-If you like this applet, chances are you don't like your ISP :) Don't worry, you're not alone... feel free to name and shame your ISP and the limits you're restricted to in the comments section. It won't change anything of course, but you never know.. it might make you feel better :)
+## Warning about use on Distributions other than Mint:
+
+   * This Applet currently assumes the NMClient and NetworkManager libraries are available and in use as is the case in Mint versions up to 18.3 and most other current distro versions.
+   * It  cannot be loaded on Fedora 27 (and possibly future versions of Linux Mint or other distros) due to the move from NMClient and NetworkManager libraries to NM.
+   * Attempting to add this applet on Fedora 27 may cause Cinnamon to continually crash (issue #1647).
+
+### Support
+
+The original author of this Applet was Clem. More recently it has been supported by @pdcurtis who occasionally checks the comments on the [Cinnamon Spices Web Site](http://cinnamon-spices.linuxmint.com/applets/view/31), however that does not automatically notify him so if you want a rapid response please also note that mentioning @pdcurtis in any conversation on github will cause it to be emailed to him.
+


### PR DESCRIPTION
This is a holding action which adds warnings about issue #1647 to the README.md but makes no changes to the code to address the problem of the move from NMClient and NetworkManager libraries to NM in Fedora 27 at this point in time.

The original author of this applet was Clem but I made the most recent modifications in response to a bug which prevented it identifying the active device. The solution used code based on the code in netusagemonitor@pdcurtis so I feel responsible for eventually helping to sorti it out! In fact this is much simpler and shorter code so will be an ideal test of changes.
