### PR TITLE
Cinnamenu@json: Support more compact layouts

### DIFF
--- a/Cinnamenu@json/CHANGELOG.md
+++ b/Cinnamenu@json/CHANGELOG.md
@@ -1,5 +1,11 @@
 Changelog
 
+### 3.2.4
+
+  * Lowered the minimum possible custom height to 360px.
+  * Lowered the minimum possible number of columns to 2.
+  * Reduced the widths of the columns so the menu is more compact.
+
 ### 3.2.3
 
   * Fixed a bug that can prevent being able to open applications after exiting the context menu.

--- a/Cinnamenu@json/files/Cinnamenu@json/applet.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/applet.js
@@ -2074,7 +2074,7 @@ CinnamenuApplet.prototype = {
     this.state.set({
       isListView: this.state.settings.startupViewMode === ApplicationsViewMode.LIST,
       displayed: true,
-      menuHeight: menuHeight < 530 ? 530 : menuHeight
+      menuHeight: menuHeight < 360 ? 360 : menuHeight
     });
 
     let section = new PopupMenu.PopupMenuSection();

--- a/Cinnamenu@json/files/Cinnamenu@json/constants.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/constants.js
@@ -9,25 +9,25 @@ function _(str) {
   return Gettext.dgettext('Cinnamenu@json', str);
 }
 
-var REMEMBER_RECENT_KEY = 'remember-recent-files';
+const REMEMBER_RECENT_KEY = 'remember-recent-files';
 
-var ApplicationType = {
+const ApplicationType = {
   _applications: 0,
   _places: 1,
   _recent: 2,
   _windows: 3,
   _providers: 4
 };
-var AppTypes = Object.keys(ApplicationType);
+const AppTypes = Object.keys(ApplicationType);
 
-var ApplicationsViewMode = {
+const ApplicationsViewMode = {
   LIST: 0,
   GRID: 1
 };
 
-var fuzzyOptions = {
+const fuzzyOptions = {
   before: '<b><u>',
   after: '</u></b>'
 }
 
-var gridWidths = [0, 0, 0, 625, 700, 725, 900, 1025];
+const gridWidths = [0, 240, 340, 498, 644, 725, 840, 980];

--- a/Cinnamenu@json/files/Cinnamenu@json/metadata.json
+++ b/Cinnamenu@json/files/Cinnamenu@json/metadata.json
@@ -3,6 +3,6 @@
   "name": "Cinnamenu",
   "description": "A flexible menu providing formatting options, web bookmarks, open window lookup, and search provider support with fuzzy searching.",
   "max-instances": 1,
-  "version": "3.2.3",
+  "version": "3.2.4",
   "cinnamon-version": ["3.2", "3.4", "3.6", "3.8"]
 }

--- a/Cinnamenu@json/files/Cinnamenu@json/settings-schema.json
+++ b/Cinnamenu@json/files/Cinnamenu@json/settings-schema.json
@@ -247,7 +247,7 @@
   "apps-grid-column-count": {
     "type": "spinbutton",
     "default": 4,
-    "min": 3,
+    "min": 2,
     "max": 7,
     "step": 1,
     "units": "columns",

--- a/Cinnamenu@json/files/Cinnamenu@json/settings-schema.json
+++ b/Cinnamenu@json/files/Cinnamenu@json/settings-schema.json
@@ -311,7 +311,7 @@
   "custom-menu-height": {
     "type": "spinbutton",
     "default": 530,
-    "min": 530,
+    "min": 360,
     "max": 9999,
     "step": 1,
     "units": "px",


### PR DESCRIPTION
  * Lowered the minimum possible custom height to 360px.
  * Lowered the minimum possible number of columns to 2.
  * Reduced the widths of the columns so the menu is more compact.

Closes #1918, closes #1928 