### PR TITLE
mem-monitor-text@datanom.net: add opportunity to customize label prefix

### DIFF
--- a/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/applet.js
+++ b/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/applet.js
@@ -6,10 +6,11 @@ const Mainloop = imports.mainloop;
 const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
 const Gettext = imports.gettext;
+const Settings = imports.ui.settings;
 const UUID = "mem-monitor-text@datanom.net";
 const GLib = imports.gi.GLib;
 
-Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale")
+Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
 
 function _(str) {
   return Gettext.dgettext(UUID, str);
@@ -26,6 +27,9 @@ MyApplet.prototype = {
         Applet.TextApplet.prototype._init.call(this, orientation);
 
 		try {
+            this.settings = new Settings.AppletSettings(this, UUID, this.instance_id);
+            this.settings.bindProperty(Settings.BindingDirection.IN, "mem-label", "mem_label", this._update, null);
+
 			this.itemOpenSysMon = new PopupMenu.PopupMenuItem(_("Open System Monitor"));
 			this.itemOpenSysMon.connect('activate', Lang.bind(this, this._runSysMonActivate));
 			this._applet_context_menu.addMenuItem(this.itemOpenSysMon);
@@ -61,10 +65,10 @@ MyApplet.prototype = {
 			this.buffer = this.gtop.buffer;
 			this.cached = this.gtop.cached;
 			this.maxmem = this.gtop.total;
-		
+
 			this.realuse = this.usage - this.buffer - this.cached;
 			let percent = Math.round((this.realuse * 100) / this.maxmem);
-			this.set_applet_label(_("   " + percent.toString()).slice(-3) + "%");
+			this.set_applet_label(this.mem_label + " " + percent.toString().slice(-3) + "%");
 			this.set_applet_tooltip(_("Click to open Gnome system monitor"));
 		}
 		catch (e) {
@@ -82,6 +86,5 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation) {
-	let myApplet = new MyApplet(orientation);
-	return myApplet;
+	return new MyApplet(orientation);
 }

--- a/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/applet.js
+++ b/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/applet.js
@@ -13,78 +13,78 @@ const GLib = imports.gi.GLib;
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
 
 function _(str) {
-  return Gettext.dgettext(UUID, str);
+    return Gettext.dgettext(UUID, str);
 }
 
 function MyApplet(orientation) {
-	this._init(orientation);
+    this._init(orientation);
 }
 
 MyApplet.prototype = {
-	__proto__: Applet.TextApplet.prototype,
+    __proto__: Applet.TextApplet.prototype,
 
     _init: function(orientation) {
         Applet.TextApplet.prototype._init.call(this, orientation);
 
-		try {
+        try {
             this.settings = new Settings.AppletSettings(this, UUID, this.instance_id);
             this.settings.bindProperty(Settings.BindingDirection.IN, "mem-label", "mem_label", this._update, null);
 
-			this.itemOpenSysMon = new PopupMenu.PopupMenuItem(_("Open System Monitor"));
-			this.itemOpenSysMon.connect('activate', Lang.bind(this, this._runSysMonActivate));
-			this._applet_context_menu.addMenuItem(this.itemOpenSysMon);
+            this.itemOpenSysMon = new PopupMenu.PopupMenuItem(_("Open System Monitor"));
+            this.itemOpenSysMon.connect('activate', Lang.bind(this, this._runSysMonActivate));
+            this._applet_context_menu.addMenuItem(this.itemOpenSysMon);
 
-			this.gtop = new GTop.glibtop_mem();
+            this.gtop = new GTop.glibtop_mem();
 
-			this._applet_label.set_style('min-width: 2.5em; text-align: left');
+            this._applet_label.set_style('min-width: 2.5em; text-align: left');
 
-			this.usage = 0;
-			this.maxmem = 0;
-			this.buffer = 0;
-			this.cached = 0;
+            this.usage = 0;
+            this.maxmem = 0;
+            this.buffer = 0;
+            this.cached = 0;
 
-			this._update();
-		}
-		catch (e) {
-			global.logError(e);
-		}
-	},
+            this._update();
+        }
+        catch (e) {
+            global.logError(e);
+        }
+    },
 
-	on_applet_clicked: function(event) {
-		this._runSysMon();
-	},
+    on_applet_clicked: function(event) {
+        this._runSysMon();
+    },
 
-	_runSysMonActivate: function() {
-		this._runSysMon();
-	},
+    _runSysMonActivate: function() {
+        this._runSysMon();
+    },
 
-	_update: function() {
-		try {
-			GTop.glibtop_get_mem(this.gtop);
-			this.usage = this.gtop.used;
-			this.buffer = this.gtop.buffer;
-			this.cached = this.gtop.cached;
-			this.maxmem = this.gtop.total;
+    _update: function() {
+        try {
+            GTop.glibtop_get_mem(this.gtop);
+            this.usage = this.gtop.used;
+            this.buffer = this.gtop.buffer;
+            this.cached = this.gtop.cached;
+            this.maxmem = this.gtop.total;
 
-			this.realuse = this.usage - this.buffer - this.cached;
-			let percent = Math.round((this.realuse * 100) / this.maxmem);
-			this.set_applet_label(this.mem_label + " " + percent.toString().slice(-3) + "%");
-			this.set_applet_tooltip(_("Click to open Gnome system monitor"));
-		}
-		catch (e) {
-			global.logError(e);
-		}
+            this.realuse = this.usage - this.buffer - this.cached;
+            let percent = Math.round((this.realuse * 100) / this.maxmem);
+            this.set_applet_label(this.mem_label + " " + percent.toString().slice(-3) + "%");
+            this.set_applet_tooltip(_("Click to open Gnome system monitor"));
+        }
+        catch (e) {
+            global.logError(e);
+        }
 
-		Mainloop.timeout_add(2000, Lang.bind(this, this._update));
-	},
+        Mainloop.timeout_add(2000, Lang.bind(this, this._update));
+    },
 
-	_runSysMon: function() {
-		let _appSys = Cinnamon.AppSystem.get_default();
-		let _gsmApp = _appSys.lookup_app('gnome-system-monitor.desktop');
-		_gsmApp.activate();
-	},
+    _runSysMon: function() {
+        let _appSys = Cinnamon.AppSystem.get_default();
+        let _gsmApp = _appSys.lookup_app('gnome-system-monitor.desktop');
+        _gsmApp.activate();
+    },
 };
 
 function main(metadata, orientation) {
-	return new MyApplet(orientation);
+    return new MyApplet(orientation);
 }

--- a/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/po/da.po
+++ b/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/po/da.po
@@ -18,15 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: da\n"
 
-#: applet.js:29
+#: applet.js:33
 msgid "Open System Monitor"
 msgstr "Åbn systemovervågning"
 
-#: applet.js:67
-msgid "  Mem: "
-msgstr "  Huk: "
-
-#: applet.js:68
+#: applet.js:72
 msgid "Click to open Gnome system monitor"
 msgstr "Klik for at åbne Gnome-systemovervågning"
 
@@ -37,3 +33,7 @@ msgstr "Viser forbruget af hukommelse."
 #. mem-monitor-text@datanom.net->metadata.json->name
 msgid "Simple Memory Monitor"
 msgstr "Enkel hukommelsesovervågning"
+
+#. mem-monitor-text@datanom.net->settings-schema.json->mem-label->tooltip
+msgid "Enter custom text to show in the panel."
+msgstr "Indtast selvvalgt tekst som vises i panelet."

--- a/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/po/hr.po
+++ b/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/po/hr.po
@@ -18,15 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Language: hr\n"
 
-#: applet.js:29
+#: applet.js:33
 msgid "Open System Monitor"
 msgstr "Otvori nadgledatelja sustava"
 
-#: applet.js:67
-msgid "  Mem: "
-msgstr "  Mem: "
-
-#: applet.js:68
+#: applet.js:72
 msgid "Click to open Gnome system monitor"
 msgstr "Kliknite za otvaranje Nadgledatelja sustava"
 

--- a/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/po/mem-monitor-text@datanom.net.pot
+++ b/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/po/mem-monitor-text@datanom.net.pot
@@ -17,15 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:29
+#: applet.js:33
 msgid "Open System Monitor"
 msgstr ""
 
-#: applet.js:67
-msgid "  Mem: "
-msgstr ""
-
-#: applet.js:68
+#: applet.js:72
 msgid "Click to open Gnome system monitor"
 msgstr ""
 
@@ -35,4 +31,8 @@ msgstr ""
 
 #. mem-monitor-text@datanom.net->metadata.json->name
 msgid "Simple Memory Monitor"
+msgstr ""
+
+#. mem-monitor-text@datanom.net->settings-schema.json->mem-label->tooltip
+msgid "Enter custom text to show in the panel."
 msgstr ""

--- a/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/po/sv.po
+++ b/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/po/sv.po
@@ -18,15 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Language: sv\n"
 
-#: applet.js:29
+#: applet.js:33
 msgid "Open System Monitor"
 msgstr "Öppna systemövervakaren"
 
-#: applet.js:67
-msgid "  Mem: "
-msgstr " Minne: "
-
-#: applet.js:68
+#: applet.js:72
 msgid "Click to open Gnome system monitor"
 msgstr "Klicka för att öppna systemövervakaren"
 
@@ -37,3 +33,7 @@ msgstr "Ett enkelt panelprogram som visar minnesanvändning."
 #. mem-monitor-text@datanom.net->metadata.json->name
 msgid "Simple Memory Monitor"
 msgstr "Enkel minnesövervakare"
+
+#. mem-monitor-text@datanom.net->settings-schema.json->mem-label->tooltip
+msgid "Enter custom text to show in the panel."
+msgstr "Ange anpassad text att visa i panelen"

--- a/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/po/zh_CN.po
+++ b/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/po/zh_CN.po
@@ -18,15 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "Language: zh_CN\n"
 
-#: applet.js:29
+#: applet.js:33
 msgid "Open System Monitor"
 msgstr "打开系统监视器"
 
-#: applet.js:67
-msgid "  Mem: "
-msgstr "  内存："
-
-#: applet.js:68
+#: applet.js:72
 msgid "Click to open Gnome system monitor"
 msgstr "点击打开Gnome系统监视器"
 
@@ -37,3 +33,7 @@ msgstr "一个显示内存使用率的简单的小程序。"
 #. mem-monitor-text@datanom.net->metadata.json->name
 msgid "Simple Memory Monitor"
 msgstr "简单的内存监视器"
+
+#. mem-monitor-text@datanom.net->settings-schema.json->mem-label->tooltip
+msgid "Enter custom text to show in the panel."
+msgstr "输入要在面板中显示的自定义文本。"

--- a/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/settings-schema.json
+++ b/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/settings-schema.json
@@ -1,0 +1,8 @@
+{
+ "mem-label" : {
+	"type" : "entry",
+	"default" : "mem:",
+	"description" : "Text:",
+	"tooltip" : "Enter custom text to show in the panel."
+ }
+}


### PR DESCRIPTION
It really looks strange, that you've decided to remove prefix (in pr https://github.com/linuxmint/cinnamon-spices-applets/pull/1920) instead of adding the opportunity to customize (or just remove) prefix in applet settings (like we have in `cpu-monitor-text@gnemonix`).

**Related issue:** https://github.com/linuxmint/cinnamon-spices-applets/issues/1422

Sorry for weird diff. The second commit is just about using spaces instead of tabs. (https://github.com/linuxmint/cinnamon-spices-applets/pull/1936/commits/9d1c096d0bada41eebc6d142c56cee542f8075dd)