### PR TITLE
CinnVIIStarkMenu@NikoKrause: replace missing default terminal icon

### DIFF
--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/3.4/settings-schema.json
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/3.4/settings-schema.json
@@ -310,7 +310,7 @@
         {"checkbox": true, "command": "xdg-open computer:///",  "label": "Computer", "icon": "computer"},
         {"checkbox": true, "command": "cinnamon-settings",      "label": "System Settings", "icon": "preferences-system"},
         {"checkbox": true, "command": "system-config-printer",  "label": "Printers", "icon": "printer"},
-        {"checkbox": true, "command": "gnome-terminal",         "label": "Terminal", "icon": "terminal"},
+        {"checkbox": true, "command": "gnome-terminal",         "label": "Terminal", "icon": "utilities-terminal"},
         {"checkbox": true, "command": "cinnamon-settings info", "label": "System Info", "icon": "cs-details"}
     ]
  },


### PR DESCRIPTION
The desktop file for GNOME terminal in my system uses "utilities-terminal", not "terminal". That icon is not even in the hicolor theme nor in Adwaita on my system, so it is missing.