### PR TITLE
[serviceLauncher@hulygun] Added fix for cinnamon 3.8

### DIFF
--- a/serviceLauncher@hulygun/files/serviceLauncher@hulygun/applet.js
+++ b/serviceLauncher@hulygun/files/serviceLauncher@hulygun/applet.js
@@ -80,7 +80,7 @@ function checkService(service) {
     let [res, pid, in_fd, out_fd, err_fd] =
         GLib.spawn_async_with_pipes(
             null, ["pgrep", service], null, GLib.SpawnFlags.SEARCH_PATH, null);
-    out_reader = new Gio.DataInputStream({base_stream: new Gio.UnixInputStream({fd: out_fd})});
+    const out_reader = new Gio.DataInputStream({base_stream: new Gio.UnixInputStream({fd: out_fd})});
     let [out, size] = out_reader.read_line(null);
     var result = false;
     if (out != null) {


### PR DESCRIPTION
Used a variable without declaration. This should not break older cinnamon versions (though I only tested with cinnamon 3.8).