### PR TITLE
sound-with-apps-volume@koutch: Add a Keybinding Option for Calling Up the Applet

### DIFF
--- a/sound-with-apps-volume@koutch/files/sound-with-apps-volume@koutch/applet.js
+++ b/sound-with-apps-volume@koutch/files/sound-with-apps-volume@koutch/applet.js
@@ -1119,6 +1119,9 @@ MyApplet.prototype = {
             this.settings.bindProperty(Settings.BindingDirection.IN, "launch-name", "launch_name", this._applySettings, null);
             this.settings.bindProperty(Settings.BindingDirection.IN, "launch-command", "launch_command", this._applySettings, null);
             this.settings.bindProperty(Settings.BindingDirection.IN, "launch-in-terminal", "launch_in_terminal", this._applySettings, null);
+            this.settings.bindProperty(Settings.BindingDirection.IN, "keybinding", "keybinding", this._onKeySettingsUpdated, null);
+
+            Main.keybindingManager.addHotKey(UUID, this.keybinding, Lang.bind(this, this.on_applet_clicked));
 
             this.slider_volumeMax = 1;
             this.stop_scroll = false;/// to make a short pause when volume reach 100% while scrolling the applet
@@ -1314,6 +1317,14 @@ MyApplet.prototype = {
         }
 
         this.menu.toggle();
+    },
+    _onKeySettingsUpdated: function _onKeySettingsUpdated() {
+        if (this.keybinding != null) {
+            Main.keybindingManager.addHotKey(UUID,
+                                             this.keybinding,
+                                             Lang.bind(this,
+                                                       this.on_applet_clicked));
+        }
     },
 
     _toggle_out_mute: function() {

--- a/sound-with-apps-volume@koutch/files/sound-with-apps-volume@koutch/applet.js
+++ b/sound-with-apps-volume@koutch/files/sound-with-apps-volume@koutch/applet.js
@@ -1121,7 +1121,7 @@ MyApplet.prototype = {
             this.settings.bindProperty(Settings.BindingDirection.IN, "launch-in-terminal", "launch_in_terminal", this._applySettings, null);
             this.settings.bindProperty(Settings.BindingDirection.IN, "keybinding", "keybinding", this._onKeySettingsUpdated, null);
 
-            Main.keybindingManager.addHotKey(UUID, this.keybinding, Lang.bind(this, this.on_applet_clicked));
+            Main.keybindingManager.addHotKey(this.metadata.uuid, this.keybinding, Lang.bind(this, this.on_applet_clicked));
 
             this.slider_volumeMax = 1;
             this.stop_scroll = false;/// to make a short pause when volume reach 100% while scrolling the applet
@@ -1294,6 +1294,8 @@ MyApplet.prototype = {
         ///@koucth Settings
         this.settings.finalize();    // This is called when a user removes the applet from the panel..
 
+        Main.keybindingManager.removeHotKey(this.metadata.uuid);
+
         if (this.hideSystray)
             this.unregisterSystrayIcons();
         if (this._iconTimeoutId) {
@@ -1320,7 +1322,7 @@ MyApplet.prototype = {
     },
     _onKeySettingsUpdated: function _onKeySettingsUpdated() {
         if (this.keybinding != null) {
-            Main.keybindingManager.addHotKey(UUID,
+            Main.keybindingManager.addHotKey(this.metadata.uuid,
                                              this.keybinding,
                                              Lang.bind(this,
                                                        this.on_applet_clicked));

--- a/sound-with-apps-volume@koutch/files/sound-with-apps-volume@koutch/settings-schema.json
+++ b/sound-with-apps-volume@koutch/files/sound-with-apps-volume@koutch/settings-schema.json
@@ -101,7 +101,7 @@
  },
  "keybinding": {
     "type": "keybinding",
-    "description": "Set the keybinding to call up a menu of the sound details",
+    "description": "Set the keybinding to call up the applet",
     "default": "<Super>v"
  },
   "div3" : {

--- a/sound-with-apps-volume@koutch/files/sound-with-apps-volume@koutch/settings-schema.json
+++ b/sound-with-apps-volume@koutch/files/sound-with-apps-volume@koutch/settings-schema.json
@@ -99,6 +99,11 @@
     "description": "Show Output device",
     "tooltip": "show/hide Output device"
  },
+ "keybinding": {
+    "type": "keybinding",
+    "description": "Set the keybinding to call up a menu of the sound details",
+    "default": "<Super>v"
+ },
   "div3" : {
     "type" : "separator"
  },


### PR DESCRIPTION
I prefer mouseless control usage, when feasible, and, particularly for volume, it'd be super useful (especially when most of the applet is already able to be controlled via arrow keys, currently).

@koutch