### PR TITLE
Fixed rendering and added option to show decimal value in CPU usage.

### DIFF
--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.2/applet.js
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.2/applet.js
@@ -182,7 +182,7 @@ MyApplet.prototype = {
         graph.setDrawBorder(this.cfg_draw_border);
         graph.bg_color = this.bg_color;
         graph.border_color = this.border_color;
-        tooltip_decimals = this.getGraphTooltipDecimals(graph_idx);
+        let tooltip_decimals = this.getGraphTooltipDecimals(graph_idx);
         if (typeof tooltip_decimals !== "undefined")
             provider.setTextDecimals(tooltip_decimals);
         
@@ -377,9 +377,9 @@ MyApplet.prototype = {
         else
             for (let i = 0; i < this.graphs.length; i++)
                 if (this.graphs[i]) {
-                    let provider = this.graphs[graph_idx].provider;
+                    let provider = this.graphs[i].provider;
                     if ("setTextDecimals" in provider)
-                        provider.setTextDecimals(this.getGraphTooltipDecimals(graph_idx));
+                        provider.setTextDecimals(this.getGraphTooltipDecimals(i));
                 }
     },
 

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.2/applet.js
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.2/applet.js
@@ -106,6 +106,7 @@ MyApplet.prototype = {
                 ["cpu_enabled", this.on_cfg_changed_graph_enabled, 0],
                 ["cpu_override_graph_width", this.on_cfg_changed_graph_width, 0],
                 ["cpu_graph_width", this.on_cfg_changed_graph_width, 0],
+                ["cpu_tooltip_decimals", this.on_cfg_changed_tooltip_decimals, 0],
                 ["cpu_color_0", this.on_cfg_changed_color, 0],
                 ["cpu_color_1", this.on_cfg_changed_color, 0],
                 ["cpu_color_2", this.on_cfg_changed_color, 0],
@@ -181,6 +182,9 @@ MyApplet.prototype = {
         graph.setDrawBorder(this.cfg_draw_border);
         graph.bg_color = this.bg_color;
         graph.border_color = this.border_color;
+        tooltip_decimals = this.getGraphTooltipDecimals(graph_idx);
+        if (typeof tooltip_decimals !== "undefined")
+            provider.setTextDecimals(tooltip_decimals);
         
         return graph;
     },
@@ -234,6 +238,13 @@ MyApplet.prototype = {
                 break;
         }
         return c;
+    },
+
+    getGraphTooltipDecimals: function(graph_idx) {
+        let graph_id = this.graph_ids[graph_idx];
+        let prop = "cfg_" + graph_id + "_tooltip_decimals";
+        if (this.hasOwnProperty(prop))
+            return this[prop];
     },
     
     //Cinnamon callbacks
@@ -355,6 +366,21 @@ MyApplet.prototype = {
             for (let i = 0; i < this.graphs.length; i++)
                 if (this.graphs[i])
                     this.graphs[i].setWidth(this.getGraphWidth(i), this.vertical);
+    },
+
+    on_cfg_changed_tooltip_decimals: function(decimals, graph_idx) {
+        if (graph_idx) {
+            let provider = this.graphs[graph_idx].provider;
+            if ("setTextDecimals" in provider)
+                provider.setTextDecimals(this.getGraphTooltipDecimals(graph_idx));
+        }
+        else
+            for (let i = 0; i < this.graphs.length; i++)
+                if (this.graphs[i]) {
+                    let provider = this.graphs[graph_idx].provider;
+                    if ("setTextDecimals" in provider)
+                        provider.setTextDecimals(this.getGraphTooltipDecimals(graph_idx));
+                }
     },
 
     on_cfg_changed_color: function(width, graph_idx) {

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.2/graph.js
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.2/graph.js
@@ -113,6 +113,7 @@ Graph.prototype = {
         let border_width = this.draw_border ? 1 : 0;
         let graph_width = width - 2 * border_width;
         let graph_height = height - 2 * border_width;
+        cr.setLineWidth(1);
         //background
         cr.setSourceRGBA(this.bg_color[0], this.bg_color[1], this.bg_color[2], this.bg_color[3]);
         cr.rectangle(border_width, border_width, graph_width, graph_height);
@@ -121,11 +122,16 @@ Graph.prototype = {
         if (this.smooth)
         {
             for (let j = this.dim - 1; j >= 0; --j) {
-                cr.moveTo(border_width, graph_height + border_width);
                 this._setColor(cr, j);
+                cr.moveTo(border_width, graph_height + border_width);
                 for (let i = 0; i < this.data.length; ++i) {
                     let v = Math.round(graph_height * Math.min(1, this.scale * this.dataSum(i, j)));
-                    cr.lineTo(i + border_width, graph_height + border_width - v);
+                    v = graph_height + border_width - v;
+                    if (i == 0)
+                        cr.lineTo(i + border_width, v);
+                    cr.lineTo(i + border_width + 0.5, v);
+                    if (i == this.data.length - 1)
+                        cr.lineTo(i + border_width + 1, v);
                 }
                 cr.lineTo(graph_width + border_width, graph_height + border_width);
                 cr.lineTo(border_width, graph_height + border_width);
@@ -137,7 +143,7 @@ Graph.prototype = {
             for (let i = 0; i < this.data.length; ++i) {
                 for (let j = this.dim - 1; j >= 0; --j) {
                     this._setColor(cr, j);
-                    cr.moveTo(i + border_width, graph_height + border_width);
+                    cr.moveTo(i + border_width + 0.5, graph_height + border_width);
                     let v = Math.round(graph_height * Math.min(1, this.scale * this.dataSum(i, j)));
                     cr.relLineTo(0, -v);
                     cr.stroke();
@@ -147,7 +153,7 @@ Graph.prototype = {
         //border
         if (this.draw_border) {
             cr.setSourceRGBA(this.border_color[0], this.border_color[1], this.border_color[2], this.border_color[3]);
-            cr.rectangle(0, 0, width, height);
+            cr.rectangle(0.5, 0.5, width - 1, height - 1);
             cr.stroke();
         }
     },

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.2/providers.js
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.2/providers.js
@@ -22,6 +22,7 @@ CpuData.prototype = {
         this.sys_last = 0;
         this.iowait_last = 0;
         this.total_last = 0;
+        this.text_decimals = 0;
     },
     
     getDim: function() {
@@ -47,12 +48,16 @@ CpuData.prototype = {
         this.iowait_last = this.gtop.iowait;
         this.total_last = this.gtop.total;
         let used = 1-idle-nice-sys-iowait;
-        this.text = Math.round(100 * used) + " %";
+        this.text = (100 * used).toFixed(this.text_decimals) + " %";
         return [used, nice, sys, iowait];
     },
     
     getText: function() {
         return [_("CPU:"), this.text];
+    },
+
+    setTextDecimals: function(decimals) {
+        this.text_decimals = Math.max(0, decimals);
     }
 };
 

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.2/settings-schema.json
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.2/settings-schema.json
@@ -25,7 +25,7 @@
         "cpu_g": {
             "type": "section",
             "title": "General",
-            "keys": ["cpu_enabled", "cpu_override_graph_width", "cpu_graph_width"]
+            "keys": ["cpu_enabled", "cpu_override_graph_width", "cpu_graph_width", "cpu_tooltip_decimals"]
         },
         "cpu_c": {
             "type": "section",
@@ -181,6 +181,15 @@
         "description": "Graph width",
         "units": "pixels",
         "dependency": "cpu_override_graph_width"
+    },
+    "cpu_tooltip_decimals": {
+        "type": "spinbutton",
+        "default": 0,
+        "min": 0,
+        "max": 10,
+        "step": 1,
+        "description": "Show this many decimals in the tooltip",
+        "units": "decimals"
     },
     "cpu_color_0": {
         "type": "colorchooser",

--- a/sysmonitor@orcus/files/sysmonitor@orcus/metadata.json
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/metadata.json
@@ -2,7 +2,7 @@
     "description": "Displays CPU, memory, swap and network usage and load in graphs", 
     "uuid": "sysmonitor@orcus", 
     "name": "System Monitor", 
-    "version": "1.6.2", 
+    "version": "1.6.3",
     "icon": "utilities-system-monitor",
     "max-instances": -1,
     "multiversion": true


### PR DESCRIPTION
I've fixed the rendering, where some lines were half pixel off and therefore a bit blurry. All graphs should now be pixel perfect.
I've also added an option to show decimal values in the tooltip for CPU usage, configurable in the applet settings. It closes  #1815.