### PR TITLE
sound150@claudiux: v1.4.1 - Magnetic property of 100% Volume mark bec…

### DIFF
--- a/sound150@claudiux/CHANGELOG.md
+++ b/sound150@claudiux/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## CHANGELOG
 
+### v1.4.1
+ * The magnetic property of the 100% mark becomes optionnal.
+ * Translations:
+   * Available languages: English, French, Spanish, Italian, Russian and now **Danish** (thanks to @Alan01!).
+
 ### v1.4.0
  * The 100% mark in sound settings becomes magnetic.
  * The applet and sound settings sliders become synchronized.

--- a/sound150@claudiux/README.md
+++ b/sound150@claudiux/README.md
@@ -79,6 +79,6 @@ The **Sound 150%** applet is designed to allow translations of some messages (in
 
 The installation of the available languages is done automatically.
 
-Languages already available: English, French, Spanish, Italian, Russian (thanks to @sem5959!).
+Languages already available: English, French, Spanish, Italian, Russian (thanks to @sem5959!) and Danish (thanks to @Alan01!).
 
-Any new translation will be wellcomed.
+Any new translation is welcome.

--- a/sound150@claudiux/files/sound150@claudiux/3.4/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/3.4/applet.js
@@ -264,7 +264,10 @@ VolumeSlider.prototype = {
             muted = true;
         } else {
             muted = false;
-            if (this.applet.magnetic_on===true && volume != this.applet._volumeNominal && volume > this.applet._volumeNominal*(1-VOLUME_ADJUSTMENT_STEP/2) && volume < this.applet._volumeNominal*(1+VOLUME_ADJUSTMENT_STEP/2)) {
+
+            let magneticOn = (this.applet.magneticOn!==null && this.applet.magneticOn===true);
+
+            if (magneticOn===true && volume != this.applet._volumeNominal && volume > this.applet._volumeNominal*(1-VOLUME_ADJUSTMENT_STEP/2) && volume < this.applet._volumeNominal*(1+VOLUME_ADJUSTMENT_STEP/2)) {
                 volume = this.applet._volumeNominal; // 100% is magnetic
             }
         }
@@ -281,7 +284,9 @@ VolumeSlider.prototype = {
     _update: function(){
         let value = (!this.stream || this.stream.is_muted)? 0 : this.stream.volume / this.applet._volumeNominal;
 
-        if (this.applet.magnetic_on===true && value != 1 && value>1-VOLUME_ADJUSTMENT_STEP/2 && value<1+VOLUME_ADJUSTMENT_STEP/2) {
+        let magneticOn = (this.applet.magneticOn!==null && this.applet.magneticOn===true);
+
+        if (magneticOn===true && value != 1 && value>1-VOLUME_ADJUSTMENT_STEP/2 && value<1+VOLUME_ADJUSTMENT_STEP/2) {
             value = 1; // 100% is magnetic
             this.applet._output.volume = this.applet._volumeNominal;
             this.applet._output.push_volume()
@@ -1040,13 +1045,14 @@ MyApplet.prototype = {
             this.settings.bind("showalbum", "showalbum", this.on_settings_changed);
             this.settings.bind("truncatetext", "truncatetext", this.on_settings_changed);
 
+            this.settings.bind("magneticOn", "magneticOn", this.on_settings_changed);
+
             this.settings.bind("percentMaxVol", "percentMaxVol", this.on_settings_changed);
             log('_init: percentMaxVol=' + this.percentMaxVol);
             this.settings.bind("stepVolume", "stepVolume", this.on_settings_changed);
             log('_init: stepVolume=' + this.stepVolume);
             VOLUME_ADJUSTMENT_STEP = 1*this.stepVolume/100;
 
-            this.settings.bind("magnetic_on", "magnetic_on", this.on_settings_changed);
 
             this.settings.bind("adaptColor", "adaptColor", this.on_settings_changed);
 
@@ -1317,7 +1323,7 @@ MyApplet.prototype = {
                     this._output.change_is_muted(true);
             } else {
                 let quotient = this._output.volume/this._volumeNominal;
-                if (this.magnetic_on===true && quotient != 1 && quotient>1-VOLUME_ADJUSTMENT_STEP/2 && quotient<1+VOLUME_ADJUSTMENT_STEP/2)
+                if (this.magneticOn===true && quotient != 1 && quotient>1-VOLUME_ADJUSTMENT_STEP/2 && quotient<1+VOLUME_ADJUSTMENT_STEP/2)
                     this._output.volume = this._volumeNominal; // 100% is magnetic
             }
             this._output.push_volume();
@@ -1325,7 +1331,7 @@ MyApplet.prototype = {
         else if (direction == Clutter.ScrollDirection.UP) {
             this._output.volume = Math.min(this._volumeMax, currentVolume + this._volumeNominal * VOLUME_ADJUSTMENT_STEP);
             let quotient = this._output.volume/this._volumeNominal;
-            if (this.magnetic_on===true && quotient != 1 && quotient>1-VOLUME_ADJUSTMENT_STEP/2 && quotient<1+VOLUME_ADJUSTMENT_STEP/2)
+            if (this.magneticOn===true && quotient != 1 && quotient>1-VOLUME_ADJUSTMENT_STEP/2 && quotient<1+VOLUME_ADJUSTMENT_STEP/2)
                 this._output.volume = this._volumeNominal; // 100% is magnetic
             this._output.push_volume();
             this._output.change_is_muted(false);

--- a/sound150@claudiux/files/sound150@claudiux/3.4/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/3.4/applet.js
@@ -264,8 +264,8 @@ VolumeSlider.prototype = {
             muted = true;
         } else {
             muted = false;
-            if (volume != this.applet._volumeNominal && volume > this.applet._volumeNominal*(1-VOLUME_ADJUSTMENT_STEP/2) && volume < this.applet._volumeNominal*(1+VOLUME_ADJUSTMENT_STEP/2)) {
-                volume = this.applet._volumeNominal;
+            if (this.applet.magnetic_on===true && volume != this.applet._volumeNominal && volume > this.applet._volumeNominal*(1-VOLUME_ADJUSTMENT_STEP/2) && volume < this.applet._volumeNominal*(1+VOLUME_ADJUSTMENT_STEP/2)) {
+                volume = this.applet._volumeNominal; // 100% is magnetic
             }
         }
         this.stream.volume = volume;
@@ -281,7 +281,7 @@ VolumeSlider.prototype = {
     _update: function(){
         let value = (!this.stream || this.stream.is_muted)? 0 : this.stream.volume / this.applet._volumeNominal;
 
-        if (value != 1 && value>1-VOLUME_ADJUSTMENT_STEP/2 && value<1+VOLUME_ADJUSTMENT_STEP/2) {
+        if (this.applet.magnetic_on===true && value != 1 && value>1-VOLUME_ADJUSTMENT_STEP/2 && value<1+VOLUME_ADJUSTMENT_STEP/2) {
             value = 1; // 100% is magnetic
             this.applet._output.volume = this.applet._volumeNominal;
             this.applet._output.push_volume()
@@ -1046,6 +1046,8 @@ MyApplet.prototype = {
             log('_init: stepVolume=' + this.stepVolume);
             VOLUME_ADJUSTMENT_STEP = 1*this.stepVolume/100;
 
+            this.settings.bind("magnetic_on", "magnetic_on", this.on_settings_changed);
+
             this.settings.bind("adaptColor", "adaptColor", this.on_settings_changed);
 
             this.settings.bind("hideSystray", "hideSystray", function() {
@@ -1315,7 +1317,7 @@ MyApplet.prototype = {
                     this._output.change_is_muted(true);
             } else {
                 let quotient = this._output.volume/this._volumeNominal;
-                if (quotient != 1 && quotient>1-VOLUME_ADJUSTMENT_STEP/2 && quotient<1+VOLUME_ADJUSTMENT_STEP/2)
+                if (this.magnetic_on===true && quotient != 1 && quotient>1-VOLUME_ADJUSTMENT_STEP/2 && quotient<1+VOLUME_ADJUSTMENT_STEP/2)
                     this._output.volume = this._volumeNominal; // 100% is magnetic
             }
             this._output.push_volume();
@@ -1323,7 +1325,7 @@ MyApplet.prototype = {
         else if (direction == Clutter.ScrollDirection.UP) {
             this._output.volume = Math.min(this._volumeMax, currentVolume + this._volumeNominal * VOLUME_ADJUSTMENT_STEP);
             let quotient = this._output.volume/this._volumeNominal;
-            if (quotient != 1 && quotient>1-VOLUME_ADJUSTMENT_STEP/2 && quotient<1+VOLUME_ADJUSTMENT_STEP/2)
+            if (this.magnetic_on===true && quotient != 1 && quotient>1-VOLUME_ADJUSTMENT_STEP/2 && quotient<1+VOLUME_ADJUSTMENT_STEP/2)
                 this._output.volume = this._volumeNominal; // 100% is magnetic
             this._output.push_volume();
             this._output.change_is_muted(false);

--- a/sound150@claudiux/files/sound150@claudiux/3.4/settings-schema.json
+++ b/sound150@claudiux/files/sound150@claudiux/3.4/settings-schema.json
@@ -101,7 +101,14 @@
             "1%": 1
         },
         "tooltip": "% of nominal volume",
-        "description": "+/-"
+        "description": "+/-",
+        "tooltip": "Step"
+    },
+    "magnetic_on": {
+        "type": "switch",
+        "description": "Magnetize the 'Volume 100%' mark",
+        "tooltip": "When checked, the 'Volume 100%' mark becomes magnetic: the volume is automatically set to 100% when the distance between the volume value and 100% is lesser than a half-step.",
+        "default": true
     },
     "adaptColor": {
         "type": "switch",

--- a/sound150@claudiux/files/sound150@claudiux/3.4/settings-schema.json
+++ b/sound150@claudiux/files/sound150@claudiux/3.4/settings-schema.json
@@ -103,7 +103,7 @@
         "tooltip": "% of nominal volume",
         "description": "+/-"
     },
-    "magnetic_on": {
+    "magneticOn": {
         "type": "switch",
         "description": "Magnetize the 'Volume 100%' mark",
         "tooltip": "When checked, the 'Volume 100%' mark becomes magnetic: the volume is automatically set to 100% when the distance between the volume value and 100% is lesser than a half-step.",

--- a/sound150@claudiux/files/sound150@claudiux/3.4/settings-schema.json
+++ b/sound150@claudiux/files/sound150@claudiux/3.4/settings-schema.json
@@ -101,8 +101,7 @@
             "1%": 1
         },
         "tooltip": "% of nominal volume",
-        "description": "+/-",
-        "tooltip": "Step"
+        "description": "+/-"
     },
     "magnetic_on": {
         "type": "switch",

--- a/sound150@claudiux/files/sound150@claudiux/CHANGELOG.md
+++ b/sound150@claudiux/files/sound150@claudiux/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## CHANGELOG
 
+### v1.4.1
+ * The magnetic property of the 100% mark becomes optionnal.
+ * Translations:
+   * Available languages: English, French, Spanish, Italian, Russian and now **Danish** (thanks to @Alan01!).
+
 ### v1.4.0
  * The 100% mark in sound settings becomes magnetic.
  * The applet and sound settings sliders become synchronized.

--- a/sound150@claudiux/files/sound150@claudiux/README.md
+++ b/sound150@claudiux/files/sound150@claudiux/README.md
@@ -79,6 +79,6 @@ The **Sound 150%** applet is designed to allow translations of some messages (in
 
 The installation of the available languages is done automatically.
 
-Languages already available: English, French, Spanish, Italian, Russian (thanks to @sem5959!).
+Languages already available: English, French, Spanish, Italian, Russian (thanks to @sem5959!) and Danish (thanks to @Alan01!).
 
-Any new translation will be wellcomed.
+Any new translation is welcome.

--- a/sound150@claudiux/files/sound150@claudiux/metadata.json
+++ b/sound150@claudiux/files/sound150@claudiux/metadata.json
@@ -5,7 +5,7 @@
     "max-instances": "1",
     "description": "An applet, based on the Cinnamon one, to control sound (up to 150% of nominal volume) and music",
     "hide-configuration": false,
-    "version": "1.4.0",
+    "version": "1.4.1",
     "cinnamon-version": [
         "2.8",
         "3.0",
@@ -14,5 +14,5 @@
         "3.6",
         "3.8"
     ],
-    "last-edited": 1522090890
+    "last-edited": 1523640550
 }

--- a/sound150@claudiux/files/sound150@claudiux/po/es.po
+++ b/sound150@claudiux/files/sound150@claudiux/po/es.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: sound150@claudiux v1.0.0\n"
 "Report-Msgid-Bugs-To: Claudiux <claude.clerc@gmail.com>\n"
 "POT-Creation-Date: 2018-01-13 15:10+0100\n"
-"PO-Revision-Date: 2018-01-13 15:15+0100\n"
+"PO-Revision-Date: 2018-04-13 19:27+0200\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: Claude CLERC <claude.clerc@gmail.com>\n"
+"Last-Translator: claudiux <claude.clerc@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: es\n"
 
@@ -26,22 +26,34 @@ msgstr "Un applet, basado en el de Cinnamon, para controlar el sonido (hasta el 
 msgid "Sound 150%"
 msgstr "Sonido 150%"
 
-#: settings-schema.json:101
+#: settings-schema.json:103
 msgid "% of nominal volume"
 msgstr "% del volumen nominal"
 
-#: settings-schema.json:83
+#: settings-schema.json:85
 msgid "Maximum volume control"
 msgstr "Control de volumen máximo"
 
-#: settings-schema.json:84
+#: settings-schema.json:86
 msgid "You can try to increase the volume of your sound card up to 150% of its nominal value. Use with caution. You can also set a value less than 100%, for example on a child's computer."
 msgstr "Puede intentar aumentar el volumen de su tarjeta de sonido hasta un 150% de su valor nominal. Usar con precaución. También puede establecer un valor inferior al 100%, por ejemplo, en la computadora de un niño."
 
-#: settings-schema.json:106
+#: settings-schema.json:105
+msgid "Step"
+msgstr "Paso"
+
+#: settings-schema.json:109
+msgid "Magnetize the 'Volume 100%' mark"
+msgstr "Magnetizar el signo del 100% del volumen"
+
+#: settings-schema.json:110
+msgid "When checked, the 'Volume 100%' mark becomes magnetic: the volume is automatically set to 100% when the distance between the volume value and 100% is lesser than a half-step."
+msgstr "Cuando está marcada, la marca 'Volumen 100%' se vuelve magnética: el volumen se ajusta automáticamente al 100% cuando la diferencia entre el valor del volumen y el 100% es inferior a medio paso."
+
+#: settings-schema.json:115
 msgid "Adjust the color of the icon to the volume"
 msgstr "Ajustar el color del icono al volumen"
 
-#: settings-schema.json:107
+#: settings-schema.json:116
 msgid "From 101% to 115%: yellow; from 116% to 130%: orange; beyond 130%: red."
 msgstr "Del 101% al 115%: amarillo; de 116% a 130%: naranja; más allá del 130%: rojo."

--- a/sound150@claudiux/files/sound150@claudiux/po/fr.po
+++ b/sound150@claudiux/files/sound150@claudiux/po/fr.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: sound150@claudiux\n"
 "Report-Msgid-Bugs-To: Claudiux <claude.clerc@gmail.com>\n"
 "POT-Creation-Date: 2018-01-12 16:01+0100\n"
-"PO-Revision-Date: 2018-01-12 16:05+0100\n"
+"PO-Revision-Date: 2018-04-13 19:11+0200\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: Claude CLERC <claude.clerc@gmail.com>\n"
+"Last-Translator: claudiux <claude.clerc@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Language: fr\n"
 
@@ -26,22 +26,34 @@ msgstr "Une applet, basée sur celle de Cinnamon, pour contrôler le son (jusqu'
 msgid "Sound 150%"
 msgstr "Son 150%"
 
-#: settings-schema.json:72
+#: settings-schema.json:103
 msgid "% of nominal volume"
 msgstr "% du volume nominal"
 
-#: settings-schema.json:74
+#: settings-schema.json:85
 msgid "Maximum volume control"
 msgstr "Contrôle du volume maximum"
 
-#: settings-schema.json:75
+#: settings-schema.json:86
 msgid "You can try to increase the volume of your sound card up to 150% of its nominal value. Use with caution. You can also set a value less than 100%, for example on a child's computer."
 msgstr "Vous pouvez essayer d'augmenter le volume de votre carte audio jusqu'à 150% de son volume nominal. Utiliser avec précaution. Vous pouvez aussi fixer une valeur inférieure à 100%, par exemple sur l'ordinateur d'un enfant."
 
-#: settings-schema.json:106
+#: settings-schema.json:105
+msgid "Step"
+msgstr "Pas"
+
+#: settings-schema.json:109
+msgid "Magnetize the 'Volume 100%' mark"
+msgstr "Rendre magnétique la marque Volume 100%"
+
+#: settings-schema.json:110
+msgid "When checked, the 'Volume 100%' mark becomes magnetic: the volume is automatically set to 100% when the distance between the volume value and 100% is lesser than a half-step."
+msgstr "Quand cette case est cochée, la marque Volume 100% devient magnétique : le volume est automatiquement réglé à 100% quand la distance entre la valeur du volume et 100% est inférieure à un demi-pas."
+
+#: settings-schema.json:115
 msgid "Adjust the color of the icon to the volume"
 msgstr "Ajuster la couleur de l'icone au volume"
 
-#: settings-schema.json:107
+#: settings-schema.json:116
 msgid "From 101% to 115%: yellow; from 116% to 130%: orange; beyond 130%: red."
 msgstr "De 101% a 115%: jaune; de 116% à 130%: orange; au-delà de 130%: rouge."

--- a/sound150@claudiux/files/sound150@claudiux/po/it.po
+++ b/sound150@claudiux/files/sound150@claudiux/po/it.po
@@ -8,13 +8,13 @@ msgstr ""
 "Project-Id-Version: sound150@claudiux v1.0.0\n"
 "Report-Msgid-Bugs-To: Claudiux <claude.clerc@gmail.com>\n"
 "POT-Creation-Date: 2018-01-13 15:01+0100\n"
-"PO-Revision-Date: 2018-01-13 15:08+0100\n"
+"PO-Revision-Date: 2018-04-13 19:25+0200\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: Claude CLERC <claude.clerc@gmail.com>\n"
+"Last-Translator: claudiux <claude.clerc@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: it\n"
 
@@ -26,22 +26,34 @@ msgstr "Un'applet, basata su quello di Cinnamon, per controllare il suono (fino 
 msgid "Sound 150%"
 msgstr "Suono 150%"
 
-#: settings-schema.json:72
+#: settings-schema.json:103
 msgid "% of nominal volume"
 msgstr "% di volume nominale"
 
-#: settings-schema.json:74
+#: settings-schema.json:85
 msgid "Maximum volume control"
 msgstr "Controllo del volume massimo"
 
-#: settings-schema.json:75
+#: settings-schema.json:86
 msgid "You can try to increase the volume of your sound card up to 150% of its nominal value. Use with caution. You can also set a value less than 100%, for example on a child's computer."
 msgstr "Puoi provare ad aumentare il volume della tua scheda audio fino al 150% del suo valore nominale. Usare con cautela. Puoi anche impostare un valore inferiore al 100%, ad esempio sul computer di un bambino."
 
-#: settings-schema.json:106
+#: settings-schema.json:105
+msgid "Step"
+msgstr "Passo"
+
+#: settings-schema.json:109
+msgid "Magnetize the 'Volume 100%' mark"
+msgstr "Magnetizzare il segno del 100% del volume"
+
+#: settings-schema.json:110
+msgid "When checked, the 'Volume 100%' mark becomes magnetic: the volume is automatically set to 100% when the distance between the volume value and 100% is lesser than a half-step."
+msgstr "Se selezionato, il segno Volume 100% diventa magnetico: il volume viene automaticamente impostato su 100% quando la differenza tra il valore del volume e il 100% è inferiore a un mezzo passo."
+
+#: settings-schema.json:115
 msgid "Adjust the color of the icon to the volume"
 msgstr "Regolare il colore dell'icona sul volume"
 
-#: settings-schema.json:107
+#: settings-schema.json:116
 msgid "From 101% to 115%: yellow; from 116% to 130%: orange; beyond 130%: red."
 msgstr "Dal 101% al 115%: giallo; dal 116% al 130%: arancio; oltre il 130%: rosso."

--- a/sound150@claudiux/files/sound150@claudiux/po/sound150@claudiux.pot
+++ b/sound150@claudiux/files/sound150@claudiux/po/sound150@claudiux.pot
@@ -25,22 +25,34 @@ msgstr ""
 msgid "Sound 150%"
 msgstr ""
 
-#: settings-schema.json:101
+#: settings-schema.json:103
 msgid "% of nominal volume"
 msgstr ""
 
-#: settings-schema.json:83
+#: settings-schema.json:85
 msgid "Maximum volume control"
 msgstr ""
 
-#: settings-schema.json:84
+#: settings-schema.json:86
 msgid "You can try to increase the volume of your sound card up to 150% of its nominal value. Use with caution. You can also set a value less than 100%, for example on a child's computer."
 msgstr ""
 
-#: settings-schema.json:106
+#: settings-schema.json:105
+msgid "Step"
+msgstr ""
+
+#: settings-schema.json:109
+msgid "Magnetize the 'Volume 100%' mark"
+msgstr ""
+
+#: settings-schema.json:110
+msgid "When checked, the 'Volume 100%' mark becomes magnetic: the volume is automatically set to 100% when the distance between the volume value and 100% is lesser than a half-step."
+msgstr ""
+
+#: settings-schema.json:115
 msgid "Adjust the color of the icon to the volume"
 msgstr ""
 
-#: settings-schema.json:107
+#: settings-schema.json:116
 msgid "From 101% to 115%: yellow; from 116% to 130%: orange; beyond 130%: red."
 msgstr ""


### PR DESCRIPTION
…omes optionnal

Hi,

This is the v1.4.1 of the sound150@claudiux applet.
There is now an option in settings to set/unset the magnetic property of the 100% volume mark, as requested by an user.

The .pot file and the fr.po, es.po, it.po are updated to translate the new messages.

Can you merge this sound150 branch with your master branch, please?

Best regards.

claudiux