### PR TITLE
Fixed broken commands in ShutdownApplet.

### DIFF
--- a/ShutdownApplet@DeathMD/files/ShutdownApplet@DeathMD/applet.js
+++ b/ShutdownApplet@DeathMD/files/ShutdownApplet@DeathMD/applet.js
@@ -42,26 +42,23 @@ MyApplet.prototype = {
             this.menu.addMenuItem(this._contentSection);      
                                                                                        
   	    this.menu.addAction(_("Screen Lock"), function(event) {
-                Util.spawnCommandLine("dbus-send --session --type=method_call --print-reply --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.Lock");
-		Util.spawnCommandLine("gnome-screensaver-command -l");
+		Util.spawnCommandLine("cinnamon-screensaver-command --lock");
             });
                                                           
-
             this.menu.addAction(_("Suspend"), function(event) {
-                Util.spawnCommandLine("dbus-send --print-reply --system --dest=org.freedesktop.UPower /org/freedesktop/UPower org.freedesktop.UPower.Suspend");
+		Util.spawnCommandLine("systemctl suspend");
             });
-	    
                           
-             this.menu.addAction(_("Restart"), function(event) {
-                Util.spawnCommandLine("dbus-send --system --print-reply --system --dest=org.freedesktop.ConsoleKit /org/freedesktop/ConsoleKit/Manager org.freedesktop.ConsoleKit.Manager.Restart");
+            this.menu.addAction(_("Restart"), function(event) {
+		Util.spawnCommandLine("systemctl reboot");
             });  
             
-        this.menu.addAction(_("Log Out"), function(event) {
-                Util.spawnCommandLine("dbus-send --session --type=method_call --print-reply --dest=org.gnome.SessionManager /org/gnome/SessionManager org.gnome.SessionManager.Logout uint32:1");
+	    this.menu.addAction(_("Log Out"), function(event) {
+		Util.spawnCommandLine("gnome-session-quit --no-prompt");
             });
             
-	     this.menu.addAction(_("Shutdown"), function(event) {
-                Util.spawnCommandLine("dbus-send --system --print-reply --system --dest=org.freedesktop.ConsoleKit /org/freedesktop/ConsoleKit/Manager org.freedesktop.ConsoleKit.Manager.Stop");
+	    this.menu.addAction(_("Shutdown"), function(event) {
+		Util.spawnCommandLine("systemctl poweroff");
             });                        
         }
         catch (e) {

--- a/ShutdownApplet@DeathMD/info.json
+++ b/ShutdownApplet@DeathMD/info.json
@@ -1,4 +1,4 @@
 {
-    "author": "none",
+    "author": "icarter09",
     "original_author": "DeathMD"
 }


### PR DESCRIPTION
@jaszhix or @NikoKrause:

All of the commands, except 'log out', were not working. Fixed the broken commands. This PR should fix #1053. 

Also took ownership of this applet once I realized it was no longer being maintained. 