### PR TITLE
temperature@fevimu: Resolved 'NaN' applet value when 'sensors' command returns no Package or Core temperature but shows 'CPU Temperature'

### DIFF
--- a/temperature@fevimu/files/temperature@fevimu/applet.js
+++ b/temperature@fevimu/files/temperature@fevimu/applet.js
@@ -127,6 +127,7 @@ CPUTemperatureApplet.prototype = {
         let packageCount = 0;
         let s = 0;
         let n = 0; //sum and count
+        let temp = 0;
         for (let i = 0; i < tempInfo.length; i++) {
           if (tempInfo[i].label.indexOf('Package') > -1) {
             critical = tempInfo[i].crit ? tempInfo[i].crit : 0;
@@ -138,9 +139,16 @@ CPUTemperatureApplet.prototype = {
             s += tempInfo[i].value;
             n++;
           }
+          if (tempInfo[i].label.indexOf('CPU') > -1) {
+            temp = tempInfo[i].value;
+          }
           items.push(tempInfo[i].label + ' ' + this._formatTemp(tempInfo[i].value));
         }
-        let temp = (packageIds / packageCount) || (s / n);
+        if (packageCount != 0) {
+            temp = (packageIds / packageCount);
+        } else if (n != 0) {
+            temp = s / n;
+        }
         let label = this._formatTemp(temp);
         if (critical && temp >= critical) {
           this.title = _('Critical') + ': ' + label;


### PR DESCRIPTION
NaN was caused by division by zero while trying to calculate mean temp for all Packages/Cores. On my computer lm-sensors returns only 'CPU Temperature', no Package/Core temperatures.