### PR TITLE
vpnLookOut@claudiux v3.3.0 - A new option allows requested disconnection…

### DIFF
--- a/vpnLookOut@claudiux/CHANGELOG.md
+++ b/vpnLookOut@claudiux/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 3.3.0~20181120
+  * New option in Settings (VPN layout):
+   * "Do not try to reconnect automatically if the VPN has been disconnected by the user"
+   * This option appears only when the option "Try to reconnect to VPN when it shuts down incidentally" is checked.
+
 ### 3.2.1~20181115
   * Improves display and management of Activity Log.
 

--- a/vpnLookOut@claudiux/files/vpnLookOut@claudiux/3.8/settings-schema.json
+++ b/vpnLookOut@claudiux/files/vpnLookOut@claudiux/3.8/settings-schema.json
@@ -45,7 +45,8 @@
                 "vpnInterface",
                 "vpnName",
                 "connectAtStartup",
-                "reconnect"
+                "reconnect",
+                "respectUserRequest"
             ]
         },
         "section2": {
@@ -120,6 +121,14 @@
         "description": "Try to reconnect to VPN when it shuts down incidentally.",
         "tooltip": "Checking this allows this applet to try to reconnect to VPN when it shuts down incidentally."
     },
+    "respectUserRequest": {
+		"type": "checkbox",
+        "indent": true,
+        "default": false,
+        "description": "Do not try to reconnect automatically if the VPN has been disconnected by the user.",
+        "tooltip": "If, by this applet only, the user disconnects the VPN, then no automatic reconnection will be tried.",
+        "dependency": "reconnect"
+	},
     "refreshInterval-spinner": {
         "type": "spinbutton",
         "default": 5,

--- a/vpnLookOut@claudiux/files/vpnLookOut@claudiux/CHANGELOG.md
+++ b/vpnLookOut@claudiux/files/vpnLookOut@claudiux/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 3.3.0~20181120
+  * New option in Settings (VPN layout):
+   * "Do not try to reconnect automatically if the VPN has been disconnected by the user"
+   * This option appears only when the option "Try to reconnect to VPN when it shuts down incidentally" is checked.
+
 ### 3.2.1~20181115
   * Improves display and management of Activity Log.
 

--- a/vpnLookOut@claudiux/files/vpnLookOut@claudiux/HELP.md
+++ b/vpnLookOut@claudiux/files/vpnLookOut@claudiux/HELP.md
@@ -142,6 +142,8 @@ _Connect to VPN as this applet starts_: Useful if you want to be connected to yo
 
 _Try to reconnect to VPN when it shuts down incidentally_: Useful if being connected to your VPN is paramount.
 
+_Do not try to reconnect automatically if the VPN has been disconnected by the user_ : If, by this applet _only_, the user disconnects the VPN, then no automatic reconnection will be tried.
+
 **Activity Logs**
 
 _Log the VPN status changes and the VPN-related Apps status changes_: This option allows this applet to log the VPN status changes and the VPN-related applications status changes. You will can display the log file to make diagnostics.

--- a/vpnLookOut@claudiux/files/vpnLookOut@claudiux/help.html
+++ b/vpnLookOut@claudiux/files/vpnLookOut@claudiux/help.html
@@ -177,6 +177,7 @@ apt install transmission transmission-gtk</p>
 <p><em>VPN Name</em>: This information is automatically changed when connecting to a VPN. It therefore contains the name of the last VPN to which you connected.</p>
 <p><em>Connect to VPN as this applet starts</em>: Useful if you want to be connected to your VPN at startup of Cinnamon, immediatly after you log in.</p>
 <p><em>Try to reconnect to VPN when it shuts down incidentally</em>: Useful if being connected to your VPN is paramount.</p>
+<p><em>Do not try to reconnect automatically if the VPN has been disconnected by the user</em> : If, by this applet <em>only</em>, the user disconnects the VPN, then no automatic reconnection will be tried.</p>
 <p><strong>Activity Logs</strong></p>
 <p><em>Log the VPN status changes and the VPN-related Apps status changes</em>: This option allows this applet to log the VPN status changes and the VPN-related applications status changes. You will can display the log file to make diagnostics.</p>
 <p><em>Lifetime (days)</em>: Lifetime of a record in the log file, in days. When this applet starts, then once a day, the too old records are deleted from the log file.</p>

--- a/vpnLookOut@claudiux/files/vpnLookOut@claudiux/metadata.json
+++ b/vpnLookOut@claudiux/files/vpnLookOut@claudiux/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "vpnLookOut@claudiux",
     "max-instances": "1",
     "name": "VPN Look-Out Applet",
-    "version": "3.2.1~20181115",
+    "version": "3.3.0~20181120",
     "hide-configuration": false,
     "description": "A Cinnamon applet that watches over the VPN link, displays its status, allows to connect at start-up to the last VPN used, allows to reconnect the VPN link if it incidentally drops, and can stop or restart VPN-related apps according to the state of the VPN.",
     "multiversion": true,
@@ -14,5 +14,6 @@
         "3.6",
         "3.8",
         "4.0"
-    ]
+    ],
+    "last-edited": 1542542528
 }

