### PR TITLE
collapsible-systray@feuerfuchs.eu: Avoid passing xlet context to SignalManager

### DIFF
--- a/collapsible-systray@feuerfuchs.eu/files/collapsible-systray@feuerfuchs.eu/applet.js
+++ b/collapsible-systray@feuerfuchs.eu/files/collapsible-systray@feuerfuchs.eu/applet.js
@@ -94,7 +94,7 @@ CollapsibleSystrayApplet.prototype = {
         // Variables
 
         this._direction          = (orientation == St.Side.TOP || orientation == St.Side.BOTTOM) ? this.Direction.HORIZONTAL : this.Direction.VERTICAL;
-        this._signalManager      = new SignalManager.SignalManager(this);
+        this._signalManager      = new SignalManager.SignalManager(null);
         this._hovering           = false;
         this._hoverTimerID       = null;
         this._registeredAppIcons = {};


### PR DESCRIPTION
Passing context to the SignalManager constructor creates circular references, which makes memory management more complicated for the JS engine.

This is a fix for https://github.com/linuxmint/Cinnamon/pull/7868.

@Feuerfuchs 