### PR TITLE
CinnVIIStarkMenu@NikoKrause: remove custom padding of favorite apps buttons

### DIFF
--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/3.4/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/3.4/applet.js
@@ -1031,7 +1031,6 @@ FavoritesButton.prototype = {
         let icon_size = iconSize; //0.6*real_size;
         if (icon_size > MAX_FAV_ICON_SIZE)
             icon_size = MAX_FAV_ICON_SIZE;
-        this.actor.style = "padding-top: "+(icon_size / 3)+"px;padding-bottom: "+(icon_size / 3)+"px;";
 
         this.actor.add_style_class_name('menu-favorites-button');
 


### PR DESCRIPTION
This made the buttons' vertical paddings to be different from the horizontal ones.
Let themes define the correct padding.

![screenshot from 2018-05-15 15-23-45](https://user-images.githubusercontent.com/10391266/40060150-37b45c1a-5856-11e8-8b54-306155f1f67f.png)

@NikoKrause 