### PR TITLE
gpaste-reloaded@feuerfuchs.eu: Avoid passing xlet context to SignalManager

### DIFF
--- a/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/applet.js
+++ b/gpaste-reloaded@feuerfuchs.eu/files/gpaste-reloaded@feuerfuchs.eu/applet.js
@@ -176,7 +176,7 @@ GPasteApplet.prototype = {
             this._historyName      = "";
             this._historyItems     = [];
             this._historyListItems = [];
-            this._signalManager    = new SignalManager.SignalManager(this);
+            this._signalManager    = new SignalManager.SignalManager(null);
 
             GPaste.Client.new(Lang.bind(this, function (obj, result) {
                 this._client = GPaste.Client.new_finish(result);
@@ -185,14 +185,14 @@ GPasteApplet.prototype = {
                 // Watch client signals
 
                 // Client
-                this._signalManager.connect(this._client, 'update',         this._onClientUpdate);
-                this._signalManager.connect(this._client, 'show-history',   this._onClientShowHistory);
-                this._signalManager.connect(this._client, 'switch-history', this._onClientSwitchHistory);
-                this._signalManager.connect(this._client, 'tracking',       this._onClientTracking);
-                this._signalManager.connect(this._client, 'delete-history', this._onClientDeleteHistory);
+                this._signalManager.connect(this._client, 'update',         Lang.bind(this, this._onClientUpdate));
+                this._signalManager.connect(this._client, 'show-history',   Lang.bind(this, this._onClientShowHistory));
+                this._signalManager.connect(this._client, 'switch-history', Lang.bind(this, this._onClientSwitchHistory));
+                this._signalManager.connect(this._client, 'tracking',       Lang.bind(this, this._onClientTracking));
+                this._signalManager.connect(this._client, 'delete-history', Lang.bind(this, this._onClientDeleteHistory));
 
                 // Client settings
-                this._signalManager.connect(this._clientSettings, 'changed::max-displayed-history-size', this._createHistoryItems);
+                this._signalManager.connect(this._clientSettings, 'changed::max-displayed-history-size', Lang.bind(this, this._createHistoryItems));
 
                 //
                 // Init


### PR DESCRIPTION
Passing context to the SignalManager constructor creates circular references, which makes memory management more complicated for the JS engine.

This is a fix for https://github.com/linuxmint/Cinnamon/pull/7868.

@Feuerfuchs 