### PR TITLE
sysmonitor@orcus: Fix GTop import

### DIFF
--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.2/init.js
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.2/init.js
@@ -1,10 +1,13 @@
 const Gettext = imports.gettext;
 const GLib = imports.gi.GLib;
+
+var GTop;
 try {
-    var GTop = imports.gi.GTop;
+    GTop = imports.gi.GTop;
 }
 catch (e) {
-    var GTop = null;
+    global.log(e)
+    GTop = null;
 }
 
 const UUID = "sysmonitor@orcus";


### PR DESCRIPTION
The new module importer for xlets only recognizes variables on the top level.