### PR TITLE
bash-sensors: fix stylesheet handling

### DIFF
--- a/bash-sensors@pkkk/files/bash-sensors@pkkk/applet.js
+++ b/bash-sensors@pkkk/files/bash-sensors@pkkk/applet.js
@@ -53,7 +53,12 @@ MyApplet.prototype = {
 
     on_applet_clicked: function (event) {
         if (!this.menu.isOpen) {
-            this.menu.setCustomStyleClass("click")
+            if(this.menu.setCustomStyleClass) {
+                this.menu.setCustomStyleClass("click");
+            }
+            else if(this.menu.actor.add_style_class_name) {
+                this.menu.actor.add_style_class_name("click");
+            }
             let cmd = (this.menuScript && this.menuScript.trim()) ? this.menuScript : this.script1;
             let cmd_output = this.spawn_sync(cmd);
             let cmd_stdout = cmd_output[0] ? cmd_output[1].toString() : _("script error");
@@ -63,7 +68,6 @@ MyApplet.prototype = {
         this.update();
         this.menu.toggle();
     },
-
     update: function () {
         if (this.dynamicTooltip) {
             let cmd = (this.tooltipScript && this.tooltipScript.trim()) ? this.tooltipScript : this.script1;


### PR DESCRIPTION
older Cinnamon versions do not have the setCustomStyleClass method and use actor.add_style_class_name instead