### PR TITLE
multicore-sys-monitor@ccadeptic23: 1.8.7

### DIFF
--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/ConfigSettings.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/ConfigSettings.js
@@ -84,18 +84,6 @@ ConfigSettings.prototype = {
   },
   adjustDevices: function(deviceType, newDeviceList) {
     let isChanged = false;
-    // Do a migration for the switch from storing devices in objects to arrays
-    if (this._prefs[deviceType].devices != null
-      && !Array.isArray(this._prefs[deviceType].devices)) {
-      let keys = Object.keys(this._prefs[deviceType].devices);
-      let devices = [];
-      for (let i = 0; i < keys.length; i++) {
-        this._prefs[deviceType].devices[keys[i]].id = keys[i];
-        devices.push(this._prefs[deviceType].devices[keys[i]]);
-      }
-      this._prefs[deviceType].devices = devices;
-      isChanged = true;
-    }
 
     let interfaceKeys = map(this._prefs[deviceType].devices, function(device) {
       return device.id;
@@ -122,21 +110,20 @@ ConfigSettings.prototype = {
     }
 
     for (let i = 0; i < newDeviceList.length; i++) {
+      let refIndex = findIndex(this._prefs[deviceType].devices, function(device) {
+        return device.id === newDeviceList[i].id;
+      });
       if (interfaceKeys.indexOf(newDeviceList[i].id) === -1) {
         // Use default values
         this._prefs[deviceType].devices.push({
           id: newDeviceList[i].id,
-          enabled: true,
+          enabled: refIndex > -1,
           show: true,
           colors: [[1, 1, 1, 0.8], [0, 0, 0, 0.6]]
         });
         isChanged = true;
       } else {
         // reuse it and its values
-        let refIndex = findIndex(this._prefs[deviceType].devices, function(device) {
-          return device.id === newDeviceList[i].id;
-        });
-
         if (refIndex > -1) {
           Object.assign(this._prefs[deviceType].devices[refIndex], newDeviceList[i]);
           this._prefs[deviceType].devices[refIndex].show = 4;

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/applet.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/applet.js
@@ -162,7 +162,7 @@ MyApplet.prototype = {
     this.actor.set_offscreen_redirect(Clutter.OffscreenRedirect.ALWAYS);
     this.childProcessHandler = null;
     this.metadata = metadata;
-    this._panelHeight = panel_height;
+    this.panelHeight = panel_height;
     this.configFilePath = GLib.get_home_dir() + '/.cinnamon/configs/' + metadata.uuid;
     this.shouldUpdate = true;
 
@@ -202,7 +202,7 @@ MyApplet.prototype = {
     this.graphArea = new St.DrawingArea();
 
     this.graphArea.width = 1;
-    this.graphArea.height = this._panelHeight * global.ui_scale;
+    this.graphArea.height = this.panelHeight * global.ui_scale;
 
     this.graphArea.connect('repaint', Lang.bind(this, this.onGraphRepaint));
 
@@ -246,6 +246,10 @@ MyApplet.prototype = {
     this.graphArea.destroy();
     this.networkProvider.destroy();
     this.diskProvider.destroy();
+  },
+
+  on_panel_height_changed: function() {
+    this.panelHeight = this._panelHeight;
   },
 
   _initContextMenu: function() {
@@ -347,7 +351,7 @@ MyApplet.prototype = {
             // no label for the backdrop
             false,
             width,
-            this._panelHeight - 2 * global.ui_scale,
+            this.panelHeight - 2 * global.ui_scale,
             [0, 0, 0, 0],
             // clear background so that it doesn't mess up the other one
             [0, 0, 0, 0],
@@ -361,7 +365,7 @@ MyApplet.prototype = {
           areaContext,
           this.configSettings._prefs.labelsOn,
           width,
-          this._panelHeight - 2 * global.ui_scale,
+          this.panelHeight - 2 * global.ui_scale,
           this.configSettings._prefs.labelColor,
           this.configSettings._prefs.backgroundColor,
           this.configSettings['get' + properties[i].abbrev + 'ColorList']()
@@ -373,7 +377,7 @@ MyApplet.prototype = {
       }
     }
     area.set_width(xOffset > 1 ? xOffset - 1 : 1);
-    area.set_height(this._panelHeight);
+    area.set_height(this.panelHeight);
   }
 };
 

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
@@ -1,7 +1,7 @@
 {
     "uuid": "multicore-sys-monitor@ccadeptic23",
     "name": "Multi-Core System Monitor",
-    "version": "1.8.6",
+    "version": "1.8.7",
     "description": "Displays in realtime the cpu usage for each core/cpu and overall memory usage.",
     "multiversion": true,
     "cinnamon-version": ["2.8", "3.0", "3.2", "3.4", "3.6", "3.8", "4.0"]


### PR DESCRIPTION
- Fixes compatibility with cinnamon/new-panel-layout. This seems to be the only applet that attempted to assign to `this._panelHeight`, which is now a getter in ui/applet.
- Fixes the enabled state on devices not persisting after settings change.

Closes #2024 