### PR TITLE
IcingTaskManager@json: Fix DND

### DIFF
--- a/IcingTaskManager@json/CHANGELOG.md
+++ b/IcingTaskManager@json/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 
+### 6.3.2
+
+  * Fixed a DND regression from 6.1.0.
+
 ### 6.3.1
 
   * Fixed an issue that could impact users of Cinnamon on CJS 3.2.

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/applet.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/applet.js
@@ -200,36 +200,11 @@ PinnedFavs.prototype = {
         return favorite.id === opts.appId;
       });
     }
-    let currentAppList = this.params.state.trigger('getCurrentAppList');
-    let favoriteIds = map(this._favorites, function(favorite) {
-      return favorite.id;
-    });
-    let renderedFavoriteApps = map(currentAppList.appList, function(appGroup) {
-      return {
-        id: appGroup.groupState.appId,
-        app: appGroup.groupState.app
-      };
-    }).filter(function(renderedFavorite) {
-      return favoriteIds.indexOf(renderedFavorite.id) > -1
-    });
-    if (!this.params.state.settings.groupApps) {
-      let matched = [];
-      each(renderedFavoriteApps, function(favorite) {
-        let refFavorite = findIndex(matched, function(match) {
-          return match.id === favorite.id;
-        });
-        if (refFavorite > -1) {
-          return;
-        }
-        matched.push(favorite);
-      });
-      renderedFavoriteApps = matched;
+    let newIndex = opts.pos;
+    if (oldIndex > -1 && newIndex > oldIndex) {
+      newIndex = newIndex - 1;
     }
-    renderedFavoriteApps = renderedFavoriteApps
-      .slice(0, opts.pos)
-      .concat([{id:  opts.appId, app: opts.app}])
-      .concat(renderedFavoriteApps.slice(opts.pos + 1, renderedFavoriteApps.length))
-    this._favorites = renderedFavoriteApps;
+    this._favorites.splice(newIndex, 0, this._favorites.splice(oldIndex, 1)[0]);
     this._saveFavorites();
   },
 

--- a/IcingTaskManager@json/files/IcingTaskManager@json/metadata.json
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/metadata.json
@@ -2,7 +2,7 @@
     "description": "Window list with app grouping and thumbnails",
     "max-instances": -1,
     "name": "Icing Task Manager",
-    "version": "6.3.1",
+    "version": "6.3.2",
     "role": "panellauncher",
     "uuid": "IcingTaskManager@json",
     "multiversion": true,


### PR DESCRIPTION
This reverts DND refactoring made in #1553. The original DND behavior was changed to ensure old, uninstalled apps in the favorites list got purged, but that should probably be attempted again later in a cleaner way.