### PR TITLE
[brightness-and-gamma-applet@cardsurf] Fixes GLib.file_set_contents u…

### DIFF
--- a/brightness-and-gamma-applet@cardsurf/files/brightness-and-gamma-applet@cardsurf/files.js
+++ b/brightness-and-gamma-applet@cardsurf/files/brightness-and-gamma-applet@cardsurf/files.js
@@ -40,7 +40,7 @@ File.prototype = {
 
     overwrite: function(array_strings) {
         let string = array_strings.join(this.newline);
-        return GLib.file_set_contents(this.path, string, string.length, null);
+        return GLib.file_set_contents(this.path, string);
     },
 
     create: function() {


### PR DESCRIPTION
…sage error

Hi @cardsurf,

The `.xsession-errors` file was flooded by the _Too many arguments to function GLib.file_set_contents: expected 2, got 4_ messages.

This PR fixes this issue.

Best regards.

Claudiux