--- a/vpnLookOut@claudiux/files/vpnLookOut@claudiux/po/fr.po
+++ b/vpnLookOut@claudiux/files/vpnLookOut@claudiux/po/fr.po
@@ -5,10 +5,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: vpnLookOut@claudiux v3.2.0~20181111\n"
+"Project-Id-Version: vpnLookOut@claudiux v3.3.0~20181120\n"
 "Report-Msgid-Bugs-To: Claudiux <claude.clerc@gmail.com>\n"
 "POT-Creation-Date: 2017-12-02 19:59+0100\n"
-"PO-Revision-Date: 2018-11-11 22:54+0100\n"
+"PO-Revision-Date: 2018-11-21 00:19+0100\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -226,59 +226,67 @@ msgstr "est pleinement fonctionnel."
 msgid "All dependencies are installed"
 msgstr "Toutes les dépendances sont installées"
 
-#: 3.8/settings-schema.json:7
+#: 3.8/settings-schema.json:12
 msgid "VPN-related Apps Manager"
 msgstr "Gestionnaire d'applications liées au VPN"
 
-#: 3.8/settings-schema.json:49
+#: 3.8/settings-schema.json:77
 msgid "Settings"
 msgstr "Paramètres"
 
-#: 3.8/settings-schema.json:54
+#: 3.8/settings-schema.json:84
 msgid "Managed Apps"
 msgstr "Applications gérées"
 
-#: 3.8/settings-schema.json:59
+#: 3.8/settings-schema.json:91
 msgid "Activity Logs"
 msgstr "Journal d'activité"
 
-#: 3.8/settings-schema.json:97
+#: 3.8/settings-schema.json:128
+msgid "Do not try to reconnect automatically if the VPN has been disconnected by the user."
+msgstr "Ne pas essayer de se reconnecter automatiquement si le VPN a été déconnecté par l'utilisateur."
+
+#: 3.8/settings-schema.json:129
+msgid "If, by this applet only, the user disconnects the VPN, then no automatic reconnection will be tried."
+msgstr "Si, par cette applet seulement, l'utilisateur déconnecte le VPN, alors aucune reconnexion automatique ne sera tentée."
+
+#: 3.8/settings-schema.json:139
 msgid "Refresh interval:"
 msgstr "Intervalle de rafraîchissement :"
 
-#: 3.8/settings-schema.json:98
+#: 3.8/settings-schema.json:140
 msgid "Time interval, in seconds, between two verifications of VPN link status. A low value increases security but causes more activity. Choose a value that is greater as your computer is slow."
 msgstr "Intervalle de temps, en secondes, entre deux vérifications de l’état de la liaison VPN. Une valeur faible augmente la sécurité mais génère plus d'activité. Choisissez une valeur d'autant plus grande que votre ordinateur est lent."
 
-#: 3.8/settings-schema.json:115
+#: 3.8/settings-schema.json:156
 msgid "Emit an audible alert when VPN shuts down."
 msgstr "Émettre une alerte sonore quand le VPN tombe."
 
