### PR TITLE
Cinnamenu@json: Fix being unable to select context menu options from the first app button in a group

### DIFF
--- a/Cinnamenu@json/CHANGELOG.md
+++ b/Cinnamenu@json/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 
+### 3.2.5
+
+  * Fixed being unable to select a context menu option from the first app button in a category group.
+
 ### 3.2.4
 
   * Lowered the minimum possible custom height to 360px.

--- a/Cinnamenu@json/files/Cinnamenu@json/applet.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/applet.js
@@ -169,7 +169,7 @@ CinnamenuApplet.prototype = {
         appletReady: false,
         searchActive: false,
         itemEntered: false,
-        contextMenuIsOpen: false,
+        contextMenuIsOpen: null,
         menuHeight: 530,
         expressionActive: false,
         searchWebErrorsShown: false,

--- a/Cinnamenu@json/files/Cinnamenu@json/buttons.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/buttons.js
@@ -790,7 +790,7 @@ AppListGridButton.prototype = {
       || !this.buttonState.app
       || !this.description
       || this.state.dragIndex > -1
-      || this.state.contextMenuIsOpen) {
+      || this.state.contextMenuIsOpen != null) {
       return false;
     }
     if (opts.reset === 2) {
@@ -827,7 +827,7 @@ AppListGridButton.prototype = {
   },
 
   handleEnter: function (actor, event) {
-    if (this.state.contextMenuIsOpen || this.menu.isOpen || this.state.dragIndex > -1) {
+    if (this.state.contextMenuIsOpen != null || this.menu.isOpen || this.state.dragIndex > -1) {
       return false;
     }
 
@@ -881,7 +881,7 @@ AppListGridButton.prototype = {
     if (this.description) {
       this.buttonState.app.description = this.description;
       this.formatLabel({});
-      if (!this.state.contextMenuIsOpen && this.marqueeTimer) {
+      if (this.state.contextMenuIsOpen == null && this.marqueeTimer) {
         this.clearMarqueeTimer();
       }
     }
@@ -893,21 +893,20 @@ AppListGridButton.prototype = {
     }
   },
 
-  handleButtonRelease: function(actor, e){
+  handleButtonRelease: function(actor, e) {
     let button = !e ? 3 : e.get_button();
     if (button === 1) {
-      if (this.state.contextMenuIsOpen) {
+      if (this.state.contextMenuIsOpen != null) {
         if (this.menu.isOpen && this.menu._activeMenuItem) {
           this.menu._activeMenuItem.activate();
         } else {
           this.activateContextMenus(e, true);
-          this.state.set({contextMenuIsOpen: false});
+          this.state.set({contextMenuIsOpen: null});
         }
         return false;
       }
       this.activate(e);
     } else if (button === 3) {
-      // Prevent the menu from clipping if this button is partially visible.
       if (!this.state.isListView
         && this.buttonState.appType === ApplicationType._applications) {
         this.toggleActors(true);
@@ -1043,12 +1042,12 @@ AppListGridButton.prototype = {
 
       // In grid mode we will ensure our menu isn't overlapped by any other actors.
       if (!this.state.isListView) {
-        this.actor.raise_top();
+        this.actor.get_parent().set_child_above_sibling(this.actor, null);
       }
     } else {
       this.toggleActors(false);
       // Allow other buttons hover functions to take effect.
-      this.state.set({contextMenuIsOpen: false});
+      this.state.set({contextMenuIsOpen: null});
     }
     this.menu.toggle_with_options(this.state.settings.enableAnimation);
     return true

--- a/Cinnamenu@json/files/Cinnamenu@json/metadata.json
+++ b/Cinnamenu@json/files/Cinnamenu@json/metadata.json
@@ -3,6 +3,6 @@
   "name": "Cinnamenu",
   "description": "A flexible menu providing formatting options, web bookmarks, open window lookup, and search provider support with fuzzy searching.",
   "max-instances": 1,
-  "version": "3.2.4",
+  "version": "3.2.5",
   "cinnamon-version": ["3.2", "3.4", "3.6", "3.8"]
 }


### PR DESCRIPTION
This was caused by a regression in https://github.com/linuxmint/cinnamon-spices-applets/commit/57d7c4f2e4e03740289793e1f3e2cb9c8d185a37.

We actually do want to check for only null/undefined on `contextMenuIsOpen` because it stores the app index, which can be a falsey 0 value. This fixes up #1922 properly.

Closes #1958.