### PR TITLE
temperature@fevimu: Updated cpuIdentifier to full label 'CPU Temperat…

### DIFF
--- a/temperature@fevimu/files/temperature@fevimu/applet.js
+++ b/temperature@fevimu/files/temperature@fevimu/applet.js
@@ -8,7 +8,7 @@ const Settings = imports.ui.settings;
 const Gettext = imports.gettext;
 
 const sensorRegex = /^([\sA-z\w]+[\s|:|\d]{1,4})(?:\s+\+)(\d+\.\d+)°[FC]|(?:\s+\()([a-z]+)(?:[\s=+]+)(\d+\.\d)°[FC],\s([a-z]+)(?:[\s=+]+)(\d+\.\d)/gm;
-const cpuIdentifiers = ['Tctl', 'CPU'];
+const cpuIdentifiers = ['Tctl', 'CPU Temperature'];
 
 const _ = function(str) {
   let translation = Gettext.gettext(str);


### PR DESCRIPTION
…ure' instead of substring 'CPU'. That's what is required after a807ec2ac305ecf19f7782598c33708076d27709.