-#: 3.8/settings-schema.json:116
+#: 3.8/settings-schema.json:157
 msgid "Checking this allows this applet to emit an audible alert when VPN shuts down."
 msgstr "Cocher cette option permet à cette applet d'émettre un son quand le VPN est tombé."
 
-#: 3.8/settings-schema.json:122
+#: 3.8/settings-schema.json:163
 msgid "Emit this audible alert when this Applet starts, if VPN is down."
 msgstr "Émettre cette alerte sonore au démarrage de cette applet, si la liaison VPN n'est pas active."
 
-#: 3.8/settings-schema.json:123
+#: 3.8/settings-schema.json:164
 msgid "Check this if you want to emit this audible alert when this Applet starts, if VPN is down."
 msgstr "Cochez cette case si vous voulez émettre cette alerte sonore dès le démarrage de cette applet, si la connexion VPN n'est pas active."
 
-#: 3.8/settings-schema.json:135
+#: 3.8/settings-schema.json:176
 msgid "Manage VPN-related Apps"
 msgstr "Gérer les applications liées au VPN"
 
-#: 3.8/settings-schema.json:136
+#: 3.8/settings-schema.json:177
 msgid "This option allows this applet to manage the VPN-related applications you listed above."
 msgstr "Cette option permet à cette applet de gérer les applications liées au VPN que vous aurez énumérées ci-dessus."
 
-#: 3.8/settings-schema.json:140
+#: 3.8/settings-schema.json:181
 msgid "Managed applications"
 msgstr "Applications gérées"
 
-#: 3.8/settings-schema.json:141
+#: 3.8/settings-schema.json:182
 msgid ""
 "Name: What you want.\n"
 "Command: The command to run the application, without its path.\n"
@@ -286,37 +294,37 @@ msgid ""
 "Shutdown: Set to TRUE if you want to close the application as soon as the VPN link is stopped.\n"
 "VPN only: Set to TRUE if you want to quickly stop this application if it is started while the VPN is idle."
 msgstr ""
-"Nom : Nom de l'application.\n"
+"Nom : Ce que vous voulez.\n"
 "Commande : La commande permettant de lancer l'application, sans son chemin.\n"
 "Redémarrer : TRUE si vous voulez redémarrer cette application dès que le lien VPN redevient actif.\n"
 "Fermer : TRUE si vous voulez que cette application soit fermée dès que le lien VPN est perdu.\n"
 "VPN seulement : TRUE si vous voulez fermer rapidement cette application, si elle est lancée pendant que le VPN est inactif."
 
-#: 3.8/settings-schema.json:145
+#: 3.8/settings-schema.json:186
 msgid "Name"
 msgstr "Nom"
 
-#: 3.8/settings-schema.json:150
+#: 3.8/settings-schema.json:191
 msgid "Command"
 msgstr "Commande"
 
-#: 3.8/settings-schema.json:155
+#: 3.8/settings-schema.json:196
 msgid "Restart"
 msgstr "Redémarrer"
 
-#: 3.8/settings-schema.json:160
+#: 3.8/settings-schema.json:201
 msgid "Shut down"
 msgstr "Fermer"
 
-#: 3.8/settings-schema.json:165
+#: 3.8/settings-schema.json:206
 msgid "VPN only"
 msgstr "VPN seulement"
 
-#: 3.8/settings-schema.json:184
+#: 3.8/settings-schema.json:225
 msgid "Log the VPN status changes and the VPN-related Apps status changes"
 msgstr "Consigner les changements d'état du VPN et les changements d'état des applications liées au VPN"
 
-#: 3.8/settings-schema.json:185
+#: 3.8/settings-schema.json:226
 msgid ""
 "This option allows this applet to log the VPN status changes and the VPN-related applications status changes.\n"
 "You will can display the log file to make diagnostics."
@@ -324,34 +332,34 @@ msgstr ""
 "Cette option permet à cette applet de consigner les changements d'état du VPN et les changements d'état des applications liées au VPN.\n"
 "Vous pourrez afficher le fichier journal pour effectuer des diagnostics."
 
