### PR TITLE
vnstat@linuxmint.com Update to address issue 1647

### DIFF
--- a/vnstat@linuxmint.com/README.md
+++ b/vnstat@linuxmint.com/README.md
@@ -13,21 +13,23 @@ The applet detects which device you're currently using, and simply exports a gra
 ## What you need for it to work:
 
 You need:
-* To install vnstat
-* To install vnstati
-* To have the vnstat daemon running
-* To have vnstat configured for the devices you are using.
+
+  * To install vnstat
+  * To install vnstati
+  * To have the vnstat daemon running
+  * To have vnstat configured for the devices you are using.
 
 Notes: In Linux Mint, you can simply run `apt install vnstati` and that will take care of everything for the built in devices. In other distributions it might depend on the way things are packaged but it's likely to be similar.
 
 It is possible to add additional devices, for example a USB Mobile Internet stick. Running `man vnstat` will give some information on how to proceed but beware it is not trivial.
 
 
-## Warning about use on Distributions other than Mint:
+## Use on Distributions other than Mint:
 
-   * This Applet currently assumes the NMClient and NetworkManager libraries are available and in use as is the case in Mint versions up to 18.3 and most other current distro versions.
-   * It  cannot be loaded on Fedora 27 (and possibly future versions of Linux Mint or other distros) due to the move from NMClient and NetworkManager libraries to NM.
-   * Attempting to add this applet on Fedora 27 may cause Cinnamon to continually crash (issue #1647).
+  * It currently assumes the NMClient and NetworkManager libraries are in use as is the case in Mint versions up to 18.3 and most other current distro versions.
+  * The latest versions can also switch to the more recent NM library if the NetworkManager Library is not available on your distribution.
+  * It is possible that you may have to set up vnstati on other distributions - running `man vnstat` will providee information on how to proceed if that is the case.
+  * Feedback on your experiences on other distributions would be welcome.
 
 ### Support
 

--- a/vnstat@linuxmint.com/files/vnstat@linuxmint.com/applet.js
+++ b/vnstat@linuxmint.com/files/vnstat@linuxmint.com/applet.js
@@ -72,7 +72,8 @@ MyApplet.prototype = {
             this._device = "null";
             this.vnstatImage = GLib.get_home_dir() + "/vnstatlmapplet.png";
 //            this._client = NMClient.Client.new();
-            this._client = NMClient_new();
+            let args = newNM ? [null] : [];
+            this._client = NMClient_new.apply(this, args);
             
         }
         catch (e) {

--- a/vnstat@linuxmint.com/files/vnstat@linuxmint.com/applet.js
+++ b/vnstat@linuxmint.com/files/vnstat@linuxmint.com/applet.js
@@ -8,8 +8,25 @@ const Util = imports.misc.util;
 const PopupMenu = imports.ui.popupMenu;
 const UPowerGlib = imports.gi.UPowerGlib;
 const GLib = imports.gi.GLib;
-const NMClient = imports.gi.NMClient;
-const NetworkManager = imports.gi.NetworkManager;
+// const NMClient = imports.gi.NMClient;
+// const NetworkManager = imports.gi.NetworkManager;
+
+// Code for selecting network manager thanks to Jeffrey Bush
+const GIRepository = imports.gi.GIRepository;
+let CONNECTED_STATE, NMClient_new;
+let nm_index = GIRepository.Repository.get_default().get_loaded_namespaces().indexOf('NetworkManager')
+if (nm_index == -1) {
+  // The NetworkManager repository is not currently loaded so load the NM repo
+  const NM = imports.gi.NM;
+  CONNECTED_STATE = NM.DeviceState.Activated;
+  NMClient_new = () => { return NM.Client.new(null); }
+} else {
+  // The NetworkManager repository is current loaded so load it and the NMClient repos
+  const NMClient = imports.gi.NMClient;
+  const NetworkManager = imports.gi.NetworkManager;
+  CONNECTED_STATE = NetworkManager.DeviceState.ACTIVATED;
+  NMClient_new = () => { return NMClient.Client.new(); }
+}
 
 // l10n/translation
 const Gettext = imports.gettext;
@@ -47,7 +64,8 @@ MyApplet.prototype = {
             
             this._device = "null";
             this.vnstatImage = GLib.get_home_dir() + "/vnstatlmapplet.png";
-            this._client = NMClient.Client.new();
+//            this._client = NMClient.Client.new();
+            this._client = NMClient_new();
             
         }
         catch (e) {
@@ -64,7 +82,7 @@ MyApplet.prototype = {
     
     _update: function() {
         this._updateDevice();
-        this._updateGraph();
+        this._updateGraph(); // Comment this out to test without vnstat installed
     },
 
     getInterfaces: function () {
@@ -76,7 +94,9 @@ MyApplet.prototype = {
         if (interfaces != null) {
            for (let i = 0; i < interfaces.length; i++) {
                 let iname = interfaces[i].get_iface();
-                if (iname == name && interfaces[i].state == NetworkManager.DeviceState.ACTIVATED) {
+//                if (iname == name && interfaces[i].state ==  NetworkManager.DeviceState.ACTIVATED) {
+                if (iname == name && interfaces[i].state == CONNECTED_STATE) {
+
                    return true;
                  }
              }
@@ -93,7 +113,7 @@ MyApplet.prototype = {
                     let iname = interfaces[i].get_iface();
                     if (this.isInterfaceAvailable(iname)) {
                         this._device = iname; 
-//                        global.logError("Test output - vnstat using device: " + this._device);   
+//                        global.logError("Test output - vnstat@linuxmin.com detected device: " + this._device);   // Comment out unless testing
                     }
                 }
             }


### PR DESCRIPTION
This addresses issue #1647 where certain applet cannot be loaded on Fedora 27 (and possibly future versions of Linux Mint or other distros) due to the move from NMClient and NetworkManager libraries to NM.

 * The version 2 fix uses the code for selecting the network manager for the multicore-sys-monitor@ccadeptic23 thanks to @jaszhix 

 * A section has been added to README.md covering use on Distributions other than Mint and to note that @pdcurtis is currently providing support.

I have only been able to do a very basic checks on distributions other than Mint so I have initially marked this WIP in case anyone is prepared to check further on Fedora 27 or other Distros using the libnm library before it is merged. 
