### PR TITLE
[cryptocoin@guantanamoe] Fix 'value is null' error when no currency symbol or name is selected

### DIFF
--- a/cryptocoin@guantanamoe/files/cryptocoin@guantanamoe/settings-schema.json
+++ b/cryptocoin@guantanamoe/files/cryptocoin@guantanamoe/settings-schema.json
@@ -32,7 +32,7 @@
         "options": {
             "Name": "name",
             "Symbol": "symbol",
-            "None": null
+            "None": "none"
         }
     }
 }


### PR DESCRIPTION
This PR fixes an error with Cinnamon 3.6.7 with the applet Cryptocoin that causes the applet fails loading after Cinnamon restart when you have selected to not show the currency name or symbol:

### Steps to reproduce

* Install Cryptocoin applet
* Configure the applet option "Show Currency" to "None"
* Restart Cinnamon (`Ctrl + Alt + F2` write `r` and `enter`)

### Current Behavior

The applet fails loading with the next message on the log:

```
error t=2018-05-08T13:02:45Z this.settingsData[key].value is null
trace t=2018-05-08T13:02:45Z 
<----------------
XletSettingsBase.prototype.bindWithObject@/usr/share/cinnamon/js/ui/settings.js:323:66
XletSettingsBase.prototype.bind@/usr/share/cinnamon/js/ui/settings.js:343:16
XletSettingsBase.prototype.bindProperty@/usr/share/cinnamon/js/ui/settings.js:362:16
MyApplet.prototype._init@/home/erick/.local/share/cinnamon/applets/cryptocoin@guantanamoe/applet.js:48:9
MyApplet@/home/erick/.local/share/cinnamon/applets/cryptocoin@guantanamoe/applet.js:27:5
main@/home/erick/.local/share/cinnamon/applets/cryptocoin@guantanamoe/applet.js:158:12
createApplet@/usr/share/cinnamon/js/ui/appletManager.js:512:18
addAppletToPanels@/usr/share/cinnamon/js/ui/appletManager.js:301:22
finishExtensionLoad@/usr/share/cinnamon/js/ui/appletManager.js:60:18
loadExtension@/usr/share/cinnamon/js/ui/extension.js:452:17
init@/usr/share/cinnamon/js/ui/appletManager.js:47:9
start@/usr/share/cinnamon/js/ui/main.js:493:5
@<main>:1:31
---------------->
error t=2018-05-08T13:02:45Z [Applet "cryptocoin@guantanamoe"]: Failed to evaluate 'main' function on applet: cryptocoin@guantanamoe/33
error t=2018-05-08T13:02:45Z Could not load applet cryptocoin@guantanamoe
```

### Expected behavior

The applet must load correctly.

/cc @imDeprecated 