-#: 3.8/settings-schema.json:208
+#: 3.8/settings-schema.json:249
 msgid "Lifetime (days)"
 msgstr "Durée de vie (en jours)"
 
-#: 3.8/settings-schema.json:209
+#: 3.8/settings-schema.json:250
 msgid "Lifetime of a record in the log file, in days."
 msgstr "Durée de vie, en jours, d'un événement enregistré dans le journal."
 
-#: 3.8/applet.js:311
+#: 3.8/applet.js:331
 msgid "TRUE"
 msgstr "OUI"
 
-#: 3.8/applet.js:312
+#: 3.8/applet.js:332
 msgid "FALSE"
 msgstr "NON"
 
-#: 3.8/applet.js:890
+#: 3.8/applet.js:922
 msgid "View Activity Logs"
 msgstr "Journal d'activité"
 
-#: 3.8/applet.js:991
+#: 3.8/applet.js:1023
 msgid "Started by vpnLookOut: "
 msgstr "Démarré par vpnLookOut: "
 
-#: 3.8/applet.js:1017
+#: 3.8/applet.js:1049
 msgid "Blocked by vpnLookOut: "
 msgstr "Bloqué par vpnLookOut: "
 
-#: 3.8/applet.js:1061
+#: 3.8/applet.js:1097
 msgid "Stopped by vpnLookOut: "
 msgstr "Fermé par vpnLookOut: "

--- a/vpnLookOut@claudiux/files/vpnLookOut@claudiux/po/vpnLookOut@claudiux.pot
+++ b/vpnLookOut@claudiux/files/vpnLookOut@claudiux/po/vpnLookOut@claudiux.pot
@@ -6,10 +6,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: vpnLookOut@claudiux v3.2.0~20181111\n"
+"Project-Id-Version: vpnLookOut@claudiux v3.3.0~20181120\n"
 "Report-Msgid-Bugs-To: Claudiux <claude.clerc@gmail.com>\n"
 "POT-Creation-Date: 2017-12-02 19:59+0100\n"
-"PO-Revision-Date: 2018-11-12 10:18+0100\n"
+"PO-Revision-Date: 2018-11-21 00:16+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
@@ -225,115 +225,123 @@ msgstr ""
 msgid "VPN-related Apps Manager"
 msgstr ""
 
-#: 3.8/settings-schema.json:76
+#: 3.8/settings-schema.json:77
 msgid "Settings"
 msgstr ""
 
-#: 3.8/settings-schema.json:83
+#: 3.8/settings-schema.json:84
 msgid "Managed Apps"
 msgstr ""
 
-#: 3.8/settings-schema.json:90
+#: 3.8/settings-schema.json:91
 msgid "Activity Logs"
 msgstr ""
 
-#: 3.8/settings-schema.json:130
+#: 3.8/settings-schema.json:128
+msgid "Do not try to reconnect automatically if the VPN has been disconnected by the user."
+msgstr ""
+
+#: 3.8/settings-schema.json:129
+msgid "If, by this applet only, the user disconnects the VPN, then no automatic reconnection will be tried."
+msgstr ""
+
+#: 3.8/settings-schema.json:139
 msgid "Refresh interval:"
 msgstr ""
 
-#: 3.8/settings-schema.json:131
+#: 3.8/settings-schema.json:140
 msgid "Time interval, in seconds, between two verifications of VPN link status. A low value increases security but causes more activity. Choose a value that is greater as your computer is slow."
 msgstr ""
 
-#: 3.8/settings-schema.json:147
+#: 3.8/settings-schema.json:156
 msgid "Emit an audible alert when VPN shuts down."
 msgstr ""
 
-#: 3.8/settings-schema.json:148
+#: 3.8/settings-schema.json:157
 msgid "Checking this allows this applet to emit an audible alert when VPN shuts down."
 msgstr ""
 
-#: 3.8/settings-schema.json:154
+#: 3.8/settings-schema.json:163
 msgid "Emit this audible alert when this Applet starts, if VPN is down."
 msgstr ""
 
