### PR TITLE
hwmonitor@sylfurd: Fixed this.panel is null

### DIFF
--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/applet.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/applet.js
@@ -54,15 +54,15 @@ try {
     gtopFailed = true;
 }
 
-function GraphicalHWMonitorApplet(metadata, orientation, panel_height) {
-    this._init(metadata, orientation, panel_height);
+function GraphicalHWMonitorApplet(metadata, orientation, panel_height, instance_id) {
+    this._init(metadata, orientation, panel_height, instance_id);
 }
 
 GraphicalHWMonitorApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function (metadata, orientation, panel_height) {
-        Applet.IconApplet.prototype._init.call(this, orientation, panel_height);
+    _init: function (metadata, orientation, panel_height, instance_id) {
+        Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
 
         this.graphs = [];
 
@@ -306,6 +306,6 @@ MemDataProvider.prototype = {
 };
 
 
-function main(metadata, orientation, panel_height) {
-    return new GraphicalHWMonitorApplet(metadata, orientation, panel_height);
+function main(metadata, orientation, panel_height, instance_id) {
+    return new GraphicalHWMonitorApplet(metadata, orientation, panel_height, instance_id);
 }


### PR DESCRIPTION
Fixed an error where hwmonitor totally stoped working with Cinnamon 4.0.0

Example error :
```
[hwmonitor@sylfurd]: this.panel is null
[hwmonitor@sylfurd]: Failed to evaluate 'main' function on applet: hwmonitor@sylfurd/19
trace t=2018-11-07T10:40:08Z 
<----------------
get _panelHeight@/usr/share/cinnamon/js/ui/applet.js:630:9
anonymous/GraphicalHWMonitorApplet.prototype._init@/home/d1ceward/.local/share/cinnamon/applets/hwmonitor@sylfurd/applet.js:80:9
GraphicalHWMonitorApplet@/home/d1ceward/.local/share/cinnamon/applets/hwmonitor@sylfurd/applet.js:58:5
main@/home/d1ceward/.local/share/cinnamon/applets/hwmonitor@sylfurd/applet.js:310:12
createApplet@/usr/share/cinnamon/js/ui/appletManager.js:580:18
addAppletToPanels@/usr/share/cinnamon/js/ui/appletManager.js:355:22
finishExtensionLoad@/usr/share/cinnamon/js/ui/appletManager.js:94:14
Extension.prototype._init/<@/usr/share/cinnamon/js/ui/extension.js:253:17
```

Applet has no issued author/maintainer
[https://github.com/linuxmint/cinnamon-spices-applets/blob/master/.github/CODEOWNERS](https://github.com/linuxmint/cinnamon-spices-applets/blob/master/.github/CODEOWNERS#L115)