### PR TITLE
Cinnamenu: Fix multi-instance behavior

### DIFF
--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/applet.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/applet.js
@@ -490,7 +490,7 @@ class CinnamenuApplet extends TextIconApplet {
       this.state.settings.overlayKey,
       () => {
         if (Main.overview.visible || Main.expo.visible) return;
-        if (global.screen.get_current_monitor() === this.panel.monitorIndex) {
+        if (!this.getOtherInstance || global.screen.get_current_monitor() === this.panel.monitorIndex) {
           this.menu.toggle_with_options(this.state.settings.enableAnimation);
         } else if (typeof this.getOtherInstance === 'function') {
           let instance = this.getOtherInstance();


### PR DESCRIPTION
Fixes an issue with the menu only opening on the primary monitor when activated with the Super key when only one instance is in use.