### PR TITLE
temperature@fevimu: Limit compatibility to Cinnamon 3.6, 3.8

### DIFF
--- a/temperature@fevimu/files/temperature@fevimu/metadata.json
+++ b/temperature@fevimu/files/temperature@fevimu/metadata.json
@@ -1,5 +1,6 @@
 {
-"uuid": "temperature@fevimu",
-"name": "CPU Temperature Indicator",
-"description": "Shows CPU Temperature"
+  "uuid": "temperature@fevimu",
+  "name": "CPU Temperature Indicator",
+  "description": "Shows CPU Temperature",
+  "cinnamon-version": ["3.6", "3.8"]
 }


### PR DESCRIPTION
Not using sub-directories due to the original version having a memory leak issue.