-#: 3.8/settings-schema.json:155
+#: 3.8/settings-schema.json:164
 msgid "Check this if you want to emit this audible alert when this Applet starts, if VPN is down."
 msgstr ""
 
-#: 3.8/settings-schema.json:167
+#: 3.8/settings-schema.json:176
 msgid "Manage VPN-related Apps"
 msgstr ""
 
-#: 3.8/settings-schema.json:168
+#: 3.8/settings-schema.json:177
 msgid "This option allows this applet to manage the VPN-related applications you listed above."
 msgstr ""
 
-#: 3.8/settings-schema.json:172
+#: 3.8/settings-schema.json:181
 msgid "Managed applications"
 msgstr ""
 
-#: 3.8/settings-schema.json:173
+#: 3.8/settings-schema.json:182
 msgid "Name: What you want.\nCommand: The command to run the application, without its path.\nRestart: Set to TRUE if you want to restart this application as soon as the VPN link becomes active again.\nShutdown: Set to TRUE if you want to close the application as soon as the VPN link is stopped.\nVPN only: Set to TRUE if you want to quickly stop this application if it is started while the VPN is idle."
 msgstr ""
 
-#: 3.8/settings-schema.json:177
+#: 3.8/settings-schema.json:186
 msgid "Name"
 msgstr ""
 
-#: 3.8/settings-schema.json:182
+#: 3.8/settings-schema.json:191
 msgid "Command"
 msgstr ""
 
-#: 3.8/settings-schema.json:187
+#: 3.8/settings-schema.json:196
 msgid "Restart"
 msgstr ""
 
-#: 3.8/settings-schema.json:192
+#: 3.8/settings-schema.json:201
 msgid "Shut down"
 msgstr ""
 
-#: 3.8/settings-schema.json:197
+#: 3.8/settings-schema.json:206
 msgid "VPN only"
 msgstr ""
 
-#: 3.8/settings-schema.json:216
+#: 3.8/settings-schema.json:225
 msgid "Log the VPN status changes and the VPN-related Apps status changes"
 msgstr ""
 
-#: 3.8/settings-schema.json:217
+#: 3.8/settings-schema.json:226
 msgid "This option allows this applet to log the VPN status changes and the VPN-related applications status changes.\nYou will can display the log file to make diagnostics."
 msgstr ""
 
-#: 3.8/settings-schema.json:240
+#: 3.8/settings-schema.json:249
 msgid "Lifetime (days)"
 msgstr ""
 
-#: 3.8/settings-schema.json:241
+#: 3.8/settings-schema.json:250
 msgid "Lifetime of a record in the log file, in days."
 msgstr ""
 
-#: 3.8/applet.js:311
+#: 3.8/applet.js:331
 msgid "TRUE"
 msgstr ""
 
-#: 3.8/applet.js:312
+#: 3.8/applet.js:332
 msgid "FALSE"
 msgstr ""
 
-#: 3.8/applet.js:890
+#: 3.8/applet.js:922
 msgid "View Activity Logs"
 msgstr ""
 
-#: 3.8/applet.js:991
+#: 3.8/applet.js:1023
 msgid "Started by vpnLookOut: "
 msgstr ""
 
-#: 3.8/applet.js:1017
+#: 3.8/applet.js:1049
 msgid "Blocked by vpnLookOut: "
 msgstr ""
 
-#: 3.8/applet.js:1061
+#: 3.8/applet.js:1097
 msgid "Stopped by vpnLookOut: "
 msgstr ""
 


### PR DESCRIPTION
… even if automatic reconnection is selected

Hi,

There are some changes requested by an user:
When the option "Try to reconnect to VPN when it shuts down incidentally." was checked, the Disconnect button was hidden.
A new option "Do not try to reconnect automatically if the VPN has been disconnected by the user", complementary to the previous one, allows the user to voluntarily disconnect the VPN (the disconnect button is shown) and not to try to reconnect it afterwards.

I also temporarily disabled the automatic installation of translations, which crashed Cinnamon during the installation of this applet.

Can you merge this branch with your master one, please?

Best regards.

Claudiux