### PR TITLE
bash-sensors@pkkk: Dynamic tooltips

### DIFF
--- a/bash-sensors@pkkk/files/bash-sensors@pkkk/applet.js
+++ b/bash-sensors@pkkk/files/bash-sensors@pkkk/applet.js
@@ -25,7 +25,6 @@ MyApplet.prototype = {
     _init: function (metadata, orientation, panelHeight, instance_id) {
         Applet.TextApplet.prototype._init.call(this, orientation);
         this.path = metadata.path;
-        this.set_applet_tooltip(_("Bash Sensors!"));
         this.settings = new Settings.AppletSettings(this, UUID, instance_id);
 
         this.menuManager = new PopupMenu.PopupMenuManager(this);
@@ -35,7 +34,7 @@ MyApplet.prototype = {
         this.menuLabel = new St.Label({text: '<init>'});
 
         this.bind_settings();
-        this.update();
+        this.autoupdate();
 
         item.addActor(this.menuLabel);
         section.addMenuItem(item);
@@ -57,13 +56,23 @@ MyApplet.prototype = {
             let cmd = (this.menuScript && this.menuScript.trim()) ? this.menuScript : this.script1;
             let cmd_output = this.spawn_sync(cmd);
             let cmd_stdout = cmd_output[0] ? cmd_output[1].toString() : _("script error");
-            this.menuLabel.set_text(cmd_stdout);
+            this.menuLabel.set_text(cmd_stdout.trimRight());
         }
 
+        this.update();
         this.menu.toggle();
     },
 
     update: function () {
+        if (this.dynamicTooltip) {
+            let cmd = (this.tooltipScript && this.tooltipScript.trim()) ? this.tooltipScript : this.script1;
+            let cmd_output = this.spawn_sync(cmd);
+            let cmd_stdout = cmd_output[0] ? cmd_output[1].toString() : _("script error");
+            this.set_applet_tooltip(cmd_stdout.trim());
+        } else {
+            this.set_applet_tooltip(this.tooltipScript.trim());
+        }
+
         let full = '';
         let scripts = this.script2 && this.script2.trim() && this.enableScript2 ?
             [this.script1, this.script2] : [this.script1];
@@ -78,11 +87,17 @@ MyApplet.prototype = {
             full += cmd_stdout + '\n';
         }
         this.set_applet_label(full.trimRight());
-        Mainloop.timeout_add(this.refreshInterval * 1000, Lang.bind(this, this.update));
+    },
+
+    autoupdate: function () {
+        this.update();
+        if (this.refreshInterval) {
+            Mainloop.timeout_add(this.refreshInterval * 1000, Lang.bind(this, this.autoupdate));
+        }
     },
 
     bind_settings: function () {
-        for (let str of ["refreshInterval", "script1", "script2", "enableScript2", "menuScript"]) {
+        for (let str of ["refreshInterval", "script1", "script2", "tooltipScript", "enableScript2", "dynamicTooltip", "menuScript"]) {
             this.settings.bindProperty(Settings.BindingDirection.IN,
                 str,
                 str,

--- a/bash-sensors@pkkk/files/bash-sensors@pkkk/po/bash-sensors@pkkk.pot
+++ b/bash-sensors@pkkk/files/bash-sensors@pkkk/po/bash-sensors@pkkk.pot
@@ -8,31 +8,27 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-21 18:55+0800\n"
+"POT-Creation-Date: 2018-04-16 18:34+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: \n"
 
-#: applet.js:36
-msgid "Bash Sensors!"
-msgstr ""
-
-#: applet.js:67 applet.js:80
+#: applet.js:58 applet.js:70 applet.js:80
 msgid "script error"
-msgstr ""
-
-#. bash-sensors@pkkk->metadata.json->name
-msgid "Bash Sensors"
 msgstr ""
 
 #. bash-sensors@pkkk->metadata.json->description
 msgid ""
 "Write your Bash commands to specify applet output (temperature sensors and "
 "not only!)"
+msgstr ""
+
+#. bash-sensors@pkkk->metadata.json->name
+msgid "Bash Sensors"
 msgstr ""
 
 #. bash-sensors@pkkk->settings-schema.json->head->description
@@ -43,12 +39,16 @@ msgstr ""
 msgid "Two-line mode (command 2 enabled)"
 msgstr ""
 
-#. bash-sensors@pkkk->settings-schema.json->menuScript->description
-msgid "Menu command (on applet left-click)"
+#. bash-sensors@pkkk->settings-schema.json->tooltipScript->description
+msgid "Tooltip command or static tooltip text"
 msgstr ""
 
-#. bash-sensors@pkkk->settings-schema.json->menuScript->tooltip
-msgid "allows to display lots of information in popup menu"
+#. bash-sensors@pkkk->settings-schema.json->tooltipScript->tooltip
+msgid "tooltip (static or dynamic)"
+msgstr ""
+
+#. bash-sensors@pkkk->settings-schema.json->dynamicTooltip->description
+msgid "Dynamic tooltip (use output of tooltip command as tooltip)"
 msgstr ""
 
 #. bash-sensors@pkkk->settings-schema.json->script1->description
@@ -68,9 +68,17 @@ msgid "second line of output (optional)"
 msgstr ""
 
 #. bash-sensors@pkkk->settings-schema.json->refreshInterval->description
-msgid "Refresh interval"
+msgid "Refresh interval [0 for no refresh]"
 msgstr ""
 
 #. bash-sensors@pkkk->settings-schema.json->refreshInterval->units
 msgid "seconds"
+msgstr ""
+
+#. bash-sensors@pkkk->settings-schema.json->menuScript->description
+msgid "Menu command (on applet left-click)"
+msgstr ""
+
+#. bash-sensors@pkkk->settings-schema.json->menuScript->tooltip
+msgid "allows to display lots of information in popup menu"
 msgstr ""

--- a/bash-sensors@pkkk/files/bash-sensors@pkkk/settings-schema.json
+++ b/bash-sensors@pkkk/files/bash-sensors@pkkk/settings-schema.json
@@ -6,11 +6,11 @@
 	"refreshInterval": {
 		"type": "spinbutton",
 		"default": 10,
-		"min": 1,
+		"min": 0,
 		"max": 60,
 		"step": 1,
 		"units": "seconds",
-		"description": "Refresh interval"
+		"description": "Refresh interval [0 for no refresh]"
 	},
 	"script1": {
 		"type": "entry",
@@ -23,13 +23,23 @@
 		"default": true,
 		"description": "Two-line mode (command 2 enabled)"
 	},
-
 	"script2": {
 		"type": "entry",
 		"default": "echo 'configuration required'",
 		"description": "Command 2",
 		"tooltip": "second line of output (optional)",
         "dependency": "enableScript2"
+	},
+	"dynamicTooltip": {
+		"type": "checkbox",
+		"default": false,
+		"description": "Dynamic tooltip (use output of tooltip command as tooltip)"
+	},
+	"tooltipScript": {
+		"type": "entry",
+		"default": "Bash sensors!",
+		"description": "Tooltip command or static tooltip text",
+		"tooltip": "tooltip (static or dynamic)"
 	},
 	"menuScript": {
 		"type": "entry",


### PR DESCRIPTION
I wanted to have a custom tooltip for the bash-sensors@pkkk applet. Because I already touched the tooltip display I added the possibility to dynamically generate it.

I also noticed that the label is not automatically updated when the applet is (left-)clicked. This is fixed. Now it makes sense to add the option to disable the automatic updates, so that the label and tooltip only gets updated when the applet is clicked.

Is the pot file automatically updated?

- Refresh interval can be set to 0 to disable automatic updates (updates of the labels happen only if the applet is left-clicked).
- Tooltip can be dynamic using the output of a special command.
- Command output when left-clicking on the applet is trimmed on the right-hand side removing the trailing newline character which makes the output higher than required.
- Applet label and tooltip is immediately updated when the applet is left-clicked.