### PR TITLE
ShutdownApplet@shelley: Fixed broken commands

### DIFF
--- a/ShutdownApplet@shelley/files/ShutdownApplet@shelley/applet.js
+++ b/ShutdownApplet@shelley/files/ShutdownApplet@shelley/applet.js
@@ -40,29 +40,25 @@ MyApplet.prototype = {
             this._contentSection = new PopupMenu.PopupMenuSection();
             this.menu.addMenuItem(this._contentSection);      
                                                                                        
-  	    this.menu.addAction(_("Screen Lock"), function(event) {
-                Util.spawnCommandLine("dbus-send --session --type=method_call --print-reply --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.Lock");
+            this.menu.addAction(_("Screen Lock"), function(event) {
+                Util.spawnCommandLine("cinnamon-screensaver-command --lock");
             });                                                                         
 
             this.menu.addAction(_("Suspend"), function(event) {
-                Util.spawnCommandLine("dbus-send --print-reply --system --dest=org.freedesktop.UPower /org/freedesktop/UPower org.freedesktop.UPower.Suspend");
+                Util.spawnCommandLine("systemctl suspend");
             });
 	    
-              this.menu.addAction(_("Hibernate"), function(event) {
-                Util.spawnCommandLine("dbus-send --print-reply --system --dest=org.freedesktop.UPower /org/freedesktop/UPower org.freedesktop.UPower.Suspend");
-            });  
-            
              this.menu.addAction(_("Restart"), function(event) {
-                Util.spawnCommandLine("dbus-send --system --print-reply --system --dest=org.freedesktop.ConsoleKit /org/freedesktop/ConsoleKit/Manager org.freedesktop.ConsoleKit.Manager.Restart");
+                Util.spawnCommandLine("systemctl reboot");
             });  
             
-        this.menu.addAction(_("Log Out"), function(event) {
-                Util.spawnCommandLine("dbus-send --session --type=method_call --print-reply --dest=org.gnome.SessionManager /org/gnome/SessionManager org.gnome.SessionManager.Logout uint32:1");
+            this.menu.addAction(_("Log Out"), function(event) {
+                Util.spawnCommandLine("gnome-session-quit --no-prompt");
             });
             
-	     this.menu.addAction(_("Shutdown"), function(event) {
-                Util.spawnCommandLine("dbus-send --system --print-reply --system --dest=org.freedesktop.ConsoleKit /org/freedesktop/ConsoleKit/Manager org.freedesktop.ConsoleKit.Manager.Stop");
-            });                        
+             this.menu.addAction(_("Shutdown"), function(event) {
+                Util.spawnCommandLine("systemctl poweroff");
+             });                        
         }
         catch (e) {
             global.logError(e);

--- a/ShutdownApplet@shelley/info.json
+++ b/ShutdownApplet@shelley/info.json
@@ -1,4 +1,4 @@
 {
-    "author": "none",
+    "author": "icarter09",
     "original_author": "shelley"
 }


### PR DESCRIPTION
This is a fix for #1053. Fixed broken commands in applet. Removed Hibernate option since it requires swap to work correctly and would operate on a case-by-case basis for each user.

@jaszhix can you merge this whenever you have a moment? Thanks.