### PR TITLE
Redshift: Fixed issue of Brightness level not being remembered.

### DIFF
--- a/redshift@marvel4u/files/redshift@marvel4u/applet.js
+++ b/redshift@marvel4u/files/redshift@marvel4u/applet.js
@@ -159,6 +159,7 @@ MyApplet.prototype = {
 
         this.maxBrightness = 100;
         this.minBrightness = 10;
+        this.appletClicked = false;
 
         this.do_UI_update_slider();
         this.refreshRedshiftValues();
@@ -167,7 +168,7 @@ MyApplet.prototype = {
     on_applet_clicked: function (event) {
         // update brightness UI if values altered by system
         // todo: use watcher on dbus instead
-
+        this.appletClicked = true;
         this.do_UI_update_probe();
         this.menu.toggle();
     },
@@ -199,9 +200,13 @@ MyApplet.prototype = {
 
     do_UI_update_probe: function () {
         let currentBrightness = this.getSystemBrightness();
-        this._brightnessSlider.setValue(currentBrightness); // slider position
-        this.brightness = currentBrightness * 100;
+        if (this.appletClicked) {
+            this._brightnessSlider.setValue(this.brightness / 100); // slider position
+        } else {
+            this._brightnessSlider.setValue(currentBrightness); // slider position
+        }
         this.do_UI_update_slider();
+        this.appletClicked = false;
     },
 
     do_UI_update_colortag: function () {
@@ -331,7 +336,7 @@ MyApplet.prototype = {
     },
 
     updateTooltip: function () {
-        var tooltip = _('Brightness') + ': ' + this.brightness + '%\n';
+        let tooltip = _('Brightness') + ': ' + this.brightness + '%\n';
         tooltip += _('Redshift') + ': ' + _(this.enabled ? 'On' : 'Off');
         if (this.enabled) {
             tooltip += '\n';


### PR DESCRIPTION
@Marvel4U This PR is for issue [1598.](https://github.com/linuxmint/cinnamon-spices-applets/issues/1598) I added logic that allows for the Brightness level to be remembered by whatever the user selected. Both the numeric value and the slider remember the setting. Also changed a "var" to "let".

If any of the code looks incorrect or needs to be changed, feel free to change whatever or let me know and I'll make adjusts accordingly. 