### PR TITLE
IcingTaskManager@json: 6.3.8

### DIFF
--- a/IcingTaskManager@json/CHANGELOG.md
+++ b/IcingTaskManager@json/CHANGELOG.md
@@ -1,5 +1,10 @@
 Changelog
 
+### 6.3.8
+
+  * Fixed inability to see hover previews when thumbnails are disabled.
+  * Addressed an issue affecting apps that defer passing window metadata to Muffin, such as Spotify.
+
 ### 6.3.7
 
   * Addressed an issue with the focus pseudo class styling reverting on hover.

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.8/appGroup.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.8/appGroup.js
@@ -143,6 +143,7 @@ class AppGroup {
     });
     this._numLabel = new St.Label({
       style_class: 'window-list-item-label window-icon-list-numlabel',
+      text: ''
     });
     this._numLabel.clutter_text.ellipsize = false;
 

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.8/specialMenus.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.8/specialMenus.js
@@ -1075,7 +1075,7 @@ class WindowThumbnail {
       return;
     }
     if (!this.metaWindowActor) {
-      return;
+      this.metaWindowActor = this.metaWindow.get_compositor_private();
     }
     this.state.set({
       overlayPreview: new Clutter.Clone({

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.8/specialMenus.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.8/specialMenus.js
@@ -1062,7 +1062,7 @@ class WindowThumbnail {
         if (this.labelContainer) {
           this.labelContainer.set_width(this.thumbnailWidth);
         }
-        this._label.text = this.metaWindow.title;
+        this._label.text = this.metaWindow.title || '';
         this.getThumbnail();
       }
     };

--- a/IcingTaskManager@json/files/IcingTaskManager@json/metadata.json
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/metadata.json
@@ -2,7 +2,7 @@
     "description": "Window list with app grouping and thumbnails",
     "max-instances": -1,
     "name": "Icing Task Manager",
-    "version": "6.3.7",
+    "version": "6.3.8",
     "role": "panellauncher",
     "uuid": "IcingTaskManager@json",
     "multiversion": true,


### PR DESCRIPTION
  * Fixed inability to see hover previews when thumbnails are disabled.
  * Addressed an issue affecting apps that defer passing window metadata to Muffin, such as Spotify.