### PR TITLE
[download-and-upload-speed@cardsurf] Show speed in bits

### DIFF
--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/applet.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/applet.js
@@ -690,7 +690,7 @@ MyApplet.prototype = {
             return [number, unit];
         }
         else {
-            bits = this.convert_to_bits(bytes);
+            let bits = this.convert_to_bits(bytes);
             let [number, unit] = this.convert_bits_to_readable_unit(bits);
             return [number, unit];
         }


### PR DESCRIPTION
Fixed an issue of not showing speed in bits in Cinnamon 3.8