### PR TITLE
IcingTaskManager@json: Present single window on scroll over app icon

### DIFF
--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.4/applet.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.4/applet.js
@@ -776,7 +776,7 @@ MyApplet.prototype = {
       z = direction === 0 ? focusedIndex - 1 : focusedIndex + 1;
       count = this.appLists[this.state.currentWs].appList.length - 1;
     } else {
-      if (!source.groupState || source.groupState.metaWindows.length < 2) {
+      if (!source.groupState || source.groupState.metaWindows.length < 1) {
         return;
       }
       let focusedIndex = findIndex(source.groupState.metaWindows, function(metaWindow) {
@@ -797,6 +797,9 @@ MyApplet.prototype = {
         z += 1;
       }
       if (limit < 0) {
+        if (count === 0) {
+          z = 0;
+        }
         break;
       } else if (z < 0) {
         z = count;

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.8/applet.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.8/applet.js
@@ -739,7 +739,7 @@ class ITMApplet extends Applet.Applet {
       z = direction === 0 ? focusedIndex - 1 : focusedIndex + 1;
       count = this.appLists[this.state.currentWs].appList.length - 1;
     } else {
-      if (!source.groupState || source.groupState.metaWindows.length < 2) {
+      if (!source.groupState || source.groupState.metaWindows.length < 1) {
         return;
       }
       let focusedIndex = findIndex(source.groupState.metaWindows, function(metaWindow) {
@@ -760,6 +760,9 @@ class ITMApplet extends Applet.Applet {
         z += 1;
       }
       if (limit < 0) {
+        if (count === 0) {
+          z = 0;
+        }
         break;
       } else if (z < 0) {
         z = count;


### PR DESCRIPTION
Adjusted for 3.4 and 3.8 branches of applet. PR accepted by applet
developer @jaszhix within the separate repo:

  https://github.com/jaszhix/icingtaskmanager

Description:
When "Group apps" is activated and "Mouse wheel scroll behavior" is set
to "Cycle windows", scrolling over an app icon will now also present
the window if there exists only one window for the app icon.

Previously, only scrolling over icons that represented *multiple*
windows (grouped together) cycled through the app's existing windows,
presenting them (bringing them to foreground). If there was only one
window open, nothing happened upon scrolling on an icon, which is kind
of disruptive. You first had to move your finger and *click* the icon
to present the single window.

Now, scrolling an app's icon works the same on all active app's icons.