### PR TITLE
[WIP] netusagemonitor@pdcurtis Update to version 3.2.5

### DIFF
--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/CHANGELOG.md
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Changelog covering recent significant changes
 
+## 3.2.5
+
+  * Changes to check which network manager libraries are in use and choose which to use - addresses/solves issue #1647 with Fedora versions 27 and higher.
+  * Note that there may be problems with option of disconnecting the network manager when data usage limit is exceeded so checks are needed under NM before the issue can be marked as closed.
+  * Use xdg-open in place of gedit or xed to allow use on more distros
+  * Update README.md
+
 ## 3.2.4
 
  * Change method of inhibiting display of vnstati image when vnstati not installed or enabled in settings by substituting a tiny image instead of use of an extra mainBox.
@@ -25,7 +32,7 @@ Support new facility on Cinnamon Spices Web Site to display a CHANGELOG.md
 
  * Harmonise with code writen by author for vnstat@cinnamon.org
 
-##3.2.0
+## 3.2.0
 
  * Remove duplicate let declarations occurances in common coding for Cinnamon 3.4 thanks to @NikoKraus  [#604]
 

--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/README.md
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/README.md
@@ -12,13 +12,8 @@ The Network Usage Monitor Applet (NUMA) enables one to continuously display the 
    * For full facilities including use of notifications, audible alerts and statistics the ```gir1.2-gtop-2.0 vnstat vnstati zenity sox libsox-fmt-mp3``` libraries must be installed. They can be installed  by the synaptic package manager or with the terminal command:
             ```sudo apt-get install gir1.2-gtop-2.0 vnstat vnstati zenity sox libsox-fmt-mp3``
    * Cinnamon Version 2.2 or higher ie. It can be used with all supported versions of Mint.
-
-## Warning about use on Distributions other than Mint:
-
-   * This Applet was originally designed to be used with Cinnamon running under Mint and has largely been tested under Mint.
-   * It currently assumes the NMClient and NetworkManager libraries are available and in use as is the case in Mint versions up to 18.3 and most other current distro versions.
-   * It  cannot be loaded on Fedora 27 (and possibly future versions of Linux Mint or other distros) due to the move from NMClient and NetworkManager libraries to NM.
-   * Attempting to add this applet on Fedora 27 may cause Cinnamon to continually crash (issue #1647).
+   * It currently assumes the NMClient and NetworkManager libraries are in use as is the case in Mint versions up to 18.3 and most other current distro versions.
+   * The latest versions can also switch to the more recent NM library if the NetworkManager Library is not available.
 
 ## Features:
 

--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/applet.js
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/applet.js
@@ -7,13 +7,30 @@ const Lang = imports.lang;
 const Mainloop = imports.mainloop;
 const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
-const NetworkManager = imports.gi.NetworkManager;
+// const NetworkManager = imports.gi.NetworkManager;
 const Main = imports.ui.main;
 const Settings = imports.ui.settings; // Needed for settings API
 const Clutter = imports.gi.Clutter; // Needed for vnstat addition
 const ModalDialog = imports.ui.modalDialog; // Needed for Modal Dialog used in Alert
-const NMClient = imports.gi.NMClient; // Needed for modifications to NM calls 
+// const NMClient = imports.gi.NMClient; 
 const Gettext = imports.gettext; // ++ Needed for translations
+
+// Code for selecting network manager thanks to Jeffrey Bush
+const GIRepository = imports.gi.GIRepository;
+let CONNECTED_STATE, NMClient_new;
+let nm_index = GIRepository.Repository.get_default().get_loaded_namespaces().indexOf('NetworkManager')
+if (nm_index == -1) {
+  // The NetworkManager repository is not currently loaded so load the NM repo
+  const NM = imports.gi.NM;
+  CONNECTED_STATE = NM.DeviceState.Activated;
+  NMClient_new = () => { return NM.Client.new(null); }
+} else {
+  // The NetworkManager repository is current loaded so load it and the NMClient repos
+  const NMClient = imports.gi.NMClient;
+  const NetworkManager = imports.gi.NetworkManager;
+  CONNECTED_STATE = NetworkManager.DeviceState.ACTIVATED;
+  NMClient_new = () => { return NMClient.Client.new(); }
+}
 
 // Localisation/translation support - moved up and slightly non standard due to GTOP test which follows.
 var UUID = "netusagemonitor@pdcurtis";
@@ -234,12 +251,14 @@ MyApplet.prototype = {
 
             this.applet_running = true; //** New
  
-            this._client = NMClient.Client.new(); //++
+//            this._client = NMClient.Client.new();
+            this._client = NMClient_new();
 
             if (this.versionCompare( GLib.getenv('CINNAMON_VERSION') ,"3.0" ) <= 0 ){
                this.textEd = "gedit";
             } else { 
-               this.textEd = "xed";
+//               this.textEd = "xed";
+               this.textEd = "xdg-open";
             }
 
             this.abortFlag = true;
@@ -406,7 +425,7 @@ MyApplet.prototype = {
         if (interfaces != null) {
             for (let i = 0; i < interfaces.length; i++) {
                 let iname = interfaces[i].get_iface();
-                if (iname == name && interfaces[i].state == NetworkManager.DeviceState.ACTIVATED) {
+                if (iname == name && interfaces[i].state == CONNECTED_STATE) {
                     return true;
                 }
             }
@@ -792,7 +811,7 @@ Note Odysius has used the index 0 (zero) to insert the menu section to position 
 
      networkingDisable: function () {
           if(!this.abortFlag) {
-               this._client.networking_enabled = false; // Call to NMClient
+               this._client.networking_enabled = false; // Need to check with NM library
                alertModalNetworkingDisabled = new AlertDialog_(("THE DATA USAGE LIMIT HAS BEEN EXCEEDED\n\nAll Network connections managed by the Network Manager have been Disabled\n\nYou will need to use the Network Manager Applet to Re-enable them\nwhen the data usage problem has been resolved\n\n Some connections using ppp0 may not have been disabled or may need to be restarted manually"));
               alertModalNetworkingDisabled.open();
           } else {
@@ -1181,5 +1200,11 @@ Transition to new cinnamon-spices-applets repository from github.com/pdcurtis/ci
  * Change method of inhibiting display of vnstati image when vnstati not installed or enabled in settings by substituting a tiny image instead of use of an extra mainBox which led to CJS warnings.
  * Improved notification when vnstat and vnstati not installed
  * Tidy up code 
- * Better formatting of CHANGELOG.md     
+ * Better formatting of CHANGELOG.md
+## 3.2.4.1
+  * Changes to README.md to alert users to problems on Fedora 27 with changes in network manager libraries - issue #1647
+## 3.2.5
+  * Changes to check which network manager libraries are in use and choose which to use - addresses/solves issue #1647 with Fedora versions 27 and higher.
+  * Note that there may be problems with option of disconnecting the network manager when data usage limit is exceeded so checks are needed under NM before the issue can be marked as closed.
+  * Use xdg-open in place of gedit or xed to allow use on more distros 
 */

--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/changelog.txt
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/changelog.txt
@@ -173,3 +173,9 @@ Transition to new cinnamon-spices-applets repository from github.com/pdcurtis/ci
  * Improved notification when vnstat and vnstati not installed
  * Tidy up code 
  * Better formatting of CHANGELOG.md
+## 3.2.4.1
+  * Changes to README.md to alert users to problems on Fedora 27 with changes in network manager libraries - issue #1647
+## 3.2.5
+  * Changes to check which network manager libraries are in use and choose which to use - addresses/solves issue #1647 with Fedora versions 27 and higher.
+  * Use xdg-open in place of gedit or xed to allow use on more distros
+  * Note that there may be problems with option of disconnecting the network manager when data usage limit is exceeded so checks are needed under NM before the issue can be marked as closed.

--- a/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/metadata.json
+++ b/netusagemonitor@pdcurtis/files/netusagemonitor@pdcurtis/metadata.json
@@ -3,6 +3,6 @@
     "uuid": "netusagemonitor@pdcurtis", 
     "name": "Network Data Usage Monitor", 
     "description": "A Comprehensive Data Usage Monitor with alerts and cumulative data functions",
-    "version": "3.2.4"
+    "version": "3.2.5"
 }
 


### PR DESCRIPTION
This addresses issue #1647 where certain applet cannot be loaded on Fedora 27 (and possibly future versions of Linux Mint or other distros) due to the move from NMClient and NetworkManager libraries to NM.

 *  The fix uses the code for selecting the network manager for the multicore-sys-monitor@ccadeptic23 thanks to @jaszhix  
  *  The use of xed has been changed to xdg-open to cover more distributions.
  *  A section has been added to README.md covering use on Distributions other than Mint

I have only been able to do a very basic checks on distributions other than Mint so I have initially marked this WIP in case anyone is prepared to check further on Fedora 27 or other Distros using the libnm library before it is merged.