### PR TITLE
 batterymonitor@pdcurtis Update to version 1.3.3 

### DIFF
--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/CHANGELOG.md
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 1.3.3
+  * Use xdg-open in place of gedit or xed to allow use on more distros
+
 ### 1.3.2
 
  * Add checks that sox and zenity are installed and warn that full facilities are not available without them.

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/applet.js
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/applet.js
@@ -139,7 +139,7 @@ MyApplet.prototype = {
             if (this.versionCompare(GLib.getenv('CINNAMON_VERSION'), "3.0") <= 0) {
                 this.textEd = "gedit";
             } else {
-                this.textEd = "xed";
+                this.textEd = "xdg-open";
             }
 
             // Check that all Dependencies Met by presence of sox and zenity 
@@ -564,5 +564,7 @@ Bug Fix for use with early versions of Cinnamon
  * Revert change on handling empty battery
 ### 1.3.2.2
  * Remove instance of depreciated code giving a harmless warning in .xsession-errors.
+### 1.3.3
+  * Use xdg-open in place of gedit or xed to allow use on more distros
 */
 

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/changelog.txt
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/changelog.txt
@@ -81,4 +81,5 @@ Bug Fix for use with early versions of Cinnamon
  * Revert change on handling empty battery
 ### 1.3.2.2
  * Remove instance of depreciated code giving a harmless warning in .xsession-errors.
-
+### 1.3.3
+  * Use xdg-open in place of gedit or xed to allow use on more distros

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/metadata.json
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/metadata.json
@@ -2,7 +2,7 @@
     "max-instances": "1",  
     "description": "Displays Charge as Percentage and allows Alerts and Actions", 
     "name": "Battery  Applet with Monitoring and Shutdown (BAMS)",
-    "version": "1.3.2", 
+    "version": "1.3.3", 
     "uuid": "batterymonitor@pdcurtis"
 }
 


### PR DESCRIPTION
  * Use xdg-open in place of gedit or xed to allow use on more Linux distributions 

Closes #1985 as xdg-utils is available in all recent distributions that can support the Cinnamon Desktop