### PR TITLE
IcingTaskManager@json: Add migration functionality for moving pinned apps from ITM to GWL

### DIFF
--- a/IcingTaskManager@json/CHANGELOG.md
+++ b/IcingTaskManager@json/CHANGELOG.md
@@ -1,5 +1,10 @@
 Changelog
 
+### 6.3.14
+
+  * Added a deprecation notice notification for Cinnamon 4.0 users.
+  * Added migration functionality for moving local pinned apps from ITM to Grouped Window List in Cinnamon 4.0. This can be accessed by clicking "Migrate Pinned Apps to Grouped Window List" from ITM's settings.
+
 ### 6.3.11
 
   * Fixed an issue with the applet not initializing when an open app can't be resolved by wm_class.

--- a/IcingTaskManager@json/README.md
+++ b/IcingTaskManager@json/README.md
@@ -1,6 +1,8 @@
 Icing Task Manager
 =============
 
+**Icing Task Manager is now deprecated for all Cinnamon 4.0 users. Please add the Grouped Window List applet to your panel, go to ITM's settings, and click "Migrate Pinned Apps to Grouped Window List".**
+
 **Issues should be opened on ITM's [dedicated repository](https://github.com/jaszhix/icingtaskmanager). All PRs should be submitted to the Cinnamon Spices repository.**
 
 This is a fork of the unfinished development branch of [Window List With App Grouping](https://github.com/jake-phy/WindowIconList/) applet, originally by jake-phy who forked the code from [GNOME Shell Window List](https://github.com/siefkenj/gnome-shell-windowlist/).

--- a/IcingTaskManager@json/README.md
+++ b/IcingTaskManager@json/README.md
@@ -1,7 +1,7 @@
 Icing Task Manager
 =============
 
-**Icing Task Manager is now deprecated for all Cinnamon 4.0 users. Please add the Grouped Window List applet to your panel, go to ITM's settings, and click "Migrate Pinned Apps to Grouped Window List".**
+**Icing Task Manager is deprecated for Cinnamon 4.0+. Please add the Grouped Window List applet to your panel, go to ITM's settings, and click "Migrate Pinned Apps to Grouped Window List".**
 
 **Issues should be opened on ITM's [dedicated repository](https://github.com/jaszhix/icingtaskmanager). All PRs should be submitted to the Cinnamon Spices repository.**
 

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.8/applet.js
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.8/applet.js
@@ -474,8 +474,8 @@ class ITMApplet extends Applet.Applet {
     if (this.state.settings.deprecationNoticeRun) return;
     let icon = this.getNotificationIcon();
     let header = _('Icing Task Manager is deprecated');
-    let body = _('Please upgrade to Grouped Window List for a more stable, bug-free experience.')
-      + _('Add GWL to your panel, open the applet\'s settings and click "Migrate Pinned Apps to Grouped Window List".');
+    let body = _('Please upgrade to Grouped Window List for a more stable, bug-free experience. ')
+      + _('Add GWL to your panel, then open ITM\'s settings and click "Migrate Pinned Apps to Grouped Window List".');
     Main.criticalNotify(
       header,
       body,

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.8/settings-schema.json
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.8/settings-schema.json
@@ -31,6 +31,7 @@
       "type" : "section",
       "title" : "Behavior",
       "keys": [
+        "migrationButton",
         "group-apps",
         "scroll-behavior",
         "left-click-action",
@@ -568,5 +569,10 @@
     "description" : "Mint X, Linux Mint, and Variants",
     "callback" : "handleMintXThemePreset",
     "tooltip" : "Mint X, Linux Mint, and Variants"
+  },
+  "migrationButton": {
+    "type": "button",
+    "description": "Migrate Pinned Apps to Grouped Window List",
+    "callback": "migratePinnedToGWL"
   }
 }

--- a/IcingTaskManager@json/files/IcingTaskManager@json/3.8/settings-schema.json
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/3.8/settings-schema.json
@@ -574,5 +574,9 @@
     "type": "button",
     "description": "Migrate Pinned Apps to Grouped Window List",
     "callback": "migratePinnedToGWL"
+  },
+  "deprecationNoticeRun": {
+    "type": "generic",
+    "default": false
   }
 }

--- a/IcingTaskManager@json/files/IcingTaskManager@json/metadata.json
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/metadata.json
@@ -2,7 +2,7 @@
     "description": "Window list with app grouping and thumbnails",
     "max-instances": -1,
     "name": "Icing Task Manager",
-    "version": "6.3.13",
+    "version": "6.3.14",
     "role": "panellauncher",
     "uuid": "IcingTaskManager@json",
     "multiversion": true,

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/bg.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/bg.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-10 00:43-0600\n"
+"POT-Creation-Date: 2018-12-13 18:37-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Peyu Yovev <spacy00001@gmail.com>\n"
 "Language-Team: \n"
@@ -13,53 +13,53 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: 3.8/applet.js:471
-msgid "Icing Task Manager is now Grouped Window List"
-msgstr ""
+#: 3.8/applet.js:476
+#, fuzzy
+msgid "Icing Task Manager is deprecated"
+msgstr "Диспечер на задачи Icing"
 
-#: 3.8/applet.js:472
+#: 3.8/applet.js:477
 msgid ""
-"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
-"Window List\". "
+"Please upgrade to Grouped Window List for a more stable, bug-free experience."
 msgstr ""
 
-#: 3.8/applet.js:473
+#: 3.8/applet.js:478
 msgid ""
-"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
-"List."
+"Add GWL to your panel, open the applet's settings and click \"Migrate Pinned "
+"Apps to Grouped Window List\"."
 msgstr ""
 
-#: 3.8/applet.js:485
-msgid "Migration can only be performed on Cinnamon 4.0."
+#: 3.8/applet.js:490
+msgid "Migration can only be performed on Cinnamon 4.0+."
 msgstr ""
 
-#: 3.8/applet.js:496
+#: 3.8/applet.js:501
 msgid ""
 "Please add Grouped Window List to a panel before proceeding with the "
 "migration."
 msgstr ""
 
-#: 3.8/applet.js:504
+#: 3.8/applet.js:509
 msgid "ITM settings directory could not be found!"
 msgstr ""
 
-#: 3.8/applet.js:534
+#: 3.8/applet.js:539
 msgid "System favorites enabled - no migration is needed."
 msgstr ""
 
-#: 3.8/applet.js:577
+#: 3.8/applet.js:582
 msgid "Unable to find a suitable ITM settings file to migrate."
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid "Migration complete. "
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid " settings file(s) could not be migrated."
 msgstr ""
 
-#: 3.8/applet.js:592
+#: 3.8/applet.js:597
 msgid "Migration was successful."
 msgstr ""
 
@@ -1209,6 +1209,10 @@ msgstr "Минт X, Линукс Минт и вариантите"
 #. 3.8->settings-schema.json->migrationButton->description
 msgid "Migrate Pinned Apps to Grouped Window List"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Icing Task Manager is deprecated - please use Grouped Window List"
+#~ msgstr "Диспечер на задачи Icing"
 
 #~ msgid "number"
 #~ msgstr "число"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/bg.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/bg.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-23 21:26-0600\n"
+"POT-Creation-Date: 2018-12-10 00:43-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Peyu Yovev <spacy00001@gmail.com>\n"
 "Language-Team: \n"
@@ -13,551 +13,219 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/applet.js:471
+msgid "Icing Task Manager is now Grouped Window List"
+msgstr ""
+
+#: 3.8/applet.js:472
+msgid ""
+"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
+"Window List\". "
+msgstr ""
+
+#: 3.8/applet.js:473
+msgid ""
+"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
+"List."
+msgstr ""
+
+#: 3.8/applet.js:485
+msgid "Migration can only be performed on Cinnamon 4.0."
+msgstr ""
+
+#: 3.8/applet.js:496
+msgid ""
+"Please add Grouped Window List to a panel before proceeding with the "
+"migration."
+msgstr ""
+
+#: 3.8/applet.js:504
+msgid "ITM settings directory could not be found!"
+msgstr ""
+
+#: 3.8/applet.js:534
+msgid "System favorites enabled - no migration is needed."
+msgstr ""
+
+#: 3.8/applet.js:577
+msgid "Unable to find a suitable ITM settings file to migrate."
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid "Migration complete. "
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid " settings file(s) could not be migrated."
+msgstr ""
+
+#: 3.8/applet.js:592
+msgid "Migration was successful."
+msgstr ""
+
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to the other monitor"
 msgstr "Преместване на другия монитор"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to monitor "
 msgstr "Преместване на монитор "
 
-#: 3.4/specialMenus.js:126
+#: 3.8/specialMenus.js:98 3.4/specialMenus.js:126
 msgid "Only on this workspace"
 msgstr "Само на това работно място"
 
-#: 3.4/specialMenus.js:133
+#: 3.8/specialMenus.js:105 3.4/specialMenus.js:133
 msgid "Visible on all workspaces"
 msgstr "Видимо на всички работни места"
 
-#: 3.4/specialMenus.js:140
+#: 3.8/specialMenus.js:112 3.4/specialMenus.js:140
 msgid "Move to another workspace"
 msgstr "Преместване на друго работно място"
 
-#: 3.4/specialMenus.js:168
+#: 3.8/specialMenus.js:140 3.4/specialMenus.js:168
 msgid "Places"
 msgstr "Места"
 
-#: 3.4/specialMenus.js:207
+#: 3.8/specialMenus.js:179 3.4/specialMenus.js:207
 msgid "Bookmarks/History requires gir1.2-gda-5.0"
 msgstr "Отметките/Историята изискват gir1.2-gda-5.0"
 
-#: 3.4/specialMenus.js:227
+#: 3.8/specialMenus.js:199 3.4/specialMenus.js:227
 msgid "Recent"
 msgstr "Скорошни"
 
-#: 3.4/specialMenus.js:246
+#: 3.8/specialMenus.js:218 3.4/specialMenus.js:246
 msgid "Preferences"
 msgstr "Предпочитания"
 
-#: 3.4/specialMenus.js:249
+#: 3.8/specialMenus.js:221 3.4/specialMenus.js:249
 msgid "About..."
 msgstr "Относно..."
 
-#: 3.4/specialMenus.js:253
+#: 3.8/specialMenus.js:225 3.4/specialMenus.js:253
 msgid "Configure..."
 msgstr "Настройване..."
 
-#: 3.4/specialMenus.js:257
+#: 3.8/specialMenus.js:229 3.4/specialMenus.js:257
 msgid "Remove"
 msgstr "Премахване"
 
-#: 3.4/specialMenus.js:287
+#: 3.8/specialMenus.js:259 3.4/specialMenus.js:287
 msgid "New Window"
 msgstr "Превъртане на прозорците"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Unpin from Panel"
 msgstr "Откачане от панела"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Pin to Panel"
 msgstr "Закачи на панела"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Remove from Autostart"
 msgstr "Премахване от автоматично пусканите"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Add to Autostart"
 msgstr "Добавяне към автоматично стартиране"
 
-#: 3.4/specialMenus.js:318
+#: 3.8/specialMenus.js:290 3.4/specialMenus.js:318
 msgid "Create Shortcut"
 msgstr "Създаване на пряк път"
 
-#: 3.4/specialMenus.js:329
+#: 3.8/specialMenus.js:301 3.4/specialMenus.js:329
 msgid "Restore to full opacity"
 msgstr "Възстановяване до непрозрачно"
 
-#: 3.4/specialMenus.js:337
+#: 3.8/specialMenus.js:309 3.4/specialMenus.js:337
 msgid "Restore"
 msgstr "Възстановяване"
 
-#: 3.4/specialMenus.js:342
+#: 3.8/specialMenus.js:314 3.4/specialMenus.js:342
 msgid "Minimize"
 msgstr "Минимизиране"
 
-#: 3.4/specialMenus.js:350
+#: 3.8/specialMenus.js:322 3.4/specialMenus.js:350
 msgid "Unmaximize"
 msgstr "Демаксимизиране"
 
-#: 3.4/specialMenus.js:355
+#: 3.8/specialMenus.js:327 3.4/specialMenus.js:355
 msgid "Maximize"
 msgstr "Максимизиране"
 
-#: 3.4/specialMenus.js:365
+#: 3.8/specialMenus.js:337 3.4/specialMenus.js:365
 msgid "Close others"
 msgstr "Затвори другите"
 
-#: 3.4/specialMenus.js:375
+#: 3.8/specialMenus.js:347 3.4/specialMenus.js:375
 msgid "Close all"
 msgstr "Затвори всички"
 
-#: 3.4/specialMenus.js:385
+#: 3.8/specialMenus.js:357 3.4/specialMenus.js:385
 msgid "Close"
 msgstr "Затвори"
 
-#. 2.8->settings-schema.json->thumbnail-size->description
-#. 3.4->settings-schema.json->thumbnail-size->description
-msgid "Thumbnail size"
-msgstr "Размер на миниатюрите"
+#. metadata.json->description
+msgid "Window list with app grouping and thumbnails"
+msgstr "Списък с прозорци с групиране на приложения и миниатюри"
 
-#. 2.8->settings-schema.json->thumbnail-size->tooltip
-#. 3.4->settings-schema.json->thumbnail-size->tooltip
-msgid "Controls the size of the thumbnails."
-msgstr "Регулира размера на миниатюрите."
+#. metadata.json->name
+msgid "Icing Task Manager"
+msgstr "Диспечер на задачи Icing"
 
-#. 2.8->settings-schema.json->thumbnail-size->units
-#. 3.4->settings-schema.json->thumbnail-size->units
-msgid "size"
-msgstr "размер"
-
-#. 2.8->settings-schema.json->focusPseudoClass->description
-#. 3.4->settings-schema.json->focusPseudoClass->description
-msgid "App button focus pseudo class"
-msgstr "Псевдоклас за фокусиран бутон на програма"
-
-#. 2.8->settings-schema.json->focusPseudoClass->tooltip
-#. 3.4->settings-schema.json->focusPseudoClass->tooltip
-msgid "Overrides the pseudo class for app button on focus."
-msgstr "Замества псевдокласа за фокусиран бутон."
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "active"
-msgstr "активно"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "outlined"
-msgstr "очертано"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "hover"
-msgstr "посочено"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "focus"
-msgstr "фокус"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "selected"
-msgstr "избрано"
-
-#. 2.8->settings-schema.json->icon-spacing->description
-#. 3.4->settings-schema.json->icon-spacing->description
-msgid "Icon spacing"
-msgstr "Разстояние между иконките"
-
-#. 2.8->settings-schema.json->icon-spacing->tooltip
-#. 3.4->settings-schema.json->icon-spacing->tooltip
-msgid "Controls how much space is between the icons."
-msgstr "Регулира разстоянието между иконките."
-
-#. 2.8->settings-schema.json->icon-spacing->units
-#. 2.8->settings-schema.json->icon-size->units
-#. 2.8->settings-schema.json->icon-padding->units
-#. 3.4->settings-schema.json->icon-spacing->units
-#. 3.4->settings-schema.json->thumbnail-padding->units
-#. 3.4->settings-schema.json->icon-size->units
-#. 3.4->settings-schema.json->app-button-width->units
-#. 3.4->settings-schema.json->thumbnail-close-button-size->units
-#. 3.4->settings-schema.json->icon-padding->units
-msgid "px"
-msgstr "пиксела"
-
-#. 2.8->settings-schema.json->show-thumbnails->description
-#. 3.4->settings-schema.json->show-thumbnails->description
-msgid "Show thumbnails"
-msgstr "Показване на миниатюри"
-
-#. 2.8->settings-schema.json->show-thumbnails->tooltip
-#. 3.4->settings-schema.json->show-thumbnails->tooltip
-msgid "Show window thumbnails when hovering over an app button."
-msgstr "Показване на миниатюри при посочване на програма."
-
-#. 2.8->settings-schema.json->icon-size->description
-#. 3.4->settings-schema.json->icon-size->description
-msgid "Icon size"
-msgstr "Размер на иконките"
-
-#. 2.8->settings-schema.json->icon-size->tooltip
-#. 3.4->settings-schema.json->icon-size->tooltip
-msgid "Set icon size"
-msgstr "Задаване размер на иконките"
-
-#. 2.8->settings-schema.json->hover-peek-time->description
-#. 3.4->settings-schema.json->hover-peek-time->description
-msgid "Window fade time"
-msgstr "Време на избледняване на прозорците"
-
-#. 2.8->settings-schema.json->hover-peek-time->tooltip
-#. 3.4->settings-schema.json->hover-peek-time->tooltip
-msgid "Controls how quickly a window will fade on hover."
-msgstr "Регулира колко бързо избледнява прозорец при посочване."
-
-#. 2.8->settings-schema.json->hover-peek-time->units
-#. 2.8->settings-schema.json->thumbnail-timeout->units
-#. 2.8->settings-schema.json->show-apps-order-timeout->units
-#. 3.4->settings-schema.json->hover-peek-time->units
-#. 3.4->settings-schema.json->thumbnail-timeout->units
-#. 3.4->settings-schema.json->show-apps-order-timeout->units
-msgid "milliseconds"
-msgstr "милисекунди"
-
-#. 2.8->settings-schema.json->close-button-style->description
-msgid "Allow themes to control the thumbnail close button"
-msgstr "Позволяване на темите да управляват бутона за затваряне на миниатюрите"
-
-#. 2.8->settings-schema.json->close-button-style->tooltip
-msgid ""
-"Controls whether or not the theme controls the window thumbnail's close "
-"button."
-msgstr "Регулира дали темата управлява бутона за затваряне на миниатюрите."
-
-#. 2.8->settings-schema.json->title-display->description
-#. 3.4->settings-schema.json->title-display->description
-msgid "Title display"
-msgstr "Показване на заглавието"
-
-#. 2.8->settings-schema.json->title-display->tooltip
-#. 3.4->settings-schema.json->title-display->tooltip
-msgid ""
-"focused: show focused window title, title: display the window title, app: "
-"diplay app name, none: don't display anything"
-msgstr ""
-"фокус: показва заглавието на фокусирания прозорец, заглавие: показва "
-"заглавието на прозореца, програма: показва името на програмата, без: не "
-"показва нищо."
-
-#. 2.8->settings-schema.json->title-display->options
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-#. 3.4->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->middle-click-action->options
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "None"
-msgstr "Без"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Focused"
-msgstr "Фокусирано"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "App"
-msgstr "Програма"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Title"
-msgstr "Заглавие"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->description
-#. 3.4->settings-schema.json->hoverPseudoClass->description
-msgid "App button hover pseudo class"
-msgstr "Псевдоклас за посочен бутон на програма"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
-#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons on hover."
-msgstr "Замества псевдокласа при посочване на бутон."
-
-#. 2.8->settings-schema.json->show-alerts->description
-#. 3.4->settings-schema.json->show-alerts->description
-msgid "Show app alerts and notifications"
-msgstr "Показване на известия и предупреждения"
-
-#. 2.8->settings-schema.json->show-alerts->tooltip
-#. 3.4->settings-schema.json->show-alerts->tooltip
-msgid "If enabled, notifications and alerts will appear."
-msgstr "Ако е включено, ще се показват известия и предупреждения."
-
-#. 2.8->settings-schema.json->pinOnDrag->description
-#. 2.8->settings-schema.json->pinOnDrag->tooltip
-#. 3.4->settings-schema.json->pinOnDrag->description
-#. 3.4->settings-schema.json->pinOnDrag->tooltip
-msgid "Pin apps when dragged to a new position"
-msgstr "Закачане на програмите, когато се провлачат до нова позиция"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->description
-#. 3.4->settings-schema.json->show-apps-order-hotkey->description
-msgid "Global hotkey to show the order of apps"
-msgstr "Глобална клавиши комбинация за показване на реда на програмите"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
-#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
-msgid ""
-"When triggered, the window count label will be replaced with its order in "
-"the app list temporarily."
-msgstr ""
-"При задействане, брояча на прозорците временно ще бъде заменен с реда в "
-"списъка с приложения."
-
-#. 2.8->settings-schema.json->menuItemType->description
-#. 3.4->settings-schema.json->menuItemType->description
-msgid "Menu item type"
-msgstr "Вид на елемент от менюто"
-
-#. 2.8->settings-schema.json->menuItemType->tooltip
-#. 3.4->settings-schema.json->menuItemType->tooltip
-msgid ""
-"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
-msgstr ""
-"Определя дали иконките на елемент от менюто са символични, несимволичниили, "
-"или да не се показват."
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Symbolic icons"
-msgstr "Символични иконки"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "No icons"
-msgstr "Без иконки"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Non-symbolic icons"
-msgstr "Несимволични иконки"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->description
-#. 3.4->settings-schema.json->hover-peek-opacity->description
-msgid "Window opacity"
-msgstr "Прозрачност на прозорците"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
-#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
-msgid "Opacity of the windows on hover."
-msgstr "Прозрачност на прозорците при посочване."
-
-#. 2.8->settings-schema.json->hover-peek-opacity->units
-#. 3.4->settings-schema.json->hover-peek-opacity->units
-msgid "percent"
-msgstr "проценти"
-
-#. 2.8->settings-schema.json->enable-hover-peek->description
-#. 3.4->settings-schema.json->enable-hover-peek->description
-msgid "Show windows when hovered over"
-msgstr "Показване на прозорците при посочване"
-
-#. 2.8->settings-schema.json->enable-hover-peek->tooltip
-#. 3.4->settings-schema.json->enable-hover-peek->tooltip
-msgid "Controls whether or not windows display when hovered over."
-msgstr "Регулира дали прозорците ще се покажат при посочване."
-
-#. 2.8->settings-schema.json->activePseudoClass->description
-#. 3.4->settings-schema.json->activePseudoClass->description
-msgid "App button active pseudo class"
-msgstr "Псевдоклас за активен бутон на програма"
-
-#. 2.8->settings-schema.json->activePseudoClass->tooltip
-#. 3.4->settings-schema.json->activePseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons when they are active."
-msgstr "Замества псевдокласа за активен бутон."
-
-#. 2.8->settings-schema.json->animate-thumbnails->description
-#. 3.4->settings-schema.json->animate-thumbnails->description
-msgid "Animate thumbnails"
-msgstr "Анимиране на миниатюрите"
-
-#. 2.8->settings-schema.json->animate-thumbnails->tooltip
-#. 3.4->settings-schema.json->animate-thumbnails->tooltip
-msgid "If enabled, thumbnails will animate when appearing and disappearing."
-msgstr "Ако е включено, миниатюрите ще са анимирани при появяване и скриване."
-
-#. 2.8->settings-schema.json->autostart-menu-item->description
-#. 3.4->settings-schema.json->autostart-menu-item->description
-msgid "Show autostart option"
-msgstr "Показване на опцията за автоматично пускане"
-
-#. 2.8->settings-schema.json->autostart-menu-item->tooltip
-#. 3.4->settings-schema.json->autostart-menu-item->tooltip
-msgid "Shows the autostart toggle option in an app's context menu."
-msgstr "Показва опцията за автоматично пускане в контекстното меню."
-
-#. 2.8->settings-schema.json->show-pinned->description
-#. 3.4->settings-schema.json->show-pinned->description
-msgid "Show pinned apps"
-msgstr "Показване на закачените програми"
-
-#. 2.8->settings-schema.json->show-pinned->tooltip
-#. 3.4->settings-schema.json->show-pinned->tooltip
-msgid ""
-"Controls whether or not the pinned apps appear in the panel if they are not "
-"open."
-msgstr "Регулира показването на закачените програми, ако не са отворени."
-
-#. 2.8->settings-schema.json->useSystemTooltips->description
-msgid "Use system tooltips for closed apps"
-msgstr "Използване на системните подсказки за затворените програми"
-
-#. 2.8->settings-schema.json->useSystemTooltips->tooltip
-msgid ""
-"Controls whether or not system tooltips are in use when hovering over closed "
-"pinned apps."
-msgstr ""
-"Контролира дали системните подсказки се използват, при посочване на "
-"затворените закачени програми."
+#. 2.8->settings-schema.json->ITM->description
+msgid "ITM Settings"
+msgstr "Настройки на ITM"
 
 #. 2.8->settings-schema.json->WindowList->description
 msgid "Window List Settings"
 msgstr "Настройки на списък с прозорци"
 
-#. 2.8->settings-schema.json->AppMenu->description
-msgid "Context Menu Settings"
-msgstr "Настройки на контекстното меню"
-
-#. 2.8->settings-schema.json->Thumbnails->description
-msgid "Thumbnail Settings"
-msgstr "Настройки на миниатюрите"
-
-#. 2.8->settings-schema.json->show-recent->description
-#. 3.4->settings-schema.json->show-recent->description
-msgid "Show recent items"
-msgstr "Показване на скорошните елементи"
-
-#. 2.8->settings-schema.json->show-recent->tooltip
-#. 3.4->settings-schema.json->show-recent->tooltip
-msgid "Controls whether recent items will appear in the context menu."
-msgstr "Регулира дали скорошните елементи ще се показват в контекстното меню."
-
-#. 2.8->settings-schema.json->vertical-thumbnails->description
-#. 3.4->settings-schema.json->vertical-thumbnails->description
-msgid "Enable vertical thumbnails"
-msgstr "Отвесни миниатюри"
-
-#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
-#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
-msgid "If enabled, thumbnails will stack vertically."
-msgstr "Ако е включено, миниатюрите ще се трупат отвесно."
-
-#. 2.8->settings-schema.json->thumbnail-timeout->description
-#. 3.4->settings-schema.json->thumbnail-timeout->description
-msgid "Thumbnail timeout"
-msgstr "Забавяне при показване на миниатюрите"
-
-#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
-#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
-msgid ""
-"Controls how quickly an app's set of window thumbnails will fade out when "
-"the mouse leaves the app button."
-msgstr ""
-"Регулира колко бързо миниатюрите на дадена програма ще избледнеят, когато "
-"мишката се оттегли от бутона."
-
-#. 2.8->settings-schema.json->ThemeSettings->description
-msgid "Theme Settings"
-msgstr "Настройки на темата"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->description
-#. 3.4->settings-schema.json->onclick-thumbnails->description
-msgid "Open thumbnails on click"
-msgstr "Отваряне на миниатюрите при щракване"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
-#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
-msgid "Open the thumbnails on click if there is more than one window open."
-msgstr ""
-"Отваряне на миниатюрите при щракване, ако има повече от един отворен "
-"прозорец."
-
-#. 2.8->settings-schema.json->panelLauncherClass->description
-msgid "Use the panel launcher class for pinned apps"
-msgstr "Използване на класа на стартера за закачените програми"
-
-#. 2.8->settings-schema.json->panelLauncherClass->tooltip
-msgid "Enabling this helps with certain themes."
-msgstr "Разрешаването на това помага с определени теми."
-
-#. 2.8->settings-schema.json->include-all-windows->description
-#. 3.4->settings-schema.json->include-all-windows->description
-msgid "Include all app windows"
-msgstr "Включване на всички прозорци"
-
-#. 2.8->settings-schema.json->include-all-windows->tooltip
-#. 3.4->settings-schema.json->include-all-windows->tooltip
-msgid ""
-"Controls whether or not thumbnails for smalller child windows, such as exit "
-"confirmations and file dialogues will be included in the thumbnail list."
-msgstr ""
-"Регулира дали в списъка ще се показват миниатюри за по-малки прозорци, като "
-"потвърждения и диалози."
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->description
-#. 3.4->settings-schema.json->cycleMenusHotkey->description
-msgid "Global hotkey for cycling through thumbnail menus"
-msgstr "Повсеместна клавишна комбинация за прелистване на миниатюрите"
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
-#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
-msgid "This allows you to cycle through the menus without activating a window."
-msgstr ""
-"Това ви позволява да прелиствате през менютата без активиране на прозореца."
-
-#. 2.8->settings-schema.json->enable-iconSize->description
-#. 3.4->settings-schema.json->enable-iconSize->description
-msgid "Adjust icon size"
-msgstr "Регулиране на размера на иконките"
-
-#. 2.8->settings-schema.json->enable-iconSize->tooltip
-#. 3.4->settings-schema.json->enable-iconSize->tooltip
-msgid "Adjust icon size independent of Cinnamon's panel scaling."
-msgstr "Регулиране на размера на иконките независимо от настройките на панела."
-
 #. 2.8->settings-schema.json->number-display->description
+#. 3.8->settings-schema.json->number-display->description
 #. 3.4->settings-schema.json->number-display->description
 msgid "Number display"
 msgstr "Показване на брой"
 
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Smart"
+msgstr "Умно"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Normal"
+msgstr "Нормално"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "None"
+msgstr "Без"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "All"
+msgstr "Всички"
+
 #. 2.8->settings-schema.json->number-display->tooltip
+#. 3.8->settings-schema.json->number-display->tooltip
 #. 3.4->settings-schema.json->number-display->tooltip
 msgid ""
 "normal: display window number, smart: display window number if more than one "
@@ -568,42 +236,95 @@ msgstr ""
 "прозорец. без: не се показва бройка. Всички: показване на бройка и за "
 "любимите."
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "All"
-msgstr "Всички"
+#. 2.8->settings-schema.json->title-display->description
+#. 3.8->settings-schema.json->title-display->description
+#. 3.4->settings-schema.json->title-display->description
+msgid "Title display"
+msgstr "Показване на заглавието"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Smart"
-msgstr "Умно"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "App"
+msgstr "Програма"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Normal"
-msgstr "Нормално"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Title"
+msgstr "Заглавие"
 
-#. 2.8->settings-schema.json->ITM->description
-msgid "ITM Settings"
-msgstr "Настройки на ITM"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Focused"
+msgstr "Фокусирано"
 
-#. 2.8->settings-schema.json->HoverPeek->description
-msgid "Hover Peek Settings"
-msgstr "Настройки при посочване"
-
-#. 2.8->settings-schema.json->icon-padding->description
-#. 3.4->settings-schema.json->icon-padding->description
-msgid "Icon padding"
-msgstr "Разстояние между иконките"
-
-#. 2.8->settings-schema.json->icon-padding->tooltip
-#. 3.4->settings-schema.json->icon-padding->tooltip
+#. 2.8->settings-schema.json->title-display->tooltip
+#. 3.8->settings-schema.json->title-display->tooltip
+#. 3.4->settings-schema.json->title-display->tooltip
 msgid ""
-"Controls how much horizontal padding is inside the app buttons. Padding is "
-"only applied to instances of this applet on horizontal panels."
+"focused: show focused window title, title: display the window title, app: "
+"diplay app name, none: don't display anything"
 msgstr ""
-"Регулира какво да е хоризонталното отстояние между бутоните. Отстоянието се "
-"прилага само при хоризонтални панели."
+"фокус: показва заглавието на фокусирания прозорец, заглавие: показва "
+"заглавието на прозореца, програма: показва името на програмата, без: не "
+"показва нищо."
+
+#. 2.8->settings-schema.json->group-apps->description
+#. 3.8->settings-schema.json->group-apps->description
+#. 3.4->settings-schema.json->group-apps->description
+msgid "Group apps"
+msgstr "Групиране"
+
+#. 2.8->settings-schema.json->group-apps->tooltip
+#. 3.8->settings-schema.json->group-apps->tooltip
+#. 3.4->settings-schema.json->group-apps->tooltip
+msgid "Group each app's set of windows."
+msgstr "Групиране на прозорците на всяка програма"
+
+#. 2.8->settings-schema.json->show-alerts->description
+#. 3.8->settings-schema.json->show-alerts->description
+#. 3.4->settings-schema.json->show-alerts->description
+msgid "Show app alerts and notifications"
+msgstr "Показване на известия и предупреждения"
+
+#. 2.8->settings-schema.json->show-alerts->tooltip
+#. 3.8->settings-schema.json->show-alerts->tooltip
+#. 3.4->settings-schema.json->show-alerts->tooltip
+msgid "If enabled, notifications and alerts will appear."
+msgstr "Ако е включено, ще се показват известия и предупреждения."
+
+#. 2.8->settings-schema.json->show-pinned->description
+#. 3.8->settings-schema.json->show-pinned->description
+#. 3.4->settings-schema.json->show-pinned->description
+msgid "Show pinned apps"
+msgstr "Показване на закачените програми"
+
+#. 2.8->settings-schema.json->show-pinned->tooltip
+#. 3.8->settings-schema.json->show-pinned->tooltip
+#. 3.4->settings-schema.json->show-pinned->tooltip
+msgid ""
+"Controls whether or not the pinned apps appear in the panel if they are not "
+"open."
+msgstr "Регулира показването на закачените програми, ако не са отворени."
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->description
+msgid "Arrange pinned apps"
+msgstr "Подреждане на закачените програми"
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
+msgid "Arrange pinned apps into a different order."
+msgstr "Подреждане на закачените програми по друг начин."
+
+#. 2.8->settings-schema.json->pinOnDrag->description
+#. 2.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.8->settings-schema.json->pinOnDrag->description
+#. 3.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.4->settings-schema.json->pinOnDrag->description
+#. 3.4->settings-schema.json->pinOnDrag->tooltip
+msgid "Pin apps when dragged to a new position"
+msgstr "Закачане на програмите, когато се провлачат до нова позиция"
 
 #. 2.8->settings-schema.json->middle-click-action->description
 msgid "Middle clicking app buttons creates new app instances"
@@ -619,12 +340,258 @@ msgstr ""
 "копчета на програми. Ако е изключено, щракването ще затвори последно "
 "фокусирания прозорец от групата."
 
+#. 2.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.4->settings-schema.json->cycleMenusHotkey->description
+msgid "Global hotkey for cycling through thumbnail menus"
+msgstr "Повсеместна клавишна комбинация за прелистване на миниатюрите"
+
+#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
+msgid "This allows you to cycle through the menus without activating a window."
+msgstr ""
+"Това ви позволява да прелиствате през менютата без активиране на прозореца."
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.4->settings-schema.json->show-apps-order-hotkey->description
+msgid "Global hotkey to show the order of apps"
+msgstr "Глобална клавиши комбинация за показване на реда на програмите"
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
+msgid ""
+"When triggered, the window count label will be replaced with its order in "
+"the app list temporarily."
+msgstr ""
+"При задействане, брояча на прозорците временно ще бъде заменен с реда в "
+"списъка с приложения."
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->units
+#. 2.8->settings-schema.json->thumbnail-timeout->units
+#. 2.8->settings-schema.json->hover-peek-time->units
+#. 3.8->settings-schema.json->show-apps-order-timeout->units
+#. 3.8->settings-schema.json->thumbnail-timeout->units
+#. 3.8->settings-schema.json->hover-peek-time->units
+#. 3.4->settings-schema.json->show-apps-order-timeout->units
+#. 3.4->settings-schema.json->thumbnail-timeout->units
+#. 3.4->settings-schema.json->hover-peek-time->units
+msgid "milliseconds"
+msgstr "милисекунди"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.4->settings-schema.json->show-apps-order-timeout->description
+msgid "Duration of the apps order display on hotkey press"
+msgstr "Продължителност на показването на реда при натискане на клавиш"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
+msgid ""
+"Determines the duration the window count labels are replaced with the app's "
+"order number."
+msgstr ""
+"Определя продължителността, след която броячите се заменят с пореден номер "
+"на програмата."
+
+#. 2.8->settings-schema.json->Thumbnails->description
+msgid "Thumbnail Settings"
+msgstr "Настройки на миниатюрите"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->description
+#. 3.8->settings-schema.json->thumbnail-timeout->description
+#. 3.4->settings-schema.json->thumbnail-timeout->description
+msgid "Thumbnail timeout"
+msgstr "Забавяне при показване на миниатюрите"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
+msgid ""
+"Controls how quickly an app's set of window thumbnails will fade out when "
+"the mouse leaves the app button."
+msgstr ""
+"Регулира колко бързо миниатюрите на дадена програма ще избледнеят, когато "
+"мишката се оттегли от бутона."
+
+#. 2.8->settings-schema.json->thumbnail-size->units
+#. 3.8->settings-schema.json->thumbnail-size->units
+#. 3.4->settings-schema.json->thumbnail-size->units
+msgid "size"
+msgstr "размер"
+
+#. 2.8->settings-schema.json->thumbnail-size->description
+#. 3.8->settings-schema.json->thumbnail-size->description
+#. 3.4->settings-schema.json->thumbnail-size->description
+msgid "Thumbnail size"
+msgstr "Размер на миниатюрите"
+
+#. 2.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-size->tooltip
+msgid "Controls the size of the thumbnails."
+msgstr "Регулира размера на миниатюрите."
+
+#. 2.8->settings-schema.json->show-thumbnails->description
+#. 3.8->settings-schema.json->show-thumbnails->description
+#. 3.4->settings-schema.json->show-thumbnails->description
+msgid "Show thumbnails"
+msgstr "Показване на миниатюри"
+
+#. 2.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.4->settings-schema.json->show-thumbnails->tooltip
+msgid "Show window thumbnails when hovering over an app button."
+msgstr "Показване на миниатюри при посочване на програма."
+
+#. 2.8->settings-schema.json->animate-thumbnails->description
+#. 3.8->settings-schema.json->animate-thumbnails->description
+#. 3.4->settings-schema.json->animate-thumbnails->description
+msgid "Animate thumbnails"
+msgstr "Анимиране на миниатюрите"
+
+#. 2.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.4->settings-schema.json->animate-thumbnails->tooltip
+msgid "If enabled, thumbnails will animate when appearing and disappearing."
+msgstr "Ако е включено, миниатюрите ще са анимирани при появяване и скриване."
+
+#. 2.8->settings-schema.json->vertical-thumbnails->description
+#. 3.8->settings-schema.json->vertical-thumbnails->description
+#. 3.4->settings-schema.json->vertical-thumbnails->description
+msgid "Enable vertical thumbnails"
+msgstr "Отвесни миниатюри"
+
+#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
+msgid "If enabled, thumbnails will stack vertically."
+msgstr "Ако е включено, миниатюрите ще се трупат отвесно."
+
+#. 2.8->settings-schema.json->sort-thumbnails->description
+#. 3.8->settings-schema.json->sort-thumbnails->description
+#. 3.4->settings-schema.json->sort-thumbnails->description
+msgid "Sort windows for each app by last focused"
+msgstr "Подреждане на прозорците на всяка програма по последно фокусиране"
+
+#. 2.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.4->settings-schema.json->sort-thumbnails->tooltip
+msgid ""
+"Controls whether the order windows appear for an app is by last focused, or "
+"the order they were opened."
+msgstr ""
+"Регулира дали реда на прозорците за дадена програма ще е по последно "
+"фокусиране или по ред на отваряне."
+
+#. 2.8->settings-schema.json->onclick-thumbnails->description
+#. 3.8->settings-schema.json->onclick-thumbnails->description
+#. 3.4->settings-schema.json->onclick-thumbnails->description
+msgid "Open thumbnails on click"
+msgstr "Отваряне на миниатюрите при щракване"
+
+#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
+msgid "Open the thumbnails on click if there is more than one window open."
+msgstr ""
+"Отваряне на миниатюрите при щракване, ако има повече от един отворен "
+"прозорец."
+
+#. 2.8->settings-schema.json->include-all-windows->description
+#. 3.8->settings-schema.json->include-all-windows->description
+#. 3.4->settings-schema.json->include-all-windows->description
+msgid "Include all app windows"
+msgstr "Включване на всички прозорци"
+
+#. 2.8->settings-schema.json->include-all-windows->tooltip
+#. 3.8->settings-schema.json->include-all-windows->tooltip
+#. 3.4->settings-schema.json->include-all-windows->tooltip
+msgid ""
+"Controls whether or not thumbnails for smalller child windows, such as exit "
+"confirmations and file dialogues will be included in the thumbnail list."
+msgstr ""
+"Регулира дали в списъка ще се показват миниатюри за по-малки прозорци, като "
+"потвърждения и диалози."
+
+#. 2.8->settings-schema.json->AppMenu->description
+msgid "Context Menu Settings"
+msgstr "Настройки на контекстното меню"
+
+#. 2.8->settings-schema.json->show-recent->description
+#. 3.8->settings-schema.json->show-recent->description
+#. 3.4->settings-schema.json->show-recent->description
+msgid "Show recent items"
+msgstr "Показване на скорошните елементи"
+
+#. 2.8->settings-schema.json->show-recent->tooltip
+#. 3.8->settings-schema.json->show-recent->tooltip
+#. 3.4->settings-schema.json->show-recent->tooltip
+msgid "Controls whether recent items will appear in the context menu."
+msgstr "Регулира дали скорошните елементи ще се показват в контекстното меню."
+
+#. 2.8->settings-schema.json->menuItemType->description
+#. 3.8->settings-schema.json->menuItemType->description
+#. 3.4->settings-schema.json->menuItemType->description
+msgid "Menu item type"
+msgstr "Вид на елемент от менюто"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Symbolic icons"
+msgstr "Символични иконки"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Non-symbolic icons"
+msgstr "Несимволични иконки"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "No icons"
+msgstr "Без иконки"
+
+#. 2.8->settings-schema.json->menuItemType->tooltip
+#. 3.8->settings-schema.json->menuItemType->tooltip
+#. 3.4->settings-schema.json->menuItemType->tooltip
+msgid ""
+"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
+msgstr ""
+"Определя дали иконките на елемент от менюто са символични, несимволичниили, "
+"или да не се показват."
+
 #. 2.8->settings-schema.json->firefox-menu->description
+#. 3.8->settings-schema.json->firefox-menu->description
 #. 3.4->settings-schema.json->firefox-menu->description
 msgid "Firefox context menu"
 msgstr "Меню на Firefox"
 
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Most Visited"
+msgstr "Най-посещавани"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Recent History"
+msgstr "Скорошна история"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Bookmarks"
+msgstr "Отметки"
+
 #. 2.8->settings-schema.json->firefox-menu->tooltip
+#. 3.8->settings-schema.json->firefox-menu->tooltip
 #. 3.4->settings-schema.json->firefox-menu->tooltip
 msgid ""
 "Most Visited: show the sites you visit most, Recent History: display the the "
@@ -633,20 +600,142 @@ msgstr ""
 "Най-посещавани: показва най-посещаваните места, скорошна история: показва "
 "последно посетените страници, отметки: показва любимите ви отметки."
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Bookmarks"
-msgstr "Отметки"
+#. 2.8->settings-schema.json->autostart-menu-item->description
+#. 3.8->settings-schema.json->autostart-menu-item->description
+#. 3.4->settings-schema.json->autostart-menu-item->description
+msgid "Show autostart option"
+msgstr "Показване на опцията за автоматично пускане"
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Most Visited"
-msgstr "Най-посещавани"
+#. 2.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.4->settings-schema.json->autostart-menu-item->tooltip
+msgid "Shows the autostart toggle option in an app's context menu."
+msgstr "Показва опцията за автоматично пускане в контекстното меню."
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Recent History"
-msgstr "Скорошна история"
+#. 2.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.4->settings-schema.json->monitor-move-all-windows->description
+msgid "Apply the monitor move option to all windows"
+msgstr "Прилагане на опцията за местене на монитор на всички прозорци"
+
+#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
+msgid ""
+"When clicking \"Move to monitor\" in the context menu, this option will move "
+"all of an app's windows instead of just the last focused window from the app."
+msgstr ""
+"Когато щракнете върху \"Преместване на монитор\" в контекстното меню, тази "
+"опция ще премести всички прозорци на дадена програма, а не само последно "
+"фокусирания."
+
+#. 2.8->settings-schema.json->HoverPeek->description
+msgid "Hover Peek Settings"
+msgstr "Настройки при посочване"
+
+#. 2.8->settings-schema.json->enable-hover-peek->description
+#. 3.8->settings-schema.json->enable-hover-peek->description
+#. 3.4->settings-schema.json->enable-hover-peek->description
+msgid "Show windows when hovered over"
+msgstr "Показване на прозорците при посочване"
+
+#. 2.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.4->settings-schema.json->enable-hover-peek->tooltip
+msgid "Controls whether or not windows display when hovered over."
+msgstr "Регулира дали прозорците ще се покажат при посочване."
+
+#. 2.8->settings-schema.json->hover-peek-time->description
+#. 3.8->settings-schema.json->hover-peek-time->description
+#. 3.4->settings-schema.json->hover-peek-time->description
+msgid "Window fade time"
+msgstr "Време на избледняване на прозорците"
+
+#. 2.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.4->settings-schema.json->hover-peek-time->tooltip
+msgid "Controls how quickly a window will fade on hover."
+msgstr "Регулира колко бързо избледнява прозорец при посочване."
+
+#. 2.8->settings-schema.json->hover-peek-opacity->units
+#. 3.8->settings-schema.json->hover-peek-opacity->units
+#. 3.4->settings-schema.json->hover-peek-opacity->units
+msgid "percent"
+msgstr "проценти"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->description
+#. 3.8->settings-schema.json->hover-peek-opacity->description
+#. 3.4->settings-schema.json->hover-peek-opacity->description
+msgid "Window opacity"
+msgstr "Прозрачност на прозорците"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
+msgid "Opacity of the windows on hover."
+msgstr "Прозрачност на прозорците при посочване."
+
+#. 2.8->settings-schema.json->ThemeSettings->description
+msgid "Theme Settings"
+msgstr "Настройки на темата"
+
+#. 2.8->settings-schema.json->show-active->description
+#. 3.8->settings-schema.json->show-active->description
+#. 3.4->settings-schema.json->show-active->description
+msgid "Show active app indicators"
+msgstr "Показване на показателя за активна програма"
+
+#. 2.8->settings-schema.json->show-active->tooltip
+#. 3.8->settings-schema.json->show-active->tooltip
+#. 3.4->settings-schema.json->show-active->tooltip
+msgid "Active app styling will indicate if an app is active."
+msgstr "Показателят указва дали дадена програма е активна."
+
+#. 2.8->settings-schema.json->icon-spacing->units
+#. 2.8->settings-schema.json->icon-padding->units
+#. 2.8->settings-schema.json->icon-size->units
+#. 3.8->settings-schema.json->app-button-width->units
+#. 3.8->settings-schema.json->thumbnail-close-button-size->units
+#. 3.8->settings-schema.json->thumbnail-padding->units
+#. 3.8->settings-schema.json->icon-spacing->units
+#. 3.8->settings-schema.json->icon-padding->units
+#. 3.8->settings-schema.json->icon-size->units
+#. 3.4->settings-schema.json->app-button-width->units
+#. 3.4->settings-schema.json->thumbnail-close-button-size->units
+#. 3.4->settings-schema.json->thumbnail-padding->units
+#. 3.4->settings-schema.json->icon-spacing->units
+#. 3.4->settings-schema.json->icon-padding->units
+#. 3.4->settings-schema.json->icon-size->units
+msgid "px"
+msgstr "пиксела"
+
+#. 2.8->settings-schema.json->icon-spacing->description
+#. 3.8->settings-schema.json->icon-spacing->description
+#. 3.4->settings-schema.json->icon-spacing->description
+msgid "Icon spacing"
+msgstr "Разстояние между иконките"
+
+#. 2.8->settings-schema.json->icon-spacing->tooltip
+#. 3.8->settings-schema.json->icon-spacing->tooltip
+#. 3.4->settings-schema.json->icon-spacing->tooltip
+msgid "Controls how much space is between the icons."
+msgstr "Регулира разстоянието между иконките."
+
+#. 2.8->settings-schema.json->icon-padding->description
+#. 3.8->settings-schema.json->icon-padding->description
+#. 3.4->settings-schema.json->icon-padding->description
+msgid "Icon padding"
+msgstr "Разстояние между иконките"
+
+#. 2.8->settings-schema.json->icon-padding->tooltip
+#. 3.8->settings-schema.json->icon-padding->tooltip
+#. 3.4->settings-schema.json->icon-padding->tooltip
+msgid ""
+"Controls how much horizontal padding is inside the app buttons. Padding is "
+"only applied to instances of this applet on horizontal panels."
+msgstr ""
+"Регулира какво да е хоризонталното отстояние между бутоните. Отстоянието се "
+"прилага само при хоризонтални панели."
 
 #. 2.8->settings-schema.json->themePadding->description
 msgid "Use theme padding to center button icons"
@@ -657,286 +746,236 @@ msgstr ""
 msgid "If button icons look off-centered, toggling this may help."
 msgstr "Това може да помогне, ако иконките на копчетата не са центрирани."
 
-#. 2.8->settings-schema.json->group-apps->description
-#. 3.4->settings-schema.json->group-apps->description
-msgid "Group apps"
-msgstr "Групиране"
+#. 2.8->settings-schema.json->enable-iconSize->description
+#. 3.8->settings-schema.json->enable-iconSize->description
+#. 3.4->settings-schema.json->enable-iconSize->description
+msgid "Adjust icon size"
+msgstr "Регулиране на размера на иконките"
 
-#. 2.8->settings-schema.json->group-apps->tooltip
-#. 3.4->settings-schema.json->group-apps->tooltip
-msgid "Group each app's set of windows."
-msgstr "Групиране на прозорците на всяка програма"
+#. 2.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.4->settings-schema.json->enable-iconSize->tooltip
+msgid "Adjust icon size independent of Cinnamon's panel scaling."
+msgstr "Регулиране на размера на иконките независимо от настройките на панела."
 
-#. 2.8->settings-schema.json->show-active->description
-#. 3.4->settings-schema.json->show-active->description
-msgid "Show active app indicators"
-msgstr "Показване на показателя за активна програма"
+#. 2.8->settings-schema.json->icon-size->description
+#. 3.8->settings-schema.json->icon-size->description
+#. 3.4->settings-schema.json->icon-size->description
+msgid "Icon size"
+msgstr "Размер на иконките"
 
-#. 2.8->settings-schema.json->show-active->tooltip
-#. 3.4->settings-schema.json->show-active->tooltip
-msgid "Active app styling will indicate if an app is active."
-msgstr "Показателят указва дали дадена програма е активна."
+#. 2.8->settings-schema.json->icon-size->tooltip
+#. 3.8->settings-schema.json->icon-size->tooltip
+#. 3.4->settings-schema.json->icon-size->tooltip
+msgid "Set icon size"
+msgstr "Задаване размер на иконките"
 
-#. 2.8->settings-schema.json->show-apps-order-timeout->description
-#. 3.4->settings-schema.json->show-apps-order-timeout->description
-msgid "Duration of the apps order display on hotkey press"
-msgstr "Продължителност на показването на реда при натискане на клавиш"
+#. 2.8->settings-schema.json->hoverPseudoClass->description
+#. 3.8->settings-schema.json->hoverPseudoClass->description
+#. 3.4->settings-schema.json->hoverPseudoClass->description
+msgid "App button hover pseudo class"
+msgstr "Псевдоклас за посочен бутон на програма"
 
-#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
-#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
-msgid ""
-"Determines the duration the window count labels are replaced with the app's "
-"order number."
-msgstr ""
-"Определя продължителността, след която броячите се заменят с пореден номер "
-"на програмата."
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->description
-msgid "Arrange pinned apps"
-msgstr "Подреждане на закачените програми"
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
-msgid "Arrange pinned apps into a different order."
-msgstr "Подреждане на закачените програми по друг начин."
-
-#. 2.8->settings-schema.json->monitor-move-all-windows->description
-#. 3.4->settings-schema.json->monitor-move-all-windows->description
-msgid "Apply the monitor move option to all windows"
-msgstr "Прилагане на опцията за местене на монитор на всички прозорци"
-
-#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
-#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
-msgid ""
-"When clicking \"Move to monitor\" in the context menu, this option will move "
-"all of an app's windows instead of just the last focused window from the app."
-msgstr ""
-"Когато щракнете върху \"Преместване на монитор\" в контекстното меню, тази "
-"опция ще премести всички прозорци на дадена програма, а не само последно "
-"фокусирания."
-
-#. 2.8->settings-schema.json->sort-thumbnails->description
-#. 3.4->settings-schema.json->sort-thumbnails->description
-msgid "Sort windows for each app by last focused"
-msgstr "Подреждане на прозорците на всяка програма по последно фокусиране"
-
-#. 2.8->settings-schema.json->sort-thumbnails->tooltip
-#. 3.4->settings-schema.json->sort-thumbnails->tooltip
-msgid ""
-"Controls whether the order windows appear for an app is by last focused, or "
-"the order they were opened."
-msgstr ""
-"Регулира дали реда на прозорците за дадена програма ще е по последно "
-"фокусиране или по ред на отваряне."
-
-#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
 #. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
 #. 3.4->settings-schema.json->activePseudoClass->options
-msgid "checked"
-msgstr "маркирано"
+msgid "hover"
+msgstr "посочено"
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
-msgid "Highlight the last focused window within an app group"
-msgstr "Освети последния прозорец на фокус в групата с приложения"
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "focus"
+msgstr "фокус"
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "active"
+msgstr "активно"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "outlined"
+msgstr "очертано"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "selected"
+msgstr "избрано"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons on hover."
+msgstr "Замества псевдокласа при посочване на бутон."
+
+#. 2.8->settings-schema.json->focusPseudoClass->description
+#. 3.8->settings-schema.json->focusPseudoClass->description
+#. 3.4->settings-schema.json->focusPseudoClass->description
+msgid "App button focus pseudo class"
+msgstr "Псевдоклас за фокусиран бутон на програма"
+
+#. 2.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.4->settings-schema.json->focusPseudoClass->tooltip
+msgid "Overrides the pseudo class for app button on focus."
+msgstr "Замества псевдокласа за фокусиран бутон."
+
+#. 2.8->settings-schema.json->activePseudoClass->description
+#. 3.8->settings-schema.json->activePseudoClass->description
+#. 3.4->settings-schema.json->activePseudoClass->description
+msgid "App button active pseudo class"
+msgstr "Псевдоклас за активен бутон на програма"
+
+#. 2.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.4->settings-schema.json->activePseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons when they are active."
+msgstr "Замества псевдокласа за активен бутон."
+
+#. 2.8->settings-schema.json->panelLauncherClass->description
+msgid "Use the panel launcher class for pinned apps"
+msgstr "Използване на класа на стартера за закачените програми"
+
+#. 2.8->settings-schema.json->panelLauncherClass->tooltip
+msgid "Enabling this helps with certain themes."
+msgstr "Разрешаването на това помага с определени теми."
+
+#. 2.8->settings-schema.json->close-button-style->description
+msgid "Allow themes to control the thumbnail close button"
+msgstr "Позволяване на темите да управляват бутона за затваряне на миниатюрите"
+
+#. 2.8->settings-schema.json->close-button-style->tooltip
 msgid ""
-"When enabled, the last window that was interacted with will be indicated."
+"Controls whether or not the theme controls the window thumbnail's close "
+"button."
+msgstr "Регулира дали темата управлява бутона за затваряне на миниатюрите."
+
+#. 2.8->settings-schema.json->useSystemTooltips->description
+msgid "Use system tooltips for closed apps"
+msgstr "Използване на системните подсказки за затворените програми"
+
+#. 2.8->settings-schema.json->useSystemTooltips->tooltip
+msgid ""
+"Controls whether or not system tooltips are in use when hovering over closed "
+"pinned apps."
 msgstr ""
-"Когато е включено, последния прозорец, с който сте взаимодействали ще бъде "
-"откроен."
+"Контролира дали системните подсказки се използват, при посочване на "
+"затворените закачени програми."
 
-#. 3.4->settings-schema.json->app-button-transition-duration->description
-msgid "App button transition duration"
-msgstr "Продължителност на прехода на бутона на приложението"
+#. 3.8->settings-schema.json->generalPage->title
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr "Общи"
 
-#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
-msgid ""
-"Overrides the theme's animation time for app buttons. If set to zero, the "
-"theme's transition duration will be used."
-msgstr ""
-"Презаписва времето за анимация на темата за бутоните. Ако е нула, ще се "
-"използва времето за преход на темата."
+#. 3.8->settings-schema.json->panelPage->title
+#. 3.4->settings-schema.json->panelPage->title
+msgid "Panel"
+msgstr "Панел"
 
-#. 3.4->settings-schema.json->app-button-transition-duration->units
-msgid "ms"
-msgstr "мс"
-
-#. 3.4->settings-schema.json->thumbnail-padding->description
-msgid "Thumbnail padding"
-msgstr "Разстояние в миниатюрите"
-
-#. 3.4->settings-schema.json->thumbnail-padding->tooltip
-msgid "Controls how much space will be around the window preview thumbnails."
-msgstr "Регулира колко разстояние да има около миниатюрата на прозорец."
-
-#. 3.4->settings-schema.json->system-favorites->description
-msgid "Use system favorites for pinned apps"
-msgstr "Задаване на любимите като закачени програми"
-
-#. 3.4->settings-schema.json->system-favorites->tooltip
-msgid ""
-"Controls whether or not pinned apps consist of the system favorites list."
-msgstr "Регулира дали любимите се показват като закачени програми."
-
-#. 3.4->settings-schema.json->generalSection->title
-msgid "Behavior"
-msgstr "Поведение"
-
+#. 3.8->settings-schema.json->thumbnailsPage->title
+#. 3.8->settings-schema.json->thumbnailsSection->title
 #. 3.4->settings-schema.json->thumbnailsPage->title
 #. 3.4->settings-schema.json->thumbnailsSection->title
 msgid "Thumbnails"
 msgstr "Миниатюри"
 
-#. 3.4->settings-schema.json->presetSection->title
-msgid "Recommended Presets"
-msgstr "Препоръчани настройки"
-
-#. 3.4->settings-schema.json->appButtonsSection->title
-msgid "App Buttons"
-msgstr "Бутони на програми"
-
-#. 3.4->settings-schema.json->generalPage->title
-msgid "General"
-msgstr "Общи"
-
-#. 3.4->settings-schema.json->hoverPeekSection->title
-msgid "Hover Peek"
-msgstr "Преглед при посочване"
-
-#. 3.4->settings-schema.json->panelPage->title
-msgid "Panel"
-msgstr "Панел"
-
-#. 3.4->settings-schema.json->iconSection->title
-msgid "Icons"
-msgstr "Иконки"
-
-#. 3.4->settings-schema.json->hotKeysSection->title
-msgid "Hot Keys"
-msgstr "Клавишни комбинации"
-
-#. 3.4->settings-schema.json->stylingSection->title
-msgid "Styling"
-msgstr "Стил"
-
+#. 3.8->settings-schema.json->contextMenuPage->title
 #. 3.4->settings-schema.json->contextMenuPage->title
 msgid "Context Menu"
 msgstr "Контекстно меню"
 
+#. 3.8->settings-schema.json->themePage->title
 #. 3.4->settings-schema.json->themePage->title
 msgid "Theming"
 msgstr "Тема"
 
-#. 3.4->settings-schema.json->mintYPreset->description
-#. 3.4->settings-schema.json->mintYPreset->tooltip
-msgid "Mint Y and Variants"
-msgstr "Минт Y и вариантите"
+#. 3.8->settings-schema.json->generalSection->title
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr "Поведение"
 
-#. 3.4->settings-schema.json->show-icons->description
-msgid "Show icons"
-msgstr "Показва иконки"
+#. 3.8->settings-schema.json->appButtonsSection->title
+#. 3.4->settings-schema.json->appButtonsSection->title
+msgid "App Buttons"
+msgstr "Бутони на програми"
 
-#. 3.4->settings-schema.json->show-icons->tooltip
-msgid "Show the window's icon next to the title."
-msgstr "Покажи иконката на прозореца до заглавието."
+#. 3.8->settings-schema.json->hotKeysSection->title
+#. 3.4->settings-schema.json->hotKeysSection->title
+msgid "Hot Keys"
+msgstr "Клавишни комбинации"
 
-#. 3.4->settings-schema.json->enable-app-button-dragging->description
-#. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
-msgid "Enable app button dragging"
-msgstr "Позволяване на влаченето на бутони"
+#. 3.8->settings-schema.json->hoverPeekSection->title
+#. 3.4->settings-schema.json->hoverPeekSection->title
+msgid "Hover Peek"
+msgstr "Преглед при посочване"
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
-msgid "Show new window option"
-msgstr "Показване на опцията за нов прозорец"
+#. 3.8->settings-schema.json->stylingSection->title
+#. 3.4->settings-schema.json->stylingSection->title
+msgid "Styling"
+msgstr "Стил"
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
-msgid ""
-"Shows the \"New Window\" option in an app's context menu if it doesn't "
-"already have one from the app's own action menu items."
-msgstr ""
-"Показва \"Нов прозорец\" опцията в контекстното меню на приложението, ако "
-"приложението няма такава в менюто си."
+#. 3.8->settings-schema.json->iconSection->title
+#. 3.4->settings-schema.json->iconSection->title
+msgid "Icons"
+msgstr "Иконки"
 
-#. 3.4->settings-schema.json->app-button-width->description
-msgid "App button width"
-msgstr "Ширина на бутона"
+#. 3.8->settings-schema.json->presetSection->title
+#. 3.4->settings-schema.json->presetSection->title
+msgid "Recommended Presets"
+msgstr "Препоръчани настройки"
 
-#. 3.4->settings-schema.json->app-button-width->tooltip
-msgid ""
-"Controls the width of the application button. This option only works for "
-"horizontal panels."
-msgstr ""
-"Регулира ширината на копчето на програма. Тази опция работи само при "
-"хоризонтални панели."
-
-#. 3.4->settings-schema.json->mintXPreset->description
-#. 3.4->settings-schema.json->mintXPreset->tooltip
-msgid "Mint X, Linux Mint, and Variants"
-msgstr "Минт X, Линукс Минт и вариантите"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->description
-msgid "Launcher animation effect"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
-#. 3.4->settings-schema.json->left-click-action->description
-#. 3.4->settings-schema.json->left-click-action->tooltip
-msgid "Left click action"
-msgstr "Действие при натискане на ляв бутон"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Scale"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Fade"
-msgstr ""
-
-#. 3.4->settings-schema.json->enable-app-button-width->description
-msgid "Use a custom width for app buttons"
-msgstr "Задаване широчина на бутоните за приложения"
-
-#. 3.4->settings-schema.json->enable-app-button-width->tooltip
-msgid "When disabled, the app button width is determined by the panel height."
-msgstr ""
-"Когато е изключено, широчината на бутоните на приложенията ще се определя от "
-"височината на панела."
-
-#. 3.4->settings-schema.json->list-monitor-windows->description
-msgid "Only list windows from the monitor displaying this instance"
-msgstr "Да се показват само прозорци от текущо показващия монитор"
-
-#. 3.4->settings-schema.json->list-monitor-windows->tooltip
-msgid ""
-"This option will only come into effect for monitors displaying an ITM "
-"instance."
-msgstr "Опцията се задейства само за монитори, показващи екземпляр на ITM"
-
-#. 3.4->settings-schema.json->thumbnail-close-button-size->description
-msgid "Close button size"
-msgstr "Размер на бутона за затваряне"
-
-#. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
-msgid "Controls how large the thumbnail close button is."
-msgstr "Контролира каква е широчината на бутона за затваряне на миниатюрите."
-
-#. 3.4->settings-schema.json->middle-click-action->description
-#. 3.4->settings-schema.json->middle-click-action->tooltip
-msgid "Middle click action"
-msgstr "Действие при натискане на колелцето"
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Launch new app instance"
-msgstr "Стартирай нова инстанция на приложението"
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Close last focused window in group"
-msgstr "Затвори последно фокусирания прозорец в групата с приложения"
-
+#. 3.8->settings-schema.json->scroll-behavior->description
 #. 3.4->settings-schema.json->scroll-behavior->description
 msgid "Mouse wheel scroll behavior"
 msgstr "Поведение на скрола на мишката"
 
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+msgid "Cycle apps"
+msgstr "Превъртане на приложенията"
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+msgid "Cycle windows"
+msgstr "Превъртане на прозорците"
+
+#. 3.8->settings-schema.json->scroll-behavior->tooltip
 #. 3.4->settings-schema.json->scroll-behavior->tooltip
 msgid ""
 "Choose if scrolling the mouse wheel cycles running apps, an app button's "
@@ -945,24 +984,141 @@ msgstr ""
 "Изберете дали да включите превъртането на работещите приложения с колелцето "
 "на мишката."
 
-#. 3.4->settings-schema.json->scroll-behavior->options
-msgid "Cycle apps"
-msgstr "Превъртане на приложенията"
+#. 3.8->settings-schema.json->left-click-action->description
+#. 3.8->settings-schema.json->left-click-action->tooltip
+#. 3.8->settings-schema.json->launcher-animation-effect->tooltip
+#. 3.4->settings-schema.json->left-click-action->description
+#. 3.4->settings-schema.json->left-click-action->tooltip
+#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
+msgid "Left click action"
+msgstr "Действие при натискане на ляв бутон"
 
-#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
 #. 3.4->settings-schema.json->left-click-action->options
-msgid "Cycle windows"
-msgstr "Превъртане на прозорците"
+msgid "Toggle activation of last focused window"
+msgstr "Превключва активността към последно посочения прозорец"
 
+#. 3.8->settings-schema.json->middle-click-action->description
+#. 3.8->settings-schema.json->middle-click-action->tooltip
+#. 3.4->settings-schema.json->middle-click-action->description
+#. 3.4->settings-schema.json->middle-click-action->tooltip
+msgid "Middle click action"
+msgstr "Действие при натискане на колелцето"
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Launch new app instance"
+msgstr "Стартирай нова инстанция на приложението"
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Close last focused window in group"
+msgstr "Затвори последно фокусирания прозорец в групата с приложения"
+
+#. 3.8->settings-schema.json->system-favorites->description
+#. 3.4->settings-schema.json->system-favorites->description
+msgid "Use system favorites for pinned apps"
+msgstr "Задаване на любимите като закачени програми"
+
+#. 3.8->settings-schema.json->system-favorites->tooltip
+#. 3.4->settings-schema.json->system-favorites->tooltip
+msgid ""
+"Controls whether or not pinned apps consist of the system favorites list."
+msgstr "Регулира дали любимите се показват като закачени програми."
+
+#. 3.8->settings-schema.json->show-all-workspaces->description
+#. 3.8->settings-schema.json->show-all-workspaces->tooltip
 #. 3.4->settings-schema.json->show-all-workspaces->description
 #. 3.4->settings-schema.json->show-all-workspaces->tooltip
 msgid "Show windows from all workspaces"
 msgstr "Показва прозорците от всички работни места"
 
+#. 3.8->settings-schema.json->enable-app-button-dragging->description
+#. 3.8->settings-schema.json->enable-app-button-dragging->tooltip
+#. 3.4->settings-schema.json->enable-app-button-dragging->description
+#. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
+msgid "Enable app button dragging"
+msgstr "Позволяване на влаченето на бутони"
+
+#. 3.8->settings-schema.json->launcher-animation-effect->description
+#. 3.4->settings-schema.json->launcher-animation-effect->description
+msgid "Launcher animation effect"
+msgstr ""
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Fade"
+msgstr ""
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Scale"
+msgstr ""
+
+#. 3.8->settings-schema.json->list-monitor-windows->description
+#. 3.4->settings-schema.json->list-monitor-windows->description
+msgid "Only list windows from the monitor displaying this instance"
+msgstr "Да се показват само прозорци от текущо показващия монитор"
+
+#. 3.8->settings-schema.json->list-monitor-windows->tooltip
+#. 3.4->settings-schema.json->list-monitor-windows->tooltip
+msgid ""
+"This option will only come into effect for monitors displaying an ITM "
+"instance."
+msgstr "Опцията се задейства само за монитори, показващи екземпляр на ITM"
+
+#. 3.8->settings-schema.json->enable-app-button-width->description
+#. 3.4->settings-schema.json->enable-app-button-width->description
+msgid "Use a custom width for app buttons"
+msgstr "Задаване широчина на бутоните за приложения"
+
+#. 3.8->settings-schema.json->enable-app-button-width->tooltip
+#. 3.4->settings-schema.json->enable-app-button-width->tooltip
+msgid "When disabled, the app button width is determined by the panel height."
+msgstr ""
+"Когато е изключено, широчината на бутоните на приложенията ще се определя от "
+"височината на панела."
+
+#. 3.8->settings-schema.json->app-button-width->description
+#. 3.4->settings-schema.json->app-button-width->description
+msgid "App button width"
+msgstr "Ширина на бутона"
+
+#. 3.8->settings-schema.json->app-button-width->tooltip
+#. 3.4->settings-schema.json->app-button-width->tooltip
+msgid ""
+"Controls the width of the application button. This option only works for "
+"horizontal panels."
+msgstr ""
+"Регулира ширината на копчето на програма. Тази опция работи само при "
+"хоризонтални панели."
+
+#. 3.8->settings-schema.json->thumbnail-close-button-size->description
+#. 3.4->settings-schema.json->thumbnail-close-button-size->description
+msgid "Close button size"
+msgstr "Размер на бутона за затваряне"
+
+#. 3.8->settings-schema.json->thumbnail-close-button-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
+msgid "Controls how large the thumbnail close button is."
+msgstr "Контролира каква е широчината на бутона за затваряне на миниатюрите."
+
+#. 3.8->settings-schema.json->thumbnail-padding->description
+#. 3.4->settings-schema.json->thumbnail-padding->description
+msgid "Thumbnail padding"
+msgstr "Разстояние в миниатюрите"
+
+#. 3.8->settings-schema.json->thumbnail-padding->tooltip
+#. 3.4->settings-schema.json->thumbnail-padding->tooltip
+msgid "Controls how much space will be around the window preview thumbnails."
+msgstr "Регулира колко разстояние да има около миниатюрата на прозорец."
+
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->description
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
 msgid "Cycle windows on mouse wheel scroll"
 msgstr "Превключване на прозорци със скрола на мишката"
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->tooltip
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
 msgid ""
 "Choose whether or not scrolling the mouse wheel cycles windows when hovering "
@@ -971,17 +1127,88 @@ msgstr ""
 "Изберете дали скрол с колелцето на мишката ще превключва прозорците, при "
 "посочване на менюто на миниатюрата."
 
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "Toggle activation of last focused window"
-msgstr "Превключва активността към последно посочения прозорец"
+#. 3.8->settings-schema.json->show-icons->description
+#. 3.4->settings-schema.json->show-icons->description
+msgid "Show icons"
+msgstr "Показва иконки"
 
-#. IcingTaskManager@json->metadata.json->name
-msgid "Icing Task Manager"
-msgstr "Диспечер на задачи Icing"
+#. 3.8->settings-schema.json->show-icons->tooltip
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr "Покажи иконката на прозореца до заглавието."
 
-#. IcingTaskManager@json->metadata.json->description
-msgid "Window list with app grouping and thumbnails"
-msgstr "Списък с прозорци с групиране на приложения и миниатюри"
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->description
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
+msgid "Highlight the last focused window within an app group"
+msgstr "Освети последния прозорец на фокус в групата с приложения"
+
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+msgid ""
+"When enabled, the last window that was interacted with will be indicated."
+msgstr ""
+"Когато е включено, последния прозорец, с който сте взаимодействали ще бъде "
+"откроен."
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->description
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+msgid "Show new window option"
+msgstr "Показване на опцията за нов прозорец"
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->tooltip
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+"Показва \"Нов прозорец\" опцията в контекстното меню на приложението, ако "
+"приложението няма такава в менюто си."
+
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr "маркирано"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->units
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr "мс"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->description
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr "Продължителност на прехода на бутона на приложението"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->tooltip
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+"Презаписва времето за анимация на темата за бутоните. Ако е нула, ще се "
+"използва времето за преход на темата."
+
+#. 3.8->settings-schema.json->mintYPreset->description
+#. 3.8->settings-schema.json->mintYPreset->tooltip
+#. 3.4->settings-schema.json->mintYPreset->description
+#. 3.4->settings-schema.json->mintYPreset->tooltip
+msgid "Mint Y and Variants"
+msgstr "Минт Y и вариантите"
+
+#. 3.8->settings-schema.json->mintXPreset->description
+#. 3.8->settings-schema.json->mintXPreset->tooltip
+#. 3.4->settings-schema.json->mintXPreset->description
+#. 3.4->settings-schema.json->mintXPreset->tooltip
+msgid "Mint X, Linux Mint, and Variants"
+msgstr "Минт X, Линукс Минт и вариантите"
+
+#. 3.8->settings-schema.json->migrationButton->description
+msgid "Migrate Pinned Apps to Grouped Window List"
+msgstr ""
 
 #~ msgid "number"
 #~ msgstr "число"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/da.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/da.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-10 00:43-0600\n"
+"POT-Creation-Date: 2018-12-13 18:37-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: Dansk <dansk@dansk-gruppen.dk>\n"
@@ -13,53 +13,53 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: 3.8/applet.js:471
-msgid "Icing Task Manager is now Grouped Window List"
-msgstr ""
+#: 3.8/applet.js:476
+#, fuzzy
+msgid "Icing Task Manager is deprecated"
+msgstr "Icing programhåndtering"
 
-#: 3.8/applet.js:472
+#: 3.8/applet.js:477
 msgid ""
-"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
-"Window List\". "
+"Please upgrade to Grouped Window List for a more stable, bug-free experience."
 msgstr ""
 
-#: 3.8/applet.js:473
+#: 3.8/applet.js:478
 msgid ""
-"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
-"List."
+"Add GWL to your panel, open the applet's settings and click \"Migrate Pinned "
+"Apps to Grouped Window List\"."
 msgstr ""
 
-#: 3.8/applet.js:485
-msgid "Migration can only be performed on Cinnamon 4.0."
+#: 3.8/applet.js:490
+msgid "Migration can only be performed on Cinnamon 4.0+."
 msgstr ""
 
-#: 3.8/applet.js:496
+#: 3.8/applet.js:501
 msgid ""
 "Please add Grouped Window List to a panel before proceeding with the "
 "migration."
 msgstr ""
 
-#: 3.8/applet.js:504
+#: 3.8/applet.js:509
 msgid "ITM settings directory could not be found!"
 msgstr ""
 
-#: 3.8/applet.js:534
+#: 3.8/applet.js:539
 msgid "System favorites enabled - no migration is needed."
 msgstr ""
 
-#: 3.8/applet.js:577
+#: 3.8/applet.js:582
 msgid "Unable to find a suitable ITM settings file to migrate."
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid "Migration complete. "
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid " settings file(s) could not be migrated."
 msgstr ""
 
-#: 3.8/applet.js:592
+#: 3.8/applet.js:597
 msgid "Migration was successful."
 msgstr ""
 
@@ -1210,3 +1210,7 @@ msgstr "Mint X, Linux Mint, og varianter"
 #. 3.8->settings-schema.json->migrationButton->description
 msgid "Migrate Pinned Apps to Grouped Window List"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Icing Task Manager is deprecated - please use Grouped Window List"
+#~ msgstr "Icing programhåndtering"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/da.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/da.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-23 21:32-0600\n"
+"POT-Creation-Date: 2018-12-10 00:43-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: Dansk <dansk@dansk-gruppen.dk>\n"
@@ -13,551 +13,219 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/applet.js:471
+msgid "Icing Task Manager is now Grouped Window List"
+msgstr ""
+
+#: 3.8/applet.js:472
+msgid ""
+"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
+"Window List\". "
+msgstr ""
+
+#: 3.8/applet.js:473
+msgid ""
+"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
+"List."
+msgstr ""
+
+#: 3.8/applet.js:485
+msgid "Migration can only be performed on Cinnamon 4.0."
+msgstr ""
+
+#: 3.8/applet.js:496
+msgid ""
+"Please add Grouped Window List to a panel before proceeding with the "
+"migration."
+msgstr ""
+
+#: 3.8/applet.js:504
+msgid "ITM settings directory could not be found!"
+msgstr ""
+
+#: 3.8/applet.js:534
+msgid "System favorites enabled - no migration is needed."
+msgstr ""
+
+#: 3.8/applet.js:577
+msgid "Unable to find a suitable ITM settings file to migrate."
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid "Migration complete. "
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid " settings file(s) could not be migrated."
+msgstr ""
+
+#: 3.8/applet.js:592
+msgid "Migration was successful."
+msgstr ""
+
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to the other monitor"
 msgstr "Flyt til den anden skærm"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to monitor "
 msgstr "Flyt til skærm "
 
-#: 3.4/specialMenus.js:126
+#: 3.8/specialMenus.js:98 3.4/specialMenus.js:126
 msgid "Only on this workspace"
 msgstr "Kun på dette arbejdsområde"
 
-#: 3.4/specialMenus.js:133
+#: 3.8/specialMenus.js:105 3.4/specialMenus.js:133
 msgid "Visible on all workspaces"
 msgstr "Synlig på alle arbejdsområder"
 
-#: 3.4/specialMenus.js:140
+#: 3.8/specialMenus.js:112 3.4/specialMenus.js:140
 msgid "Move to another workspace"
 msgstr "Flyt til et andet arbejdsområde"
 
-#: 3.4/specialMenus.js:168
+#: 3.8/specialMenus.js:140 3.4/specialMenus.js:168
 msgid "Places"
 msgstr "Steder"
 
-#: 3.4/specialMenus.js:207
+#: 3.8/specialMenus.js:179 3.4/specialMenus.js:207
 msgid "Bookmarks/History requires gir1.2-gda-5.0"
 msgstr "Bogmærker/historik kræver gir1.2-gda-5.0"
 
-#: 3.4/specialMenus.js:227
+#: 3.8/specialMenus.js:199 3.4/specialMenus.js:227
 msgid "Recent"
 msgstr "Seneste"
 
-#: 3.4/specialMenus.js:246
+#: 3.8/specialMenus.js:218 3.4/specialMenus.js:246
 msgid "Preferences"
 msgstr "Indstillinger"
 
-#: 3.4/specialMenus.js:249
+#: 3.8/specialMenus.js:221 3.4/specialMenus.js:249
 msgid "About..."
 msgstr "Om..."
 
-#: 3.4/specialMenus.js:253
+#: 3.8/specialMenus.js:225 3.4/specialMenus.js:253
 msgid "Configure..."
 msgstr "Konfigurér..."
 
-#: 3.4/specialMenus.js:257
+#: 3.8/specialMenus.js:229 3.4/specialMenus.js:257
 msgid "Remove"
 msgstr "Fjern"
 
-#: 3.4/specialMenus.js:287
+#: 3.8/specialMenus.js:259 3.4/specialMenus.js:287
 msgid "New Window"
 msgstr "Nyt vindue"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Unpin from Panel"
 msgstr "Frigør fra panel"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Pin to Panel"
 msgstr "Fastgør til panel"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Remove from Autostart"
 msgstr "Fjern fra automatisk opstart"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Add to Autostart"
 msgstr "Tilføj til automatisk opstart"
 
-#: 3.4/specialMenus.js:318
+#: 3.8/specialMenus.js:290 3.4/specialMenus.js:318
 msgid "Create Shortcut"
 msgstr "Opret genvej"
 
-#: 3.4/specialMenus.js:329
+#: 3.8/specialMenus.js:301 3.4/specialMenus.js:329
 msgid "Restore to full opacity"
 msgstr "Gendan til fuld uigennemsigtighed"
 
-#: 3.4/specialMenus.js:337
+#: 3.8/specialMenus.js:309 3.4/specialMenus.js:337
 msgid "Restore"
 msgstr "Gendan"
 
-#: 3.4/specialMenus.js:342
+#: 3.8/specialMenus.js:314 3.4/specialMenus.js:342
 msgid "Minimize"
 msgstr "Minimér"
 
-#: 3.4/specialMenus.js:350
+#: 3.8/specialMenus.js:322 3.4/specialMenus.js:350
 msgid "Unmaximize"
 msgstr "Gendan"
 
-#: 3.4/specialMenus.js:355
+#: 3.8/specialMenus.js:327 3.4/specialMenus.js:355
 msgid "Maximize"
 msgstr "Maksimér"
 
-#: 3.4/specialMenus.js:365
+#: 3.8/specialMenus.js:337 3.4/specialMenus.js:365
 msgid "Close others"
 msgstr "Luk andre"
 
-#: 3.4/specialMenus.js:375
+#: 3.8/specialMenus.js:347 3.4/specialMenus.js:375
 msgid "Close all"
 msgstr "Luk alle"
 
-#: 3.4/specialMenus.js:385
+#: 3.8/specialMenus.js:357 3.4/specialMenus.js:385
 msgid "Close"
 msgstr "Luk"
 
-#. 2.8->settings-schema.json->thumbnail-size->description
-#. 3.4->settings-schema.json->thumbnail-size->description
-msgid "Thumbnail size"
-msgstr "Miniaturestørrelse"
+#. metadata.json->description
+msgid "Window list with app grouping and thumbnails"
+msgstr "Vinduesliste med miniaturer og gruppering af programmer"
 
-#. 2.8->settings-schema.json->thumbnail-size->tooltip
-#. 3.4->settings-schema.json->thumbnail-size->tooltip
-msgid "Controls the size of the thumbnails."
-msgstr "Kontrollerer størrelsen på miniaturer."
+#. metadata.json->name
+msgid "Icing Task Manager"
+msgstr "Icing programhåndtering"
 
-#. 2.8->settings-schema.json->thumbnail-size->units
-#. 3.4->settings-schema.json->thumbnail-size->units
-msgid "size"
-msgstr "størrelse"
-
-#. 2.8->settings-schema.json->focusPseudoClass->description
-#. 3.4->settings-schema.json->focusPseudoClass->description
-msgid "App button focus pseudo class"
-msgstr "Pseudoklasse for programknapsfokus"
-
-#. 2.8->settings-schema.json->focusPseudoClass->tooltip
-#. 3.4->settings-schema.json->focusPseudoClass->tooltip
-msgid "Overrides the pseudo class for app button on focus."
-msgstr "Tilsidesætter pseudoklassen for programknappen ved fokus."
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "active"
-msgstr "aktiv"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "outlined"
-msgstr "kontur"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "hover"
-msgstr "svæv"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "focus"
-msgstr "fokus"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "selected"
-msgstr "valgt"
-
-#. 2.8->settings-schema.json->icon-spacing->description
-#. 3.4->settings-schema.json->icon-spacing->description
-msgid "Icon spacing"
-msgstr "Ikonmellemrum"
-
-#. 2.8->settings-schema.json->icon-spacing->tooltip
-#. 3.4->settings-schema.json->icon-spacing->tooltip
-msgid "Controls how much space is between the icons."
-msgstr "Kontrollerer mellemrummet mellem ikoner."
-
-#. 2.8->settings-schema.json->icon-spacing->units
-#. 2.8->settings-schema.json->icon-size->units
-#. 2.8->settings-schema.json->icon-padding->units
-#. 3.4->settings-schema.json->icon-spacing->units
-#. 3.4->settings-schema.json->thumbnail-padding->units
-#. 3.4->settings-schema.json->icon-size->units
-#. 3.4->settings-schema.json->app-button-width->units
-#. 3.4->settings-schema.json->thumbnail-close-button-size->units
-#. 3.4->settings-schema.json->icon-padding->units
-msgid "px"
-msgstr "px"
-
-#. 2.8->settings-schema.json->show-thumbnails->description
-#. 3.4->settings-schema.json->show-thumbnails->description
-msgid "Show thumbnails"
-msgstr "Vis miniaturer"
-
-#. 2.8->settings-schema.json->show-thumbnails->tooltip
-#. 3.4->settings-schema.json->show-thumbnails->tooltip
-msgid "Show window thumbnails when hovering over an app button."
-msgstr "Vis vinduesminiaturer, når markøren føres hen over en programknap."
-
-#. 2.8->settings-schema.json->icon-size->description
-#. 3.4->settings-schema.json->icon-size->description
-msgid "Icon size"
-msgstr "Ikonstørrelse"
-
-#. 2.8->settings-schema.json->icon-size->tooltip
-#. 3.4->settings-schema.json->icon-size->tooltip
-msgid "Set icon size"
-msgstr "Angiv ikonstørrelse"
-
-#. 2.8->settings-schema.json->hover-peek-time->description
-#. 3.4->settings-schema.json->hover-peek-time->description
-msgid "Window fade time"
-msgstr "Udtoningstid for vindue"
-
-#. 2.8->settings-schema.json->hover-peek-time->tooltip
-#. 3.4->settings-schema.json->hover-peek-time->tooltip
-msgid "Controls how quickly a window will fade on hover."
-msgstr ""
-"Kontrollerer hvor hurtigt et vindue vil tone ud, når markøren føres hen over."
-
-#. 2.8->settings-schema.json->hover-peek-time->units
-#. 2.8->settings-schema.json->thumbnail-timeout->units
-#. 2.8->settings-schema.json->show-apps-order-timeout->units
-#. 3.4->settings-schema.json->hover-peek-time->units
-#. 3.4->settings-schema.json->thumbnail-timeout->units
-#. 3.4->settings-schema.json->show-apps-order-timeout->units
-msgid "milliseconds"
-msgstr "millisekunder"
-
-#. 2.8->settings-schema.json->close-button-style->description
-msgid "Allow themes to control the thumbnail close button"
-msgstr "Tillad at temaet kontrollerer lukkeknappen i miniaturen"
-
-#. 2.8->settings-schema.json->close-button-style->tooltip
-msgid ""
-"Controls whether or not the theme controls the window thumbnail's close "
-"button."
-msgstr "Kontrollerer om temaet bestemmer udseendet på miniaturens lukkeknap."
-
-#. 2.8->settings-schema.json->title-display->description
-#. 3.4->settings-schema.json->title-display->description
-msgid "Title display"
-msgstr "Titelvisning"
-
-#. 2.8->settings-schema.json->title-display->tooltip
-#. 3.4->settings-schema.json->title-display->tooltip
-msgid ""
-"focused: show focused window title, title: display the window title, app: "
-"diplay app name, none: don't display anything"
-msgstr ""
-"Fokuseret: vis fokuseret vindues titel, Titel: vis vinduestitlen, Program: "
-"vis programnavnet, Ingen: vis ikke noget"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-#. 3.4->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->middle-click-action->options
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "None"
-msgstr "Ingen"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Focused"
-msgstr "Fokuseret"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "App"
-msgstr "Program"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Title"
-msgstr "Titel"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->description
-#. 3.4->settings-schema.json->hoverPseudoClass->description
-msgid "App button hover pseudo class"
-msgstr "Pseudoklasse for programknapsvævning"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
-#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons on hover."
-msgstr ""
-"Tilsidesætter pseudoklassen for programknapper, når markøren føres hen over."
-
-#. 2.8->settings-schema.json->show-alerts->description
-#. 3.4->settings-schema.json->show-alerts->description
-msgid "Show app alerts and notifications"
-msgstr "Vis beskeder og advarsler fra programmer"
-
-#. 2.8->settings-schema.json->show-alerts->tooltip
-#. 3.4->settings-schema.json->show-alerts->tooltip
-msgid "If enabled, notifications and alerts will appear."
-msgstr "Når aktiveret vil beskeder og advarsler optræde."
-
-#. 2.8->settings-schema.json->pinOnDrag->description
-#. 2.8->settings-schema.json->pinOnDrag->tooltip
-#. 3.4->settings-schema.json->pinOnDrag->description
-#. 3.4->settings-schema.json->pinOnDrag->tooltip
-msgid "Pin apps when dragged to a new position"
-msgstr "Fastgør programmer, når de trækkes til en ny placering"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->description
-#. 3.4->settings-schema.json->show-apps-order-hotkey->description
-msgid "Global hotkey to show the order of apps"
-msgstr "Global genvejstast til at vise programrækkefølgen"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
-#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
-msgid ""
-"When triggered, the window count label will be replaced with its order in "
-"the app list temporarily."
-msgstr ""
-"Når genvejstasten trykkes, vil vinduestælleren midlertidigt blive erstattet "
-"med rækkefølgen i programlisten."
-
-#. 2.8->settings-schema.json->menuItemType->description
-#. 3.4->settings-schema.json->menuItemType->description
-msgid "Menu item type"
-msgstr "Menuelementtype"
-
-#. 2.8->settings-schema.json->menuItemType->tooltip
-#. 3.4->settings-schema.json->menuItemType->tooltip
-msgid ""
-"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
-msgstr ""
-"Bestemmer om menuelementikoner er symbolske, ikke-symbolske eller ikke vises."
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Symbolic icons"
-msgstr "Symbolske ikoner"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "No icons"
-msgstr "Ingen ikoner"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Non-symbolic icons"
-msgstr "Ikke-symbolske ikoner"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->description
-#. 3.4->settings-schema.json->hover-peek-opacity->description
-msgid "Window opacity"
-msgstr "Vinduesuigennemsigtighed"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
-#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
-msgid "Opacity of the windows on hover."
-msgstr "Vinduernes uigennemsigtighed når markøren føres hen over miniaturen."
-
-#. 2.8->settings-schema.json->hover-peek-opacity->units
-#. 3.4->settings-schema.json->hover-peek-opacity->units
-msgid "percent"
-msgstr "procent"
-
-#. 2.8->settings-schema.json->enable-hover-peek->description
-#. 3.4->settings-schema.json->enable-hover-peek->description
-msgid "Show windows when hovered over"
-msgstr "Vis vinduer, når markøren føres hen over miniaturen"
-
-#. 2.8->settings-schema.json->enable-hover-peek->tooltip
-#. 3.4->settings-schema.json->enable-hover-peek->tooltip
-msgid "Controls whether or not windows display when hovered over."
-msgstr "Kontrollerer om vinduer vises, når markøren føres hen over miniaturen."
-
-#. 2.8->settings-schema.json->activePseudoClass->description
-#. 3.4->settings-schema.json->activePseudoClass->description
-msgid "App button active pseudo class"
-msgstr "Pseudoklasse for aktiv programknap"
-
-#. 2.8->settings-schema.json->activePseudoClass->tooltip
-#. 3.4->settings-schema.json->activePseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons when they are active."
-msgstr "Tilsidesætter pseudoklassen for programknapper, når de er aktive."
-
-#. 2.8->settings-schema.json->animate-thumbnails->description
-#. 3.4->settings-schema.json->animate-thumbnails->description
-msgid "Animate thumbnails"
-msgstr "Animér miniaturer"
-
-#. 2.8->settings-schema.json->animate-thumbnails->tooltip
-#. 3.4->settings-schema.json->animate-thumbnails->tooltip
-msgid "If enabled, thumbnails will animate when appearing and disappearing."
-msgstr "Når aktiveret vil miniaturer animeres, når de dukker op og forsvinder."
-
-#. 2.8->settings-schema.json->autostart-menu-item->description
-#. 3.4->settings-schema.json->autostart-menu-item->description
-msgid "Show autostart option"
-msgstr "Vis til-/fravalg af automatisk opstart"
-
-#. 2.8->settings-schema.json->autostart-menu-item->tooltip
-#. 3.4->settings-schema.json->autostart-menu-item->tooltip
-msgid "Shows the autostart toggle option in an app's context menu."
-msgstr ""
-"Viser tilføj til/fjern fra automatisk opstart i et programs genvejsmenu"
-
-#. 2.8->settings-schema.json->show-pinned->description
-#. 3.4->settings-schema.json->show-pinned->description
-msgid "Show pinned apps"
-msgstr "Vis fastgjorte programmer"
-
-#. 2.8->settings-schema.json->show-pinned->tooltip
-#. 3.4->settings-schema.json->show-pinned->tooltip
-msgid ""
-"Controls whether or not the pinned apps appear in the panel if they are not "
-"open."
-msgstr ""
-"Kontrollerer om fastgjorte programmer vises i statusfeltet, hvis de ikke er "
-"åbne."
-
-#. 2.8->settings-schema.json->useSystemTooltips->description
-msgid "Use system tooltips for closed apps"
-msgstr "Anvend systemværktøjstip for lukkede programmer"
-
-#. 2.8->settings-schema.json->useSystemTooltips->tooltip
-msgid ""
-"Controls whether or not system tooltips are in use when hovering over closed "
-"pinned apps."
-msgstr ""
-"Kontrollerer om systemværktøjstip anvendes, når markøren føres hen over "
-"lukkede, fastgjorte programmer."
+#. 2.8->settings-schema.json->ITM->description
+msgid "ITM Settings"
+msgstr "Indstillinger for Icing"
 
 #. 2.8->settings-schema.json->WindowList->description
 msgid "Window List Settings"
 msgstr "Indstillinger for vinduesliste"
 
-#. 2.8->settings-schema.json->AppMenu->description
-msgid "Context Menu Settings"
-msgstr "Indstillinger for genvejsmenu"
-
-#. 2.8->settings-schema.json->Thumbnails->description
-msgid "Thumbnail Settings"
-msgstr "Indstillinger for miniaturer"
-
-#. 2.8->settings-schema.json->show-recent->description
-#. 3.4->settings-schema.json->show-recent->description
-msgid "Show recent items"
-msgstr "Vis seneste elementer"
-
-#. 2.8->settings-schema.json->show-recent->tooltip
-#. 3.4->settings-schema.json->show-recent->tooltip
-msgid "Controls whether recent items will appear in the context menu."
-msgstr "Kontrollerer om seneste elementer optræder i genvejsmenuen."
-
-#. 2.8->settings-schema.json->vertical-thumbnails->description
-#. 3.4->settings-schema.json->vertical-thumbnails->description
-msgid "Enable vertical thumbnails"
-msgstr "Aktivér lodrette miniaturer"
-
-#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
-#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
-msgid "If enabled, thumbnails will stack vertically."
-msgstr "Når aktiveret vil miniaturer vises i en kolonne."
-
-#. 2.8->settings-schema.json->thumbnail-timeout->description
-#. 3.4->settings-schema.json->thumbnail-timeout->description
-msgid "Thumbnail timeout"
-msgstr "Miniaturetimeout"
-
-#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
-#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
-msgid ""
-"Controls how quickly an app's set of window thumbnails will fade out when "
-"the mouse leaves the app button."
-msgstr ""
-"Kontrollerer hvor hurtigt et programs miniaturer vil tone ud, når markøren "
-"fjernes fra programknappen."
-
-#. 2.8->settings-schema.json->ThemeSettings->description
-msgid "Theme Settings"
-msgstr "Indstillinger for tema"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->description
-#. 3.4->settings-schema.json->onclick-thumbnails->description
-msgid "Open thumbnails on click"
-msgstr "Åbn miniaturer ved klik"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
-#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
-msgid "Open the thumbnails on click if there is more than one window open."
-msgstr "Åbn miniaturerne ved klik, hvis der er mere et vindue åbent."
-
-#. 2.8->settings-schema.json->panelLauncherClass->description
-msgid "Use the panel launcher class for pinned apps"
-msgstr "Anvend panelprogramstarterklassen for fastgjorte programmer"
-
-#. 2.8->settings-schema.json->panelLauncherClass->tooltip
-msgid "Enabling this helps with certain themes."
-msgstr "Aktivering af denne kan hjælpe med visse temaer."
-
-#. 2.8->settings-schema.json->include-all-windows->description
-#. 3.4->settings-schema.json->include-all-windows->description
-msgid "Include all app windows"
-msgstr "Inkludér alle programmets vinduer"
-
-#. 2.8->settings-schema.json->include-all-windows->tooltip
-#. 3.4->settings-schema.json->include-all-windows->tooltip
-msgid ""
-"Controls whether or not thumbnails for smalller child windows, such as exit "
-"confirmations and file dialogues will be included in the thumbnail list."
-msgstr ""
-"Kontrollerer om miniaturer af mindre vinduer, f.eks. afslutbekræftelse og "
-"fildialoger, inkluderes i miniaturelisten."
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->description
-#. 3.4->settings-schema.json->cycleMenusHotkey->description
-msgid "Global hotkey for cycling through thumbnail menus"
-msgstr "Global genvejstast for at bladre gennem miniaturemenuer"
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
-#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
-msgid "This allows you to cycle through the menus without activating a window."
-msgstr "Dette lader dig bladre gennem menuer uden at aktivere et vindue."
-
-#. 2.8->settings-schema.json->enable-iconSize->description
-#. 3.4->settings-schema.json->enable-iconSize->description
-msgid "Adjust icon size"
-msgstr "Justér ikonstørrelse"
-
-#. 2.8->settings-schema.json->enable-iconSize->tooltip
-#. 3.4->settings-schema.json->enable-iconSize->tooltip
-msgid "Adjust icon size independent of Cinnamon's panel scaling."
-msgstr "Justér ikonstørrelse uafhængigt af Cinnamons panelskalering."
-
 #. 2.8->settings-schema.json->number-display->description
+#. 3.8->settings-schema.json->number-display->description
 #. 3.4->settings-schema.json->number-display->description
 msgid "Number display"
 msgstr "Antalvisning"
 
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Smart"
+msgstr "Smart"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Normal"
+msgstr "Normal"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "None"
+msgstr "Ingen"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "All"
+msgstr "Alle"
+
 #. 2.8->settings-schema.json->number-display->tooltip
+#. 3.8->settings-schema.json->number-display->tooltip
 #. 3.4->settings-schema.json->number-display->tooltip
 msgid ""
 "normal: display window number, smart: display window number if more than one "
@@ -567,42 +235,96 @@ msgstr ""
 "Normal: vis antal vinduer, Smart: vis antal vinduer hvis mere end ét, Ingen: "
 "vis ikke antal vinduer, Alle: vis også antal for favoritter"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "All"
-msgstr "Alle"
+#. 2.8->settings-schema.json->title-display->description
+#. 3.8->settings-schema.json->title-display->description
+#. 3.4->settings-schema.json->title-display->description
+msgid "Title display"
+msgstr "Titelvisning"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Smart"
-msgstr "Smart"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "App"
+msgstr "Program"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Normal"
-msgstr "Normal"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Title"
+msgstr "Titel"
 
-#. 2.8->settings-schema.json->ITM->description
-msgid "ITM Settings"
-msgstr "Indstillinger for Icing"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Focused"
+msgstr "Fokuseret"
 
-#. 2.8->settings-schema.json->HoverPeek->description
-msgid "Hover Peek Settings"
-msgstr "Indstillinger for markørsvævning"
-
-#. 2.8->settings-schema.json->icon-padding->description
-#. 3.4->settings-schema.json->icon-padding->description
-msgid "Icon padding"
-msgstr "Ikonudfyldning"
-
-#. 2.8->settings-schema.json->icon-padding->tooltip
-#. 3.4->settings-schema.json->icon-padding->tooltip
+#. 2.8->settings-schema.json->title-display->tooltip
+#. 3.8->settings-schema.json->title-display->tooltip
+#. 3.4->settings-schema.json->title-display->tooltip
 msgid ""
-"Controls how much horizontal padding is inside the app buttons. Padding is "
-"only applied to instances of this applet on horizontal panels."
+"focused: show focused window title, title: display the window title, app: "
+"diplay app name, none: don't display anything"
 msgstr ""
-"Kontrollerer hvor meget horisontal udfyldning der er inden i "
-"programknapperne. Udfyldning anvendes kun på vandrette paneler."
+"Fokuseret: vis fokuseret vindues titel, Titel: vis vinduestitlen, Program: "
+"vis programnavnet, Ingen: vis ikke noget"
+
+#. 2.8->settings-schema.json->group-apps->description
+#. 3.8->settings-schema.json->group-apps->description
+#. 3.4->settings-schema.json->group-apps->description
+msgid "Group apps"
+msgstr "Gruppér programmer"
+
+#. 2.8->settings-schema.json->group-apps->tooltip
+#. 3.8->settings-schema.json->group-apps->tooltip
+#. 3.4->settings-schema.json->group-apps->tooltip
+msgid "Group each app's set of windows."
+msgstr "Gruppér hvert programs vinduer."
+
+#. 2.8->settings-schema.json->show-alerts->description
+#. 3.8->settings-schema.json->show-alerts->description
+#. 3.4->settings-schema.json->show-alerts->description
+msgid "Show app alerts and notifications"
+msgstr "Vis beskeder og advarsler fra programmer"
+
+#. 2.8->settings-schema.json->show-alerts->tooltip
+#. 3.8->settings-schema.json->show-alerts->tooltip
+#. 3.4->settings-schema.json->show-alerts->tooltip
+msgid "If enabled, notifications and alerts will appear."
+msgstr "Når aktiveret vil beskeder og advarsler optræde."
+
+#. 2.8->settings-schema.json->show-pinned->description
+#. 3.8->settings-schema.json->show-pinned->description
+#. 3.4->settings-schema.json->show-pinned->description
+msgid "Show pinned apps"
+msgstr "Vis fastgjorte programmer"
+
+#. 2.8->settings-schema.json->show-pinned->tooltip
+#. 3.8->settings-schema.json->show-pinned->tooltip
+#. 3.4->settings-schema.json->show-pinned->tooltip
+msgid ""
+"Controls whether or not the pinned apps appear in the panel if they are not "
+"open."
+msgstr ""
+"Kontrollerer om fastgjorte programmer vises i statusfeltet, hvis de ikke er "
+"åbne."
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->description
+msgid "Arrange pinned apps"
+msgstr "Arrangér fastgjorte programmer"
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
+msgid "Arrange pinned apps into a different order."
+msgstr "Arrangér fastgjorte programmer i en anden rækkefølge."
+
+#. 2.8->settings-schema.json->pinOnDrag->description
+#. 2.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.8->settings-schema.json->pinOnDrag->description
+#. 3.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.4->settings-schema.json->pinOnDrag->description
+#. 3.4->settings-schema.json->pinOnDrag->tooltip
+msgid "Pin apps when dragged to a new position"
+msgstr "Fastgør programmer, når de trækkes til en ny placering"
 
 #. 2.8->settings-schema.json->middle-click-action->description
 msgid "Middle clicking app buttons creates new app instances"
@@ -619,69 +341,54 @@ msgstr ""
 "sat til falsk, vil det sidst fokuserede vindue i programgruppen blive lukket "
 "ved klik med midterste tast."
 
-#. 2.8->settings-schema.json->firefox-menu->description
-#. 3.4->settings-schema.json->firefox-menu->description
-msgid "Firefox context menu"
-msgstr "Firefox' genvejsmenu"
+#. 2.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.4->settings-schema.json->cycleMenusHotkey->description
+msgid "Global hotkey for cycling through thumbnail menus"
+msgstr "Global genvejstast for at bladre gennem miniaturemenuer"
 
-#. 2.8->settings-schema.json->firefox-menu->tooltip
-#. 3.4->settings-schema.json->firefox-menu->tooltip
+#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
+msgid "This allows you to cycle through the menus without activating a window."
+msgstr "Dette lader dig bladre gennem menuer uden at aktivere et vindue."
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.4->settings-schema.json->show-apps-order-hotkey->description
+msgid "Global hotkey to show the order of apps"
+msgstr "Global genvejstast til at vise programrækkefølgen"
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
 msgid ""
-"Most Visited: show the sites you visit most, Recent History: display the the "
-"last pages you visited, Bookmarks: show your favorite bookmarks."
+"When triggered, the window count label will be replaced with its order in "
+"the app list temporarily."
 msgstr ""
-"Mest besøgte: vis de steder du besøger mest, Seneste: vis de sider du sidst "
-"besøgte. Bogmærker: vis dine favoritbogmærker."
+"Når genvejstasten trykkes, vil vinduestælleren midlertidigt blive erstattet "
+"med rækkefølgen i programlisten."
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Bookmarks"
-msgstr "Bogmærker"
-
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Most Visited"
-msgstr "Mest besøgte"
-
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Recent History"
-msgstr "Seneste"
-
-#. 2.8->settings-schema.json->themePadding->description
-msgid "Use theme padding to center button icons"
-msgstr "Anvend temaudfyldning til at centrere knapikoner"
-
-#. 2.8->settings-schema.json->themePadding->tooltip
-msgid "If button icons look off-centered, toggling this may help."
-msgstr "Hvis knapikoner ser ucentrerede ud, kan det hjælpe at slå denne til."
-
-#. 2.8->settings-schema.json->group-apps->description
-#. 3.4->settings-schema.json->group-apps->description
-msgid "Group apps"
-msgstr "Gruppér programmer"
-
-#. 2.8->settings-schema.json->group-apps->tooltip
-#. 3.4->settings-schema.json->group-apps->tooltip
-msgid "Group each app's set of windows."
-msgstr "Gruppér hvert programs vinduer."
-
-#. 2.8->settings-schema.json->show-active->description
-#. 3.4->settings-schema.json->show-active->description
-msgid "Show active app indicators"
-msgstr "Vis indikator for aktive programmer"
-
-#. 2.8->settings-schema.json->show-active->tooltip
-#. 3.4->settings-schema.json->show-active->tooltip
-msgid "Active app styling will indicate if an app is active."
-msgstr "Aktive programmer fremhæves."
+#. 2.8->settings-schema.json->show-apps-order-timeout->units
+#. 2.8->settings-schema.json->thumbnail-timeout->units
+#. 2.8->settings-schema.json->hover-peek-time->units
+#. 3.8->settings-schema.json->show-apps-order-timeout->units
+#. 3.8->settings-schema.json->thumbnail-timeout->units
+#. 3.8->settings-schema.json->hover-peek-time->units
+#. 3.4->settings-schema.json->show-apps-order-timeout->units
+#. 3.4->settings-schema.json->thumbnail-timeout->units
+#. 3.4->settings-schema.json->hover-peek-time->units
+msgid "milliseconds"
+msgstr "millisekunder"
 
 #. 2.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.8->settings-schema.json->show-apps-order-timeout->description
 #. 3.4->settings-schema.json->show-apps-order-timeout->description
 msgid "Duration of the apps order display on hotkey press"
 msgstr "Varigheden af visning af programrækkefølgen når genvejstasten trykkes"
 
 #. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.8->settings-schema.json->show-apps-order-timeout->tooltip
 #. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
 msgid ""
 "Determines the duration the window count labels are replaced with the app's "
@@ -690,20 +397,227 @@ msgstr ""
 "Bestemmer varigheden af visningen af vinduestælleren, når genvejstasten "
 "trykkes."
 
-#. 2.8->settings-schema.json->arrange-pinnedApps->description
-msgid "Arrange pinned apps"
-msgstr "Arrangér fastgjorte programmer"
+#. 2.8->settings-schema.json->Thumbnails->description
+msgid "Thumbnail Settings"
+msgstr "Indstillinger for miniaturer"
 
-#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
-msgid "Arrange pinned apps into a different order."
-msgstr "Arrangér fastgjorte programmer i en anden rækkefølge."
+#. 2.8->settings-schema.json->thumbnail-timeout->description
+#. 3.8->settings-schema.json->thumbnail-timeout->description
+#. 3.4->settings-schema.json->thumbnail-timeout->description
+msgid "Thumbnail timeout"
+msgstr "Miniaturetimeout"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
+msgid ""
+"Controls how quickly an app's set of window thumbnails will fade out when "
+"the mouse leaves the app button."
+msgstr ""
+"Kontrollerer hvor hurtigt et programs miniaturer vil tone ud, når markøren "
+"fjernes fra programknappen."
+
+#. 2.8->settings-schema.json->thumbnail-size->units
+#. 3.8->settings-schema.json->thumbnail-size->units
+#. 3.4->settings-schema.json->thumbnail-size->units
+msgid "size"
+msgstr "størrelse"
+
+#. 2.8->settings-schema.json->thumbnail-size->description
+#. 3.8->settings-schema.json->thumbnail-size->description
+#. 3.4->settings-schema.json->thumbnail-size->description
+msgid "Thumbnail size"
+msgstr "Miniaturestørrelse"
+
+#. 2.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-size->tooltip
+msgid "Controls the size of the thumbnails."
+msgstr "Kontrollerer størrelsen på miniaturer."
+
+#. 2.8->settings-schema.json->show-thumbnails->description
+#. 3.8->settings-schema.json->show-thumbnails->description
+#. 3.4->settings-schema.json->show-thumbnails->description
+msgid "Show thumbnails"
+msgstr "Vis miniaturer"
+
+#. 2.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.4->settings-schema.json->show-thumbnails->tooltip
+msgid "Show window thumbnails when hovering over an app button."
+msgstr "Vis vinduesminiaturer, når markøren føres hen over en programknap."
+
+#. 2.8->settings-schema.json->animate-thumbnails->description
+#. 3.8->settings-schema.json->animate-thumbnails->description
+#. 3.4->settings-schema.json->animate-thumbnails->description
+msgid "Animate thumbnails"
+msgstr "Animér miniaturer"
+
+#. 2.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.4->settings-schema.json->animate-thumbnails->tooltip
+msgid "If enabled, thumbnails will animate when appearing and disappearing."
+msgstr "Når aktiveret vil miniaturer animeres, når de dukker op og forsvinder."
+
+#. 2.8->settings-schema.json->vertical-thumbnails->description
+#. 3.8->settings-schema.json->vertical-thumbnails->description
+#. 3.4->settings-schema.json->vertical-thumbnails->description
+msgid "Enable vertical thumbnails"
+msgstr "Aktivér lodrette miniaturer"
+
+#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
+msgid "If enabled, thumbnails will stack vertically."
+msgstr "Når aktiveret vil miniaturer vises i en kolonne."
+
+#. 2.8->settings-schema.json->sort-thumbnails->description
+#. 3.8->settings-schema.json->sort-thumbnails->description
+#. 3.4->settings-schema.json->sort-thumbnails->description
+msgid "Sort windows for each app by last focused"
+msgstr "Sortér hvert programs vinduer efter sidst fokuseret"
+
+#. 2.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.4->settings-schema.json->sort-thumbnails->tooltip
+msgid ""
+"Controls whether the order windows appear for an app is by last focused, or "
+"the order they were opened."
+msgstr ""
+"Kontrollerer om rækkefølgen, et programs vinduer vises i, er efter sidst "
+"fokuseret eller rækkefølgen, de blev åbnet i."
+
+#. 2.8->settings-schema.json->onclick-thumbnails->description
+#. 3.8->settings-schema.json->onclick-thumbnails->description
+#. 3.4->settings-schema.json->onclick-thumbnails->description
+msgid "Open thumbnails on click"
+msgstr "Åbn miniaturer ved klik"
+
+#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
+msgid "Open the thumbnails on click if there is more than one window open."
+msgstr "Åbn miniaturerne ved klik, hvis der er mere et vindue åbent."
+
+#. 2.8->settings-schema.json->include-all-windows->description
+#. 3.8->settings-schema.json->include-all-windows->description
+#. 3.4->settings-schema.json->include-all-windows->description
+msgid "Include all app windows"
+msgstr "Inkludér alle programmets vinduer"
+
+#. 2.8->settings-schema.json->include-all-windows->tooltip
+#. 3.8->settings-schema.json->include-all-windows->tooltip
+#. 3.4->settings-schema.json->include-all-windows->tooltip
+msgid ""
+"Controls whether or not thumbnails for smalller child windows, such as exit "
+"confirmations and file dialogues will be included in the thumbnail list."
+msgstr ""
+"Kontrollerer om miniaturer af mindre vinduer, f.eks. afslutbekræftelse og "
+"fildialoger, inkluderes i miniaturelisten."
+
+#. 2.8->settings-schema.json->AppMenu->description
+msgid "Context Menu Settings"
+msgstr "Indstillinger for genvejsmenu"
+
+#. 2.8->settings-schema.json->show-recent->description
+#. 3.8->settings-schema.json->show-recent->description
+#. 3.4->settings-schema.json->show-recent->description
+msgid "Show recent items"
+msgstr "Vis seneste elementer"
+
+#. 2.8->settings-schema.json->show-recent->tooltip
+#. 3.8->settings-schema.json->show-recent->tooltip
+#. 3.4->settings-schema.json->show-recent->tooltip
+msgid "Controls whether recent items will appear in the context menu."
+msgstr "Kontrollerer om seneste elementer optræder i genvejsmenuen."
+
+#. 2.8->settings-schema.json->menuItemType->description
+#. 3.8->settings-schema.json->menuItemType->description
+#. 3.4->settings-schema.json->menuItemType->description
+msgid "Menu item type"
+msgstr "Menuelementtype"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Symbolic icons"
+msgstr "Symbolske ikoner"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Non-symbolic icons"
+msgstr "Ikke-symbolske ikoner"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "No icons"
+msgstr "Ingen ikoner"
+
+#. 2.8->settings-schema.json->menuItemType->tooltip
+#. 3.8->settings-schema.json->menuItemType->tooltip
+#. 3.4->settings-schema.json->menuItemType->tooltip
+msgid ""
+"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
+msgstr ""
+"Bestemmer om menuelementikoner er symbolske, ikke-symbolske eller ikke vises."
+
+#. 2.8->settings-schema.json->firefox-menu->description
+#. 3.8->settings-schema.json->firefox-menu->description
+#. 3.4->settings-schema.json->firefox-menu->description
+msgid "Firefox context menu"
+msgstr "Firefox' genvejsmenu"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Most Visited"
+msgstr "Mest besøgte"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Recent History"
+msgstr "Seneste"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Bookmarks"
+msgstr "Bogmærker"
+
+#. 2.8->settings-schema.json->firefox-menu->tooltip
+#. 3.8->settings-schema.json->firefox-menu->tooltip
+#. 3.4->settings-schema.json->firefox-menu->tooltip
+msgid ""
+"Most Visited: show the sites you visit most, Recent History: display the the "
+"last pages you visited, Bookmarks: show your favorite bookmarks."
+msgstr ""
+"Mest besøgte: vis de steder du besøger mest, Seneste: vis de sider du sidst "
+"besøgte. Bogmærker: vis dine favoritbogmærker."
+
+#. 2.8->settings-schema.json->autostart-menu-item->description
+#. 3.8->settings-schema.json->autostart-menu-item->description
+#. 3.4->settings-schema.json->autostart-menu-item->description
+msgid "Show autostart option"
+msgstr "Vis til-/fravalg af automatisk opstart"
+
+#. 2.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.4->settings-schema.json->autostart-menu-item->tooltip
+msgid "Shows the autostart toggle option in an app's context menu."
+msgstr ""
+"Viser tilføj til/fjern fra automatisk opstart i et programs genvejsmenu"
 
 #. 2.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.8->settings-schema.json->monitor-move-all-windows->description
 #. 3.4->settings-schema.json->monitor-move-all-windows->description
 msgid "Apply the monitor move option to all windows"
 msgstr "Anvend \"Flyt til skærm\"-valgmuligheden på alle vinduer"
 
 #. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.8->settings-schema.json->monitor-move-all-windows->tooltip
 #. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
 msgid ""
 "When clicking \"Move to monitor\" in the context menu, this option will move "
@@ -713,231 +627,354 @@ msgstr ""
 "tillade flytning af alle et programs vinduer i stedet for det sidst "
 "fokuserede."
 
-#. 2.8->settings-schema.json->sort-thumbnails->description
-#. 3.4->settings-schema.json->sort-thumbnails->description
-msgid "Sort windows for each app by last focused"
-msgstr "Sortér hvert programs vinduer efter sidst fokuseret"
+#. 2.8->settings-schema.json->HoverPeek->description
+msgid "Hover Peek Settings"
+msgstr "Indstillinger for markørsvævning"
 
-#. 2.8->settings-schema.json->sort-thumbnails->tooltip
-#. 3.4->settings-schema.json->sort-thumbnails->tooltip
-msgid ""
-"Controls whether the order windows appear for an app is by last focused, or "
-"the order they were opened."
+#. 2.8->settings-schema.json->enable-hover-peek->description
+#. 3.8->settings-schema.json->enable-hover-peek->description
+#. 3.4->settings-schema.json->enable-hover-peek->description
+msgid "Show windows when hovered over"
+msgstr "Vis vinduer, når markøren føres hen over miniaturen"
+
+#. 2.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.4->settings-schema.json->enable-hover-peek->tooltip
+msgid "Controls whether or not windows display when hovered over."
+msgstr "Kontrollerer om vinduer vises, når markøren føres hen over miniaturen."
+
+#. 2.8->settings-schema.json->hover-peek-time->description
+#. 3.8->settings-schema.json->hover-peek-time->description
+#. 3.4->settings-schema.json->hover-peek-time->description
+msgid "Window fade time"
+msgstr "Udtoningstid for vindue"
+
+#. 2.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.4->settings-schema.json->hover-peek-time->tooltip
+msgid "Controls how quickly a window will fade on hover."
 msgstr ""
-"Kontrollerer om rækkefølgen, et programs vinduer vises i, er efter sidst "
-"fokuseret eller rækkefølgen, de blev åbnet i."
+"Kontrollerer hvor hurtigt et vindue vil tone ud, når markøren føres hen over."
 
-#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->hover-peek-opacity->units
+#. 3.8->settings-schema.json->hover-peek-opacity->units
+#. 3.4->settings-schema.json->hover-peek-opacity->units
+msgid "percent"
+msgstr "procent"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->description
+#. 3.8->settings-schema.json->hover-peek-opacity->description
+#. 3.4->settings-schema.json->hover-peek-opacity->description
+msgid "Window opacity"
+msgstr "Vinduesuigennemsigtighed"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
+msgid "Opacity of the windows on hover."
+msgstr "Vinduernes uigennemsigtighed når markøren føres hen over miniaturen."
+
+#. 2.8->settings-schema.json->ThemeSettings->description
+msgid "Theme Settings"
+msgstr "Indstillinger for tema"
+
+#. 2.8->settings-schema.json->show-active->description
+#. 3.8->settings-schema.json->show-active->description
+#. 3.4->settings-schema.json->show-active->description
+msgid "Show active app indicators"
+msgstr "Vis indikator for aktive programmer"
+
+#. 2.8->settings-schema.json->show-active->tooltip
+#. 3.8->settings-schema.json->show-active->tooltip
+#. 3.4->settings-schema.json->show-active->tooltip
+msgid "Active app styling will indicate if an app is active."
+msgstr "Aktive programmer fremhæves."
+
+#. 2.8->settings-schema.json->icon-spacing->units
+#. 2.8->settings-schema.json->icon-padding->units
+#. 2.8->settings-schema.json->icon-size->units
+#. 3.8->settings-schema.json->app-button-width->units
+#. 3.8->settings-schema.json->thumbnail-close-button-size->units
+#. 3.8->settings-schema.json->thumbnail-padding->units
+#. 3.8->settings-schema.json->icon-spacing->units
+#. 3.8->settings-schema.json->icon-padding->units
+#. 3.8->settings-schema.json->icon-size->units
+#. 3.4->settings-schema.json->app-button-width->units
+#. 3.4->settings-schema.json->thumbnail-close-button-size->units
+#. 3.4->settings-schema.json->thumbnail-padding->units
+#. 3.4->settings-schema.json->icon-spacing->units
+#. 3.4->settings-schema.json->icon-padding->units
+#. 3.4->settings-schema.json->icon-size->units
+msgid "px"
+msgstr "px"
+
+#. 2.8->settings-schema.json->icon-spacing->description
+#. 3.8->settings-schema.json->icon-spacing->description
+#. 3.4->settings-schema.json->icon-spacing->description
+msgid "Icon spacing"
+msgstr "Ikonmellemrum"
+
+#. 2.8->settings-schema.json->icon-spacing->tooltip
+#. 3.8->settings-schema.json->icon-spacing->tooltip
+#. 3.4->settings-schema.json->icon-spacing->tooltip
+msgid "Controls how much space is between the icons."
+msgstr "Kontrollerer mellemrummet mellem ikoner."
+
+#. 2.8->settings-schema.json->icon-padding->description
+#. 3.8->settings-schema.json->icon-padding->description
+#. 3.4->settings-schema.json->icon-padding->description
+msgid "Icon padding"
+msgstr "Ikonudfyldning"
+
+#. 2.8->settings-schema.json->icon-padding->tooltip
+#. 3.8->settings-schema.json->icon-padding->tooltip
+#. 3.4->settings-schema.json->icon-padding->tooltip
+msgid ""
+"Controls how much horizontal padding is inside the app buttons. Padding is "
+"only applied to instances of this applet on horizontal panels."
+msgstr ""
+"Kontrollerer hvor meget horisontal udfyldning der er inden i "
+"programknapperne. Udfyldning anvendes kun på vandrette paneler."
+
+#. 2.8->settings-schema.json->themePadding->description
+msgid "Use theme padding to center button icons"
+msgstr "Anvend temaudfyldning til at centrere knapikoner"
+
+#. 2.8->settings-schema.json->themePadding->tooltip
+msgid "If button icons look off-centered, toggling this may help."
+msgstr "Hvis knapikoner ser ucentrerede ud, kan det hjælpe at slå denne til."
+
+#. 2.8->settings-schema.json->enable-iconSize->description
+#. 3.8->settings-schema.json->enable-iconSize->description
+#. 3.4->settings-schema.json->enable-iconSize->description
+msgid "Adjust icon size"
+msgstr "Justér ikonstørrelse"
+
+#. 2.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.4->settings-schema.json->enable-iconSize->tooltip
+msgid "Adjust icon size independent of Cinnamon's panel scaling."
+msgstr "Justér ikonstørrelse uafhængigt af Cinnamons panelskalering."
+
+#. 2.8->settings-schema.json->icon-size->description
+#. 3.8->settings-schema.json->icon-size->description
+#. 3.4->settings-schema.json->icon-size->description
+msgid "Icon size"
+msgstr "Ikonstørrelse"
+
+#. 2.8->settings-schema.json->icon-size->tooltip
+#. 3.8->settings-schema.json->icon-size->tooltip
+#. 3.4->settings-schema.json->icon-size->tooltip
+msgid "Set icon size"
+msgstr "Angiv ikonstørrelse"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->description
+#. 3.8->settings-schema.json->hoverPseudoClass->description
+#. 3.4->settings-schema.json->hoverPseudoClass->description
+msgid "App button hover pseudo class"
+msgstr "Pseudoklasse for programknapsvævning"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
 #. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
 #. 3.4->settings-schema.json->activePseudoClass->options
-msgid "checked"
-msgstr "tjekket"
+msgid "hover"
+msgstr "svæv"
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
-msgid "Highlight the last focused window within an app group"
-msgstr "Fremhæv det seneste vindue med fokus i en programgruppe"
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "focus"
+msgstr "fokus"
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
-msgid ""
-"When enabled, the last window that was interacted with will be indicated."
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "active"
+msgstr "aktiv"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "outlined"
+msgstr "kontur"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "selected"
+msgstr "valgt"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons on hover."
 msgstr ""
-"Når aktiveret vil det seneste vindue, der blev interageret med, blive "
-"fremhævet."
+"Tilsidesætter pseudoklassen for programknapper, når markøren føres hen over."
 
-#. 3.4->settings-schema.json->app-button-transition-duration->description
-msgid "App button transition duration"
-msgstr "Varighed af overgang for programknappen"
+#. 2.8->settings-schema.json->focusPseudoClass->description
+#. 3.8->settings-schema.json->focusPseudoClass->description
+#. 3.4->settings-schema.json->focusPseudoClass->description
+msgid "App button focus pseudo class"
+msgstr "Pseudoklasse for programknapsfokus"
 
-#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+#. 2.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.4->settings-schema.json->focusPseudoClass->tooltip
+msgid "Overrides the pseudo class for app button on focus."
+msgstr "Tilsidesætter pseudoklassen for programknappen ved fokus."
+
+#. 2.8->settings-schema.json->activePseudoClass->description
+#. 3.8->settings-schema.json->activePseudoClass->description
+#. 3.4->settings-schema.json->activePseudoClass->description
+msgid "App button active pseudo class"
+msgstr "Pseudoklasse for aktiv programknap"
+
+#. 2.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.4->settings-schema.json->activePseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons when they are active."
+msgstr "Tilsidesætter pseudoklassen for programknapper, når de er aktive."
+
+#. 2.8->settings-schema.json->panelLauncherClass->description
+msgid "Use the panel launcher class for pinned apps"
+msgstr "Anvend panelprogramstarterklassen for fastgjorte programmer"
+
+#. 2.8->settings-schema.json->panelLauncherClass->tooltip
+msgid "Enabling this helps with certain themes."
+msgstr "Aktivering af denne kan hjælpe med visse temaer."
+
+#. 2.8->settings-schema.json->close-button-style->description
+msgid "Allow themes to control the thumbnail close button"
+msgstr "Tillad at temaet kontrollerer lukkeknappen i miniaturen"
+
+#. 2.8->settings-schema.json->close-button-style->tooltip
 msgid ""
-"Overrides the theme's animation time for app buttons. If set to zero, the "
-"theme's transition duration will be used."
-msgstr ""
-"Tilsidesætter temaets animationstid for programknapper. Hvis sat til nul vil "
-"temaets overgangsvarighed bliv brugt."
+"Controls whether or not the theme controls the window thumbnail's close "
+"button."
+msgstr "Kontrollerer om temaet bestemmer udseendet på miniaturens lukkeknap."
 
-#. 3.4->settings-schema.json->app-button-transition-duration->units
-msgid "ms"
-msgstr "ms"
+#. 2.8->settings-schema.json->useSystemTooltips->description
+msgid "Use system tooltips for closed apps"
+msgstr "Anvend systemværktøjstip for lukkede programmer"
 
-#. 3.4->settings-schema.json->thumbnail-padding->description
-msgid "Thumbnail padding"
-msgstr "Udfyldning for miniaturer"
-
-#. 3.4->settings-schema.json->thumbnail-padding->tooltip
-msgid "Controls how much space will be around the window preview thumbnails."
-msgstr ""
-"Kontrollerer hvor meget plads der vil være rundt om vinduet med "
-"forhåndsvisning af miniaturer."
-
-#. 3.4->settings-schema.json->system-favorites->description
-msgid "Use system favorites for pinned apps"
-msgstr "Anvend systemfavoritter til fastgjorte programmer"
-
-#. 3.4->settings-schema.json->system-favorites->tooltip
+#. 2.8->settings-schema.json->useSystemTooltips->tooltip
 msgid ""
-"Controls whether or not pinned apps consist of the system favorites list."
-msgstr "Kontrollerer om fastgjorte programmer består af systemfavoritlisten."
+"Controls whether or not system tooltips are in use when hovering over closed "
+"pinned apps."
+msgstr ""
+"Kontrollerer om systemværktøjstip anvendes, når markøren føres hen over "
+"lukkede, fastgjorte programmer."
 
-#. 3.4->settings-schema.json->generalSection->title
-msgid "Behavior"
-msgstr "Opførsel"
+#. 3.8->settings-schema.json->generalPage->title
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr "Generel"
 
+#. 3.8->settings-schema.json->panelPage->title
+#. 3.4->settings-schema.json->panelPage->title
+msgid "Panel"
+msgstr "Panel"
+
+#. 3.8->settings-schema.json->thumbnailsPage->title
+#. 3.8->settings-schema.json->thumbnailsSection->title
 #. 3.4->settings-schema.json->thumbnailsPage->title
 #. 3.4->settings-schema.json->thumbnailsSection->title
 msgid "Thumbnails"
 msgstr "Miniaturer"
 
-#. 3.4->settings-schema.json->presetSection->title
-msgid "Recommended Presets"
-msgstr "Anbefalede forudindstillinger"
-
-#. 3.4->settings-schema.json->appButtonsSection->title
-msgid "App Buttons"
-msgstr "Programknapper"
-
-#. 3.4->settings-schema.json->generalPage->title
-msgid "General"
-msgstr "Generel"
-
-#. 3.4->settings-schema.json->hoverPeekSection->title
-msgid "Hover Peek"
-msgstr "Markørsvævning for smugkig"
-
-#. 3.4->settings-schema.json->panelPage->title
-msgid "Panel"
-msgstr "Panel"
-
-#. 3.4->settings-schema.json->iconSection->title
-msgid "Icons"
-msgstr "Ikoner"
-
-#. 3.4->settings-schema.json->hotKeysSection->title
-msgid "Hot Keys"
-msgstr "Genvejstaster"
-
-#. 3.4->settings-schema.json->stylingSection->title
-msgid "Styling"
-msgstr "Stil"
-
+#. 3.8->settings-schema.json->contextMenuPage->title
 #. 3.4->settings-schema.json->contextMenuPage->title
 msgid "Context Menu"
 msgstr "Genvejsmenu"
 
+#. 3.8->settings-schema.json->themePage->title
 #. 3.4->settings-schema.json->themePage->title
 msgid "Theming"
 msgstr "Tema"
 
-#. 3.4->settings-schema.json->mintYPreset->description
-#. 3.4->settings-schema.json->mintYPreset->tooltip
-msgid "Mint Y and Variants"
-msgstr "Mint Y og varianter"
+#. 3.8->settings-schema.json->generalSection->title
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr "Opførsel"
 
-#. 3.4->settings-schema.json->show-icons->description
-msgid "Show icons"
-msgstr "Vis ikoner"
+#. 3.8->settings-schema.json->appButtonsSection->title
+#. 3.4->settings-schema.json->appButtonsSection->title
+msgid "App Buttons"
+msgstr "Programknapper"
 
-#. 3.4->settings-schema.json->show-icons->tooltip
-msgid "Show the window's icon next to the title."
-msgstr "Vis vinduets ikoner ved siden af titlen."
+#. 3.8->settings-schema.json->hotKeysSection->title
+#. 3.4->settings-schema.json->hotKeysSection->title
+msgid "Hot Keys"
+msgstr "Genvejstaster"
 
-#. 3.4->settings-schema.json->enable-app-button-dragging->description
-#. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
-msgid "Enable app button dragging"
-msgstr "Aktivér trækning af programknapper"
+#. 3.8->settings-schema.json->hoverPeekSection->title
+#. 3.4->settings-schema.json->hoverPeekSection->title
+msgid "Hover Peek"
+msgstr "Markørsvævning for smugkig"
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
-msgid "Show new window option"
-msgstr "Vis indstillinger for nyt vindue"
+#. 3.8->settings-schema.json->stylingSection->title
+#. 3.4->settings-schema.json->stylingSection->title
+msgid "Styling"
+msgstr "Stil"
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
-msgid ""
-"Shows the \"New Window\" option in an app's context menu if it doesn't "
-"already have one from the app's own action menu items."
-msgstr ""
-"Viser indstillinger for \"Nyt vindue\" i et programs genvejsmenu, hvis der "
-"ikke allerede er en fra programmets egen menu."
+#. 3.8->settings-schema.json->iconSection->title
+#. 3.4->settings-schema.json->iconSection->title
+msgid "Icons"
+msgstr "Ikoner"
 
-#. 3.4->settings-schema.json->app-button-width->description
-msgid "App button width"
-msgstr "Programknappens bredde"
+#. 3.8->settings-schema.json->presetSection->title
+#. 3.4->settings-schema.json->presetSection->title
+msgid "Recommended Presets"
+msgstr "Anbefalede forudindstillinger"
 
-#. 3.4->settings-schema.json->app-button-width->tooltip
-msgid ""
-"Controls the width of the application button. This option only works for "
-"horizontal panels."
-msgstr ""
-"Kontrollerer programknappens bredde. Denne indstilling virker kun på "
-"vandrette paneler."
-
-#. 3.4->settings-schema.json->mintXPreset->description
-#. 3.4->settings-schema.json->mintXPreset->tooltip
-msgid "Mint X, Linux Mint, and Variants"
-msgstr "Mint X, Linux Mint, og varianter"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->description
-msgid "Launcher animation effect"
-msgstr "Animationseffekter til programstarter"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
-#. 3.4->settings-schema.json->left-click-action->description
-#. 3.4->settings-schema.json->left-click-action->tooltip
-msgid "Left click action"
-msgstr "Handling ved venstreklik"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Scale"
-msgstr "Skalér"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Fade"
-msgstr "Udton"
-
-#. 3.4->settings-schema.json->enable-app-button-width->description
-msgid "Use a custom width for app buttons"
-msgstr "Anvend en tilpasset bredde til programknapper"
-
-#. 3.4->settings-schema.json->enable-app-button-width->tooltip
-msgid "When disabled, the app button width is determined by the panel height."
-msgstr "Når deaktiveret bestemmes programknappens bredde af panelhøjden."
-
-#. 3.4->settings-schema.json->list-monitor-windows->description
-msgid "Only list windows from the monitor displaying this instance"
-msgstr "Oplist kun vinduer fra skærmen, som viser denne forekomst"
-
-#. 3.4->settings-schema.json->list-monitor-windows->tooltip
-msgid ""
-"This option will only come into effect for monitors displaying an ITM "
-"instance."
-msgstr ""
-"Denne indstilling vil kun få effekt på skærme, som viser en forekomst af "
-"Icing."
-
-#. 3.4->settings-schema.json->thumbnail-close-button-size->description
-msgid "Close button size"
-msgstr "Luk-knappens størrelse"
-
-#. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
-msgid "Controls how large the thumbnail close button is."
-msgstr "Kontrollerer lukkeknappens størrelse i miniaturen."
-
-#. 3.4->settings-schema.json->middle-click-action->description
-#. 3.4->settings-schema.json->middle-click-action->tooltip
-msgid "Middle click action"
-msgstr "Handling ved midterklik"
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Launch new app instance"
-msgstr "Start ny forekomst af programmet"
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Close last focused window in group"
-msgstr "Luk det seneste vindue med fokus i en programgruppe"
-
+#. 3.8->settings-schema.json->scroll-behavior->description
 #. 3.4->settings-schema.json->scroll-behavior->description
 msgid "Mouse wheel scroll behavior"
 msgstr "Opførsel af musens rullehjul"
 
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+msgid "Cycle apps"
+msgstr "Gennemløb programmer"
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+msgid "Cycle windows"
+msgstr "Gennemløb vinduer"
+
+#. 3.8->settings-schema.json->scroll-behavior->tooltip
 #. 3.4->settings-schema.json->scroll-behavior->tooltip
 msgid ""
 "Choose if scrolling the mouse wheel cycles running apps, an app button's "
@@ -946,24 +983,143 @@ msgstr ""
 "Vælg om rulning med musehjulet løber gennem kørende programmer eller gennem "
 "et programs vinduer ved svævning over programknapperne."
 
-#. 3.4->settings-schema.json->scroll-behavior->options
-msgid "Cycle apps"
-msgstr "Gennemløb programmer"
+#. 3.8->settings-schema.json->left-click-action->description
+#. 3.8->settings-schema.json->left-click-action->tooltip
+#. 3.8->settings-schema.json->launcher-animation-effect->tooltip
+#. 3.4->settings-schema.json->left-click-action->description
+#. 3.4->settings-schema.json->left-click-action->tooltip
+#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
+msgid "Left click action"
+msgstr "Handling ved venstreklik"
 
-#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
 #. 3.4->settings-schema.json->left-click-action->options
-msgid "Cycle windows"
-msgstr "Gennemløb vinduer"
+msgid "Toggle activation of last focused window"
+msgstr "Skift til det seneste fokuserede vindue"
 
+#. 3.8->settings-schema.json->middle-click-action->description
+#. 3.8->settings-schema.json->middle-click-action->tooltip
+#. 3.4->settings-schema.json->middle-click-action->description
+#. 3.4->settings-schema.json->middle-click-action->tooltip
+msgid "Middle click action"
+msgstr "Handling ved midterklik"
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Launch new app instance"
+msgstr "Start ny forekomst af programmet"
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Close last focused window in group"
+msgstr "Luk det seneste vindue med fokus i en programgruppe"
+
+#. 3.8->settings-schema.json->system-favorites->description
+#. 3.4->settings-schema.json->system-favorites->description
+msgid "Use system favorites for pinned apps"
+msgstr "Anvend systemfavoritter til fastgjorte programmer"
+
+#. 3.8->settings-schema.json->system-favorites->tooltip
+#. 3.4->settings-schema.json->system-favorites->tooltip
+msgid ""
+"Controls whether or not pinned apps consist of the system favorites list."
+msgstr "Kontrollerer om fastgjorte programmer består af systemfavoritlisten."
+
+#. 3.8->settings-schema.json->show-all-workspaces->description
+#. 3.8->settings-schema.json->show-all-workspaces->tooltip
 #. 3.4->settings-schema.json->show-all-workspaces->description
 #. 3.4->settings-schema.json->show-all-workspaces->tooltip
 msgid "Show windows from all workspaces"
 msgstr "Vis vinduer fra alle arbejdsområder"
 
+#. 3.8->settings-schema.json->enable-app-button-dragging->description
+#. 3.8->settings-schema.json->enable-app-button-dragging->tooltip
+#. 3.4->settings-schema.json->enable-app-button-dragging->description
+#. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
+msgid "Enable app button dragging"
+msgstr "Aktivér trækning af programknapper"
+
+#. 3.8->settings-schema.json->launcher-animation-effect->description
+#. 3.4->settings-schema.json->launcher-animation-effect->description
+msgid "Launcher animation effect"
+msgstr "Animationseffekter til programstarter"
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Fade"
+msgstr "Udton"
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Scale"
+msgstr "Skalér"
+
+#. 3.8->settings-schema.json->list-monitor-windows->description
+#. 3.4->settings-schema.json->list-monitor-windows->description
+msgid "Only list windows from the monitor displaying this instance"
+msgstr "Oplist kun vinduer fra skærmen, som viser denne forekomst"
+
+#. 3.8->settings-schema.json->list-monitor-windows->tooltip
+#. 3.4->settings-schema.json->list-monitor-windows->tooltip
+msgid ""
+"This option will only come into effect for monitors displaying an ITM "
+"instance."
+msgstr ""
+"Denne indstilling vil kun få effekt på skærme, som viser en forekomst af "
+"Icing."
+
+#. 3.8->settings-schema.json->enable-app-button-width->description
+#. 3.4->settings-schema.json->enable-app-button-width->description
+msgid "Use a custom width for app buttons"
+msgstr "Anvend en tilpasset bredde til programknapper"
+
+#. 3.8->settings-schema.json->enable-app-button-width->tooltip
+#. 3.4->settings-schema.json->enable-app-button-width->tooltip
+msgid "When disabled, the app button width is determined by the panel height."
+msgstr "Når deaktiveret bestemmes programknappens bredde af panelhøjden."
+
+#. 3.8->settings-schema.json->app-button-width->description
+#. 3.4->settings-schema.json->app-button-width->description
+msgid "App button width"
+msgstr "Programknappens bredde"
+
+#. 3.8->settings-schema.json->app-button-width->tooltip
+#. 3.4->settings-schema.json->app-button-width->tooltip
+msgid ""
+"Controls the width of the application button. This option only works for "
+"horizontal panels."
+msgstr ""
+"Kontrollerer programknappens bredde. Denne indstilling virker kun på "
+"vandrette paneler."
+
+#. 3.8->settings-schema.json->thumbnail-close-button-size->description
+#. 3.4->settings-schema.json->thumbnail-close-button-size->description
+msgid "Close button size"
+msgstr "Luk-knappens størrelse"
+
+#. 3.8->settings-schema.json->thumbnail-close-button-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
+msgid "Controls how large the thumbnail close button is."
+msgstr "Kontrollerer lukkeknappens størrelse i miniaturen."
+
+#. 3.8->settings-schema.json->thumbnail-padding->description
+#. 3.4->settings-schema.json->thumbnail-padding->description
+msgid "Thumbnail padding"
+msgstr "Udfyldning for miniaturer"
+
+#. 3.8->settings-schema.json->thumbnail-padding->tooltip
+#. 3.4->settings-schema.json->thumbnail-padding->tooltip
+msgid "Controls how much space will be around the window preview thumbnails."
+msgstr ""
+"Kontrollerer hvor meget plads der vil være rundt om vinduet med "
+"forhåndsvisning af miniaturer."
+
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->description
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
 msgid "Cycle windows on mouse wheel scroll"
 msgstr "Genemløb vinduer ved rulning med musehjulet"
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->tooltip
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
 msgid ""
 "Choose whether or not scrolling the mouse wheel cycles windows when hovering "
@@ -972,14 +1128,85 @@ msgstr ""
 "Vælg om rulning med musehjulet medfører, at vinduer gennemløbes, når "
 "markøren er over en miniaturemenu."
 
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "Toggle activation of last focused window"
-msgstr "Skift til det seneste fokuserede vindue"
+#. 3.8->settings-schema.json->show-icons->description
+#. 3.4->settings-schema.json->show-icons->description
+msgid "Show icons"
+msgstr "Vis ikoner"
 
-#. IcingTaskManager@json->metadata.json->name
-msgid "Icing Task Manager"
-msgstr "Icing programhåndtering"
+#. 3.8->settings-schema.json->show-icons->tooltip
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr "Vis vinduets ikoner ved siden af titlen."
 
-#. IcingTaskManager@json->metadata.json->description
-msgid "Window list with app grouping and thumbnails"
-msgstr "Vinduesliste med miniaturer og gruppering af programmer"
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->description
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
+msgid "Highlight the last focused window within an app group"
+msgstr "Fremhæv det seneste vindue med fokus i en programgruppe"
+
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+msgid ""
+"When enabled, the last window that was interacted with will be indicated."
+msgstr ""
+"Når aktiveret vil det seneste vindue, der blev interageret med, blive "
+"fremhævet."
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->description
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+msgid "Show new window option"
+msgstr "Vis indstillinger for nyt vindue"
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->tooltip
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+"Viser indstillinger for \"Nyt vindue\" i et programs genvejsmenu, hvis der "
+"ikke allerede er en fra programmets egen menu."
+
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr "tjekket"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->units
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr "ms"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->description
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr "Varighed af overgang for programknappen"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->tooltip
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+"Tilsidesætter temaets animationstid for programknapper. Hvis sat til nul vil "
+"temaets overgangsvarighed bliv brugt."
+
+#. 3.8->settings-schema.json->mintYPreset->description
+#. 3.8->settings-schema.json->mintYPreset->tooltip
+#. 3.4->settings-schema.json->mintYPreset->description
+#. 3.4->settings-schema.json->mintYPreset->tooltip
+msgid "Mint Y and Variants"
+msgstr "Mint Y og varianter"
+
+#. 3.8->settings-schema.json->mintXPreset->description
+#. 3.8->settings-schema.json->mintXPreset->tooltip
+#. 3.4->settings-schema.json->mintXPreset->description
+#. 3.4->settings-schema.json->mintXPreset->tooltip
+msgid "Mint X, Linux Mint, and Variants"
+msgstr "Mint X, Linux Mint, og varianter"
+
+#. 3.8->settings-schema.json->migrationButton->description
+msgid "Migrate Pinned Apps to Grouped Window List"
+msgstr ""

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/de.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-10 00:43-0600\n"
+"POT-Creation-Date: 2018-12-13 18:37-0600\n"
 "PO-Revision-Date: 2017-07-27 12:54+0200\n"
 "Last-Translator: Pandiora <Pandiora@github.com>\n"
 "Language-Team: \n"
@@ -14,53 +14,53 @@ msgstr ""
 "X-Poedit-Basepath: .\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: 3.8/applet.js:471
-msgid "Icing Task Manager is now Grouped Window List"
-msgstr ""
+#: 3.8/applet.js:476
+#, fuzzy
+msgid "Icing Task Manager is deprecated"
+msgstr "Icing Task Manager"
 
-#: 3.8/applet.js:472
+#: 3.8/applet.js:477
 msgid ""
-"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
-"Window List\". "
+"Please upgrade to Grouped Window List for a more stable, bug-free experience."
 msgstr ""
 
-#: 3.8/applet.js:473
+#: 3.8/applet.js:478
 msgid ""
-"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
-"List."
+"Add GWL to your panel, open the applet's settings and click \"Migrate Pinned "
+"Apps to Grouped Window List\"."
 msgstr ""
 
-#: 3.8/applet.js:485
-msgid "Migration can only be performed on Cinnamon 4.0."
+#: 3.8/applet.js:490
+msgid "Migration can only be performed on Cinnamon 4.0+."
 msgstr ""
 
-#: 3.8/applet.js:496
+#: 3.8/applet.js:501
 msgid ""
 "Please add Grouped Window List to a panel before proceeding with the "
 "migration."
 msgstr ""
 
-#: 3.8/applet.js:504
+#: 3.8/applet.js:509
 msgid "ITM settings directory could not be found!"
 msgstr ""
 
-#: 3.8/applet.js:534
+#: 3.8/applet.js:539
 msgid "System favorites enabled - no migration is needed."
 msgstr ""
 
-#: 3.8/applet.js:577
+#: 3.8/applet.js:582
 msgid "Unable to find a suitable ITM settings file to migrate."
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid "Migration complete. "
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid " settings file(s) could not be migrated."
 msgstr ""
 
-#: 3.8/applet.js:592
+#: 3.8/applet.js:597
 msgid "Migration was successful."
 msgstr ""
 
@@ -1232,6 +1232,10 @@ msgstr "Mint-Y und Varianten"
 #. 3.8->settings-schema.json->migrationButton->description
 msgid "Migrate Pinned Apps to Grouped Window List"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Icing Task Manager is deprecated - please use Grouped Window List"
+#~ msgstr "Icing Task Manager"
 
 #~ msgid "number"
 #~ msgstr "Anzahl"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/de.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-23 21:32-0600\n"
+"POT-Creation-Date: 2018-12-10 00:43-0600\n"
 "PO-Revision-Date: 2017-07-27 12:54+0200\n"
 "Last-Translator: Pandiora <Pandiora@github.com>\n"
 "Language-Team: \n"
@@ -14,564 +14,220 @@ msgstr ""
 "X-Poedit-Basepath: .\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/applet.js:471
+msgid "Icing Task Manager is now Grouped Window List"
+msgstr ""
+
+#: 3.8/applet.js:472
+msgid ""
+"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
+"Window List\". "
+msgstr ""
+
+#: 3.8/applet.js:473
+msgid ""
+"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
+"List."
+msgstr ""
+
+#: 3.8/applet.js:485
+msgid "Migration can only be performed on Cinnamon 4.0."
+msgstr ""
+
+#: 3.8/applet.js:496
+msgid ""
+"Please add Grouped Window List to a panel before proceeding with the "
+"migration."
+msgstr ""
+
+#: 3.8/applet.js:504
+msgid "ITM settings directory could not be found!"
+msgstr ""
+
+#: 3.8/applet.js:534
+msgid "System favorites enabled - no migration is needed."
+msgstr ""
+
+#: 3.8/applet.js:577
+msgid "Unable to find a suitable ITM settings file to migrate."
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid "Migration complete. "
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid " settings file(s) could not be migrated."
+msgstr ""
+
+#: 3.8/applet.js:592
+msgid "Migration was successful."
+msgstr ""
+
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to the other monitor"
 msgstr "Auf den anderen Monitor verschieben"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to monitor "
 msgstr "Verschieben auf Monitor "
 
-#: 3.4/specialMenus.js:126
+#: 3.8/specialMenus.js:98 3.4/specialMenus.js:126
 msgid "Only on this workspace"
 msgstr "Nur auf dieser Arbeitsfläche"
 
-#: 3.4/specialMenus.js:133
+#: 3.8/specialMenus.js:105 3.4/specialMenus.js:133
 msgid "Visible on all workspaces"
 msgstr "Auf allen Arbeitsflächen anzeigen"
 
-#: 3.4/specialMenus.js:140
+#: 3.8/specialMenus.js:112 3.4/specialMenus.js:140
 msgid "Move to another workspace"
 msgstr "Auf andere Arbeitsfläche verschieben"
 
-#: 3.4/specialMenus.js:168
+#: 3.8/specialMenus.js:140 3.4/specialMenus.js:168
 msgid "Places"
 msgstr "Orte"
 
-#: 3.4/specialMenus.js:207
+#: 3.8/specialMenus.js:179 3.4/specialMenus.js:207
 msgid "Bookmarks/History requires gir1.2-gda-5.0"
 msgstr ""
 
-#: 3.4/specialMenus.js:227
+#: 3.8/specialMenus.js:199 3.4/specialMenus.js:227
 msgid "Recent"
 msgstr "Kürzlich"
 
-#: 3.4/specialMenus.js:246
+#: 3.8/specialMenus.js:218 3.4/specialMenus.js:246
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: 3.4/specialMenus.js:249
+#: 3.8/specialMenus.js:221 3.4/specialMenus.js:249
 msgid "About..."
 msgstr "Über …"
 
-#: 3.4/specialMenus.js:253
+#: 3.8/specialMenus.js:225 3.4/specialMenus.js:253
 msgid "Configure..."
 msgstr "Einrichten …"
 
-#: 3.4/specialMenus.js:257
+#: 3.8/specialMenus.js:229 3.4/specialMenus.js:257
 msgid "Remove"
 msgstr "Entfernen"
 
-#: 3.4/specialMenus.js:287
+#: 3.8/specialMenus.js:259 3.4/specialMenus.js:287
 #, fuzzy
 msgid "New Window"
 msgstr "Zeige alle Anwendungs-Fenster an"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Unpin from Panel"
 msgstr "Von Taskleiste lösen"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Pin to Panel"
 msgstr "An Taskleiste Anheften"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Remove from Autostart"
 msgstr "Aus Autostart entfernen"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Add to Autostart"
 msgstr "Zum Autostart hinzufügen"
 
-#: 3.4/specialMenus.js:318
+#: 3.8/specialMenus.js:290 3.4/specialMenus.js:318
 msgid "Create Shortcut"
 msgstr "Verknüpfung erstellen"
 
-#: 3.4/specialMenus.js:329
+#: 3.8/specialMenus.js:301 3.4/specialMenus.js:329
 msgid "Restore to full opacity"
 msgstr "Volle Deckkraft wiederherstellen"
 
-#: 3.4/specialMenus.js:337
+#: 3.8/specialMenus.js:309 3.4/specialMenus.js:337
 msgid "Restore"
 msgstr "Wiederherstellen"
 
-#: 3.4/specialMenus.js:342
+#: 3.8/specialMenus.js:314 3.4/specialMenus.js:342
 msgid "Minimize"
 msgstr "Minimieren"
 
-#: 3.4/specialMenus.js:350
+#: 3.8/specialMenus.js:322 3.4/specialMenus.js:350
 msgid "Unmaximize"
 msgstr "Zurücksetzen"
 
-#: 3.4/specialMenus.js:355
+#: 3.8/specialMenus.js:327 3.4/specialMenus.js:355
 msgid "Maximize"
 msgstr "Maximieren"
 
-#: 3.4/specialMenus.js:365
+#: 3.8/specialMenus.js:337 3.4/specialMenus.js:365
 msgid "Close others"
 msgstr "Andere schließen"
 
-#: 3.4/specialMenus.js:375
+#: 3.8/specialMenus.js:347 3.4/specialMenus.js:375
 msgid "Close all"
 msgstr "Alle schließen"
 
-#: 3.4/specialMenus.js:385
+#: 3.8/specialMenus.js:357 3.4/specialMenus.js:385
 msgid "Close"
 msgstr "Schließen"
 
-#. 2.8->settings-schema.json->thumbnail-size->description
-#. 3.4->settings-schema.json->thumbnail-size->description
-msgid "Thumbnail size"
-msgstr "Vorschaubild-Größe"
+#. metadata.json->description
+msgid "Window list with app grouping and thumbnails"
+msgstr "Fensterliste mit Anwendungsgruppierung und Fenstervorschau"
 
-#. 2.8->settings-schema.json->thumbnail-size->tooltip
-#. 3.4->settings-schema.json->thumbnail-size->tooltip
-msgid "Controls the size of the thumbnails."
-msgstr "Steuert die Größe der Vorschaubilder."
+#. metadata.json->name
+msgid "Icing Task Manager"
+msgstr "Icing Task Manager"
 
-#. 2.8->settings-schema.json->thumbnail-size->units
-#. 3.4->settings-schema.json->thumbnail-size->units
-msgid "size"
-msgstr "Größe"
-
-#. 2.8->settings-schema.json->focusPseudoClass->description
-#. 3.4->settings-schema.json->focusPseudoClass->description
-msgid "App button focus pseudo class"
-msgstr "App-Schaltfläche Fokus Pseudo-Klasse"
-
-#. 2.8->settings-schema.json->focusPseudoClass->tooltip
-#. 3.4->settings-schema.json->focusPseudoClass->tooltip
-msgid "Overrides the pseudo class for app button on focus."
-msgstr "Überschreibt die Pseudoklasse für App-Schaltfläche auf Fokus."
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "active"
-msgstr "aktiv"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "outlined"
-msgstr "eingerahmt"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "hover"
-msgstr "schweben"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "focus"
-msgstr "fokussieren"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "selected"
-msgstr "ausgewählt"
-
-#. 2.8->settings-schema.json->icon-spacing->description
-#. 3.4->settings-schema.json->icon-spacing->description
-msgid "Icon spacing"
-msgstr "Icon-Abstand"
-
-#. 2.8->settings-schema.json->icon-spacing->tooltip
-#. 3.4->settings-schema.json->icon-spacing->tooltip
-msgid "Controls how much space is between the icons."
-msgstr "Legt den Abstand zwischen den Icons der Anwendungs-Leiste fest."
-
-#. 2.8->settings-schema.json->icon-spacing->units
-#. 2.8->settings-schema.json->icon-size->units
-#. 2.8->settings-schema.json->icon-padding->units
-#. 3.4->settings-schema.json->icon-spacing->units
-#. 3.4->settings-schema.json->thumbnail-padding->units
-#. 3.4->settings-schema.json->icon-size->units
-#. 3.4->settings-schema.json->app-button-width->units
-#. 3.4->settings-schema.json->thumbnail-close-button-size->units
-#. 3.4->settings-schema.json->icon-padding->units
-msgid "px"
-msgstr "Pixel"
-
-#. 2.8->settings-schema.json->show-thumbnails->description
-#. 3.4->settings-schema.json->show-thumbnails->description
-msgid "Show thumbnails"
-msgstr "Zeige Vorschaubilder"
-
-#. 2.8->settings-schema.json->show-thumbnails->tooltip
-#. 3.4->settings-schema.json->show-thumbnails->tooltip
-msgid "Show window thumbnails when hovering over an app button."
-msgstr ""
-"Zeigt Fenster-Vorschaubilder beim Hovern über einer Anwendungs-Schaltfläche "
-"an."
-
-#. 2.8->settings-schema.json->icon-size->description
-#. 3.4->settings-schema.json->icon-size->description
-msgid "Icon size"
-msgstr "Icongröße"
-
-#. 2.8->settings-schema.json->icon-size->tooltip
-#. 3.4->settings-schema.json->icon-size->tooltip
-msgid "Set icon size"
-msgstr "Icongröße anpassen"
-
-#. 2.8->settings-schema.json->hover-peek-time->description
-#. 3.4->settings-schema.json->hover-peek-time->description
-msgid "Window fade time"
-msgstr "Fenster-Einblendungszeit"
-
-#. 2.8->settings-schema.json->hover-peek-time->tooltip
-#. 3.4->settings-schema.json->hover-peek-time->tooltip
-msgid "Controls how quickly a window will fade on hover."
-msgstr ""
-"Steuert die Geschwindigkeit mit der Fenster beim Hovern eingeblendet werden."
-
-#. 2.8->settings-schema.json->hover-peek-time->units
-#. 2.8->settings-schema.json->thumbnail-timeout->units
-#. 2.8->settings-schema.json->show-apps-order-timeout->units
-#. 3.4->settings-schema.json->hover-peek-time->units
-#. 3.4->settings-schema.json->thumbnail-timeout->units
-#. 3.4->settings-schema.json->show-apps-order-timeout->units
-msgid "milliseconds"
-msgstr "Millisekunden"
-
-#. 2.8->settings-schema.json->close-button-style->description
-msgid "Allow themes to control the thumbnail close button"
-msgstr ""
-"Erlaube Themen die Schaltflächen zum beenden der Anwendungen zu steuern"
-
-#. 2.8->settings-schema.json->close-button-style->tooltip
-msgid ""
-"Controls whether or not the theme controls the window thumbnail's close "
-"button."
-msgstr ""
-"Steuert, ob das Thema die Schaltfläche zum Schließen der Fenster-"
-"Miniaturansicht steuert."
-
-#. 2.8->settings-schema.json->title-display->description
-#. 3.4->settings-schema.json->title-display->description
-msgid "Title display"
-msgstr "Titel-Anzeige"
-
-#. 2.8->settings-schema.json->title-display->tooltip
-#. 3.4->settings-schema.json->title-display->tooltip
-msgid ""
-"focused: show focused window title, title: display the window title, app: "
-"diplay app name, none: don't display anything"
-msgstr ""
-"Fokussiert: Zeigt fokussierten Fenstertitel, Titel: Zeigt Fenstertitel, "
-"Anwendung: Zeigt Name der Anwendung, keine: Zeigt nichts an"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-#. 3.4->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->middle-click-action->options
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "None"
-msgstr "Keine"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Focused"
-msgstr "Fokussiert"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "App"
-msgstr "Anwendung"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Title"
-msgstr "Titel"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->description
-#. 3.4->settings-schema.json->hoverPseudoClass->description
-msgid "App button hover pseudo class"
-msgstr "App-Taste Hover-Pseudoklasse"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
-#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons on hover."
-msgstr "Überschreibt die Pseudoklasse für App-Schaltflächen beim Hovern."
-
-#. 2.8->settings-schema.json->show-alerts->description
-#. 3.4->settings-schema.json->show-alerts->description
-msgid "Show app alerts and notifications"
-msgstr "Zeige Benachrichtigungen und Warnmeldungen von Anwendungen"
-
-#. 2.8->settings-schema.json->show-alerts->tooltip
-#. 3.4->settings-schema.json->show-alerts->tooltip
-msgid "If enabled, notifications and alerts will appear."
-msgstr "Wenn aktiviert, werden Benachrichtigungen und Warnmeldungen angezeigt."
-
-#. 2.8->settings-schema.json->pinOnDrag->description
-#. 2.8->settings-schema.json->pinOnDrag->tooltip
-#. 3.4->settings-schema.json->pinOnDrag->description
-#. 3.4->settings-schema.json->pinOnDrag->tooltip
-msgid "Pin apps when dragged to a new position"
-msgstr "Pin apps, wenn auf eine neue Position gezogen"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->description
-#. 3.4->settings-schema.json->show-apps-order-hotkey->description
-msgid "Global hotkey to show the order of apps"
-msgstr "Globales Tastaturkürzel, um die Reihenfolge der Apps anzuzeigen"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
-#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
-msgid ""
-"When triggered, the window count label will be replaced with its order in "
-"the app list temporarily."
-msgstr ""
-"Wenn es ausgelöst wird, wird das Fensterzähler-Label durch seine Reihenfolge "
-"in der Anwendungs-Liste vorübergehend ersetzt."
-
-#. 2.8->settings-schema.json->menuItemType->description
-#. 3.4->settings-schema.json->menuItemType->description
-msgid "Menu item type"
-msgstr "Menüpunkttyp"
-
-#. 2.8->settings-schema.json->menuItemType->tooltip
-#. 3.4->settings-schema.json->menuItemType->tooltip
-msgid ""
-"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
-msgstr ""
-"Legt fest, ob Icons für das Menüelement symbolisch, nicht symbolisch oder "
-"nicht dargestellt sind."
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Symbolic icons"
-msgstr "Symbolische Icons"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "No icons"
-msgstr "Keine Icons"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Non-symbolic icons"
-msgstr "Nicht-symbolische Icons"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->description
-#. 3.4->settings-schema.json->hover-peek-opacity->description
-msgid "Window opacity"
-msgstr "Fenster-Transparenz"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
-#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
-msgid "Opacity of the windows on hover."
-msgstr "Steuert die Transparenz der Vorschaubilder."
-
-#. 2.8->settings-schema.json->hover-peek-opacity->units
-#. 3.4->settings-schema.json->hover-peek-opacity->units
-msgid "percent"
-msgstr "Prozent"
-
-#. 2.8->settings-schema.json->enable-hover-peek->description
-#. 3.4->settings-schema.json->enable-hover-peek->description
-msgid "Show windows when hovered over"
-msgstr "Zeige Fenster beim Hovern"
-
-#. 2.8->settings-schema.json->enable-hover-peek->tooltip
-#. 3.4->settings-schema.json->enable-hover-peek->tooltip
-msgid "Controls whether or not windows display when hovered over."
-msgstr "Steuert, ob Fenster-Vorschaubilder beim Hovern angezeigt werden."
-
-#. 2.8->settings-schema.json->activePseudoClass->description
-#. 3.4->settings-schema.json->activePseudoClass->description
-msgid "App button active pseudo class"
-msgstr "App-Taste aktive Pseudoklasse"
-
-#. 2.8->settings-schema.json->activePseudoClass->tooltip
-#. 3.4->settings-schema.json->activePseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons when they are active."
-msgstr ""
-"Überschreibt die Pseudoklasse für App-Schaltflächen, wenn sie aktiv sind."
-
-#. 2.8->settings-schema.json->animate-thumbnails->description
-#. 3.4->settings-schema.json->animate-thumbnails->description
-msgid "Animate thumbnails"
-msgstr "Animierte Miniaturansichten"
-
-#. 2.8->settings-schema.json->animate-thumbnails->tooltip
-#. 3.4->settings-schema.json->animate-thumbnails->tooltip
-msgid "If enabled, thumbnails will animate when appearing and disappearing."
-msgstr ""
-"Wenn aktiviert, werden Miniaturansichten animiert, wenn sie angezeigt werden "
-"oder verschwinden."
-
-#. 2.8->settings-schema.json->autostart-menu-item->description
-#. 3.4->settings-schema.json->autostart-menu-item->description
-msgid "Show autostart option"
-msgstr "Autostart-Option anzeigen"
-
-#. 2.8->settings-schema.json->autostart-menu-item->tooltip
-#. 3.4->settings-schema.json->autostart-menu-item->tooltip
-msgid "Shows the autostart toggle option in an app's context menu."
-msgstr "Zeigt die Autostart-Umschaltoption im Kontextmenü einer App an."
-
-#. 2.8->settings-schema.json->show-pinned->description
-#. 3.4->settings-schema.json->show-pinned->description
-msgid "Show pinned apps"
-msgstr "Zeige angeheftete Anwendungen"
-
-#. 2.8->settings-schema.json->show-pinned->tooltip
-#. 3.4->settings-schema.json->show-pinned->tooltip
-msgid ""
-"Controls whether or not the pinned apps appear in the panel if they are not "
-"open."
-msgstr ""
-"Steuert, ob angeheftete Anwendungen angezeigt werden, wenn sie nicht "
-"geöffnet sind."
-
-#. 2.8->settings-schema.json->useSystemTooltips->description
-msgid "Use system tooltips for closed apps"
-msgstr "Verwende System-Tooltips für geschlossene Anwendungen"
-
-#. 2.8->settings-schema.json->useSystemTooltips->tooltip
-msgid ""
-"Controls whether or not system tooltips are in use when hovering over closed "
-"pinned apps."
-msgstr ""
-"Steuert, ob System-Tooltips beim Hovern über geschlossene, angeheftete "
-"Anwendungen verwendet werden."
+#. 2.8->settings-schema.json->ITM->description
+msgid "ITM Settings"
+msgstr "ITM-Einstellungen"
 
 #. 2.8->settings-schema.json->WindowList->description
 msgid "Window List Settings"
 msgstr "Fensterlisten-Einstellungen"
 
-#. 2.8->settings-schema.json->AppMenu->description
-msgid "Context Menu Settings"
-msgstr "Kontextmenü-Einstellungen"
-
-#. 2.8->settings-schema.json->Thumbnails->description
-msgid "Thumbnail Settings"
-msgstr "Vorschaubild-Einstellungen"
-
-#. 2.8->settings-schema.json->show-recent->description
-#. 3.4->settings-schema.json->show-recent->description
-msgid "Show recent items"
-msgstr "Zeige kürzlich verwendete Elemente"
-
-#. 2.8->settings-schema.json->show-recent->tooltip
-#. 3.4->settings-schema.json->show-recent->tooltip
-msgid "Controls whether recent items will appear in the context menu."
-msgstr ""
-"Steuert, ob kürzlich verwendete Elemente im Kontextmenü angezeigt werden."
-
-#. 2.8->settings-schema.json->vertical-thumbnails->description
-#. 3.4->settings-schema.json->vertical-thumbnails->description
-msgid "Enable vertical thumbnails"
-msgstr "Aktiviere vertikale Vorschaubilder"
-
-#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
-#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
-msgid "If enabled, thumbnails will stack vertically."
-msgstr "Wenn aktiviert, werden Vorschaubilder vertikal gestapelt."
-
-#. 2.8->settings-schema.json->thumbnail-timeout->description
-#. 3.4->settings-schema.json->thumbnail-timeout->description
-msgid "Thumbnail timeout"
-msgstr "Vorschaubild-Ausblendungsverzögerung"
-
-#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
-#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
-msgid ""
-"Controls how quickly an app's set of window thumbnails will fade out when "
-"the mouse leaves the app button."
-msgstr ""
-"Steuert, wie schnell die zu einer Anwendung gehörenden Vorschaubilder "
-"ausgeblendet werden, wenn die Maus die Anwendungs-Schaltfläche verlässt."
-
-#. 2.8->settings-schema.json->ThemeSettings->description
-msgid "Theme Settings"
-msgstr "Themen-Einstellungen"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->description
-#. 3.4->settings-schema.json->onclick-thumbnails->description
-msgid "Open thumbnails on click"
-msgstr "Öffnen der Vorschaubilder durch Klicken"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
-#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
-msgid "Open the thumbnails on click if there is more than one window open."
-msgstr ""
-"Öffnen der Vorschaubilder durch Klicken, wenn bereits mehr als ein Fenster "
-"geöffnet ist."
-
-#. 2.8->settings-schema.json->panelLauncherClass->description
-msgid "Use the panel launcher class for pinned apps"
-msgstr "Verwenden Sie die Panel-Launcher-Klasse für angeheftete Aanwendungen"
-
-#. 2.8->settings-schema.json->panelLauncherClass->tooltip
-msgid "Enabling this helps with certain themes."
-msgstr "Dies hilft bei bestimmten Themen."
-
-#. 2.8->settings-schema.json->include-all-windows->description
-#. 3.4->settings-schema.json->include-all-windows->description
-msgid "Include all app windows"
-msgstr "Zeige alle Anwendungs-Fenster an"
-
-#. 2.8->settings-schema.json->include-all-windows->tooltip
-#. 3.4->settings-schema.json->include-all-windows->tooltip
-msgid ""
-"Controls whether or not thumbnails for smalller child windows, such as exit "
-"confirmations and file dialogues will be included in the thumbnail list."
-msgstr ""
-"Steuert, ob Vorschaubilder für kleine untergeordnete Fenster, z. B. Exit-"
-"Bestätigungen und Dateidialoge, in die Vorschaubild-Liste aufgenommen werden."
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->description
-#. 3.4->settings-schema.json->cycleMenusHotkey->description
-msgid "Global hotkey for cycling through thumbnail menus"
-msgstr "Globales Tastaturkürzel zum Durchlaufen von Vorschaubildern-Menüs"
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
-#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
-msgid "This allows you to cycle through the menus without activating a window."
-msgstr ""
-"Dadurch können Sie durch die Menüs navigieren, ohne ein Fenster zu "
-"aktivieren."
-
-#. 2.8->settings-schema.json->enable-iconSize->description
-#. 3.4->settings-schema.json->enable-iconSize->description
-msgid "Adjust icon size"
-msgstr "Icongröße anpassen"
-
-#. 2.8->settings-schema.json->enable-iconSize->tooltip
-#. 3.4->settings-schema.json->enable-iconSize->tooltip
-msgid "Adjust icon size independent of Cinnamon's panel scaling."
-msgstr "Icongröße unabhängig von der Cinnamon-Leiste anpassen."
-
 #. 2.8->settings-schema.json->number-display->description
+#. 3.8->settings-schema.json->number-display->description
 #. 3.4->settings-schema.json->number-display->description
 msgid "Number display"
 msgstr "Fensteranzahl anzeigen"
 
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Smart"
+msgstr "Smart"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Normal"
+msgstr "Normal"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "None"
+msgstr "Keine"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "All"
+msgstr "Alle"
+
 #. 2.8->settings-schema.json->number-display->tooltip
+#. 3.8->settings-schema.json->number-display->tooltip
 #. 3.4->settings-schema.json->number-display->tooltip
 msgid ""
 "normal: display window number, smart: display window number if more than one "
@@ -582,43 +238,96 @@ msgstr ""
 "Fenster vorhanden ist, Keine: Verberge die Fensteranzahl, Alle: Zeige die "
 "Fensteranzahl auch bei angehefteten Fenstern an"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "All"
-msgstr "Alle"
+#. 2.8->settings-schema.json->title-display->description
+#. 3.8->settings-schema.json->title-display->description
+#. 3.4->settings-schema.json->title-display->description
+msgid "Title display"
+msgstr "Titel-Anzeige"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Smart"
-msgstr "Smart"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "App"
+msgstr "Anwendung"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Normal"
-msgstr "Normal"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Title"
+msgstr "Titel"
 
-#. 2.8->settings-schema.json->ITM->description
-msgid "ITM Settings"
-msgstr "ITM-Einstellungen"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Focused"
+msgstr "Fokussiert"
 
-#. 2.8->settings-schema.json->HoverPeek->description
-msgid "Hover Peek Settings"
-msgstr "Hovern für Vorschau-Einstellungen"
-
-#. 2.8->settings-schema.json->icon-padding->description
-#. 3.4->settings-schema.json->icon-padding->description
-msgid "Icon padding"
-msgstr "Icon-Polsterung"
-
-#. 2.8->settings-schema.json->icon-padding->tooltip
-#. 3.4->settings-schema.json->icon-padding->tooltip
+#. 2.8->settings-schema.json->title-display->tooltip
+#. 3.8->settings-schema.json->title-display->tooltip
+#. 3.4->settings-schema.json->title-display->tooltip
 msgid ""
-"Controls how much horizontal padding is inside the app buttons. Padding is "
-"only applied to instances of this applet on horizontal panels."
+"focused: show focused window title, title: display the window title, app: "
+"diplay app name, none: don't display anything"
 msgstr ""
-"Steuert, wie viel horizontale Polsterung innerhalb der App-Schaltflächen "
-"ist. Polsterung wird nur auf Instanzen dieses Applets auf horizontalen "
-"Leisten angewendet."
+"Fokussiert: Zeigt fokussierten Fenstertitel, Titel: Zeigt Fenstertitel, "
+"Anwendung: Zeigt Name der Anwendung, keine: Zeigt nichts an"
+
+#. 2.8->settings-schema.json->group-apps->description
+#. 3.8->settings-schema.json->group-apps->description
+#. 3.4->settings-schema.json->group-apps->description
+msgid "Group apps"
+msgstr "Gruppiere Anwendungen"
+
+#. 2.8->settings-schema.json->group-apps->tooltip
+#. 3.8->settings-schema.json->group-apps->tooltip
+#. 3.4->settings-schema.json->group-apps->tooltip
+msgid "Group each app's set of windows."
+msgstr "Gruppiere die Fenster jeder Anwendung."
+
+#. 2.8->settings-schema.json->show-alerts->description
+#. 3.8->settings-schema.json->show-alerts->description
+#. 3.4->settings-schema.json->show-alerts->description
+msgid "Show app alerts and notifications"
+msgstr "Zeige Benachrichtigungen und Warnmeldungen von Anwendungen"
+
+#. 2.8->settings-schema.json->show-alerts->tooltip
+#. 3.8->settings-schema.json->show-alerts->tooltip
+#. 3.4->settings-schema.json->show-alerts->tooltip
+msgid "If enabled, notifications and alerts will appear."
+msgstr "Wenn aktiviert, werden Benachrichtigungen und Warnmeldungen angezeigt."
+
+#. 2.8->settings-schema.json->show-pinned->description
+#. 3.8->settings-schema.json->show-pinned->description
+#. 3.4->settings-schema.json->show-pinned->description
+msgid "Show pinned apps"
+msgstr "Zeige angeheftete Anwendungen"
+
+#. 2.8->settings-schema.json->show-pinned->tooltip
+#. 3.8->settings-schema.json->show-pinned->tooltip
+#. 3.4->settings-schema.json->show-pinned->tooltip
+msgid ""
+"Controls whether or not the pinned apps appear in the panel if they are not "
+"open."
+msgstr ""
+"Steuert, ob angeheftete Anwendungen angezeigt werden, wenn sie nicht "
+"geöffnet sind."
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->description
+msgid "Arrange pinned apps"
+msgstr "Angeheftete Anwendungen anordnen"
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
+msgid "Arrange pinned apps into a different order."
+msgstr "Angeheftete Anwendungen neu anordnen"
+
+#. 2.8->settings-schema.json->pinOnDrag->description
+#. 2.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.8->settings-schema.json->pinOnDrag->description
+#. 3.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.4->settings-schema.json->pinOnDrag->description
+#. 3.4->settings-schema.json->pinOnDrag->tooltip
+msgid "Pin apps when dragged to a new position"
+msgstr "Pin apps, wenn auf eine neue Position gezogen"
 
 #. 2.8->settings-schema.json->middle-click-action->description
 msgid "Middle clicking app buttons creates new app instances"
@@ -635,12 +344,265 @@ msgstr ""
 "Wenn Sie dies auf false setzen, wird das letzte fokussierte Fenster aus der "
 "App-Gruppe beim mittleren Klick geschlossen."
 
+#. 2.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.4->settings-schema.json->cycleMenusHotkey->description
+msgid "Global hotkey for cycling through thumbnail menus"
+msgstr "Globales Tastaturkürzel zum Durchlaufen von Vorschaubildern-Menüs"
+
+#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
+msgid "This allows you to cycle through the menus without activating a window."
+msgstr ""
+"Dadurch können Sie durch die Menüs navigieren, ohne ein Fenster zu "
+"aktivieren."
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.4->settings-schema.json->show-apps-order-hotkey->description
+msgid "Global hotkey to show the order of apps"
+msgstr "Globales Tastaturkürzel, um die Reihenfolge der Apps anzuzeigen"
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
+msgid ""
+"When triggered, the window count label will be replaced with its order in "
+"the app list temporarily."
+msgstr ""
+"Wenn es ausgelöst wird, wird das Fensterzähler-Label durch seine Reihenfolge "
+"in der Anwendungs-Liste vorübergehend ersetzt."
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->units
+#. 2.8->settings-schema.json->thumbnail-timeout->units
+#. 2.8->settings-schema.json->hover-peek-time->units
+#. 3.8->settings-schema.json->show-apps-order-timeout->units
+#. 3.8->settings-schema.json->thumbnail-timeout->units
+#. 3.8->settings-schema.json->hover-peek-time->units
+#. 3.4->settings-schema.json->show-apps-order-timeout->units
+#. 3.4->settings-schema.json->thumbnail-timeout->units
+#. 3.4->settings-schema.json->hover-peek-time->units
+msgid "milliseconds"
+msgstr "Millisekunden"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.4->settings-schema.json->show-apps-order-timeout->description
+msgid "Duration of the apps order display on hotkey press"
+msgstr "Dauer der Anwendungsauflistung beim Verwenden des Tastaturkürzels"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
+msgid ""
+"Determines the duration the window count labels are replaced with the app's "
+"order number."
+msgstr ""
+"Legt die Dauer fest, die das Fensterzähler-Label durch die Reihenfolge der "
+"Anwendung ersetzt werden."
+
+#. 2.8->settings-schema.json->Thumbnails->description
+msgid "Thumbnail Settings"
+msgstr "Vorschaubild-Einstellungen"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->description
+#. 3.8->settings-schema.json->thumbnail-timeout->description
+#. 3.4->settings-schema.json->thumbnail-timeout->description
+msgid "Thumbnail timeout"
+msgstr "Vorschaubild-Ausblendungsverzögerung"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
+msgid ""
+"Controls how quickly an app's set of window thumbnails will fade out when "
+"the mouse leaves the app button."
+msgstr ""
+"Steuert, wie schnell die zu einer Anwendung gehörenden Vorschaubilder "
+"ausgeblendet werden, wenn die Maus die Anwendungs-Schaltfläche verlässt."
+
+#. 2.8->settings-schema.json->thumbnail-size->units
+#. 3.8->settings-schema.json->thumbnail-size->units
+#. 3.4->settings-schema.json->thumbnail-size->units
+msgid "size"
+msgstr "Größe"
+
+#. 2.8->settings-schema.json->thumbnail-size->description
+#. 3.8->settings-schema.json->thumbnail-size->description
+#. 3.4->settings-schema.json->thumbnail-size->description
+msgid "Thumbnail size"
+msgstr "Vorschaubild-Größe"
+
+#. 2.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-size->tooltip
+msgid "Controls the size of the thumbnails."
+msgstr "Steuert die Größe der Vorschaubilder."
+
+#. 2.8->settings-schema.json->show-thumbnails->description
+#. 3.8->settings-schema.json->show-thumbnails->description
+#. 3.4->settings-schema.json->show-thumbnails->description
+msgid "Show thumbnails"
+msgstr "Zeige Vorschaubilder"
+
+#. 2.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.4->settings-schema.json->show-thumbnails->tooltip
+msgid "Show window thumbnails when hovering over an app button."
+msgstr ""
+"Zeigt Fenster-Vorschaubilder beim Hovern über einer Anwendungs-Schaltfläche "
+"an."
+
+#. 2.8->settings-schema.json->animate-thumbnails->description
+#. 3.8->settings-schema.json->animate-thumbnails->description
+#. 3.4->settings-schema.json->animate-thumbnails->description
+msgid "Animate thumbnails"
+msgstr "Animierte Miniaturansichten"
+
+#. 2.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.4->settings-schema.json->animate-thumbnails->tooltip
+msgid "If enabled, thumbnails will animate when appearing and disappearing."
+msgstr ""
+"Wenn aktiviert, werden Miniaturansichten animiert, wenn sie angezeigt werden "
+"oder verschwinden."
+
+#. 2.8->settings-schema.json->vertical-thumbnails->description
+#. 3.8->settings-schema.json->vertical-thumbnails->description
+#. 3.4->settings-schema.json->vertical-thumbnails->description
+msgid "Enable vertical thumbnails"
+msgstr "Aktiviere vertikale Vorschaubilder"
+
+#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
+msgid "If enabled, thumbnails will stack vertically."
+msgstr "Wenn aktiviert, werden Vorschaubilder vertikal gestapelt."
+
+#. 2.8->settings-schema.json->sort-thumbnails->description
+#. 3.8->settings-schema.json->sort-thumbnails->description
+#. 3.4->settings-schema.json->sort-thumbnails->description
+msgid "Sort windows for each app by last focused"
+msgstr "Sortiert Fenster anhand zuletzt fokussierter Fenster."
+
+#. 2.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.4->settings-schema.json->sort-thumbnails->tooltip
+msgid ""
+"Controls whether the order windows appear for an app is by last focused, or "
+"the order they were opened."
+msgstr ""
+"Steuert, ob die Reihenfolge der Anzeige von Fenstern durch zuletzt "
+"fokussierte Fenster oder durch die Reihenfolge in der sie geöffnet wurden "
+"bestimmt wird."
+
+#. 2.8->settings-schema.json->onclick-thumbnails->description
+#. 3.8->settings-schema.json->onclick-thumbnails->description
+#. 3.4->settings-schema.json->onclick-thumbnails->description
+msgid "Open thumbnails on click"
+msgstr "Öffnen der Vorschaubilder durch Klicken"
+
+#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
+msgid "Open the thumbnails on click if there is more than one window open."
+msgstr ""
+"Öffnen der Vorschaubilder durch Klicken, wenn bereits mehr als ein Fenster "
+"geöffnet ist."
+
+#. 2.8->settings-schema.json->include-all-windows->description
+#. 3.8->settings-schema.json->include-all-windows->description
+#. 3.4->settings-schema.json->include-all-windows->description
+msgid "Include all app windows"
+msgstr "Zeige alle Anwendungs-Fenster an"
+
+#. 2.8->settings-schema.json->include-all-windows->tooltip
+#. 3.8->settings-schema.json->include-all-windows->tooltip
+#. 3.4->settings-schema.json->include-all-windows->tooltip
+msgid ""
+"Controls whether or not thumbnails for smalller child windows, such as exit "
+"confirmations and file dialogues will be included in the thumbnail list."
+msgstr ""
+"Steuert, ob Vorschaubilder für kleine untergeordnete Fenster, z. B. Exit-"
+"Bestätigungen und Dateidialoge, in die Vorschaubild-Liste aufgenommen werden."
+
+#. 2.8->settings-schema.json->AppMenu->description
+msgid "Context Menu Settings"
+msgstr "Kontextmenü-Einstellungen"
+
+#. 2.8->settings-schema.json->show-recent->description
+#. 3.8->settings-schema.json->show-recent->description
+#. 3.4->settings-schema.json->show-recent->description
+msgid "Show recent items"
+msgstr "Zeige kürzlich verwendete Elemente"
+
+#. 2.8->settings-schema.json->show-recent->tooltip
+#. 3.8->settings-schema.json->show-recent->tooltip
+#. 3.4->settings-schema.json->show-recent->tooltip
+msgid "Controls whether recent items will appear in the context menu."
+msgstr ""
+"Steuert, ob kürzlich verwendete Elemente im Kontextmenü angezeigt werden."
+
+#. 2.8->settings-schema.json->menuItemType->description
+#. 3.8->settings-schema.json->menuItemType->description
+#. 3.4->settings-schema.json->menuItemType->description
+msgid "Menu item type"
+msgstr "Menüpunkttyp"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Symbolic icons"
+msgstr "Symbolische Icons"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Non-symbolic icons"
+msgstr "Nicht-symbolische Icons"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "No icons"
+msgstr "Keine Icons"
+
+#. 2.8->settings-schema.json->menuItemType->tooltip
+#. 3.8->settings-schema.json->menuItemType->tooltip
+#. 3.4->settings-schema.json->menuItemType->tooltip
+msgid ""
+"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
+msgstr ""
+"Legt fest, ob Icons für das Menüelement symbolisch, nicht symbolisch oder "
+"nicht dargestellt sind."
+
 #. 2.8->settings-schema.json->firefox-menu->description
+#. 3.8->settings-schema.json->firefox-menu->description
 #. 3.4->settings-schema.json->firefox-menu->description
 msgid "Firefox context menu"
 msgstr "Firefox-Kontextmenü"
 
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Most Visited"
+msgstr "Häufige Aufrufe"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Recent History"
+msgstr "Kürzliche Aufrufe"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Bookmarks"
+msgstr "Lesezeichen"
+
 #. 2.8->settings-schema.json->firefox-menu->tooltip
+#. 3.8->settings-schema.json->firefox-menu->tooltip
 #. 3.4->settings-schema.json->firefox-menu->tooltip
 msgid ""
 "Most Visited: show the sites you visit most, Recent History: display the the "
@@ -650,20 +612,144 @@ msgstr ""
 "Zeigt Seiten die du kürzlich besucht hast, Lesezeichen: Zeigt nur deine "
 "Lesezeichen."
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Bookmarks"
-msgstr "Lesezeichen"
+#. 2.8->settings-schema.json->autostart-menu-item->description
+#. 3.8->settings-schema.json->autostart-menu-item->description
+#. 3.4->settings-schema.json->autostart-menu-item->description
+msgid "Show autostart option"
+msgstr "Autostart-Option anzeigen"
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Most Visited"
-msgstr "Häufige Aufrufe"
+#. 2.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.4->settings-schema.json->autostart-menu-item->tooltip
+msgid "Shows the autostart toggle option in an app's context menu."
+msgstr "Zeigt die Autostart-Umschaltoption im Kontextmenü einer App an."
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Recent History"
-msgstr "Kürzliche Aufrufe"
+#. 2.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.4->settings-schema.json->monitor-move-all-windows->description
+msgid "Apply the monitor move option to all windows"
+msgstr "Wenden Sie die Monitorbewegungsoption auf alle Fenster an"
+
+#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
+msgid ""
+"When clicking \"Move to monitor\" in the context menu, this option will move "
+"all of an app's windows instead of just the last focused window from the app."
+msgstr ""
+"Wenn Sie im Kontextmenü auf \"Verschieben auf Monitor\" klicken, wird diese "
+"Option alle Fenster einer Anwendung statt nur das zuletzt fokussiert Fenster "
+"verschieben."
+
+#. 2.8->settings-schema.json->HoverPeek->description
+msgid "Hover Peek Settings"
+msgstr "Hovern für Vorschau-Einstellungen"
+
+#. 2.8->settings-schema.json->enable-hover-peek->description
+#. 3.8->settings-schema.json->enable-hover-peek->description
+#. 3.4->settings-schema.json->enable-hover-peek->description
+msgid "Show windows when hovered over"
+msgstr "Zeige Fenster beim Hovern"
+
+#. 2.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.4->settings-schema.json->enable-hover-peek->tooltip
+msgid "Controls whether or not windows display when hovered over."
+msgstr "Steuert, ob Fenster-Vorschaubilder beim Hovern angezeigt werden."
+
+#. 2.8->settings-schema.json->hover-peek-time->description
+#. 3.8->settings-schema.json->hover-peek-time->description
+#. 3.4->settings-schema.json->hover-peek-time->description
+msgid "Window fade time"
+msgstr "Fenster-Einblendungszeit"
+
+#. 2.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.4->settings-schema.json->hover-peek-time->tooltip
+msgid "Controls how quickly a window will fade on hover."
+msgstr ""
+"Steuert die Geschwindigkeit mit der Fenster beim Hovern eingeblendet werden."
+
+#. 2.8->settings-schema.json->hover-peek-opacity->units
+#. 3.8->settings-schema.json->hover-peek-opacity->units
+#. 3.4->settings-schema.json->hover-peek-opacity->units
+msgid "percent"
+msgstr "Prozent"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->description
+#. 3.8->settings-schema.json->hover-peek-opacity->description
+#. 3.4->settings-schema.json->hover-peek-opacity->description
+msgid "Window opacity"
+msgstr "Fenster-Transparenz"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
+msgid "Opacity of the windows on hover."
+msgstr "Steuert die Transparenz der Vorschaubilder."
+
+#. 2.8->settings-schema.json->ThemeSettings->description
+msgid "Theme Settings"
+msgstr "Themen-Einstellungen"
+
+#. 2.8->settings-schema.json->show-active->description
+#. 3.8->settings-schema.json->show-active->description
+#. 3.4->settings-schema.json->show-active->description
+msgid "Show active app indicators"
+msgstr "Geöffnete Anwendungen hervorheben"
+
+#. 2.8->settings-schema.json->show-active->tooltip
+#. 3.8->settings-schema.json->show-active->tooltip
+#. 3.4->settings-schema.json->show-active->tooltip
+msgid "Active app styling will indicate if an app is active."
+msgstr "Geöffnete Anwendungen werden besonders hervorgehoben."
+
+#. 2.8->settings-schema.json->icon-spacing->units
+#. 2.8->settings-schema.json->icon-padding->units
+#. 2.8->settings-schema.json->icon-size->units
+#. 3.8->settings-schema.json->app-button-width->units
+#. 3.8->settings-schema.json->thumbnail-close-button-size->units
+#. 3.8->settings-schema.json->thumbnail-padding->units
+#. 3.8->settings-schema.json->icon-spacing->units
+#. 3.8->settings-schema.json->icon-padding->units
+#. 3.8->settings-schema.json->icon-size->units
+#. 3.4->settings-schema.json->app-button-width->units
+#. 3.4->settings-schema.json->thumbnail-close-button-size->units
+#. 3.4->settings-schema.json->thumbnail-padding->units
+#. 3.4->settings-schema.json->icon-spacing->units
+#. 3.4->settings-schema.json->icon-padding->units
+#. 3.4->settings-schema.json->icon-size->units
+msgid "px"
+msgstr "Pixel"
+
+#. 2.8->settings-schema.json->icon-spacing->description
+#. 3.8->settings-schema.json->icon-spacing->description
+#. 3.4->settings-schema.json->icon-spacing->description
+msgid "Icon spacing"
+msgstr "Icon-Abstand"
+
+#. 2.8->settings-schema.json->icon-spacing->tooltip
+#. 3.8->settings-schema.json->icon-spacing->tooltip
+#. 3.4->settings-schema.json->icon-spacing->tooltip
+msgid "Controls how much space is between the icons."
+msgstr "Legt den Abstand zwischen den Icons der Anwendungs-Leiste fest."
+
+#. 2.8->settings-schema.json->icon-padding->description
+#. 3.8->settings-schema.json->icon-padding->description
+#. 3.4->settings-schema.json->icon-padding->description
+msgid "Icon padding"
+msgstr "Icon-Polsterung"
+
+#. 2.8->settings-schema.json->icon-padding->tooltip
+#. 3.8->settings-schema.json->icon-padding->tooltip
+#. 3.4->settings-schema.json->icon-padding->tooltip
+msgid ""
+"Controls how much horizontal padding is inside the app buttons. Padding is "
+"only applied to instances of this applet on horizontal panels."
+msgstr ""
+"Steuert, wie viel horizontale Polsterung innerhalb der App-Schaltflächen "
+"ist. Polsterung wird nur auf Instanzen dieses Applets auf horizontalen "
+"Leisten angewendet."
 
 #. 2.8->settings-schema.json->themePadding->description
 msgid "Use theme padding to center button icons"
@@ -676,122 +762,284 @@ msgstr ""
 "Wenn die Schaltflächenicons nicht zentriert aussehen, kann das Umschalten "
 "hilfreich sein."
 
-#. 2.8->settings-schema.json->group-apps->description
-#. 3.4->settings-schema.json->group-apps->description
-msgid "Group apps"
-msgstr "Gruppiere Anwendungen"
+#. 2.8->settings-schema.json->enable-iconSize->description
+#. 3.8->settings-schema.json->enable-iconSize->description
+#. 3.4->settings-schema.json->enable-iconSize->description
+msgid "Adjust icon size"
+msgstr "Icongröße anpassen"
 
-#. 2.8->settings-schema.json->group-apps->tooltip
-#. 3.4->settings-schema.json->group-apps->tooltip
-msgid "Group each app's set of windows."
-msgstr "Gruppiere die Fenster jeder Anwendung."
+#. 2.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.4->settings-schema.json->enable-iconSize->tooltip
+msgid "Adjust icon size independent of Cinnamon's panel scaling."
+msgstr "Icongröße unabhängig von der Cinnamon-Leiste anpassen."
 
-#. 2.8->settings-schema.json->show-active->description
-#. 3.4->settings-schema.json->show-active->description
-msgid "Show active app indicators"
-msgstr "Geöffnete Anwendungen hervorheben"
+#. 2.8->settings-schema.json->icon-size->description
+#. 3.8->settings-schema.json->icon-size->description
+#. 3.4->settings-schema.json->icon-size->description
+msgid "Icon size"
+msgstr "Icongröße"
 
-#. 2.8->settings-schema.json->show-active->tooltip
-#. 3.4->settings-schema.json->show-active->tooltip
-msgid "Active app styling will indicate if an app is active."
-msgstr "Geöffnete Anwendungen werden besonders hervorgehoben."
+#. 2.8->settings-schema.json->icon-size->tooltip
+#. 3.8->settings-schema.json->icon-size->tooltip
+#. 3.4->settings-schema.json->icon-size->tooltip
+msgid "Set icon size"
+msgstr "Icongröße anpassen"
 
-#. 2.8->settings-schema.json->show-apps-order-timeout->description
-#. 3.4->settings-schema.json->show-apps-order-timeout->description
-msgid "Duration of the apps order display on hotkey press"
-msgstr "Dauer der Anwendungsauflistung beim Verwenden des Tastaturkürzels"
+#. 2.8->settings-schema.json->hoverPseudoClass->description
+#. 3.8->settings-schema.json->hoverPseudoClass->description
+#. 3.4->settings-schema.json->hoverPseudoClass->description
+msgid "App button hover pseudo class"
+msgstr "App-Taste Hover-Pseudoklasse"
 
-#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
-#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
-msgid ""
-"Determines the duration the window count labels are replaced with the app's "
-"order number."
-msgstr ""
-"Legt die Dauer fest, die das Fensterzähler-Label durch die Reihenfolge der "
-"Anwendung ersetzt werden."
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->description
-msgid "Arrange pinned apps"
-msgstr "Angeheftete Anwendungen anordnen"
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
-msgid "Arrange pinned apps into a different order."
-msgstr "Angeheftete Anwendungen neu anordnen"
-
-#. 2.8->settings-schema.json->monitor-move-all-windows->description
-#. 3.4->settings-schema.json->monitor-move-all-windows->description
-msgid "Apply the monitor move option to all windows"
-msgstr "Wenden Sie die Monitorbewegungsoption auf alle Fenster an"
-
-#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
-#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
-msgid ""
-"When clicking \"Move to monitor\" in the context menu, this option will move "
-"all of an app's windows instead of just the last focused window from the app."
-msgstr ""
-"Wenn Sie im Kontextmenü auf \"Verschieben auf Monitor\" klicken, wird diese "
-"Option alle Fenster einer Anwendung statt nur das zuletzt fokussiert Fenster "
-"verschieben."
-
-#. 2.8->settings-schema.json->sort-thumbnails->description
-#. 3.4->settings-schema.json->sort-thumbnails->description
-msgid "Sort windows for each app by last focused"
-msgstr "Sortiert Fenster anhand zuletzt fokussierter Fenster."
-
-#. 2.8->settings-schema.json->sort-thumbnails->tooltip
-#. 3.4->settings-schema.json->sort-thumbnails->tooltip
-msgid ""
-"Controls whether the order windows appear for an app is by last focused, or "
-"the order they were opened."
-msgstr ""
-"Steuert, ob die Reihenfolge der Anzeige von Fenstern durch zuletzt "
-"fokussierte Fenster oder durch die Reihenfolge in der sie geöffnet wurden "
-"bestimmt wird."
-
-#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
 #. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
 #. 3.4->settings-schema.json->activePseudoClass->options
-msgid "checked"
-msgstr ""
+msgid "hover"
+msgstr "schweben"
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
-msgid "Highlight the last focused window within an app group"
-msgstr ""
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "focus"
+msgstr "fokussieren"
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "active"
+msgstr "aktiv"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "outlined"
+msgstr "eingerahmt"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "selected"
+msgstr "ausgewählt"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons on hover."
+msgstr "Überschreibt die Pseudoklasse für App-Schaltflächen beim Hovern."
+
+#. 2.8->settings-schema.json->focusPseudoClass->description
+#. 3.8->settings-schema.json->focusPseudoClass->description
+#. 3.4->settings-schema.json->focusPseudoClass->description
+msgid "App button focus pseudo class"
+msgstr "App-Schaltfläche Fokus Pseudo-Klasse"
+
+#. 2.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.4->settings-schema.json->focusPseudoClass->tooltip
+msgid "Overrides the pseudo class for app button on focus."
+msgstr "Überschreibt die Pseudoklasse für App-Schaltfläche auf Fokus."
+
+#. 2.8->settings-schema.json->activePseudoClass->description
+#. 3.8->settings-schema.json->activePseudoClass->description
+#. 3.4->settings-schema.json->activePseudoClass->description
+msgid "App button active pseudo class"
+msgstr "App-Taste aktive Pseudoklasse"
+
+#. 2.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.4->settings-schema.json->activePseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons when they are active."
+msgstr ""
+"Überschreibt die Pseudoklasse für App-Schaltflächen, wenn sie aktiv sind."
+
+#. 2.8->settings-schema.json->panelLauncherClass->description
+msgid "Use the panel launcher class for pinned apps"
+msgstr "Verwenden Sie die Panel-Launcher-Klasse für angeheftete Aanwendungen"
+
+#. 2.8->settings-schema.json->panelLauncherClass->tooltip
+msgid "Enabling this helps with certain themes."
+msgstr "Dies hilft bei bestimmten Themen."
+
+#. 2.8->settings-schema.json->close-button-style->description
+msgid "Allow themes to control the thumbnail close button"
+msgstr ""
+"Erlaube Themen die Schaltflächen zum beenden der Anwendungen zu steuern"
+
+#. 2.8->settings-schema.json->close-button-style->tooltip
 msgid ""
-"When enabled, the last window that was interacted with will be indicated."
+"Controls whether or not the theme controls the window thumbnail's close "
+"button."
 msgstr ""
+"Steuert, ob das Thema die Schaltfläche zum Schließen der Fenster-"
+"Miniaturansicht steuert."
 
-#. 3.4->settings-schema.json->app-button-transition-duration->description
-#, fuzzy
-msgid "App button transition duration"
-msgstr "Breite der Anwendungsknöpfe"
+#. 2.8->settings-schema.json->useSystemTooltips->description
+msgid "Use system tooltips for closed apps"
+msgstr "Verwende System-Tooltips für geschlossene Anwendungen"
 
-#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+#. 2.8->settings-schema.json->useSystemTooltips->tooltip
 msgid ""
-"Overrides the theme's animation time for app buttons. If set to zero, the "
-"theme's transition duration will be used."
+"Controls whether or not system tooltips are in use when hovering over closed "
+"pinned apps."
+msgstr ""
+"Steuert, ob System-Tooltips beim Hovern über geschlossene, angeheftete "
+"Anwendungen verwendet werden."
+
+#. 3.8->settings-schema.json->generalPage->title
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
 msgstr ""
 
-#. 3.4->settings-schema.json->app-button-transition-duration->units
-msgid "ms"
+#. 3.8->settings-schema.json->panelPage->title
+#. 3.4->settings-schema.json->panelPage->title
+msgid "Panel"
+msgstr "Leiste"
+
+#. 3.8->settings-schema.json->thumbnailsPage->title
+#. 3.8->settings-schema.json->thumbnailsSection->title
+#. 3.4->settings-schema.json->thumbnailsPage->title
+#. 3.4->settings-schema.json->thumbnailsSection->title
+msgid "Thumbnails"
+msgstr "Fenstervorschau"
+
+#. 3.8->settings-schema.json->contextMenuPage->title
+#. 3.4->settings-schema.json->contextMenuPage->title
+msgid "Context Menu"
+msgstr "Kontextmenü"
+
+#. 3.8->settings-schema.json->themePage->title
+#. 3.4->settings-schema.json->themePage->title
+msgid "Theming"
+msgstr "Themen einstellen"
+
+#. 3.8->settings-schema.json->generalSection->title
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
 msgstr ""
 
-#. 3.4->settings-schema.json->thumbnail-padding->description
-#, fuzzy
-msgid "Thumbnail padding"
-msgstr "Vorschaubild-Einstellungen"
+#. 3.8->settings-schema.json->appButtonsSection->title
+#. 3.4->settings-schema.json->appButtonsSection->title
+msgid "App Buttons"
+msgstr "Anwendungsknöpfe"
 
-#. 3.4->settings-schema.json->thumbnail-padding->tooltip
-#, fuzzy
-msgid "Controls how much space will be around the window preview thumbnails."
-msgstr "Legt den Abstand zwischen den Icons der Anwendungs-Leiste fest."
+#. 3.8->settings-schema.json->hotKeysSection->title
+#. 3.4->settings-schema.json->hotKeysSection->title
+msgid "Hot Keys"
+msgstr "Tastenkürzel"
 
+#. 3.8->settings-schema.json->hoverPeekSection->title
+#. 3.4->settings-schema.json->hoverPeekSection->title
+msgid "Hover Peek"
+msgstr "Vorschau, wenn Maus"
+
+#. 3.8->settings-schema.json->stylingSection->title
+#. 3.4->settings-schema.json->stylingSection->title
+msgid "Styling"
+msgstr "Design"
+
+#. 3.8->settings-schema.json->iconSection->title
+#. 3.4->settings-schema.json->iconSection->title
+msgid "Icons"
+msgstr "Icons"
+
+#. 3.8->settings-schema.json->presetSection->title
+#. 3.4->settings-schema.json->presetSection->title
+msgid "Recommended Presets"
+msgstr "Empfohlene Voreinstellungen"
+
+#. 3.8->settings-schema.json->scroll-behavior->description
+#. 3.4->settings-schema.json->scroll-behavior->description
+msgid "Mouse wheel scroll behavior"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+msgid "Cycle apps"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#, fuzzy
+msgid "Cycle windows"
+msgstr "Zeige alle Anwendungs-Fenster an"
+
+#. 3.8->settings-schema.json->scroll-behavior->tooltip
+#. 3.4->settings-schema.json->scroll-behavior->tooltip
+msgid ""
+"Choose if scrolling the mouse wheel cycles running apps, an app button's "
+"windows on hover, or is disabled."
+msgstr ""
+
+#. 3.8->settings-schema.json->left-click-action->description
+#. 3.8->settings-schema.json->left-click-action->tooltip
+#. 3.8->settings-schema.json->launcher-animation-effect->tooltip
+#. 3.4->settings-schema.json->left-click-action->description
+#. 3.4->settings-schema.json->left-click-action->tooltip
+#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
+msgid "Left click action"
+msgstr ""
+
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->left-click-action->options
+msgid "Toggle activation of last focused window"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->description
+#. 3.8->settings-schema.json->middle-click-action->tooltip
+#. 3.4->settings-schema.json->middle-click-action->description
+#. 3.4->settings-schema.json->middle-click-action->tooltip
+msgid "Middle click action"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Launch new app instance"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Close last focused window in group"
+msgstr ""
+
+#. 3.8->settings-schema.json->system-favorites->description
 #. 3.4->settings-schema.json->system-favorites->description
 msgid "Use system favorites for pinned apps"
 msgstr "Verwende Systemfavoriten für angeheftete Anwendungen"
 
+#. 3.8->settings-schema.json->system-favorites->tooltip
 #. 3.4->settings-schema.json->system-favorites->tooltip
 msgid ""
 "Controls whether or not pinned apps consist of the system favorites list."
@@ -799,133 +1047,43 @@ msgstr ""
 "Steuert, ob angeheftete Anwendungen aus den Systemfavoriten angezeigt werden "
 "sollen."
 
-#. 3.4->settings-schema.json->generalSection->title
-msgid "Behavior"
-msgstr ""
-
-#. 3.4->settings-schema.json->thumbnailsPage->title
-#. 3.4->settings-schema.json->thumbnailsSection->title
-msgid "Thumbnails"
-msgstr "Fenstervorschau"
-
-#. 3.4->settings-schema.json->presetSection->title
-msgid "Recommended Presets"
-msgstr "Empfohlene Voreinstellungen"
-
-#. 3.4->settings-schema.json->appButtonsSection->title
-msgid "App Buttons"
-msgstr "Anwendungsknöpfe"
-
-#. 3.4->settings-schema.json->generalPage->title
-msgid "General"
-msgstr ""
-
-#. 3.4->settings-schema.json->hoverPeekSection->title
-msgid "Hover Peek"
-msgstr "Vorschau, wenn Maus"
-
-#. 3.4->settings-schema.json->panelPage->title
-msgid "Panel"
-msgstr "Leiste"
-
-#. 3.4->settings-schema.json->iconSection->title
-msgid "Icons"
-msgstr "Icons"
-
-#. 3.4->settings-schema.json->hotKeysSection->title
-msgid "Hot Keys"
-msgstr "Tastenkürzel"
-
-#. 3.4->settings-schema.json->stylingSection->title
-msgid "Styling"
-msgstr "Design"
-
-#. 3.4->settings-schema.json->contextMenuPage->title
-msgid "Context Menu"
-msgstr "Kontextmenü"
-
-#. 3.4->settings-schema.json->themePage->title
-msgid "Theming"
-msgstr "Themen einstellen"
-
-#. 3.4->settings-schema.json->mintYPreset->description
-#. 3.4->settings-schema.json->mintYPreset->tooltip
-msgid "Mint Y and Variants"
-msgstr "Mint-Y und Varianten"
-
-#. 3.4->settings-schema.json->show-icons->description
+#. 3.8->settings-schema.json->show-all-workspaces->description
+#. 3.8->settings-schema.json->show-all-workspaces->tooltip
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
 #, fuzzy
-msgid "Show icons"
-msgstr "Keine Icons"
+msgid "Show windows from all workspaces"
+msgstr "Auf allen Arbeitsflächen anzeigen"
 
-#. 3.4->settings-schema.json->show-icons->tooltip
-msgid "Show the window's icon next to the title."
-msgstr ""
-
+#. 3.8->settings-schema.json->enable-app-button-dragging->description
+#. 3.8->settings-schema.json->enable-app-button-dragging->tooltip
 #. 3.4->settings-schema.json->enable-app-button-dragging->description
 #. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
 msgid "Enable app button dragging"
 msgstr "Ziehen von Anwendungsknöpfen erlauben"
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
-#, fuzzy
-msgid "Show new window option"
-msgstr "Autostart-Option anzeigen"
-
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
-msgid ""
-"Shows the \"New Window\" option in an app's context menu if it doesn't "
-"already have one from the app's own action menu items."
-msgstr ""
-
-#. 3.4->settings-schema.json->app-button-width->description
-msgid "App button width"
-msgstr "Breite der Anwendungsknöpfe"
-
-#. 3.4->settings-schema.json->app-button-width->tooltip
-#, fuzzy
-msgid ""
-"Controls the width of the application button. This option only works for "
-"horizontal panels."
-msgstr "Steuert die Größe der Anwendungsknöpfe."
-
-#. 3.4->settings-schema.json->mintXPreset->description
-#. 3.4->settings-schema.json->mintXPreset->tooltip
-#, fuzzy
-msgid "Mint X, Linux Mint, and Variants"
-msgstr "Mint-Y und Varianten"
-
+#. 3.8->settings-schema.json->launcher-animation-effect->description
 #. 3.4->settings-schema.json->launcher-animation-effect->description
 msgid "Launcher animation effect"
 msgstr ""
 
-#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
-#. 3.4->settings-schema.json->left-click-action->description
-#. 3.4->settings-schema.json->left-click-action->tooltip
-msgid "Left click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Scale"
-msgstr ""
-
+#. 3.8->settings-schema.json->launcher-animation-effect->options
 #. 3.4->settings-schema.json->launcher-animation-effect->options
 msgid "Fade"
 msgstr ""
 
-#. 3.4->settings-schema.json->enable-app-button-width->description
-msgid "Use a custom width for app buttons"
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Scale"
 msgstr ""
 
-#. 3.4->settings-schema.json->enable-app-button-width->tooltip
-msgid "When disabled, the app button width is determined by the panel height."
-msgstr ""
-
+#. 3.8->settings-schema.json->list-monitor-windows->description
 #. 3.4->settings-schema.json->list-monitor-windows->description
 msgid "Only list windows from the monitor displaying this instance"
 msgstr ""
 "Nur Fenster von dem Monitor auflisten, auf dem diese Instanz angezeigt wird"
 
+#. 3.8->settings-schema.json->list-monitor-windows->tooltip
 #. 3.4->settings-schema.json->list-monitor-windows->tooltip
 msgid ""
 "This option will only come into effect for monitors displaying an ITM "
@@ -934,77 +1092,146 @@ msgstr ""
 "Diese Option wird nur für Monitore, die eine ITM-Instanz anzeigen, in Kraft "
 "treten."
 
+#. 3.8->settings-schema.json->enable-app-button-width->description
+#. 3.4->settings-schema.json->enable-app-button-width->description
+msgid "Use a custom width for app buttons"
+msgstr ""
+
+#. 3.8->settings-schema.json->enable-app-button-width->tooltip
+#. 3.4->settings-schema.json->enable-app-button-width->tooltip
+msgid "When disabled, the app button width is determined by the panel height."
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-width->description
+#. 3.4->settings-schema.json->app-button-width->description
+msgid "App button width"
+msgstr "Breite der Anwendungsknöpfe"
+
+#. 3.8->settings-schema.json->app-button-width->tooltip
+#. 3.4->settings-schema.json->app-button-width->tooltip
+#, fuzzy
+msgid ""
+"Controls the width of the application button. This option only works for "
+"horizontal panels."
+msgstr "Steuert die Größe der Anwendungsknöpfe."
+
+#. 3.8->settings-schema.json->thumbnail-close-button-size->description
 #. 3.4->settings-schema.json->thumbnail-close-button-size->description
 #, fuzzy
 msgid "Close button size"
 msgstr "Icongröße anpassen"
 
+#. 3.8->settings-schema.json->thumbnail-close-button-size->tooltip
 #. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
 #, fuzzy
 msgid "Controls how large the thumbnail close button is."
 msgstr ""
 "Erlaube Themen die Schaltflächen zum beenden der Anwendungen zu steuern"
 
-#. 3.4->settings-schema.json->middle-click-action->description
-#. 3.4->settings-schema.json->middle-click-action->tooltip
-msgid "Middle click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Launch new app instance"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Close last focused window in group"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->description
-msgid "Mouse wheel scroll behavior"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->tooltip
-msgid ""
-"Choose if scrolling the mouse wheel cycles running apps, an app button's "
-"windows on hover, or is disabled."
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->options
-msgid "Cycle apps"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->thumbnail-padding->description
+#. 3.4->settings-schema.json->thumbnail-padding->description
 #, fuzzy
-msgid "Cycle windows"
-msgstr "Zeige alle Anwendungs-Fenster an"
+msgid "Thumbnail padding"
+msgstr "Vorschaubild-Einstellungen"
 
-#. 3.4->settings-schema.json->show-all-workspaces->description
-#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#. 3.8->settings-schema.json->thumbnail-padding->tooltip
+#. 3.4->settings-schema.json->thumbnail-padding->tooltip
 #, fuzzy
-msgid "Show windows from all workspaces"
-msgstr "Auf allen Arbeitsflächen anzeigen"
+msgid "Controls how much space will be around the window preview thumbnails."
+msgstr "Legt den Abstand zwischen den Icons der Anwendungs-Leiste fest."
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->description
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
 msgid "Cycle windows on mouse wheel scroll"
 msgstr ""
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->tooltip
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
 msgid ""
 "Choose whether or not scrolling the mouse wheel cycles windows when hovering "
 "over a thumbnail menu."
 msgstr ""
 
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "Toggle activation of last focused window"
+#. 3.8->settings-schema.json->show-icons->description
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "Keine Icons"
+
+#. 3.8->settings-schema.json->show-icons->tooltip
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
 msgstr ""
 
-#. IcingTaskManager@json->metadata.json->name
-msgid "Icing Task Manager"
-msgstr "Icing Task Manager"
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->description
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
+msgid "Highlight the last focused window within an app group"
+msgstr ""
 
-#. IcingTaskManager@json->metadata.json->description
-msgid "Window list with app grouping and thumbnails"
-msgstr "Fensterliste mit Anwendungsgruppierung und Fenstervorschau"
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+msgid ""
+"When enabled, the last window that was interacted with will be indicated."
+msgstr ""
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->description
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "Autostart-Option anzeigen"
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->tooltip
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->units
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->description
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+#, fuzzy
+msgid "App button transition duration"
+msgstr "Breite der Anwendungsknöpfe"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->tooltip
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.8->settings-schema.json->mintYPreset->description
+#. 3.8->settings-schema.json->mintYPreset->tooltip
+#. 3.4->settings-schema.json->mintYPreset->description
+#. 3.4->settings-schema.json->mintYPreset->tooltip
+msgid "Mint Y and Variants"
+msgstr "Mint-Y und Varianten"
+
+#. 3.8->settings-schema.json->mintXPreset->description
+#. 3.8->settings-schema.json->mintXPreset->tooltip
+#. 3.4->settings-schema.json->mintXPreset->description
+#. 3.4->settings-schema.json->mintXPreset->tooltip
+#, fuzzy
+msgid "Mint X, Linux Mint, and Variants"
+msgstr "Mint-Y und Varianten"
+
+#. 3.8->settings-schema.json->migrationButton->description
+msgid "Migrate Pinned Apps to Grouped Window List"
+msgstr ""
 
 #~ msgid "number"
 #~ msgstr "Anzahl"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/default.pot
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/default.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-23 21:33-0600\n"
+"POT-Creation-Date: 2018-12-10 00:43-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,536 +17,219 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/applet.js:471
+msgid "Icing Task Manager is now Grouped Window List"
+msgstr ""
+
+#: 3.8/applet.js:472
+msgid ""
+"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped"
+" Window List\". "
+msgstr ""
+
+#: 3.8/applet.js:473
+msgid ""
+"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
+"List."
+msgstr ""
+
+#: 3.8/applet.js:485
+msgid "Migration can only be performed on Cinnamon 4.0."
+msgstr ""
+
+#: 3.8/applet.js:496
+msgid ""
+"Please add Grouped Window List to a panel before proceeding with the "
+"migration."
+msgstr ""
+
+#: 3.8/applet.js:504
+msgid "ITM settings directory could not be found!"
+msgstr ""
+
+#: 3.8/applet.js:534
+msgid "System favorites enabled - no migration is needed."
+msgstr ""
+
+#: 3.8/applet.js:577
+msgid "Unable to find a suitable ITM settings file to migrate."
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid "Migration complete. "
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid " settings file(s) could not be migrated."
+msgstr ""
+
+#: 3.8/applet.js:592
+msgid "Migration was successful."
+msgstr ""
+
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to the other monitor"
 msgstr ""
 
-#: 3.4/specialMenus.js:118
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to monitor "
 msgstr ""
 
-#: 3.4/specialMenus.js:126
+#: 3.8/specialMenus.js:98 3.4/specialMenus.js:126
 msgid "Only on this workspace"
 msgstr ""
 
-#: 3.4/specialMenus.js:133
+#: 3.8/specialMenus.js:105 3.4/specialMenus.js:133
 msgid "Visible on all workspaces"
 msgstr ""
 
-#: 3.4/specialMenus.js:140
+#: 3.8/specialMenus.js:112 3.4/specialMenus.js:140
 msgid "Move to another workspace"
 msgstr ""
 
-#: 3.4/specialMenus.js:168
+#: 3.8/specialMenus.js:140 3.4/specialMenus.js:168
 msgid "Places"
 msgstr ""
 
-#: 3.4/specialMenus.js:207
+#: 3.8/specialMenus.js:179 3.4/specialMenus.js:207
 msgid "Bookmarks/History requires gir1.2-gda-5.0"
 msgstr ""
 
-#: 3.4/specialMenus.js:227
+#: 3.8/specialMenus.js:199 3.4/specialMenus.js:227
 msgid "Recent"
 msgstr ""
 
-#: 3.4/specialMenus.js:246
+#: 3.8/specialMenus.js:218 3.4/specialMenus.js:246
 msgid "Preferences"
 msgstr ""
 
-#: 3.4/specialMenus.js:249
+#: 3.8/specialMenus.js:221 3.4/specialMenus.js:249
 msgid "About..."
 msgstr ""
 
-#: 3.4/specialMenus.js:253
+#: 3.8/specialMenus.js:225 3.4/specialMenus.js:253
 msgid "Configure..."
 msgstr ""
 
-#: 3.4/specialMenus.js:257
+#: 3.8/specialMenus.js:229 3.4/specialMenus.js:257
 msgid "Remove"
 msgstr ""
 
-#: 3.4/specialMenus.js:287
+#: 3.8/specialMenus.js:259 3.4/specialMenus.js:287
 msgid "New Window"
 msgstr ""
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Unpin from Panel"
 msgstr ""
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Pin to Panel"
 msgstr ""
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Remove from Autostart"
 msgstr ""
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Add to Autostart"
 msgstr ""
 
-#: 3.4/specialMenus.js:318
+#: 3.8/specialMenus.js:290 3.4/specialMenus.js:318
 msgid "Create Shortcut"
 msgstr ""
 
-#: 3.4/specialMenus.js:329
+#: 3.8/specialMenus.js:301 3.4/specialMenus.js:329
 msgid "Restore to full opacity"
 msgstr ""
 
-#: 3.4/specialMenus.js:337
+#: 3.8/specialMenus.js:309 3.4/specialMenus.js:337
 msgid "Restore"
 msgstr ""
 
-#: 3.4/specialMenus.js:342
+#: 3.8/specialMenus.js:314 3.4/specialMenus.js:342
 msgid "Minimize"
 msgstr ""
 
-#: 3.4/specialMenus.js:350
+#: 3.8/specialMenus.js:322 3.4/specialMenus.js:350
 msgid "Unmaximize"
 msgstr ""
 
-#: 3.4/specialMenus.js:355
+#: 3.8/specialMenus.js:327 3.4/specialMenus.js:355
 msgid "Maximize"
 msgstr ""
 
-#: 3.4/specialMenus.js:365
+#: 3.8/specialMenus.js:337 3.4/specialMenus.js:365
 msgid "Close others"
 msgstr ""
 
-#: 3.4/specialMenus.js:375
+#: 3.8/specialMenus.js:347 3.4/specialMenus.js:375
 msgid "Close all"
 msgstr ""
 
-#: 3.4/specialMenus.js:385
+#: 3.8/specialMenus.js:357 3.4/specialMenus.js:385
 msgid "Close"
 msgstr ""
 
-#. 2.8->settings-schema.json->thumbnail-size->description
-#. 3.4->settings-schema.json->thumbnail-size->description
-msgid "Thumbnail size"
+#. metadata.json->description
+msgid "Window list with app grouping and thumbnails"
 msgstr ""
 
-#. 2.8->settings-schema.json->thumbnail-size->tooltip
-#. 3.4->settings-schema.json->thumbnail-size->tooltip
-msgid "Controls the size of the thumbnails."
+#. metadata.json->name
+msgid "Icing Task Manager"
 msgstr ""
 
-#. 2.8->settings-schema.json->thumbnail-size->units
-#. 3.4->settings-schema.json->thumbnail-size->units
-msgid "size"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->description
-#. 3.4->settings-schema.json->focusPseudoClass->description
-msgid "App button focus pseudo class"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->tooltip
-#. 3.4->settings-schema.json->focusPseudoClass->tooltip
-msgid "Overrides the pseudo class for app button on focus."
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "active"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "outlined"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "hover"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "focus"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "selected"
-msgstr ""
-
-#. 2.8->settings-schema.json->icon-spacing->description
-#. 3.4->settings-schema.json->icon-spacing->description
-msgid "Icon spacing"
-msgstr ""
-
-#. 2.8->settings-schema.json->icon-spacing->tooltip
-#. 3.4->settings-schema.json->icon-spacing->tooltip
-msgid "Controls how much space is between the icons."
-msgstr ""
-
-#. 2.8->settings-schema.json->icon-spacing->units
-#. 2.8->settings-schema.json->icon-size->units
-#. 2.8->settings-schema.json->icon-padding->units
-#. 3.4->settings-schema.json->icon-spacing->units
-#. 3.4->settings-schema.json->thumbnail-padding->units
-#. 3.4->settings-schema.json->icon-size->units
-#. 3.4->settings-schema.json->app-button-width->units
-#. 3.4->settings-schema.json->thumbnail-close-button-size->units
-#. 3.4->settings-schema.json->icon-padding->units
-msgid "px"
-msgstr ""
-
-#. 2.8->settings-schema.json->show-thumbnails->description
-#. 3.4->settings-schema.json->show-thumbnails->description
-msgid "Show thumbnails"
-msgstr ""
-
-#. 2.8->settings-schema.json->show-thumbnails->tooltip
-#. 3.4->settings-schema.json->show-thumbnails->tooltip
-msgid "Show window thumbnails when hovering over an app button."
-msgstr ""
-
-#. 2.8->settings-schema.json->icon-size->description
-#. 3.4->settings-schema.json->icon-size->description
-msgid "Icon size"
-msgstr ""
-
-#. 2.8->settings-schema.json->icon-size->tooltip
-#. 3.4->settings-schema.json->icon-size->tooltip
-msgid "Set icon size"
-msgstr ""
-
-#. 2.8->settings-schema.json->hover-peek-time->description
-#. 3.4->settings-schema.json->hover-peek-time->description
-msgid "Window fade time"
-msgstr ""
-
-#. 2.8->settings-schema.json->hover-peek-time->tooltip
-#. 3.4->settings-schema.json->hover-peek-time->tooltip
-msgid "Controls how quickly a window will fade on hover."
-msgstr ""
-
-#. 2.8->settings-schema.json->hover-peek-time->units
-#. 2.8->settings-schema.json->thumbnail-timeout->units
-#. 2.8->settings-schema.json->show-apps-order-timeout->units
-#. 3.4->settings-schema.json->hover-peek-time->units
-#. 3.4->settings-schema.json->thumbnail-timeout->units
-#. 3.4->settings-schema.json->show-apps-order-timeout->units
-msgid "milliseconds"
-msgstr ""
-
-#. 2.8->settings-schema.json->close-button-style->description
-msgid "Allow themes to control the thumbnail close button"
-msgstr ""
-
-#. 2.8->settings-schema.json->close-button-style->tooltip
-msgid ""
-"Controls whether or not the theme controls the window thumbnail's close "
-"button."
-msgstr ""
-
-#. 2.8->settings-schema.json->title-display->description
-#. 3.4->settings-schema.json->title-display->description
-msgid "Title display"
-msgstr ""
-
-#. 2.8->settings-schema.json->title-display->tooltip
-#. 3.4->settings-schema.json->title-display->tooltip
-msgid ""
-"focused: show focused window title, title: display the window title, app: "
-"diplay app name, none: don't display anything"
-msgstr ""
-
-#. 2.8->settings-schema.json->title-display->options
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-#. 3.4->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->middle-click-action->options
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "None"
-msgstr ""
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Focused"
-msgstr ""
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "App"
-msgstr ""
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Title"
-msgstr ""
-
-#. 2.8->settings-schema.json->hoverPseudoClass->description
-#. 3.4->settings-schema.json->hoverPseudoClass->description
-msgid "App button hover pseudo class"
-msgstr ""
-
-#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
-#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons on hover."
-msgstr ""
-
-#. 2.8->settings-schema.json->show-alerts->description
-#. 3.4->settings-schema.json->show-alerts->description
-msgid "Show app alerts and notifications"
-msgstr ""
-
-#. 2.8->settings-schema.json->show-alerts->tooltip
-#. 3.4->settings-schema.json->show-alerts->tooltip
-msgid "If enabled, notifications and alerts will appear."
-msgstr ""
-
-#. 2.8->settings-schema.json->pinOnDrag->description
-#. 2.8->settings-schema.json->pinOnDrag->tooltip
-#. 3.4->settings-schema.json->pinOnDrag->description
-#. 3.4->settings-schema.json->pinOnDrag->tooltip
-msgid "Pin apps when dragged to a new position"
-msgstr ""
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->description
-#. 3.4->settings-schema.json->show-apps-order-hotkey->description
-msgid "Global hotkey to show the order of apps"
-msgstr ""
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
-#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
-msgid ""
-"When triggered, the window count label will be replaced with its order in "
-"the app list temporarily."
-msgstr ""
-
-#. 2.8->settings-schema.json->menuItemType->description
-#. 3.4->settings-schema.json->menuItemType->description
-msgid "Menu item type"
-msgstr ""
-
-#. 2.8->settings-schema.json->menuItemType->tooltip
-#. 3.4->settings-schema.json->menuItemType->tooltip
-msgid ""
-"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
-msgstr ""
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Symbolic icons"
-msgstr ""
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "No icons"
-msgstr ""
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Non-symbolic icons"
-msgstr ""
-
-#. 2.8->settings-schema.json->hover-peek-opacity->description
-#. 3.4->settings-schema.json->hover-peek-opacity->description
-msgid "Window opacity"
-msgstr ""
-
-#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
-#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
-msgid "Opacity of the windows on hover."
-msgstr ""
-
-#. 2.8->settings-schema.json->hover-peek-opacity->units
-#. 3.4->settings-schema.json->hover-peek-opacity->units
-msgid "percent"
-msgstr ""
-
-#. 2.8->settings-schema.json->enable-hover-peek->description
-#. 3.4->settings-schema.json->enable-hover-peek->description
-msgid "Show windows when hovered over"
-msgstr ""
-
-#. 2.8->settings-schema.json->enable-hover-peek->tooltip
-#. 3.4->settings-schema.json->enable-hover-peek->tooltip
-msgid "Controls whether or not windows display when hovered over."
-msgstr ""
-
-#. 2.8->settings-schema.json->activePseudoClass->description
-#. 3.4->settings-schema.json->activePseudoClass->description
-msgid "App button active pseudo class"
-msgstr ""
-
-#. 2.8->settings-schema.json->activePseudoClass->tooltip
-#. 3.4->settings-schema.json->activePseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons when they are active."
-msgstr ""
-
-#. 2.8->settings-schema.json->animate-thumbnails->description
-#. 3.4->settings-schema.json->animate-thumbnails->description
-msgid "Animate thumbnails"
-msgstr ""
-
-#. 2.8->settings-schema.json->animate-thumbnails->tooltip
-#. 3.4->settings-schema.json->animate-thumbnails->tooltip
-msgid "If enabled, thumbnails will animate when appearing and disappearing."
-msgstr ""
-
-#. 2.8->settings-schema.json->autostart-menu-item->description
-#. 3.4->settings-schema.json->autostart-menu-item->description
-msgid "Show autostart option"
-msgstr ""
-
-#. 2.8->settings-schema.json->autostart-menu-item->tooltip
-#. 3.4->settings-schema.json->autostart-menu-item->tooltip
-msgid "Shows the autostart toggle option in an app's context menu."
-msgstr ""
-
-#. 2.8->settings-schema.json->show-pinned->description
-#. 3.4->settings-schema.json->show-pinned->description
-msgid "Show pinned apps"
-msgstr ""
-
-#. 2.8->settings-schema.json->show-pinned->tooltip
-#. 3.4->settings-schema.json->show-pinned->tooltip
-msgid ""
-"Controls whether or not the pinned apps appear in the panel if they are not "
-"open."
-msgstr ""
-
-#. 2.8->settings-schema.json->useSystemTooltips->description
-msgid "Use system tooltips for closed apps"
-msgstr ""
-
-#. 2.8->settings-schema.json->useSystemTooltips->tooltip
-msgid ""
-"Controls whether or not system tooltips are in use when hovering over closed"
-" pinned apps."
+#. 2.8->settings-schema.json->ITM->description
+msgid "ITM Settings"
 msgstr ""
 
 #. 2.8->settings-schema.json->WindowList->description
 msgid "Window List Settings"
 msgstr ""
 
-#. 2.8->settings-schema.json->AppMenu->description
-msgid "Context Menu Settings"
-msgstr ""
-
-#. 2.8->settings-schema.json->Thumbnails->description
-msgid "Thumbnail Settings"
-msgstr ""
-
-#. 2.8->settings-schema.json->show-recent->description
-#. 3.4->settings-schema.json->show-recent->description
-msgid "Show recent items"
-msgstr ""
-
-#. 2.8->settings-schema.json->show-recent->tooltip
-#. 3.4->settings-schema.json->show-recent->tooltip
-msgid "Controls whether recent items will appear in the context menu."
-msgstr ""
-
-#. 2.8->settings-schema.json->vertical-thumbnails->description
-#. 3.4->settings-schema.json->vertical-thumbnails->description
-msgid "Enable vertical thumbnails"
-msgstr ""
-
-#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
-#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
-msgid "If enabled, thumbnails will stack vertically."
-msgstr ""
-
-#. 2.8->settings-schema.json->thumbnail-timeout->description
-#. 3.4->settings-schema.json->thumbnail-timeout->description
-msgid "Thumbnail timeout"
-msgstr ""
-
-#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
-#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
-msgid ""
-"Controls how quickly an app's set of window thumbnails will fade out when "
-"the mouse leaves the app button."
-msgstr ""
-
-#. 2.8->settings-schema.json->ThemeSettings->description
-msgid "Theme Settings"
-msgstr ""
-
-#. 2.8->settings-schema.json->onclick-thumbnails->description
-#. 3.4->settings-schema.json->onclick-thumbnails->description
-msgid "Open thumbnails on click"
-msgstr ""
-
-#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
-#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
-msgid "Open the thumbnails on click if there is more than one window open."
-msgstr ""
-
-#. 2.8->settings-schema.json->panelLauncherClass->description
-msgid "Use the panel launcher class for pinned apps"
-msgstr ""
-
-#. 2.8->settings-schema.json->panelLauncherClass->tooltip
-msgid "Enabling this helps with certain themes."
-msgstr ""
-
-#. 2.8->settings-schema.json->include-all-windows->description
-#. 3.4->settings-schema.json->include-all-windows->description
-msgid "Include all app windows"
-msgstr ""
-
-#. 2.8->settings-schema.json->include-all-windows->tooltip
-#. 3.4->settings-schema.json->include-all-windows->tooltip
-msgid ""
-"Controls whether or not thumbnails for smalller child windows, such as exit "
-"confirmations and file dialogues will be included in the thumbnail list."
-msgstr ""
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->description
-#. 3.4->settings-schema.json->cycleMenusHotkey->description
-msgid "Global hotkey for cycling through thumbnail menus"
-msgstr ""
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
-#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
-msgid ""
-"This allows you to cycle through the menus without activating a window."
-msgstr ""
-
-#. 2.8->settings-schema.json->enable-iconSize->description
-#. 3.4->settings-schema.json->enable-iconSize->description
-msgid "Adjust icon size"
-msgstr ""
-
-#. 2.8->settings-schema.json->enable-iconSize->tooltip
-#. 3.4->settings-schema.json->enable-iconSize->tooltip
-msgid "Adjust icon size independent of Cinnamon's panel scaling."
-msgstr ""
-
 #. 2.8->settings-schema.json->number-display->description
+#. 3.8->settings-schema.json->number-display->description
 #. 3.4->settings-schema.json->number-display->description
 msgid "Number display"
 msgstr ""
 
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Smart"
+msgstr ""
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Normal"
+msgstr ""
+
+#. 2.8->settings-schema.json->number-display->options
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "None"
+msgstr ""
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "All"
+msgstr ""
+
 #. 2.8->settings-schema.json->number-display->tooltip
+#. 3.8->settings-schema.json->number-display->tooltip
 #. 3.4->settings-schema.json->number-display->tooltip
 msgid ""
 "normal: display window number, smart: display window number if more than one"
@@ -554,39 +237,91 @@ msgid ""
 "favorites too"
 msgstr ""
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "All"
+#. 2.8->settings-schema.json->title-display->description
+#. 3.8->settings-schema.json->title-display->description
+#. 3.4->settings-schema.json->title-display->description
+msgid "Title display"
 msgstr ""
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Smart"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "App"
 msgstr ""
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Normal"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Title"
 msgstr ""
 
-#. 2.8->settings-schema.json->ITM->description
-msgid "ITM Settings"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Focused"
 msgstr ""
 
-#. 2.8->settings-schema.json->HoverPeek->description
-msgid "Hover Peek Settings"
-msgstr ""
-
-#. 2.8->settings-schema.json->icon-padding->description
-#. 3.4->settings-schema.json->icon-padding->description
-msgid "Icon padding"
-msgstr ""
-
-#. 2.8->settings-schema.json->icon-padding->tooltip
-#. 3.4->settings-schema.json->icon-padding->tooltip
+#. 2.8->settings-schema.json->title-display->tooltip
+#. 3.8->settings-schema.json->title-display->tooltip
+#. 3.4->settings-schema.json->title-display->tooltip
 msgid ""
-"Controls how much horizontal padding is inside the app buttons. Padding is "
-"only applied to instances of this applet on horizontal panels."
+"focused: show focused window title, title: display the window title, app: "
+"diplay app name, none: don't display anything"
+msgstr ""
+
+#. 2.8->settings-schema.json->group-apps->description
+#. 3.8->settings-schema.json->group-apps->description
+#. 3.4->settings-schema.json->group-apps->description
+msgid "Group apps"
+msgstr ""
+
+#. 2.8->settings-schema.json->group-apps->tooltip
+#. 3.8->settings-schema.json->group-apps->tooltip
+#. 3.4->settings-schema.json->group-apps->tooltip
+msgid "Group each app's set of windows."
+msgstr ""
+
+#. 2.8->settings-schema.json->show-alerts->description
+#. 3.8->settings-schema.json->show-alerts->description
+#. 3.4->settings-schema.json->show-alerts->description
+msgid "Show app alerts and notifications"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-alerts->tooltip
+#. 3.8->settings-schema.json->show-alerts->tooltip
+#. 3.4->settings-schema.json->show-alerts->tooltip
+msgid "If enabled, notifications and alerts will appear."
+msgstr ""
+
+#. 2.8->settings-schema.json->show-pinned->description
+#. 3.8->settings-schema.json->show-pinned->description
+#. 3.4->settings-schema.json->show-pinned->description
+msgid "Show pinned apps"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-pinned->tooltip
+#. 3.8->settings-schema.json->show-pinned->tooltip
+#. 3.4->settings-schema.json->show-pinned->tooltip
+msgid ""
+"Controls whether or not the pinned apps appear in the panel if they are not "
+"open."
+msgstr ""
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->description
+msgid "Arrange pinned apps"
+msgstr ""
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
+msgid "Arrange pinned apps into a different order."
+msgstr ""
+
+#. 2.8->settings-schema.json->pinOnDrag->description
+#. 2.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.8->settings-schema.json->pinOnDrag->description
+#. 3.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.4->settings-schema.json->pinOnDrag->description
+#. 3.4->settings-schema.json->pinOnDrag->tooltip
+msgid "Pin apps when dragged to a new position"
 msgstr ""
 
 #. 2.8->settings-schema.json->middle-click-action->description
@@ -600,31 +335,381 @@ msgid ""
 "on middle click."
 msgstr ""
 
+#. 2.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.4->settings-schema.json->cycleMenusHotkey->description
+msgid "Global hotkey for cycling through thumbnail menus"
+msgstr ""
+
+#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
+msgid ""
+"This allows you to cycle through the menus without activating a window."
+msgstr ""
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.4->settings-schema.json->show-apps-order-hotkey->description
+msgid "Global hotkey to show the order of apps"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
+msgid ""
+"When triggered, the window count label will be replaced with its order in "
+"the app list temporarily."
+msgstr ""
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->units
+#. 2.8->settings-schema.json->thumbnail-timeout->units
+#. 2.8->settings-schema.json->hover-peek-time->units
+#. 3.8->settings-schema.json->show-apps-order-timeout->units
+#. 3.8->settings-schema.json->thumbnail-timeout->units
+#. 3.8->settings-schema.json->hover-peek-time->units
+#. 3.4->settings-schema.json->show-apps-order-timeout->units
+#. 3.4->settings-schema.json->thumbnail-timeout->units
+#. 3.4->settings-schema.json->hover-peek-time->units
+msgid "milliseconds"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.4->settings-schema.json->show-apps-order-timeout->description
+msgid "Duration of the apps order display on hotkey press"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
+msgid ""
+"Determines the duration the window count labels are replaced with the app's "
+"order number."
+msgstr ""
+
+#. 2.8->settings-schema.json->Thumbnails->description
+msgid "Thumbnail Settings"
+msgstr ""
+
+#. 2.8->settings-schema.json->thumbnail-timeout->description
+#. 3.8->settings-schema.json->thumbnail-timeout->description
+#. 3.4->settings-schema.json->thumbnail-timeout->description
+msgid "Thumbnail timeout"
+msgstr ""
+
+#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
+msgid ""
+"Controls how quickly an app's set of window thumbnails will fade out when "
+"the mouse leaves the app button."
+msgstr ""
+
+#. 2.8->settings-schema.json->thumbnail-size->units
+#. 3.8->settings-schema.json->thumbnail-size->units
+#. 3.4->settings-schema.json->thumbnail-size->units
+msgid "size"
+msgstr ""
+
+#. 2.8->settings-schema.json->thumbnail-size->description
+#. 3.8->settings-schema.json->thumbnail-size->description
+#. 3.4->settings-schema.json->thumbnail-size->description
+msgid "Thumbnail size"
+msgstr ""
+
+#. 2.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-size->tooltip
+msgid "Controls the size of the thumbnails."
+msgstr ""
+
+#. 2.8->settings-schema.json->show-thumbnails->description
+#. 3.8->settings-schema.json->show-thumbnails->description
+#. 3.4->settings-schema.json->show-thumbnails->description
+msgid "Show thumbnails"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.4->settings-schema.json->show-thumbnails->tooltip
+msgid "Show window thumbnails when hovering over an app button."
+msgstr ""
+
+#. 2.8->settings-schema.json->animate-thumbnails->description
+#. 3.8->settings-schema.json->animate-thumbnails->description
+#. 3.4->settings-schema.json->animate-thumbnails->description
+msgid "Animate thumbnails"
+msgstr ""
+
+#. 2.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.4->settings-schema.json->animate-thumbnails->tooltip
+msgid "If enabled, thumbnails will animate when appearing and disappearing."
+msgstr ""
+
+#. 2.8->settings-schema.json->vertical-thumbnails->description
+#. 3.8->settings-schema.json->vertical-thumbnails->description
+#. 3.4->settings-schema.json->vertical-thumbnails->description
+msgid "Enable vertical thumbnails"
+msgstr ""
+
+#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
+msgid "If enabled, thumbnails will stack vertically."
+msgstr ""
+
+#. 2.8->settings-schema.json->sort-thumbnails->description
+#. 3.8->settings-schema.json->sort-thumbnails->description
+#. 3.4->settings-schema.json->sort-thumbnails->description
+msgid "Sort windows for each app by last focused"
+msgstr ""
+
+#. 2.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.4->settings-schema.json->sort-thumbnails->tooltip
+msgid ""
+"Controls whether the order windows appear for an app is by last focused, or "
+"the order they were opened."
+msgstr ""
+
+#. 2.8->settings-schema.json->onclick-thumbnails->description
+#. 3.8->settings-schema.json->onclick-thumbnails->description
+#. 3.4->settings-schema.json->onclick-thumbnails->description
+msgid "Open thumbnails on click"
+msgstr ""
+
+#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
+msgid "Open the thumbnails on click if there is more than one window open."
+msgstr ""
+
+#. 2.8->settings-schema.json->include-all-windows->description
+#. 3.8->settings-schema.json->include-all-windows->description
+#. 3.4->settings-schema.json->include-all-windows->description
+msgid "Include all app windows"
+msgstr ""
+
+#. 2.8->settings-schema.json->include-all-windows->tooltip
+#. 3.8->settings-schema.json->include-all-windows->tooltip
+#. 3.4->settings-schema.json->include-all-windows->tooltip
+msgid ""
+"Controls whether or not thumbnails for smalller child windows, such as exit "
+"confirmations and file dialogues will be included in the thumbnail list."
+msgstr ""
+
+#. 2.8->settings-schema.json->AppMenu->description
+msgid "Context Menu Settings"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-recent->description
+#. 3.8->settings-schema.json->show-recent->description
+#. 3.4->settings-schema.json->show-recent->description
+msgid "Show recent items"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-recent->tooltip
+#. 3.8->settings-schema.json->show-recent->tooltip
+#. 3.4->settings-schema.json->show-recent->tooltip
+msgid "Controls whether recent items will appear in the context menu."
+msgstr ""
+
+#. 2.8->settings-schema.json->menuItemType->description
+#. 3.8->settings-schema.json->menuItemType->description
+#. 3.4->settings-schema.json->menuItemType->description
+msgid "Menu item type"
+msgstr ""
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Symbolic icons"
+msgstr ""
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Non-symbolic icons"
+msgstr ""
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "No icons"
+msgstr ""
+
+#. 2.8->settings-schema.json->menuItemType->tooltip
+#. 3.8->settings-schema.json->menuItemType->tooltip
+#. 3.4->settings-schema.json->menuItemType->tooltip
+msgid ""
+"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
+msgstr ""
+
 #. 2.8->settings-schema.json->firefox-menu->description
+#. 3.8->settings-schema.json->firefox-menu->description
 #. 3.4->settings-schema.json->firefox-menu->description
 msgid "Firefox context menu"
 msgstr ""
 
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Most Visited"
+msgstr ""
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Recent History"
+msgstr ""
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Bookmarks"
+msgstr ""
+
 #. 2.8->settings-schema.json->firefox-menu->tooltip
+#. 3.8->settings-schema.json->firefox-menu->tooltip
 #. 3.4->settings-schema.json->firefox-menu->tooltip
 msgid ""
 "Most Visited: show the sites you visit most, Recent History: display the the"
 " last pages you visited, Bookmarks: show your favorite bookmarks."
 msgstr ""
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Bookmarks"
+#. 2.8->settings-schema.json->autostart-menu-item->description
+#. 3.8->settings-schema.json->autostart-menu-item->description
+#. 3.4->settings-schema.json->autostart-menu-item->description
+msgid "Show autostart option"
 msgstr ""
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Most Visited"
+#. 2.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.4->settings-schema.json->autostart-menu-item->tooltip
+msgid "Shows the autostart toggle option in an app's context menu."
 msgstr ""
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Recent History"
+#. 2.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.4->settings-schema.json->monitor-move-all-windows->description
+msgid "Apply the monitor move option to all windows"
+msgstr ""
+
+#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
+msgid ""
+"When clicking \"Move to monitor\" in the context menu, this option will move"
+" all of an app's windows instead of just the last focused window from the "
+"app."
+msgstr ""
+
+#. 2.8->settings-schema.json->HoverPeek->description
+msgid "Hover Peek Settings"
+msgstr ""
+
+#. 2.8->settings-schema.json->enable-hover-peek->description
+#. 3.8->settings-schema.json->enable-hover-peek->description
+#. 3.4->settings-schema.json->enable-hover-peek->description
+msgid "Show windows when hovered over"
+msgstr ""
+
+#. 2.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.4->settings-schema.json->enable-hover-peek->tooltip
+msgid "Controls whether or not windows display when hovered over."
+msgstr ""
+
+#. 2.8->settings-schema.json->hover-peek-time->description
+#. 3.8->settings-schema.json->hover-peek-time->description
+#. 3.4->settings-schema.json->hover-peek-time->description
+msgid "Window fade time"
+msgstr ""
+
+#. 2.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.4->settings-schema.json->hover-peek-time->tooltip
+msgid "Controls how quickly a window will fade on hover."
+msgstr ""
+
+#. 2.8->settings-schema.json->hover-peek-opacity->units
+#. 3.8->settings-schema.json->hover-peek-opacity->units
+#. 3.4->settings-schema.json->hover-peek-opacity->units
+msgid "percent"
+msgstr ""
+
+#. 2.8->settings-schema.json->hover-peek-opacity->description
+#. 3.8->settings-schema.json->hover-peek-opacity->description
+#. 3.4->settings-schema.json->hover-peek-opacity->description
+msgid "Window opacity"
+msgstr ""
+
+#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
+msgid "Opacity of the windows on hover."
+msgstr ""
+
+#. 2.8->settings-schema.json->ThemeSettings->description
+msgid "Theme Settings"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-active->description
+#. 3.8->settings-schema.json->show-active->description
+#. 3.4->settings-schema.json->show-active->description
+msgid "Show active app indicators"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-active->tooltip
+#. 3.8->settings-schema.json->show-active->tooltip
+#. 3.4->settings-schema.json->show-active->tooltip
+msgid "Active app styling will indicate if an app is active."
+msgstr ""
+
+#. 2.8->settings-schema.json->icon-spacing->units
+#. 2.8->settings-schema.json->icon-padding->units
+#. 2.8->settings-schema.json->icon-size->units
+#. 3.8->settings-schema.json->app-button-width->units
+#. 3.8->settings-schema.json->thumbnail-close-button-size->units
+#. 3.8->settings-schema.json->thumbnail-padding->units
+#. 3.8->settings-schema.json->icon-spacing->units
+#. 3.8->settings-schema.json->icon-padding->units
+#. 3.8->settings-schema.json->icon-size->units
+#. 3.4->settings-schema.json->app-button-width->units
+#. 3.4->settings-schema.json->thumbnail-close-button-size->units
+#. 3.4->settings-schema.json->thumbnail-padding->units
+#. 3.4->settings-schema.json->icon-spacing->units
+#. 3.4->settings-schema.json->icon-padding->units
+#. 3.4->settings-schema.json->icon-size->units
+msgid "px"
+msgstr ""
+
+#. 2.8->settings-schema.json->icon-spacing->description
+#. 3.8->settings-schema.json->icon-spacing->description
+#. 3.4->settings-schema.json->icon-spacing->description
+msgid "Icon spacing"
+msgstr ""
+
+#. 2.8->settings-schema.json->icon-spacing->tooltip
+#. 3.8->settings-schema.json->icon-spacing->tooltip
+#. 3.4->settings-schema.json->icon-spacing->tooltip
+msgid "Controls how much space is between the icons."
+msgstr ""
+
+#. 2.8->settings-schema.json->icon-padding->description
+#. 3.8->settings-schema.json->icon-padding->description
+#. 3.4->settings-schema.json->icon-padding->description
+msgid "Icon padding"
+msgstr ""
+
+#. 2.8->settings-schema.json->icon-padding->tooltip
+#. 3.8->settings-schema.json->icon-padding->tooltip
+#. 3.4->settings-schema.json->icon-padding->tooltip
+msgid ""
+"Controls how much horizontal padding is inside the app buttons. Padding is "
+"only applied to instances of this applet on horizontal panels."
 msgstr ""
 
 #. 2.8->settings-schema.json->themePadding->description
@@ -635,308 +720,450 @@ msgstr ""
 msgid "If button icons look off-centered, toggling this may help."
 msgstr ""
 
-#. 2.8->settings-schema.json->group-apps->description
-#. 3.4->settings-schema.json->group-apps->description
-msgid "Group apps"
+#. 2.8->settings-schema.json->enable-iconSize->description
+#. 3.8->settings-schema.json->enable-iconSize->description
+#. 3.4->settings-schema.json->enable-iconSize->description
+msgid "Adjust icon size"
 msgstr ""
 
-#. 2.8->settings-schema.json->group-apps->tooltip
-#. 3.4->settings-schema.json->group-apps->tooltip
-msgid "Group each app's set of windows."
+#. 2.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.4->settings-schema.json->enable-iconSize->tooltip
+msgid "Adjust icon size independent of Cinnamon's panel scaling."
 msgstr ""
 
-#. 2.8->settings-schema.json->show-active->description
-#. 3.4->settings-schema.json->show-active->description
-msgid "Show active app indicators"
+#. 2.8->settings-schema.json->icon-size->description
+#. 3.8->settings-schema.json->icon-size->description
+#. 3.4->settings-schema.json->icon-size->description
+msgid "Icon size"
 msgstr ""
 
-#. 2.8->settings-schema.json->show-active->tooltip
-#. 3.4->settings-schema.json->show-active->tooltip
-msgid "Active app styling will indicate if an app is active."
+#. 2.8->settings-schema.json->icon-size->tooltip
+#. 3.8->settings-schema.json->icon-size->tooltip
+#. 3.4->settings-schema.json->icon-size->tooltip
+msgid "Set icon size"
 msgstr ""
 
-#. 2.8->settings-schema.json->show-apps-order-timeout->description
-#. 3.4->settings-schema.json->show-apps-order-timeout->description
-msgid "Duration of the apps order display on hotkey press"
+#. 2.8->settings-schema.json->hoverPseudoClass->description
+#. 3.8->settings-schema.json->hoverPseudoClass->description
+#. 3.4->settings-schema.json->hoverPseudoClass->description
+msgid "App button hover pseudo class"
 msgstr ""
 
-#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
-#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
-msgid ""
-"Determines the duration the window count labels are replaced with the app's "
-"order number."
-msgstr ""
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->description
-msgid "Arrange pinned apps"
-msgstr ""
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
-msgid "Arrange pinned apps into a different order."
-msgstr ""
-
-#. 2.8->settings-schema.json->monitor-move-all-windows->description
-#. 3.4->settings-schema.json->monitor-move-all-windows->description
-msgid "Apply the monitor move option to all windows"
-msgstr ""
-
-#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
-#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
-msgid ""
-"When clicking \"Move to monitor\" in the context menu, this option will move"
-" all of an app's windows instead of just the last focused window from the "
-"app."
-msgstr ""
-
-#. 2.8->settings-schema.json->sort-thumbnails->description
-#. 3.4->settings-schema.json->sort-thumbnails->description
-msgid "Sort windows for each app by last focused"
-msgstr ""
-
-#. 2.8->settings-schema.json->sort-thumbnails->tooltip
-#. 3.4->settings-schema.json->sort-thumbnails->tooltip
-msgid ""
-"Controls whether the order windows appear for an app is by last focused, or "
-"the order they were opened."
-msgstr ""
-
-#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
 #. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
 #. 3.4->settings-schema.json->activePseudoClass->options
-msgid "checked"
+msgid "hover"
 msgstr ""
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
-msgid "Highlight the last focused window within an app group"
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "focus"
 msgstr ""
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "active"
+msgstr ""
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "outlined"
+msgstr ""
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "selected"
+msgstr ""
+
+#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons on hover."
+msgstr ""
+
+#. 2.8->settings-schema.json->focusPseudoClass->description
+#. 3.8->settings-schema.json->focusPseudoClass->description
+#. 3.4->settings-schema.json->focusPseudoClass->description
+msgid "App button focus pseudo class"
+msgstr ""
+
+#. 2.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.4->settings-schema.json->focusPseudoClass->tooltip
+msgid "Overrides the pseudo class for app button on focus."
+msgstr ""
+
+#. 2.8->settings-schema.json->activePseudoClass->description
+#. 3.8->settings-schema.json->activePseudoClass->description
+#. 3.4->settings-schema.json->activePseudoClass->description
+msgid "App button active pseudo class"
+msgstr ""
+
+#. 2.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.4->settings-schema.json->activePseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons when they are active."
+msgstr ""
+
+#. 2.8->settings-schema.json->panelLauncherClass->description
+msgid "Use the panel launcher class for pinned apps"
+msgstr ""
+
+#. 2.8->settings-schema.json->panelLauncherClass->tooltip
+msgid "Enabling this helps with certain themes."
+msgstr ""
+
+#. 2.8->settings-schema.json->close-button-style->description
+msgid "Allow themes to control the thumbnail close button"
+msgstr ""
+
+#. 2.8->settings-schema.json->close-button-style->tooltip
 msgid ""
-"When enabled, the last window that was interacted with will be indicated."
+"Controls whether or not the theme controls the window thumbnail's close "
+"button."
 msgstr ""
 
-#. 3.4->settings-schema.json->app-button-transition-duration->description
-msgid "App button transition duration"
+#. 2.8->settings-schema.json->useSystemTooltips->description
+msgid "Use system tooltips for closed apps"
 msgstr ""
 
-#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+#. 2.8->settings-schema.json->useSystemTooltips->tooltip
 msgid ""
-"Overrides the theme's animation time for app buttons. If set to zero, the "
-"theme's transition duration will be used."
+"Controls whether or not system tooltips are in use when hovering over closed"
+" pinned apps."
 msgstr ""
 
-#. 3.4->settings-schema.json->app-button-transition-duration->units
-msgid "ms"
+#. 3.8->settings-schema.json->generalPage->title
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
 msgstr ""
 
-#. 3.4->settings-schema.json->thumbnail-padding->description
-msgid "Thumbnail padding"
+#. 3.8->settings-schema.json->panelPage->title
+#. 3.4->settings-schema.json->panelPage->title
+msgid "Panel"
 msgstr ""
 
-#. 3.4->settings-schema.json->thumbnail-padding->tooltip
-msgid "Controls how much space will be around the window preview thumbnails."
-msgstr ""
-
-#. 3.4->settings-schema.json->system-favorites->description
-msgid "Use system favorites for pinned apps"
-msgstr ""
-
-#. 3.4->settings-schema.json->system-favorites->tooltip
-msgid ""
-"Controls whether or not pinned apps consist of the system favorites list."
-msgstr ""
-
-#. 3.4->settings-schema.json->generalSection->title
-msgid "Behavior"
-msgstr ""
-
+#. 3.8->settings-schema.json->thumbnailsPage->title
+#. 3.8->settings-schema.json->thumbnailsSection->title
 #. 3.4->settings-schema.json->thumbnailsPage->title
 #. 3.4->settings-schema.json->thumbnailsSection->title
 msgid "Thumbnails"
 msgstr ""
 
-#. 3.4->settings-schema.json->presetSection->title
-msgid "Recommended Presets"
-msgstr ""
-
-#. 3.4->settings-schema.json->appButtonsSection->title
-msgid "App Buttons"
-msgstr ""
-
-#. 3.4->settings-schema.json->generalPage->title
-msgid "General"
-msgstr ""
-
-#. 3.4->settings-schema.json->hoverPeekSection->title
-msgid "Hover Peek"
-msgstr ""
-
-#. 3.4->settings-schema.json->panelPage->title
-msgid "Panel"
-msgstr ""
-
-#. 3.4->settings-schema.json->iconSection->title
-msgid "Icons"
-msgstr ""
-
-#. 3.4->settings-schema.json->hotKeysSection->title
-msgid "Hot Keys"
-msgstr ""
-
-#. 3.4->settings-schema.json->stylingSection->title
-msgid "Styling"
-msgstr ""
-
+#. 3.8->settings-schema.json->contextMenuPage->title
 #. 3.4->settings-schema.json->contextMenuPage->title
 msgid "Context Menu"
 msgstr ""
 
+#. 3.8->settings-schema.json->themePage->title
 #. 3.4->settings-schema.json->themePage->title
 msgid "Theming"
 msgstr ""
 
-#. 3.4->settings-schema.json->mintYPreset->description
-#. 3.4->settings-schema.json->mintYPreset->tooltip
-msgid "Mint Y and Variants"
+#. 3.8->settings-schema.json->generalSection->title
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
 msgstr ""
 
-#. 3.4->settings-schema.json->show-icons->description
-msgid "Show icons"
+#. 3.8->settings-schema.json->appButtonsSection->title
+#. 3.4->settings-schema.json->appButtonsSection->title
+msgid "App Buttons"
 msgstr ""
 
-#. 3.4->settings-schema.json->show-icons->tooltip
-msgid "Show the window's icon next to the title."
+#. 3.8->settings-schema.json->hotKeysSection->title
+#. 3.4->settings-schema.json->hotKeysSection->title
+msgid "Hot Keys"
 msgstr ""
 
-#. 3.4->settings-schema.json->enable-app-button-dragging->description
-#. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
-msgid "Enable app button dragging"
+#. 3.8->settings-schema.json->hoverPeekSection->title
+#. 3.4->settings-schema.json->hoverPeekSection->title
+msgid "Hover Peek"
 msgstr ""
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
-msgid "Show new window option"
+#. 3.8->settings-schema.json->stylingSection->title
+#. 3.4->settings-schema.json->stylingSection->title
+msgid "Styling"
 msgstr ""
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
-msgid ""
-"Shows the \"New Window\" option in an app's context menu if it doesn't "
-"already have one from the app's own action menu items."
+#. 3.8->settings-schema.json->iconSection->title
+#. 3.4->settings-schema.json->iconSection->title
+msgid "Icons"
 msgstr ""
 
-#. 3.4->settings-schema.json->app-button-width->description
-msgid "App button width"
+#. 3.8->settings-schema.json->presetSection->title
+#. 3.4->settings-schema.json->presetSection->title
+msgid "Recommended Presets"
 msgstr ""
 
-#. 3.4->settings-schema.json->app-button-width->tooltip
-msgid ""
-"Controls the width of the application button. This option only works for "
-"horizontal panels."
-msgstr ""
-
-#. 3.4->settings-schema.json->mintXPreset->description
-#. 3.4->settings-schema.json->mintXPreset->tooltip
-msgid "Mint X, Linux Mint, and Variants"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->description
-msgid "Launcher animation effect"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
-#. 3.4->settings-schema.json->left-click-action->description
-#. 3.4->settings-schema.json->left-click-action->tooltip
-msgid "Left click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Scale"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Fade"
-msgstr ""
-
-#. 3.4->settings-schema.json->enable-app-button-width->description
-msgid "Use a custom width for app buttons"
-msgstr ""
-
-#. 3.4->settings-schema.json->enable-app-button-width->tooltip
-msgid "When disabled, the app button width is determined by the panel height."
-msgstr ""
-
-#. 3.4->settings-schema.json->list-monitor-windows->description
-msgid "Only list windows from the monitor displaying this instance"
-msgstr ""
-
-#. 3.4->settings-schema.json->list-monitor-windows->tooltip
-msgid ""
-"This option will only come into effect for monitors displaying an ITM "
-"instance."
-msgstr ""
-
-#. 3.4->settings-schema.json->thumbnail-close-button-size->description
-msgid "Close button size"
-msgstr ""
-
-#. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
-msgid "Controls how large the thumbnail close button is."
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->description
-#. 3.4->settings-schema.json->middle-click-action->tooltip
-msgid "Middle click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Launch new app instance"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Close last focused window in group"
-msgstr ""
-
+#. 3.8->settings-schema.json->scroll-behavior->description
 #. 3.4->settings-schema.json->scroll-behavior->description
 msgid "Mouse wheel scroll behavior"
 msgstr ""
 
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+msgid "Cycle apps"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+msgid "Cycle windows"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->tooltip
 #. 3.4->settings-schema.json->scroll-behavior->tooltip
 msgid ""
 "Choose if scrolling the mouse wheel cycles running apps, an app button's "
 "windows on hover, or is disabled."
 msgstr ""
 
-#. 3.4->settings-schema.json->scroll-behavior->options
-msgid "Cycle apps"
+#. 3.8->settings-schema.json->left-click-action->description
+#. 3.8->settings-schema.json->left-click-action->tooltip
+#. 3.8->settings-schema.json->launcher-animation-effect->tooltip
+#. 3.4->settings-schema.json->left-click-action->description
+#. 3.4->settings-schema.json->left-click-action->tooltip
+#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
+msgid "Left click action"
 msgstr ""
 
-#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
 #. 3.4->settings-schema.json->left-click-action->options
-msgid "Cycle windows"
+msgid "Toggle activation of last focused window"
 msgstr ""
 
+#. 3.8->settings-schema.json->middle-click-action->description
+#. 3.8->settings-schema.json->middle-click-action->tooltip
+#. 3.4->settings-schema.json->middle-click-action->description
+#. 3.4->settings-schema.json->middle-click-action->tooltip
+msgid "Middle click action"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Launch new app instance"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Close last focused window in group"
+msgstr ""
+
+#. 3.8->settings-schema.json->system-favorites->description
+#. 3.4->settings-schema.json->system-favorites->description
+msgid "Use system favorites for pinned apps"
+msgstr ""
+
+#. 3.8->settings-schema.json->system-favorites->tooltip
+#. 3.4->settings-schema.json->system-favorites->tooltip
+msgid ""
+"Controls whether or not pinned apps consist of the system favorites list."
+msgstr ""
+
+#. 3.8->settings-schema.json->show-all-workspaces->description
+#. 3.8->settings-schema.json->show-all-workspaces->tooltip
 #. 3.4->settings-schema.json->show-all-workspaces->description
 #. 3.4->settings-schema.json->show-all-workspaces->tooltip
 msgid "Show windows from all workspaces"
 msgstr ""
 
+#. 3.8->settings-schema.json->enable-app-button-dragging->description
+#. 3.8->settings-schema.json->enable-app-button-dragging->tooltip
+#. 3.4->settings-schema.json->enable-app-button-dragging->description
+#. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
+msgid "Enable app button dragging"
+msgstr ""
+
+#. 3.8->settings-schema.json->launcher-animation-effect->description
+#. 3.4->settings-schema.json->launcher-animation-effect->description
+msgid "Launcher animation effect"
+msgstr ""
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Fade"
+msgstr ""
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Scale"
+msgstr ""
+
+#. 3.8->settings-schema.json->list-monitor-windows->description
+#. 3.4->settings-schema.json->list-monitor-windows->description
+msgid "Only list windows from the monitor displaying this instance"
+msgstr ""
+
+#. 3.8->settings-schema.json->list-monitor-windows->tooltip
+#. 3.4->settings-schema.json->list-monitor-windows->tooltip
+msgid ""
+"This option will only come into effect for monitors displaying an ITM "
+"instance."
+msgstr ""
+
+#. 3.8->settings-schema.json->enable-app-button-width->description
+#. 3.4->settings-schema.json->enable-app-button-width->description
+msgid "Use a custom width for app buttons"
+msgstr ""
+
+#. 3.8->settings-schema.json->enable-app-button-width->tooltip
+#. 3.4->settings-schema.json->enable-app-button-width->tooltip
+msgid "When disabled, the app button width is determined by the panel height."
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-width->description
+#. 3.4->settings-schema.json->app-button-width->description
+msgid "App button width"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-width->tooltip
+#. 3.4->settings-schema.json->app-button-width->tooltip
+msgid ""
+"Controls the width of the application button. This option only works for "
+"horizontal panels."
+msgstr ""
+
+#. 3.8->settings-schema.json->thumbnail-close-button-size->description
+#. 3.4->settings-schema.json->thumbnail-close-button-size->description
+msgid "Close button size"
+msgstr ""
+
+#. 3.8->settings-schema.json->thumbnail-close-button-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
+msgid "Controls how large the thumbnail close button is."
+msgstr ""
+
+#. 3.8->settings-schema.json->thumbnail-padding->description
+#. 3.4->settings-schema.json->thumbnail-padding->description
+msgid "Thumbnail padding"
+msgstr ""
+
+#. 3.8->settings-schema.json->thumbnail-padding->tooltip
+#. 3.4->settings-schema.json->thumbnail-padding->tooltip
+msgid "Controls how much space will be around the window preview thumbnails."
+msgstr ""
+
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->description
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
 msgid "Cycle windows on mouse wheel scroll"
 msgstr ""
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->tooltip
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
 msgid ""
 "Choose whether or not scrolling the mouse wheel cycles windows when hovering"
 " over a thumbnail menu."
 msgstr ""
 
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "Toggle activation of last focused window"
+#. 3.8->settings-schema.json->show-icons->description
+#. 3.4->settings-schema.json->show-icons->description
+msgid "Show icons"
 msgstr ""
 
-#. IcingTaskManager@json->metadata.json->name
-msgid "Icing Task Manager"
+#. 3.8->settings-schema.json->show-icons->tooltip
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
 msgstr ""
 
-#. IcingTaskManager@json->metadata.json->description
-msgid "Window list with app grouping and thumbnails"
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->description
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
+msgid "Highlight the last focused window within an app group"
+msgstr ""
+
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+msgid ""
+"When enabled, the last window that was interacted with will be indicated."
+msgstr ""
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->description
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+msgid "Show new window option"
+msgstr ""
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->tooltip
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->units
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->description
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->tooltip
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.8->settings-schema.json->mintYPreset->description
+#. 3.8->settings-schema.json->mintYPreset->tooltip
+#. 3.4->settings-schema.json->mintYPreset->description
+#. 3.4->settings-schema.json->mintYPreset->tooltip
+msgid "Mint Y and Variants"
+msgstr ""
+
+#. 3.8->settings-schema.json->mintXPreset->description
+#. 3.8->settings-schema.json->mintXPreset->tooltip
+#. 3.4->settings-schema.json->mintXPreset->description
+#. 3.4->settings-schema.json->mintXPreset->tooltip
+msgid "Mint X, Linux Mint, and Variants"
+msgstr ""
+
+#. 3.8->settings-schema.json->migrationButton->description
+msgid "Migrate Pinned Apps to Grouped Window List"
 msgstr ""

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/default.pot
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/default.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-10 00:43-0600\n"
+"POT-Creation-Date: 2018-12-13 18:37-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,53 +17,53 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: 3.8/applet.js:471
-msgid "Icing Task Manager is now Grouped Window List"
+#: 3.8/applet.js:476
+msgid "Icing Task Manager is deprecated"
 msgstr ""
 
-#: 3.8/applet.js:472
+#: 3.8/applet.js:477
 msgid ""
-"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped"
-" Window List\". "
+"Please upgrade to Grouped Window List for a more stable, bug-free "
+"experience."
 msgstr ""
 
-#: 3.8/applet.js:473
+#: 3.8/applet.js:478
 msgid ""
-"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
-"List."
+"Add GWL to your panel, open the applet's settings and click \"Migrate Pinned"
+" Apps to Grouped Window List\"."
 msgstr ""
 
-#: 3.8/applet.js:485
-msgid "Migration can only be performed on Cinnamon 4.0."
+#: 3.8/applet.js:490
+msgid "Migration can only be performed on Cinnamon 4.0+."
 msgstr ""
 
-#: 3.8/applet.js:496
+#: 3.8/applet.js:501
 msgid ""
 "Please add Grouped Window List to a panel before proceeding with the "
 "migration."
 msgstr ""
 
-#: 3.8/applet.js:504
+#: 3.8/applet.js:509
 msgid "ITM settings directory could not be found!"
 msgstr ""
 
-#: 3.8/applet.js:534
+#: 3.8/applet.js:539
 msgid "System favorites enabled - no migration is needed."
 msgstr ""
 
-#: 3.8/applet.js:577
+#: 3.8/applet.js:582
 msgid "Unable to find a suitable ITM settings file to migrate."
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid "Migration complete. "
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid " settings file(s) could not be migrated."
 msgstr ""
 
-#: 3.8/applet.js:592
+#: 3.8/applet.js:597
 msgid "Migration was successful."
 msgstr ""
 

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/es.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-10 00:43-0600\n"
+"POT-Creation-Date: 2018-12-13 18:37-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Pandiora <Pandiora@github.com>\n"
 "Language-Team: \n"
@@ -13,53 +13,53 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: 3.8/applet.js:471
-msgid "Icing Task Manager is now Grouped Window List"
-msgstr ""
+#: 3.8/applet.js:476
+#, fuzzy
+msgid "Icing Task Manager is deprecated"
+msgstr "Icing Task Manager"
 
-#: 3.8/applet.js:472
+#: 3.8/applet.js:477
 msgid ""
-"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
-"Window List\". "
+"Please upgrade to Grouped Window List for a more stable, bug-free experience."
 msgstr ""
 
-#: 3.8/applet.js:473
+#: 3.8/applet.js:478
 msgid ""
-"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
-"List."
+"Add GWL to your panel, open the applet's settings and click \"Migrate Pinned "
+"Apps to Grouped Window List\"."
 msgstr ""
 
-#: 3.8/applet.js:485
-msgid "Migration can only be performed on Cinnamon 4.0."
+#: 3.8/applet.js:490
+msgid "Migration can only be performed on Cinnamon 4.0+."
 msgstr ""
 
-#: 3.8/applet.js:496
+#: 3.8/applet.js:501
 msgid ""
 "Please add Grouped Window List to a panel before proceeding with the "
 "migration."
 msgstr ""
 
-#: 3.8/applet.js:504
+#: 3.8/applet.js:509
 msgid "ITM settings directory could not be found!"
 msgstr ""
 
-#: 3.8/applet.js:534
+#: 3.8/applet.js:539
 msgid "System favorites enabled - no migration is needed."
 msgstr ""
 
-#: 3.8/applet.js:577
+#: 3.8/applet.js:582
 msgid "Unable to find a suitable ITM settings file to migrate."
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid "Migration complete. "
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid " settings file(s) could not be migrated."
 msgstr ""
 
-#: 3.8/applet.js:592
+#: 3.8/applet.js:597
 msgid "Migration was successful."
 msgstr ""
 
@@ -1231,6 +1231,10 @@ msgstr ""
 #. 3.8->settings-schema.json->migrationButton->description
 msgid "Migrate Pinned Apps to Grouped Window List"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Icing Task Manager is deprecated - please use Grouped Window List"
+#~ msgstr "Icing Task Manager"
 
 # Should not be set, just leave it blank by setting one white-space character
 #~ msgid "number"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/es.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-23 21:32-0600\n"
+"POT-Creation-Date: 2018-12-10 00:43-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Pandiora <Pandiora@github.com>\n"
 "Language-Team: \n"
@@ -13,567 +13,227 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/applet.js:471
+msgid "Icing Task Manager is now Grouped Window List"
+msgstr ""
+
+#: 3.8/applet.js:472
+msgid ""
+"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
+"Window List\". "
+msgstr ""
+
+#: 3.8/applet.js:473
+msgid ""
+"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
+"List."
+msgstr ""
+
+#: 3.8/applet.js:485
+msgid "Migration can only be performed on Cinnamon 4.0."
+msgstr ""
+
+#: 3.8/applet.js:496
+msgid ""
+"Please add Grouped Window List to a panel before proceeding with the "
+"migration."
+msgstr ""
+
+#: 3.8/applet.js:504
+msgid "ITM settings directory could not be found!"
+msgstr ""
+
+#: 3.8/applet.js:534
+msgid "System favorites enabled - no migration is needed."
+msgstr ""
+
+#: 3.8/applet.js:577
+msgid "Unable to find a suitable ITM settings file to migrate."
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid "Migration complete. "
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid " settings file(s) could not be migrated."
+msgstr ""
+
+#: 3.8/applet.js:592
+msgid "Migration was successful."
+msgstr ""
+
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 #, fuzzy
 msgid "Move to the other monitor"
 msgstr "Mover al monitor %d"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 #, fuzzy
 msgid "Move to monitor "
 msgstr "Mover al monitor %d"
 
-#: 3.4/specialMenus.js:126
+#: 3.8/specialMenus.js:98 3.4/specialMenus.js:126
 msgid "Only on this workspace"
 msgstr "Solo en esta área de trabajo"
 
-#: 3.4/specialMenus.js:133
+#: 3.8/specialMenus.js:105 3.4/specialMenus.js:133
 msgid "Visible on all workspaces"
 msgstr "Mostrar en todas las áreas de trabajo"
 
-#: 3.4/specialMenus.js:140
+#: 3.8/specialMenus.js:112 3.4/specialMenus.js:140
 #, fuzzy
 msgid "Move to another workspace"
 msgstr "Mover al área de trabajo de la izquierda"
 
-#: 3.4/specialMenus.js:168
+#: 3.8/specialMenus.js:140 3.4/specialMenus.js:168
 msgid "Places"
 msgstr ""
 
-#: 3.4/specialMenus.js:207
+#: 3.8/specialMenus.js:179 3.4/specialMenus.js:207
 msgid "Bookmarks/History requires gir1.2-gda-5.0"
 msgstr ""
 
-#: 3.4/specialMenus.js:227
+#: 3.8/specialMenus.js:199 3.4/specialMenus.js:227
 #, fuzzy
 msgid "Recent"
 msgstr "porcentaje"
 
-#: 3.4/specialMenus.js:246
+#: 3.8/specialMenus.js:218 3.4/specialMenus.js:246
 msgid "Preferences"
 msgstr ""
 
-#: 3.4/specialMenus.js:249
+#: 3.8/specialMenus.js:221 3.4/specialMenus.js:249
 msgid "About..."
 msgstr ""
 
-#: 3.4/specialMenus.js:253
+#: 3.8/specialMenus.js:225 3.4/specialMenus.js:253
 msgid "Configure..."
 msgstr ""
 
-#: 3.4/specialMenus.js:257
+#: 3.8/specialMenus.js:229 3.4/specialMenus.js:257
 msgid "Remove"
 msgstr ""
 
-#: 3.4/specialMenus.js:287
+#: 3.8/specialMenus.js:259 3.4/specialMenus.js:287
 #, fuzzy
 msgid "New Window"
 msgstr "Incluir todas las ventanas de la aplicación"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Unpin from Panel"
 msgstr "No fijar la aplicación"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Pin to Panel"
 msgstr "Fijar la aplicación"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Remove from Autostart"
 msgstr "Eliminar del inicio automático"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Add to Autostart"
 msgstr "Añadir a Autostart"
 
-#: 3.4/specialMenus.js:318
+#: 3.8/specialMenus.js:290 3.4/specialMenus.js:318
 msgid "Create Shortcut"
 msgstr "Crear acceso directo"
 
-#: 3.4/specialMenus.js:329
+#: 3.8/specialMenus.js:301 3.4/specialMenus.js:329
 msgid "Restore to full opacity"
 msgstr ""
 
-#: 3.4/specialMenus.js:337
+#: 3.8/specialMenus.js:309 3.4/specialMenus.js:337
 msgid "Restore"
 msgstr "Restaurar"
 
-#: 3.4/specialMenus.js:342
+#: 3.8/specialMenus.js:314 3.4/specialMenus.js:342
 msgid "Minimize"
 msgstr "Minimizar"
 
-#: 3.4/specialMenus.js:350
+#: 3.8/specialMenus.js:322 3.4/specialMenus.js:350
 msgid "Unmaximize"
 msgstr "No maximizada"
 
-#: 3.4/specialMenus.js:355
+#: 3.8/specialMenus.js:327 3.4/specialMenus.js:355
 msgid "Maximize"
 msgstr "Maximizar"
 
-#: 3.4/specialMenus.js:365
+#: 3.8/specialMenus.js:337 3.4/specialMenus.js:365
 msgid "Close others"
 msgstr ""
 
-#: 3.4/specialMenus.js:375
+#: 3.8/specialMenus.js:347 3.4/specialMenus.js:375
 #, fuzzy
 msgid "Close all"
 msgstr "Cerrar Todo"
 
-#: 3.4/specialMenus.js:385
+#: 3.8/specialMenus.js:357 3.4/specialMenus.js:385
 msgid "Close"
 msgstr "Cerrar"
 
-#. 2.8->settings-schema.json->thumbnail-size->description
-#. 3.4->settings-schema.json->thumbnail-size->description
-msgid "Thumbnail size"
-msgstr "Tamaño de las Miniaturas"
-
-#. 2.8->settings-schema.json->thumbnail-size->tooltip
-#. 3.4->settings-schema.json->thumbnail-size->tooltip
-msgid "Controls the size of the thumbnails."
-msgstr "Controla el tamaño de las miniaturas."
-
-# should not be set, just leave it blank and insert one white-space character
-#. 2.8->settings-schema.json->thumbnail-size->units
-#. 3.4->settings-schema.json->thumbnail-size->units
-msgid "size"
-msgstr " "
-
-#. 2.8->settings-schema.json->focusPseudoClass->description
-#. 3.4->settings-schema.json->focusPseudoClass->description
-msgid "App button focus pseudo class"
-msgstr "Pseudo clase de enfoque del botón de aplicación"
-
-#. 2.8->settings-schema.json->focusPseudoClass->tooltip
-#. 3.4->settings-schema.json->focusPseudoClass->tooltip
-msgid "Overrides the pseudo class for app button on focus."
-msgstr "Anula la pseudo clase para el botón de aplicación en el enfoque."
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "active"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "outlined"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "hover"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
+#. metadata.json->description
 #, fuzzy
-msgid "focus"
-msgstr "enfocado"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "selected"
+msgid "Window list with app grouping and thumbnails"
 msgstr ""
+"Lista de ventanas con agrupación de aplicaciones y miniaturas de ventanas"
 
-#. 2.8->settings-schema.json->icon-spacing->description
-#. 3.4->settings-schema.json->icon-spacing->description
-msgid "Icon spacing"
-msgstr "Espaciado de iconos"
+#. metadata.json->name
+msgid "Icing Task Manager"
+msgstr "Icing Task Manager"
 
-#. 2.8->settings-schema.json->icon-spacing->tooltip
-#. 3.4->settings-schema.json->icon-spacing->tooltip
-msgid "Controls how much space is between the icons."
-msgstr "Cuanto relleno poner entre los iconos"
-
-#. 2.8->settings-schema.json->icon-spacing->units
-#. 2.8->settings-schema.json->icon-size->units
-#. 2.8->settings-schema.json->icon-padding->units
-#. 3.4->settings-schema.json->icon-spacing->units
-#. 3.4->settings-schema.json->thumbnail-padding->units
-#. 3.4->settings-schema.json->icon-size->units
-#. 3.4->settings-schema.json->app-button-width->units
-#. 3.4->settings-schema.json->thumbnail-close-button-size->units
-#. 3.4->settings-schema.json->icon-padding->units
-msgid "px"
-msgstr ""
-
-#. 2.8->settings-schema.json->show-thumbnails->description
-#. 3.4->settings-schema.json->show-thumbnails->description
-msgid "Show thumbnails"
-msgstr "Mostrar Miniaturas"
-
-#. 2.8->settings-schema.json->show-thumbnails->tooltip
-#. 3.4->settings-schema.json->show-thumbnails->tooltip
-msgid "Show window thumbnails when hovering over an app button."
-msgstr "Mostrar Miniaturas de Ventanas"
-
-#. 2.8->settings-schema.json->icon-size->description
-#. 3.4->settings-schema.json->icon-size->description
-msgid "Icon size"
-msgstr "Tamaño de ícono"
-
-#. 2.8->settings-schema.json->icon-size->tooltip
-#. 3.4->settings-schema.json->icon-size->tooltip
-msgid "Set icon size"
-msgstr "Configurar el tamaño del icono"
-
-#. 2.8->settings-schema.json->hover-peek-time->description
-#. 3.4->settings-schema.json->hover-peek-time->description
-msgid "Window fade time"
-msgstr "Tiempo de desvanecimiento de las ventanas"
-
-#. 2.8->settings-schema.json->hover-peek-time->tooltip
-#. 3.4->settings-schema.json->hover-peek-time->tooltip
-msgid "Controls how quickly a window will fade on hover."
-msgstr "Tiempo de animación de las ventanas, al realizar un vistazo"
-
-#. 2.8->settings-schema.json->hover-peek-time->units
-#. 2.8->settings-schema.json->thumbnail-timeout->units
-#. 2.8->settings-schema.json->show-apps-order-timeout->units
-#. 3.4->settings-schema.json->hover-peek-time->units
-#. 3.4->settings-schema.json->thumbnail-timeout->units
-#. 3.4->settings-schema.json->show-apps-order-timeout->units
-msgid "milliseconds"
-msgstr "milisegundos"
-
-#. 2.8->settings-schema.json->close-button-style->description
-msgid "Allow themes to control the thumbnail close button"
-msgstr "Permitir que los temas controlen el botón de cierre de miniaturas"
-
-#. 2.8->settings-schema.json->close-button-style->tooltip
-msgid ""
-"Controls whether or not the theme controls the window thumbnail's close "
-"button."
-msgstr ""
-"Controla si el tema controla o no el botón de cierre de la miniatura de la "
-"ventana."
-
-#. 2.8->settings-schema.json->title-display->description
-#. 3.4->settings-schema.json->title-display->description
-msgid "Title display"
-msgstr "Título de pantalla"
-
-#. 2.8->settings-schema.json->title-display->tooltip
-#. 3.4->settings-schema.json->title-display->tooltip
-msgid ""
-"focused: show focused window title, title: display the window title, app: "
-"diplay app name, none: don't display anything"
-msgstr ""
-"enfocado: muestra el título de la ventana con el foco, título: muestra el "
-"título de la ventana, aplicación: muestra el nombre de la aplicación, nada: "
-"no muestra nada"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-#. 3.4->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->middle-click-action->options
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "None"
-msgstr "nada"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Focused"
-msgstr "enfocado"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "App"
-msgstr "aplicación"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Title"
-msgstr "título"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->description
-#. 3.4->settings-schema.json->hoverPseudoClass->description
-msgid "App button hover pseudo class"
-msgstr "Botón de la aplicación pseudo clase"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
-#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons on hover."
-msgstr ""
-"Anula la pseudo clase de los botones de la aplicación en el sentido hover."
-
-#. 2.8->settings-schema.json->show-alerts->description
-#. 3.4->settings-schema.json->show-alerts->description
-msgid "Show app alerts and notifications"
-msgstr "Mostrar alertas y notificaciones de aplicaciones"
-
-#. 2.8->settings-schema.json->show-alerts->tooltip
-#. 3.4->settings-schema.json->show-alerts->tooltip
-msgid "If enabled, notifications and alerts will appear."
-msgstr "Si está activada, aparecerán notificaciones y alertas."
-
-#. 2.8->settings-schema.json->pinOnDrag->description
-#. 2.8->settings-schema.json->pinOnDrag->tooltip
-#. 3.4->settings-schema.json->pinOnDrag->description
-#. 3.4->settings-schema.json->pinOnDrag->tooltip
-msgid "Pin apps when dragged to a new position"
-msgstr "Pin aplicaciones cuando se arrastran a una nueva posición"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->description
-#. 3.4->settings-schema.json->show-apps-order-hotkey->description
-msgid "Global hotkey to show the order of apps"
-msgstr ""
-"Tecla de acceso directo global para mostrar el orden de las aplicaciones"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
-#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
-msgid ""
-"When triggered, the window count label will be replaced with its order in "
-"the app list temporarily."
-msgstr ""
-"Cuando se activa, la etiqueta de recuento de ventanas se reemplazará "
-"temporalmente con su orden en la lista de aplicaciones."
-
-#. 2.8->settings-schema.json->menuItemType->description
-#. 3.4->settings-schema.json->menuItemType->description
-msgid "Menu item type"
-msgstr "Tipo de elemento de menú"
-
-#. 2.8->settings-schema.json->menuItemType->tooltip
-#. 3.4->settings-schema.json->menuItemType->tooltip
-msgid ""
-"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
-msgstr ""
-"Determina si los iconos de elementos de menú son simbólicos, no simbólicos o "
-"no se muestran."
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Symbolic icons"
-msgstr "Iconos simbólicos"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "No icons"
-msgstr "Sin iconos"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Non-symbolic icons"
-msgstr "Iconos no simbólicos"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->description
-#. 3.4->settings-schema.json->hover-peek-opacity->description
-msgid "Window opacity"
-msgstr "Opacidad de la ventana"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
-#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
-msgid "Opacity of the windows on hover."
-msgstr "Opacidad de las ventanas de vistazo."
-
-#. 2.8->settings-schema.json->hover-peek-opacity->units
-#. 3.4->settings-schema.json->hover-peek-opacity->units
-msgid "percent"
-msgstr "porcentaje"
-
-#. 2.8->settings-schema.json->enable-hover-peek->description
-#. 3.4->settings-schema.json->enable-hover-peek->description
-msgid "Show windows when hovered over"
-msgstr "Habilitar vistazo cuando el ratón se encuentra sobre el área."
-
-#. 2.8->settings-schema.json->enable-hover-peek->tooltip
-#. 3.4->settings-schema.json->enable-hover-peek->tooltip
-msgid "Controls whether or not windows display when hovered over."
-msgstr "Activar vistazo flotante cuando el ratón está sobre la miniatura"
-
-#. 2.8->settings-schema.json->activePseudoClass->description
-#. 3.4->settings-schema.json->activePseudoClass->description
-msgid "App button active pseudo class"
-msgstr "Pseudo clase activa del botón de aplicación"
-
-#. 2.8->settings-schema.json->activePseudoClass->tooltip
-#. 3.4->settings-schema.json->activePseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons when they are active."
-msgstr ""
-"Anula la pseudo clase de los botones de aplicación cuando están activos."
-
-#. 2.8->settings-schema.json->animate-thumbnails->description
-#. 3.4->settings-schema.json->animate-thumbnails->description
-msgid "Animate thumbnails"
-msgstr "Animar miniaturas"
-
-#. 2.8->settings-schema.json->animate-thumbnails->tooltip
-#. 3.4->settings-schema.json->animate-thumbnails->tooltip
-msgid "If enabled, thumbnails will animate when appearing and disappearing."
-msgstr ""
-"Si está activada, las miniaturas se animarán al aparecer y desaparecer."
-
-#. 2.8->settings-schema.json->autostart-menu-item->description
-#. 3.4->settings-schema.json->autostart-menu-item->description
-msgid "Show autostart option"
-msgstr "Mostrar la opción de inicio automático"
-
-#. 2.8->settings-schema.json->autostart-menu-item->tooltip
-#. 3.4->settings-schema.json->autostart-menu-item->tooltip
-msgid "Shows the autostart toggle option in an app's context menu."
-msgstr ""
-"Muestra la opción de alternar inicio automático en el menú contextual de una "
-"aplicación."
-
-#. 2.8->settings-schema.json->show-pinned->description
-#. 3.4->settings-schema.json->show-pinned->description
-msgid "Show pinned apps"
-msgstr "Mostrar aplicaciones fijas"
-
-#. 2.8->settings-schema.json->show-pinned->tooltip
-#. 3.4->settings-schema.json->show-pinned->tooltip
-msgid ""
-"Controls whether or not the pinned apps appear in the panel if they are not "
-"open."
-msgstr ""
-"Mostrar las aplicaciones fijas o simplemente mostrar las ventanas abiertas"
-
-#. 2.8->settings-schema.json->useSystemTooltips->description
-msgid "Use system tooltips for closed apps"
-msgstr "Usar sugerencias de sistema para aplicaciones cerradas"
-
-#. 2.8->settings-schema.json->useSystemTooltips->tooltip
-msgid ""
-"Controls whether or not system tooltips are in use when hovering over closed "
-"pinned apps."
-msgstr ""
-"Controla si las sugerencias del sistema están o no en uso cuando se ciernen "
-"sobre aplicaciones cerradas."
+#. 2.8->settings-schema.json->ITM->description
+msgid "ITM Settings"
+msgstr "Configuración de ITM"
 
 #. 2.8->settings-schema.json->WindowList->description
 msgid "Window List Settings"
 msgstr "Configuración de la Lista de Ventanas"
 
-#. 2.8->settings-schema.json->AppMenu->description
-msgid "Context Menu Settings"
-msgstr "Configuración del menú contextual"
-
-#. 2.8->settings-schema.json->Thumbnails->description
-msgid "Thumbnail Settings"
-msgstr "Configuración de Miniaturas"
-
-#. 2.8->settings-schema.json->show-recent->description
-#. 3.4->settings-schema.json->show-recent->description
-msgid "Show recent items"
-msgstr "Mostrar artículos recientes"
-
-#. 2.8->settings-schema.json->show-recent->tooltip
-#. 3.4->settings-schema.json->show-recent->tooltip
-msgid "Controls whether recent items will appear in the context menu."
-msgstr "Controla si los elementos recientes aparecerán en el menú contextual."
-
-#. 2.8->settings-schema.json->vertical-thumbnails->description
-#. 3.4->settings-schema.json->vertical-thumbnails->description
-msgid "Enable vertical thumbnails"
-msgstr "Miniaturas Verticales"
-
-#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
-#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
-msgid "If enabled, thumbnails will stack vertically."
-msgstr "Organizar miniaturas vertical u horizontalmente"
-
-#. 2.8->settings-schema.json->thumbnail-timeout->description
-#. 3.4->settings-schema.json->thumbnail-timeout->description
-msgid "Thumbnail timeout"
-msgstr "Tiempo de espera de las miniaturas"
-
-#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
-#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
-msgid ""
-"Controls how quickly an app's set of window thumbnails will fade out when "
-"the mouse leaves the app button."
-msgstr "Tiempo de espera de las miniaturas"
-
-#. 2.8->settings-schema.json->ThemeSettings->description
-msgid "Theme Settings"
-msgstr "Ajustes de tema"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->description
-#. 3.4->settings-schema.json->onclick-thumbnails->description
-msgid "Open thumbnails on click"
-msgstr "Abrir Miniaturas al hacer clic"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
-#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
-msgid "Open the thumbnails on click if there is more than one window open."
-msgstr ""
-"Abrir las imágenes en miniatura al hacer clic, solo si hay más de 1 ventana "
-"abierta."
-
-#. 2.8->settings-schema.json->panelLauncherClass->description
-msgid "Use the panel launcher class for pinned apps"
-msgstr "Utilice la clase de lanzador de paneles para aplicaciones fijadas"
-
-#. 2.8->settings-schema.json->panelLauncherClass->tooltip
-msgid "Enabling this helps with certain themes."
-msgstr "Habilitar esto ayuda con ciertos temas."
-
-#. 2.8->settings-schema.json->include-all-windows->description
-#. 3.4->settings-schema.json->include-all-windows->description
-msgid "Include all app windows"
-msgstr "Incluir todas las ventanas de la aplicación"
-
-#. 2.8->settings-schema.json->include-all-windows->tooltip
-#. 3.4->settings-schema.json->include-all-windows->tooltip
-msgid ""
-"Controls whether or not thumbnails for smalller child windows, such as exit "
-"confirmations and file dialogues will be included in the thumbnail list."
-msgstr ""
-"Controla si las miniaturas de las ventanas para niños pequeños, como las "
-"confirmaciones de salida y los diálogos de archivos, se incluirán en la "
-"lista de miniaturas."
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->description
-#. 3.4->settings-schema.json->cycleMenusHotkey->description
-msgid "Global hotkey for cycling through thumbnail menus"
-msgstr "Tecla de acceso rápido global para recorrer los menús en miniatura"
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
-#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
-msgid "This allows you to cycle through the menus without activating a window."
-msgstr "Esto le permite recorrer los menús sin activar una ventana."
-
-#. 2.8->settings-schema.json->enable-iconSize->description
-#. 3.4->settings-schema.json->enable-iconSize->description
-msgid "Adjust icon size"
-msgstr "Ajustar el tamaño del icono"
-
-#. 2.8->settings-schema.json->enable-iconSize->tooltip
-#. 3.4->settings-schema.json->enable-iconSize->tooltip
-msgid "Adjust icon size independent of Cinnamon's panel scaling."
-msgstr ""
-"Ajuste el tamaño del icono independiente de la escala del panel de Cinnamon."
-
 #. 2.8->settings-schema.json->number-display->description
+#. 3.8->settings-schema.json->number-display->description
 #. 3.4->settings-schema.json->number-display->description
 msgid "Number display"
 msgstr "Mostrar Número"
 
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Smart"
+msgstr "inteligente"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Normal"
+msgstr "normal"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "None"
+msgstr "nada"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "All"
+msgstr "todos"
+
 #. 2.8->settings-schema.json->number-display->tooltip
+#. 3.8->settings-schema.json->number-display->tooltip
 #. 3.4->settings-schema.json->number-display->tooltip
 msgid ""
 "normal: display window number, smart: display window number if more than one "
@@ -584,43 +244,96 @@ msgstr ""
 "la ventana, solo si hay más de una, nada: no muestra el número, todos: "
 "muestra el número también para favoritos"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "All"
-msgstr "todos"
+#. 2.8->settings-schema.json->title-display->description
+#. 3.8->settings-schema.json->title-display->description
+#. 3.4->settings-schema.json->title-display->description
+msgid "Title display"
+msgstr "Título de pantalla"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Smart"
-msgstr "inteligente"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "App"
+msgstr "aplicación"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Normal"
-msgstr "normal"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Title"
+msgstr "título"
 
-#. 2.8->settings-schema.json->ITM->description
-msgid "ITM Settings"
-msgstr "Configuración de ITM"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Focused"
+msgstr "enfocado"
 
-#. 2.8->settings-schema.json->HoverPeek->description
-msgid "Hover Peek Settings"
-msgstr "Configuración del Vistazo"
-
-#. 2.8->settings-schema.json->icon-padding->description
-#. 3.4->settings-schema.json->icon-padding->description
-msgid "Icon padding"
-msgstr "Relleno del Icono"
-
-#. 2.8->settings-schema.json->icon-padding->tooltip
-#. 3.4->settings-schema.json->icon-padding->tooltip
+#. 2.8->settings-schema.json->title-display->tooltip
+#. 3.8->settings-schema.json->title-display->tooltip
+#. 3.4->settings-schema.json->title-display->tooltip
 msgid ""
-"Controls how much horizontal padding is inside the app buttons. Padding is "
-"only applied to instances of this applet on horizontal panels."
+"focused: show focused window title, title: display the window title, app: "
+"diplay app name, none: don't display anything"
 msgstr ""
-"Controla la cantidad de relleno horizontal dentro de los botones de la "
-"aplicación. El relleno sólo se aplica a instancias de este applet en paneles "
-"horizontales."
+"enfocado: muestra el título de la ventana con el foco, título: muestra el "
+"título de la ventana, aplicación: muestra el nombre de la aplicación, nada: "
+"no muestra nada"
+
+#. 2.8->settings-schema.json->group-apps->description
+#. 3.8->settings-schema.json->group-apps->description
+#. 3.4->settings-schema.json->group-apps->description
+msgid "Group apps"
+msgstr "Aplicaciones de grupo"
+
+#. 2.8->settings-schema.json->group-apps->tooltip
+#. 3.8->settings-schema.json->group-apps->tooltip
+#. 3.4->settings-schema.json->group-apps->tooltip
+msgid "Group each app's set of windows."
+msgstr "Agrupe el conjunto de ventanas de cada aplicación."
+
+#. 2.8->settings-schema.json->show-alerts->description
+#. 3.8->settings-schema.json->show-alerts->description
+#. 3.4->settings-schema.json->show-alerts->description
+msgid "Show app alerts and notifications"
+msgstr "Mostrar alertas y notificaciones de aplicaciones"
+
+#. 2.8->settings-schema.json->show-alerts->tooltip
+#. 3.8->settings-schema.json->show-alerts->tooltip
+#. 3.4->settings-schema.json->show-alerts->tooltip
+msgid "If enabled, notifications and alerts will appear."
+msgstr "Si está activada, aparecerán notificaciones y alertas."
+
+#. 2.8->settings-schema.json->show-pinned->description
+#. 3.8->settings-schema.json->show-pinned->description
+#. 3.4->settings-schema.json->show-pinned->description
+msgid "Show pinned apps"
+msgstr "Mostrar aplicaciones fijas"
+
+#. 2.8->settings-schema.json->show-pinned->tooltip
+#. 3.8->settings-schema.json->show-pinned->tooltip
+#. 3.4->settings-schema.json->show-pinned->tooltip
+msgid ""
+"Controls whether or not the pinned apps appear in the panel if they are not "
+"open."
+msgstr ""
+"Mostrar las aplicaciones fijas o simplemente mostrar las ventanas abiertas"
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->description
+msgid "Arrange pinned apps"
+msgstr "Ordenar aplicaciones fijas"
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
+msgid "Arrange pinned apps into a different order."
+msgstr "Ordenar aplicaciones fijas en un orden diferente"
+
+#. 2.8->settings-schema.json->pinOnDrag->description
+#. 2.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.8->settings-schema.json->pinOnDrag->description
+#. 3.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.4->settings-schema.json->pinOnDrag->description
+#. 3.4->settings-schema.json->pinOnDrag->tooltip
+msgid "Pin apps when dragged to a new position"
+msgstr "Pin aplicaciones cuando se arrastran a una nueva posición"
 
 #. 2.8->settings-schema.json->middle-click-action->description
 msgid "Middle clicking app buttons creates new app instances"
@@ -638,32 +351,404 @@ msgstr ""
 "botones de la aplicación. Si establece este valor en false, se cerrará la "
 "última ventana del grupo de aplicaciones en el botón central."
 
+#. 2.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.4->settings-schema.json->cycleMenusHotkey->description
+msgid "Global hotkey for cycling through thumbnail menus"
+msgstr "Tecla de acceso rápido global para recorrer los menús en miniatura"
+
+#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
+msgid "This allows you to cycle through the menus without activating a window."
+msgstr "Esto le permite recorrer los menús sin activar una ventana."
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.4->settings-schema.json->show-apps-order-hotkey->description
+msgid "Global hotkey to show the order of apps"
+msgstr ""
+"Tecla de acceso directo global para mostrar el orden de las aplicaciones"
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
+msgid ""
+"When triggered, the window count label will be replaced with its order in "
+"the app list temporarily."
+msgstr ""
+"Cuando se activa, la etiqueta de recuento de ventanas se reemplazará "
+"temporalmente con su orden en la lista de aplicaciones."
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->units
+#. 2.8->settings-schema.json->thumbnail-timeout->units
+#. 2.8->settings-schema.json->hover-peek-time->units
+#. 3.8->settings-schema.json->show-apps-order-timeout->units
+#. 3.8->settings-schema.json->thumbnail-timeout->units
+#. 3.8->settings-schema.json->hover-peek-time->units
+#. 3.4->settings-schema.json->show-apps-order-timeout->units
+#. 3.4->settings-schema.json->thumbnail-timeout->units
+#. 3.4->settings-schema.json->hover-peek-time->units
+msgid "milliseconds"
+msgstr "milisegundos"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.4->settings-schema.json->show-apps-order-timeout->description
+msgid "Duration of the apps order display on hotkey press"
+msgstr ""
+"Duración de la visualización del pedido de aplicaciones en la tecla rápida"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
+msgid ""
+"Determines the duration the window count labels are replaced with the app's "
+"order number."
+msgstr ""
+"Determina la duración en que las etiquetas de recuento de ventanas se "
+"reemplazan con el número de pedido de la aplicación."
+
+#. 2.8->settings-schema.json->Thumbnails->description
+msgid "Thumbnail Settings"
+msgstr "Configuración de Miniaturas"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->description
+#. 3.8->settings-schema.json->thumbnail-timeout->description
+#. 3.4->settings-schema.json->thumbnail-timeout->description
+msgid "Thumbnail timeout"
+msgstr "Tiempo de espera de las miniaturas"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
+msgid ""
+"Controls how quickly an app's set of window thumbnails will fade out when "
+"the mouse leaves the app button."
+msgstr "Tiempo de espera de las miniaturas"
+
+# should not be set, just leave it blank and insert one white-space character
+#. 2.8->settings-schema.json->thumbnail-size->units
+#. 3.8->settings-schema.json->thumbnail-size->units
+#. 3.4->settings-schema.json->thumbnail-size->units
+msgid "size"
+msgstr " "
+
+#. 2.8->settings-schema.json->thumbnail-size->description
+#. 3.8->settings-schema.json->thumbnail-size->description
+#. 3.4->settings-schema.json->thumbnail-size->description
+msgid "Thumbnail size"
+msgstr "Tamaño de las Miniaturas"
+
+#. 2.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-size->tooltip
+msgid "Controls the size of the thumbnails."
+msgstr "Controla el tamaño de las miniaturas."
+
+#. 2.8->settings-schema.json->show-thumbnails->description
+#. 3.8->settings-schema.json->show-thumbnails->description
+#. 3.4->settings-schema.json->show-thumbnails->description
+msgid "Show thumbnails"
+msgstr "Mostrar Miniaturas"
+
+#. 2.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.4->settings-schema.json->show-thumbnails->tooltip
+msgid "Show window thumbnails when hovering over an app button."
+msgstr "Mostrar Miniaturas de Ventanas"
+
+#. 2.8->settings-schema.json->animate-thumbnails->description
+#. 3.8->settings-schema.json->animate-thumbnails->description
+#. 3.4->settings-schema.json->animate-thumbnails->description
+msgid "Animate thumbnails"
+msgstr "Animar miniaturas"
+
+#. 2.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.4->settings-schema.json->animate-thumbnails->tooltip
+msgid "If enabled, thumbnails will animate when appearing and disappearing."
+msgstr ""
+"Si está activada, las miniaturas se animarán al aparecer y desaparecer."
+
+#. 2.8->settings-schema.json->vertical-thumbnails->description
+#. 3.8->settings-schema.json->vertical-thumbnails->description
+#. 3.4->settings-schema.json->vertical-thumbnails->description
+msgid "Enable vertical thumbnails"
+msgstr "Miniaturas Verticales"
+
+#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
+msgid "If enabled, thumbnails will stack vertically."
+msgstr "Organizar miniaturas vertical u horizontalmente"
+
+#. 2.8->settings-schema.json->sort-thumbnails->description
+#. 3.8->settings-schema.json->sort-thumbnails->description
+#. 3.4->settings-schema.json->sort-thumbnails->description
+msgid "Sort windows for each app by last focused"
+msgstr "Ordenar las ventanas de cada aplicación por última vez"
+
+#. 2.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.4->settings-schema.json->sort-thumbnails->tooltip
+msgid ""
+"Controls whether the order windows appear for an app is by last focused, or "
+"the order they were opened."
+msgstr ""
+
+#. 2.8->settings-schema.json->onclick-thumbnails->description
+#. 3.8->settings-schema.json->onclick-thumbnails->description
+#. 3.4->settings-schema.json->onclick-thumbnails->description
+msgid "Open thumbnails on click"
+msgstr "Abrir Miniaturas al hacer clic"
+
+#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
+msgid "Open the thumbnails on click if there is more than one window open."
+msgstr ""
+"Abrir las imágenes en miniatura al hacer clic, solo si hay más de 1 ventana "
+"abierta."
+
+#. 2.8->settings-schema.json->include-all-windows->description
+#. 3.8->settings-schema.json->include-all-windows->description
+#. 3.4->settings-schema.json->include-all-windows->description
+msgid "Include all app windows"
+msgstr "Incluir todas las ventanas de la aplicación"
+
+#. 2.8->settings-schema.json->include-all-windows->tooltip
+#. 3.8->settings-schema.json->include-all-windows->tooltip
+#. 3.4->settings-schema.json->include-all-windows->tooltip
+msgid ""
+"Controls whether or not thumbnails for smalller child windows, such as exit "
+"confirmations and file dialogues will be included in the thumbnail list."
+msgstr ""
+"Controla si las miniaturas de las ventanas para niños pequeños, como las "
+"confirmaciones de salida y los diálogos de archivos, se incluirán en la "
+"lista de miniaturas."
+
+#. 2.8->settings-schema.json->AppMenu->description
+msgid "Context Menu Settings"
+msgstr "Configuración del menú contextual"
+
+#. 2.8->settings-schema.json->show-recent->description
+#. 3.8->settings-schema.json->show-recent->description
+#. 3.4->settings-schema.json->show-recent->description
+msgid "Show recent items"
+msgstr "Mostrar artículos recientes"
+
+#. 2.8->settings-schema.json->show-recent->tooltip
+#. 3.8->settings-schema.json->show-recent->tooltip
+#. 3.4->settings-schema.json->show-recent->tooltip
+msgid "Controls whether recent items will appear in the context menu."
+msgstr "Controla si los elementos recientes aparecerán en el menú contextual."
+
+#. 2.8->settings-schema.json->menuItemType->description
+#. 3.8->settings-schema.json->menuItemType->description
+#. 3.4->settings-schema.json->menuItemType->description
+msgid "Menu item type"
+msgstr "Tipo de elemento de menú"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Symbolic icons"
+msgstr "Iconos simbólicos"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Non-symbolic icons"
+msgstr "Iconos no simbólicos"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "No icons"
+msgstr "Sin iconos"
+
+#. 2.8->settings-schema.json->menuItemType->tooltip
+#. 3.8->settings-schema.json->menuItemType->tooltip
+#. 3.4->settings-schema.json->menuItemType->tooltip
+msgid ""
+"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
+msgstr ""
+"Determina si los iconos de elementos de menú son simbólicos, no simbólicos o "
+"no se muestran."
+
 #. 2.8->settings-schema.json->firefox-menu->description
+#. 3.8->settings-schema.json->firefox-menu->description
 #. 3.4->settings-schema.json->firefox-menu->description
 msgid "Firefox context menu"
 msgstr "Menú contextual de Firefox"
 
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Most Visited"
+msgstr "Más visitado"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Recent History"
+msgstr "Historia reciente"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Bookmarks"
+msgstr "Marcadores"
+
 #. 2.8->settings-schema.json->firefox-menu->tooltip
+#. 3.8->settings-schema.json->firefox-menu->tooltip
 #. 3.4->settings-schema.json->firefox-menu->tooltip
 msgid ""
 "Most Visited: show the sites you visit most, Recent History: display the the "
 "last pages you visited, Bookmarks: show your favorite bookmarks."
 msgstr ""
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Bookmarks"
-msgstr "Marcadores"
+#. 2.8->settings-schema.json->autostart-menu-item->description
+#. 3.8->settings-schema.json->autostart-menu-item->description
+#. 3.4->settings-schema.json->autostart-menu-item->description
+msgid "Show autostart option"
+msgstr "Mostrar la opción de inicio automático"
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Most Visited"
-msgstr "Más visitado"
+#. 2.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.4->settings-schema.json->autostart-menu-item->tooltip
+msgid "Shows the autostart toggle option in an app's context menu."
+msgstr ""
+"Muestra la opción de alternar inicio automático en el menú contextual de una "
+"aplicación."
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Recent History"
-msgstr "Historia reciente"
+#. 2.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.4->settings-schema.json->monitor-move-all-windows->description
+msgid "Apply the monitor move option to all windows"
+msgstr "Aplicar la opción de mover el monitor a todas las ventanas"
+
+#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
+msgid ""
+"When clicking \"Move to monitor\" in the context menu, this option will move "
+"all of an app's windows instead of just the last focused window from the app."
+msgstr ""
+"Al hacer clic en \"Mover a monitor\" en el menú contextual, esta opción Se "
+"moverá todas las ventanas de una aplicación en lugar de sólo el último "
+"enfoque De la aplicación."
+
+#. 2.8->settings-schema.json->HoverPeek->description
+msgid "Hover Peek Settings"
+msgstr "Configuración del Vistazo"
+
+#. 2.8->settings-schema.json->enable-hover-peek->description
+#. 3.8->settings-schema.json->enable-hover-peek->description
+#. 3.4->settings-schema.json->enable-hover-peek->description
+msgid "Show windows when hovered over"
+msgstr "Habilitar vistazo cuando el ratón se encuentra sobre el área."
+
+#. 2.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.4->settings-schema.json->enable-hover-peek->tooltip
+msgid "Controls whether or not windows display when hovered over."
+msgstr "Activar vistazo flotante cuando el ratón está sobre la miniatura"
+
+#. 2.8->settings-schema.json->hover-peek-time->description
+#. 3.8->settings-schema.json->hover-peek-time->description
+#. 3.4->settings-schema.json->hover-peek-time->description
+msgid "Window fade time"
+msgstr "Tiempo de desvanecimiento de las ventanas"
+
+#. 2.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.4->settings-schema.json->hover-peek-time->tooltip
+msgid "Controls how quickly a window will fade on hover."
+msgstr "Tiempo de animación de las ventanas, al realizar un vistazo"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->units
+#. 3.8->settings-schema.json->hover-peek-opacity->units
+#. 3.4->settings-schema.json->hover-peek-opacity->units
+msgid "percent"
+msgstr "porcentaje"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->description
+#. 3.8->settings-schema.json->hover-peek-opacity->description
+#. 3.4->settings-schema.json->hover-peek-opacity->description
+msgid "Window opacity"
+msgstr "Opacidad de la ventana"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
+msgid "Opacity of the windows on hover."
+msgstr "Opacidad de las ventanas de vistazo."
+
+#. 2.8->settings-schema.json->ThemeSettings->description
+msgid "Theme Settings"
+msgstr "Ajustes de tema"
+
+#. 2.8->settings-schema.json->show-active->description
+#. 3.8->settings-schema.json->show-active->description
+#. 3.4->settings-schema.json->show-active->description
+msgid "Show active app indicators"
+msgstr "Mostrar indicadores de aplicaciones activas"
+
+#. 2.8->settings-schema.json->show-active->tooltip
+#. 3.8->settings-schema.json->show-active->tooltip
+#. 3.4->settings-schema.json->show-active->tooltip
+msgid "Active app styling will indicate if an app is active."
+msgstr ""
+"El estilo de la aplicación activa indicará si una aplicación está activa."
+
+#. 2.8->settings-schema.json->icon-spacing->units
+#. 2.8->settings-schema.json->icon-padding->units
+#. 2.8->settings-schema.json->icon-size->units
+#. 3.8->settings-schema.json->app-button-width->units
+#. 3.8->settings-schema.json->thumbnail-close-button-size->units
+#. 3.8->settings-schema.json->thumbnail-padding->units
+#. 3.8->settings-schema.json->icon-spacing->units
+#. 3.8->settings-schema.json->icon-padding->units
+#. 3.8->settings-schema.json->icon-size->units
+#. 3.4->settings-schema.json->app-button-width->units
+#. 3.4->settings-schema.json->thumbnail-close-button-size->units
+#. 3.4->settings-schema.json->thumbnail-padding->units
+#. 3.4->settings-schema.json->icon-spacing->units
+#. 3.4->settings-schema.json->icon-padding->units
+#. 3.4->settings-schema.json->icon-size->units
+msgid "px"
+msgstr ""
+
+#. 2.8->settings-schema.json->icon-spacing->description
+#. 3.8->settings-schema.json->icon-spacing->description
+#. 3.4->settings-schema.json->icon-spacing->description
+msgid "Icon spacing"
+msgstr "Espaciado de iconos"
+
+#. 2.8->settings-schema.json->icon-spacing->tooltip
+#. 3.8->settings-schema.json->icon-spacing->tooltip
+#. 3.4->settings-schema.json->icon-spacing->tooltip
+msgid "Controls how much space is between the icons."
+msgstr "Cuanto relleno poner entre los iconos"
+
+#. 2.8->settings-schema.json->icon-padding->description
+#. 3.8->settings-schema.json->icon-padding->description
+#. 3.4->settings-schema.json->icon-padding->description
+msgid "Icon padding"
+msgstr "Relleno del Icono"
+
+#. 2.8->settings-schema.json->icon-padding->tooltip
+#. 3.8->settings-schema.json->icon-padding->tooltip
+#. 3.4->settings-schema.json->icon-padding->tooltip
+msgid ""
+"Controls how much horizontal padding is inside the app buttons. Padding is "
+"only applied to instances of this applet on horizontal panels."
+msgstr ""
+"Controla la cantidad de relleno horizontal dentro de los botones de la "
+"aplicación. El relleno sólo se aplica a instancias de este applet en paneles "
+"horizontales."
 
 #. 2.8->settings-schema.json->themePadding->description
 msgid "Use theme padding to center button icons"
@@ -674,121 +759,292 @@ msgid "If button icons look off-centered, toggling this may help."
 msgstr ""
 "Si los iconos de los botones parecen descentrados, cambiarlo puede ayudar."
 
-#. 2.8->settings-schema.json->group-apps->description
-#. 3.4->settings-schema.json->group-apps->description
-msgid "Group apps"
-msgstr "Aplicaciones de grupo"
+#. 2.8->settings-schema.json->enable-iconSize->description
+#. 3.8->settings-schema.json->enable-iconSize->description
+#. 3.4->settings-schema.json->enable-iconSize->description
+msgid "Adjust icon size"
+msgstr "Ajustar el tamaño del icono"
 
-#. 2.8->settings-schema.json->group-apps->tooltip
-#. 3.4->settings-schema.json->group-apps->tooltip
-msgid "Group each app's set of windows."
-msgstr "Agrupe el conjunto de ventanas de cada aplicación."
-
-#. 2.8->settings-schema.json->show-active->description
-#. 3.4->settings-schema.json->show-active->description
-msgid "Show active app indicators"
-msgstr "Mostrar indicadores de aplicaciones activas"
-
-#. 2.8->settings-schema.json->show-active->tooltip
-#. 3.4->settings-schema.json->show-active->tooltip
-msgid "Active app styling will indicate if an app is active."
+#. 2.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.4->settings-schema.json->enable-iconSize->tooltip
+msgid "Adjust icon size independent of Cinnamon's panel scaling."
 msgstr ""
-"El estilo de la aplicación activa indicará si una aplicación está activa."
+"Ajuste el tamaño del icono independiente de la escala del panel de Cinnamon."
 
-#. 2.8->settings-schema.json->show-apps-order-timeout->description
-#. 3.4->settings-schema.json->show-apps-order-timeout->description
-msgid "Duration of the apps order display on hotkey press"
-msgstr ""
-"Duración de la visualización del pedido de aplicaciones en la tecla rápida"
+#. 2.8->settings-schema.json->icon-size->description
+#. 3.8->settings-schema.json->icon-size->description
+#. 3.4->settings-schema.json->icon-size->description
+msgid "Icon size"
+msgstr "Tamaño de ícono"
 
-#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
-#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
-msgid ""
-"Determines the duration the window count labels are replaced with the app's "
-"order number."
-msgstr ""
-"Determina la duración en que las etiquetas de recuento de ventanas se "
-"reemplazan con el número de pedido de la aplicación."
+#. 2.8->settings-schema.json->icon-size->tooltip
+#. 3.8->settings-schema.json->icon-size->tooltip
+#. 3.4->settings-schema.json->icon-size->tooltip
+msgid "Set icon size"
+msgstr "Configurar el tamaño del icono"
 
-#. 2.8->settings-schema.json->arrange-pinnedApps->description
-msgid "Arrange pinned apps"
-msgstr "Ordenar aplicaciones fijas"
+#. 2.8->settings-schema.json->hoverPseudoClass->description
+#. 3.8->settings-schema.json->hoverPseudoClass->description
+#. 3.4->settings-schema.json->hoverPseudoClass->description
+msgid "App button hover pseudo class"
+msgstr "Botón de la aplicación pseudo clase"
 
-#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
-msgid "Arrange pinned apps into a different order."
-msgstr "Ordenar aplicaciones fijas en un orden diferente"
-
-#. 2.8->settings-schema.json->monitor-move-all-windows->description
-#. 3.4->settings-schema.json->monitor-move-all-windows->description
-msgid "Apply the monitor move option to all windows"
-msgstr "Aplicar la opción de mover el monitor a todas las ventanas"
-
-#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
-#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
-msgid ""
-"When clicking \"Move to monitor\" in the context menu, this option will move "
-"all of an app's windows instead of just the last focused window from the app."
-msgstr ""
-"Al hacer clic en \"Mover a monitor\" en el menú contextual, esta opción Se "
-"moverá todas las ventanas de una aplicación en lugar de sólo el último "
-"enfoque De la aplicación."
-
-#. 2.8->settings-schema.json->sort-thumbnails->description
-#. 3.4->settings-schema.json->sort-thumbnails->description
-msgid "Sort windows for each app by last focused"
-msgstr "Ordenar las ventanas de cada aplicación por última vez"
-
-#. 2.8->settings-schema.json->sort-thumbnails->tooltip
-#. 3.4->settings-schema.json->sort-thumbnails->tooltip
-msgid ""
-"Controls whether the order windows appear for an app is by last focused, or "
-"the order they were opened."
-msgstr ""
-
-#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
 #. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
 #. 3.4->settings-schema.json->activePseudoClass->options
-msgid "checked"
+msgid "hover"
 msgstr ""
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
-msgid "Highlight the last focused window within an app group"
-msgstr ""
-
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
-msgid ""
-"When enabled, the last window that was interacted with will be indicated."
-msgstr ""
-
-#. 3.4->settings-schema.json->app-button-transition-duration->description
-msgid "App button transition duration"
-msgstr ""
-
-#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
-msgid ""
-"Overrides the theme's animation time for app buttons. If set to zero, the "
-"theme's transition duration will be used."
-msgstr ""
-
-#. 3.4->settings-schema.json->app-button-transition-duration->units
-msgid "ms"
-msgstr ""
-
-#. 3.4->settings-schema.json->thumbnail-padding->description
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
 #, fuzzy
-msgid "Thumbnail padding"
-msgstr "Configuración de Miniaturas"
+msgid "focus"
+msgstr "enfocado"
 
-#. 3.4->settings-schema.json->thumbnail-padding->tooltip
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "active"
+msgstr ""
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "outlined"
+msgstr ""
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "selected"
+msgstr ""
+
+#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons on hover."
+msgstr ""
+"Anula la pseudo clase de los botones de la aplicación en el sentido hover."
+
+#. 2.8->settings-schema.json->focusPseudoClass->description
+#. 3.8->settings-schema.json->focusPseudoClass->description
+#. 3.4->settings-schema.json->focusPseudoClass->description
+msgid "App button focus pseudo class"
+msgstr "Pseudo clase de enfoque del botón de aplicación"
+
+#. 2.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.4->settings-schema.json->focusPseudoClass->tooltip
+msgid "Overrides the pseudo class for app button on focus."
+msgstr "Anula la pseudo clase para el botón de aplicación en el enfoque."
+
+#. 2.8->settings-schema.json->activePseudoClass->description
+#. 3.8->settings-schema.json->activePseudoClass->description
+#. 3.4->settings-schema.json->activePseudoClass->description
+msgid "App button active pseudo class"
+msgstr "Pseudo clase activa del botón de aplicación"
+
+#. 2.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.4->settings-schema.json->activePseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons when they are active."
+msgstr ""
+"Anula la pseudo clase de los botones de aplicación cuando están activos."
+
+#. 2.8->settings-schema.json->panelLauncherClass->description
+msgid "Use the panel launcher class for pinned apps"
+msgstr "Utilice la clase de lanzador de paneles para aplicaciones fijadas"
+
+#. 2.8->settings-schema.json->panelLauncherClass->tooltip
+msgid "Enabling this helps with certain themes."
+msgstr "Habilitar esto ayuda con ciertos temas."
+
+#. 2.8->settings-schema.json->close-button-style->description
+msgid "Allow themes to control the thumbnail close button"
+msgstr "Permitir que los temas controlen el botón de cierre de miniaturas"
+
+#. 2.8->settings-schema.json->close-button-style->tooltip
+msgid ""
+"Controls whether or not the theme controls the window thumbnail's close "
+"button."
+msgstr ""
+"Controla si el tema controla o no el botón de cierre de la miniatura de la "
+"ventana."
+
+#. 2.8->settings-schema.json->useSystemTooltips->description
+msgid "Use system tooltips for closed apps"
+msgstr "Usar sugerencias de sistema para aplicaciones cerradas"
+
+#. 2.8->settings-schema.json->useSystemTooltips->tooltip
+msgid ""
+"Controls whether or not system tooltips are in use when hovering over closed "
+"pinned apps."
+msgstr ""
+"Controla si las sugerencias del sistema están o no en uso cuando se ciernen "
+"sobre aplicaciones cerradas."
+
+#. 3.8->settings-schema.json->generalPage->title
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr ""
+
+#. 3.8->settings-schema.json->panelPage->title
+#. 3.4->settings-schema.json->panelPage->title
+msgid "Panel"
+msgstr ""
+
+#. 3.8->settings-schema.json->thumbnailsPage->title
+#. 3.8->settings-schema.json->thumbnailsSection->title
+#. 3.4->settings-schema.json->thumbnailsPage->title
+#. 3.4->settings-schema.json->thumbnailsSection->title
 #, fuzzy
-msgid "Controls how much space will be around the window preview thumbnails."
-msgstr "Cuanto relleno poner entre los iconos"
+msgid "Thumbnails"
+msgstr "Tamaño de las Miniaturas"
 
+#. 3.8->settings-schema.json->contextMenuPage->title
+#. 3.4->settings-schema.json->contextMenuPage->title
+#, fuzzy
+msgid "Context Menu"
+msgstr "Configuración del menú contextual"
+
+#. 3.8->settings-schema.json->themePage->title
+#. 3.4->settings-schema.json->themePage->title
+#, fuzzy
+msgid "Theming"
+msgstr "Ajustes de tema"
+
+#. 3.8->settings-schema.json->generalSection->title
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.8->settings-schema.json->appButtonsSection->title
+#. 3.4->settings-schema.json->appButtonsSection->title
+msgid "App Buttons"
+msgstr ""
+
+#. 3.8->settings-schema.json->hotKeysSection->title
+#. 3.4->settings-schema.json->hotKeysSection->title
+msgid "Hot Keys"
+msgstr ""
+
+#. 3.8->settings-schema.json->hoverPeekSection->title
+#. 3.4->settings-schema.json->hoverPeekSection->title
+#, fuzzy
+msgid "Hover Peek"
+msgstr "Configuración del Vistazo"
+
+#. 3.8->settings-schema.json->stylingSection->title
+#. 3.4->settings-schema.json->stylingSection->title
+msgid "Styling"
+msgstr ""
+
+#. 3.8->settings-schema.json->iconSection->title
+#. 3.4->settings-schema.json->iconSection->title
+#, fuzzy
+msgid "Icons"
+msgstr "Tamaño de ícono"
+
+#. 3.8->settings-schema.json->presetSection->title
+#. 3.4->settings-schema.json->presetSection->title
+msgid "Recommended Presets"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->description
+#. 3.4->settings-schema.json->scroll-behavior->description
+msgid "Mouse wheel scroll behavior"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+msgid "Cycle apps"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#, fuzzy
+msgid "Cycle windows"
+msgstr "Incluir todas las ventanas de la aplicación"
+
+#. 3.8->settings-schema.json->scroll-behavior->tooltip
+#. 3.4->settings-schema.json->scroll-behavior->tooltip
+msgid ""
+"Choose if scrolling the mouse wheel cycles running apps, an app button's "
+"windows on hover, or is disabled."
+msgstr ""
+
+#. 3.8->settings-schema.json->left-click-action->description
+#. 3.8->settings-schema.json->left-click-action->tooltip
+#. 3.8->settings-schema.json->launcher-animation-effect->tooltip
+#. 3.4->settings-schema.json->left-click-action->description
+#. 3.4->settings-schema.json->left-click-action->tooltip
+#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
+msgid "Left click action"
+msgstr ""
+
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->left-click-action->options
+msgid "Toggle activation of last focused window"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->description
+#. 3.8->settings-schema.json->middle-click-action->tooltip
+#. 3.4->settings-schema.json->middle-click-action->description
+#. 3.4->settings-schema.json->middle-click-action->tooltip
+msgid "Middle click action"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Launch new app instance"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Close last focused window in group"
+msgstr ""
+
+#. 3.8->settings-schema.json->system-favorites->description
 #. 3.4->settings-schema.json->system-favorites->description
 #, fuzzy
 msgid "Use system favorites for pinned apps"
 msgstr "Usar sugerencias de sistema para aplicaciones cerradas"
 
+#. 3.8->settings-schema.json->system-favorites->tooltip
 #. 3.4->settings-schema.json->system-favorites->tooltip
 #, fuzzy
 msgid ""
@@ -796,94 +1052,64 @@ msgid ""
 msgstr ""
 "Mostrar las aplicaciones fijas o simplemente mostrar las ventanas abiertas"
 
-#. 3.4->settings-schema.json->generalSection->title
-msgid "Behavior"
-msgstr ""
-
-#. 3.4->settings-schema.json->thumbnailsPage->title
-#. 3.4->settings-schema.json->thumbnailsSection->title
+#. 3.8->settings-schema.json->show-all-workspaces->description
+#. 3.8->settings-schema.json->show-all-workspaces->tooltip
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
 #, fuzzy
-msgid "Thumbnails"
-msgstr "Tamaño de las Miniaturas"
+msgid "Show windows from all workspaces"
+msgstr "Mostrar en todas las áreas de trabajo"
 
-#. 3.4->settings-schema.json->presetSection->title
-msgid "Recommended Presets"
-msgstr ""
-
-#. 3.4->settings-schema.json->appButtonsSection->title
-msgid "App Buttons"
-msgstr ""
-
-#. 3.4->settings-schema.json->generalPage->title
-msgid "General"
-msgstr ""
-
-#. 3.4->settings-schema.json->hoverPeekSection->title
-#, fuzzy
-msgid "Hover Peek"
-msgstr "Configuración del Vistazo"
-
-#. 3.4->settings-schema.json->panelPage->title
-msgid "Panel"
-msgstr ""
-
-#. 3.4->settings-schema.json->iconSection->title
-#, fuzzy
-msgid "Icons"
-msgstr "Tamaño de ícono"
-
-#. 3.4->settings-schema.json->hotKeysSection->title
-msgid "Hot Keys"
-msgstr ""
-
-#. 3.4->settings-schema.json->stylingSection->title
-msgid "Styling"
-msgstr ""
-
-#. 3.4->settings-schema.json->contextMenuPage->title
-#, fuzzy
-msgid "Context Menu"
-msgstr "Configuración del menú contextual"
-
-#. 3.4->settings-schema.json->themePage->title
-#, fuzzy
-msgid "Theming"
-msgstr "Ajustes de tema"
-
-#. 3.4->settings-schema.json->mintYPreset->description
-#. 3.4->settings-schema.json->mintYPreset->tooltip
-msgid "Mint Y and Variants"
-msgstr ""
-
-#. 3.4->settings-schema.json->show-icons->description
-#, fuzzy
-msgid "Show icons"
-msgstr "Sin iconos"
-
-#. 3.4->settings-schema.json->show-icons->tooltip
-msgid "Show the window's icon next to the title."
-msgstr ""
-
+#. 3.8->settings-schema.json->enable-app-button-dragging->description
+#. 3.8->settings-schema.json->enable-app-button-dragging->tooltip
 #. 3.4->settings-schema.json->enable-app-button-dragging->description
 #. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
 msgid "Enable app button dragging"
 msgstr ""
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
-#, fuzzy
-msgid "Show new window option"
-msgstr "Mostrar la opción de inicio automático"
-
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
-msgid ""
-"Shows the \"New Window\" option in an app's context menu if it doesn't "
-"already have one from the app's own action menu items."
+#. 3.8->settings-schema.json->launcher-animation-effect->description
+#. 3.4->settings-schema.json->launcher-animation-effect->description
+msgid "Launcher animation effect"
 msgstr ""
 
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Fade"
+msgstr ""
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Scale"
+msgstr ""
+
+#. 3.8->settings-schema.json->list-monitor-windows->description
+#. 3.4->settings-schema.json->list-monitor-windows->description
+msgid "Only list windows from the monitor displaying this instance"
+msgstr ""
+
+#. 3.8->settings-schema.json->list-monitor-windows->tooltip
+#. 3.4->settings-schema.json->list-monitor-windows->tooltip
+msgid ""
+"This option will only come into effect for monitors displaying an ITM "
+"instance."
+msgstr ""
+
+#. 3.8->settings-schema.json->enable-app-button-width->description
+#. 3.4->settings-schema.json->enable-app-button-width->description
+msgid "Use a custom width for app buttons"
+msgstr ""
+
+#. 3.8->settings-schema.json->enable-app-button-width->tooltip
+#. 3.4->settings-schema.json->enable-app-button-width->tooltip
+msgid "When disabled, the app button width is determined by the panel height."
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-width->description
 #. 3.4->settings-schema.json->app-button-width->description
 msgid "App button width"
 msgstr ""
 
+#. 3.8->settings-schema.json->app-button-width->tooltip
 #. 3.4->settings-schema.json->app-button-width->tooltip
 #, fuzzy
 msgid ""
@@ -891,119 +1117,120 @@ msgid ""
 "horizontal panels."
 msgstr "Controla el tamaño de las miniaturas."
 
-#. 3.4->settings-schema.json->mintXPreset->description
-#. 3.4->settings-schema.json->mintXPreset->tooltip
-msgid "Mint X, Linux Mint, and Variants"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->description
-msgid "Launcher animation effect"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
-#. 3.4->settings-schema.json->left-click-action->description
-#. 3.4->settings-schema.json->left-click-action->tooltip
-msgid "Left click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Scale"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Fade"
-msgstr ""
-
-#. 3.4->settings-schema.json->enable-app-button-width->description
-msgid "Use a custom width for app buttons"
-msgstr ""
-
-#. 3.4->settings-schema.json->enable-app-button-width->tooltip
-msgid "When disabled, the app button width is determined by the panel height."
-msgstr ""
-
-#. 3.4->settings-schema.json->list-monitor-windows->description
-msgid "Only list windows from the monitor displaying this instance"
-msgstr ""
-
-#. 3.4->settings-schema.json->list-monitor-windows->tooltip
-msgid ""
-"This option will only come into effect for monitors displaying an ITM "
-"instance."
-msgstr ""
-
+#. 3.8->settings-schema.json->thumbnail-close-button-size->description
 #. 3.4->settings-schema.json->thumbnail-close-button-size->description
 #, fuzzy
 msgid "Close button size"
 msgstr "Configurar el tamaño del icono"
 
+#. 3.8->settings-schema.json->thumbnail-close-button-size->tooltip
 #. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
 #, fuzzy
 msgid "Controls how large the thumbnail close button is."
 msgstr "Permitir que los temas controlen el botón de cierre de miniaturas"
 
-#. 3.4->settings-schema.json->middle-click-action->description
-#. 3.4->settings-schema.json->middle-click-action->tooltip
-msgid "Middle click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Launch new app instance"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Close last focused window in group"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->description
-msgid "Mouse wheel scroll behavior"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->tooltip
-msgid ""
-"Choose if scrolling the mouse wheel cycles running apps, an app button's "
-"windows on hover, or is disabled."
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->options
-msgid "Cycle apps"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->thumbnail-padding->description
+#. 3.4->settings-schema.json->thumbnail-padding->description
 #, fuzzy
-msgid "Cycle windows"
-msgstr "Incluir todas las ventanas de la aplicación"
+msgid "Thumbnail padding"
+msgstr "Configuración de Miniaturas"
 
-#. 3.4->settings-schema.json->show-all-workspaces->description
-#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#. 3.8->settings-schema.json->thumbnail-padding->tooltip
+#. 3.4->settings-schema.json->thumbnail-padding->tooltip
 #, fuzzy
-msgid "Show windows from all workspaces"
-msgstr "Mostrar en todas las áreas de trabajo"
+msgid "Controls how much space will be around the window preview thumbnails."
+msgstr "Cuanto relleno poner entre los iconos"
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->description
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
 msgid "Cycle windows on mouse wheel scroll"
 msgstr ""
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->tooltip
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
 msgid ""
 "Choose whether or not scrolling the mouse wheel cycles windows when hovering "
 "over a thumbnail menu."
 msgstr ""
 
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "Toggle activation of last focused window"
-msgstr ""
-
-#. IcingTaskManager@json->metadata.json->name
-msgid "Icing Task Manager"
-msgstr "Icing Task Manager"
-
-#. IcingTaskManager@json->metadata.json->description
+#. 3.8->settings-schema.json->show-icons->description
+#. 3.4->settings-schema.json->show-icons->description
 #, fuzzy
-msgid "Window list with app grouping and thumbnails"
+msgid "Show icons"
+msgstr "Sin iconos"
+
+#. 3.8->settings-schema.json->show-icons->tooltip
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
 msgstr ""
-"Lista de ventanas con agrupación de aplicaciones y miniaturas de ventanas"
+
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->description
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
+msgid "Highlight the last focused window within an app group"
+msgstr ""
+
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+msgid ""
+"When enabled, the last window that was interacted with will be indicated."
+msgstr ""
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->description
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "Mostrar la opción de inicio automático"
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->tooltip
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->units
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->description
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->tooltip
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.8->settings-schema.json->mintYPreset->description
+#. 3.8->settings-schema.json->mintYPreset->tooltip
+#. 3.4->settings-schema.json->mintYPreset->description
+#. 3.4->settings-schema.json->mintYPreset->tooltip
+msgid "Mint Y and Variants"
+msgstr ""
+
+#. 3.8->settings-schema.json->mintXPreset->description
+#. 3.8->settings-schema.json->mintXPreset->tooltip
+#. 3.4->settings-schema.json->mintXPreset->description
+#. 3.4->settings-schema.json->mintXPreset->tooltip
+msgid "Mint X, Linux Mint, and Variants"
+msgstr ""
+
+#. 3.8->settings-schema.json->migrationButton->description
+msgid "Migrate Pinned Apps to Grouped Window List"
+msgstr ""
 
 # Should not be set, just leave it blank by setting one white-space character
 #~ msgid "number"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/fr.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-10 00:43-0600\n"
+"POT-Creation-Date: 2018-12-13 18:37-0600\n"
 "PO-Revision-Date: 2018-05-16 13:55+0200\n"
 "Last-Translator: claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -18,53 +18,52 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: 3.8/applet.js:471
-msgid "Icing Task Manager is now Grouped Window List"
+#: 3.8/applet.js:476
+msgid "Icing Task Manager is deprecated"
 msgstr ""
 
-#: 3.8/applet.js:472
+#: 3.8/applet.js:477
 msgid ""
-"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
-"Window List\". "
+"Please upgrade to Grouped Window List for a more stable, bug-free experience."
 msgstr ""
 
-#: 3.8/applet.js:473
+#: 3.8/applet.js:478
 msgid ""
-"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
-"List."
+"Add GWL to your panel, open the applet's settings and click \"Migrate Pinned "
+"Apps to Grouped Window List\"."
 msgstr ""
 
-#: 3.8/applet.js:485
-msgid "Migration can only be performed on Cinnamon 4.0."
+#: 3.8/applet.js:490
+msgid "Migration can only be performed on Cinnamon 4.0+."
 msgstr ""
 
-#: 3.8/applet.js:496
+#: 3.8/applet.js:501
 msgid ""
 "Please add Grouped Window List to a panel before proceeding with the "
 "migration."
 msgstr ""
 
-#: 3.8/applet.js:504
+#: 3.8/applet.js:509
 msgid "ITM settings directory could not be found!"
 msgstr ""
 
-#: 3.8/applet.js:534
+#: 3.8/applet.js:539
 msgid "System favorites enabled - no migration is needed."
 msgstr ""
 
-#: 3.8/applet.js:577
+#: 3.8/applet.js:582
 msgid "Unable to find a suitable ITM settings file to migrate."
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid "Migration complete. "
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid " settings file(s) could not be migrated."
 msgstr ""
 
-#: 3.8/applet.js:592
+#: 3.8/applet.js:597
 msgid "Migration was successful."
 msgstr ""
 

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/fr.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/fr.po
@@ -7,638 +7,317 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-15 16:32+0200\n"
+"POT-Creation-Date: 2018-12-10 00:43-0600\n"
 "PO-Revision-Date: 2018-05-16 13:55+0200\n"
+"Last-Translator: claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: claudiux <claude.clerc@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Language: fr\n"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/applet.js:471
+msgid "Icing Task Manager is now Grouped Window List"
+msgstr ""
+
+#: 3.8/applet.js:472
+msgid ""
+"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
+"Window List\". "
+msgstr ""
+
+#: 3.8/applet.js:473
+msgid ""
+"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
+"List."
+msgstr ""
+
+#: 3.8/applet.js:485
+msgid "Migration can only be performed on Cinnamon 4.0."
+msgstr ""
+
+#: 3.8/applet.js:496
+msgid ""
+"Please add Grouped Window List to a panel before proceeding with the "
+"migration."
+msgstr ""
+
+#: 3.8/applet.js:504
+msgid "ITM settings directory could not be found!"
+msgstr ""
+
+#: 3.8/applet.js:534
+msgid "System favorites enabled - no migration is needed."
+msgstr ""
+
+#: 3.8/applet.js:577
+msgid "Unable to find a suitable ITM settings file to migrate."
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid "Migration complete. "
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid " settings file(s) could not be migrated."
+msgstr ""
+
+#: 3.8/applet.js:592
+msgid "Migration was successful."
+msgstr ""
+
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to the other monitor"
 msgstr "Déplacer vers l'autre écran"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to monitor "
 msgstr "Déplacer vers l'écran"
 
-#: 3.4/specialMenus.js:126
+#: 3.8/specialMenus.js:98 3.4/specialMenus.js:126
 msgid "Only on this workspace"
 msgstr "Seulement sur cet espace de travail"
 
-#: 3.4/specialMenus.js:133
+#: 3.8/specialMenus.js:105 3.4/specialMenus.js:133
 msgid "Visible on all workspaces"
 msgstr "Visible dans tous les espaces de travail"
 
-#: 3.4/specialMenus.js:140
+#: 3.8/specialMenus.js:112 3.4/specialMenus.js:140
 msgid "Move to another workspace"
 msgstr "Déplacer vers un autre espace de travail"
 
-#: 3.4/specialMenus.js:168
+#: 3.8/specialMenus.js:140 3.4/specialMenus.js:168
 msgid "Places"
 msgstr "Emplacements"
 
-#: 3.4/specialMenus.js:207
+#: 3.8/specialMenus.js:179 3.4/specialMenus.js:207
 msgid "Bookmarks/History requires gir1.2-gda-5.0"
 msgstr "Le paquet gir1.2-gda-5.0 est requis pour les signets et l'historique."
 
-#: 3.4/specialMenus.js:227
+#: 3.8/specialMenus.js:199 3.4/specialMenus.js:227
 msgid "Recent"
 msgstr "Emplacements récents"
 
-#: 3.4/specialMenus.js:246
+#: 3.8/specialMenus.js:218 3.4/specialMenus.js:246
 msgid "Preferences"
 msgstr "Préférences"
 
-#: 3.4/specialMenus.js:249
+#: 3.8/specialMenus.js:221 3.4/specialMenus.js:249
 msgid "About..."
 msgstr "À propos..."
 
-#: 3.4/specialMenus.js:253
+#: 3.8/specialMenus.js:225 3.4/specialMenus.js:253
 msgid "Configure..."
 msgstr "Configurer..."
 
-#: 3.4/specialMenus.js:257
+#: 3.8/specialMenus.js:229 3.4/specialMenus.js:257
 msgid "Remove"
 msgstr "Supprimer"
 
-#: 3.4/specialMenus.js:287
+#: 3.8/specialMenus.js:259 3.4/specialMenus.js:287
 msgid "New Window"
 msgstr "Nouvelle fenêtre"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Unpin from Panel"
 msgstr "Dés-épingler de la barre des tâches"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Pin to Panel"
 msgstr "Épingler à la barre des tâches"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Remove from Autostart"
 msgstr "Retirer d'Autostart"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Add to Autostart"
 msgstr "Ajouter à l'auto-démarrage"
 
-#: 3.4/specialMenus.js:318
+#: 3.8/specialMenus.js:290 3.4/specialMenus.js:318
 msgid "Create Shortcut"
 msgstr "Créer un raccourci"
 
-#: 3.4/specialMenus.js:329
+#: 3.8/specialMenus.js:301 3.4/specialMenus.js:329
 msgid "Restore to full opacity"
 msgstr "Restaurer en pleine opacité"
 
-#: 3.4/specialMenus.js:337
+#: 3.8/specialMenus.js:309 3.4/specialMenus.js:337
 msgid "Restore"
 msgstr "Restaurer"
 
-#: 3.4/specialMenus.js:342
+#: 3.8/specialMenus.js:314 3.4/specialMenus.js:342
 msgid "Minimize"
 msgstr "Minimiser"
 
-#: 3.4/specialMenus.js:350
+#: 3.8/specialMenus.js:322 3.4/specialMenus.js:350
 msgid "Unmaximize"
 msgstr "Restaurer"
 
-#: 3.4/specialMenus.js:355
+#: 3.8/specialMenus.js:327 3.4/specialMenus.js:355
 msgid "Maximize"
 msgstr "Maximiser"
 
-#: 3.4/specialMenus.js:365
+#: 3.8/specialMenus.js:337 3.4/specialMenus.js:365
 msgid "Close others"
 msgstr "Fermer les autres"
 
-#: 3.4/specialMenus.js:375
+#: 3.8/specialMenus.js:347 3.4/specialMenus.js:375
 msgid "Close all"
 msgstr "Tout fermer"
 
-#: 3.4/specialMenus.js:385
+#: 3.8/specialMenus.js:357 3.4/specialMenus.js:385
 msgid "Close"
 msgstr "Fermer"
 
-#. 2.8->settings-schema.json->thumbnail-size->description
-#. 3.4->settings-schema.json->thumbnail-size->description
-msgid "Thumbnail size"
-msgstr "Taille des miniatures"
-
-#. 2.8->settings-schema.json->thumbnail-size->tooltip
-#. 3.4->settings-schema.json->thumbnail-size->tooltip
-msgid "Controls the size of the thumbnails."
-msgstr "Contrôle la taille des miniatures."
-
-#. 2.8->settings-schema.json->thumbnail-size->units
-#. 3.4->settings-schema.json->thumbnail-size->units
-msgid "size"
-msgstr "taille"
-
-#. 2.8->settings-schema.json->focusPseudoClass->description
-#. 3.4->settings-schema.json->focusPseudoClass->description
-msgid "App button focus pseudo class"
-msgstr "Effet désiré sur le bouton d'une application lorsque celui-ci est cliqué"
-
-#. 2.8->settings-schema.json->focusPseudoClass->tooltip
-#. 3.4->settings-schema.json->focusPseudoClass->tooltip
-msgid "Overrides the pseudo class for app button on focus."
-msgstr "Remplace l'effet standard appliqué au bouton d'une application sur lequel on clique."
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "active"
-msgstr "active"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "outlined"
-msgstr "souligné"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "hover"
-msgstr "flottant"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "focus"
-msgstr "focus"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "selected"
-msgstr "sélectionné"
-
-#. 2.8->settings-schema.json->icon-spacing->description
-#. 3.4->settings-schema.json->icon-spacing->description
-msgid "Icon spacing"
-msgstr "Espacement des icônes"
-
-#. 2.8->settings-schema.json->icon-spacing->tooltip
-#. 3.4->settings-schema.json->icon-spacing->tooltip
-msgid "Controls how much space is between the icons."
-msgstr "Contrôle l'espace entre les icônes."
-
-#. 2.8->settings-schema.json->icon-spacing->units
-#. 2.8->settings-schema.json->icon-size->units
-#. 2.8->settings-schema.json->icon-padding->units
-#. 3.4->settings-schema.json->icon-spacing->units
-#. 3.4->settings-schema.json->thumbnail-padding->units
-#. 3.4->settings-schema.json->icon-size->units
-#. 3.4->settings-schema.json->app-button-width->units
-#. 3.4->settings-schema.json->thumbnail-close-button-size->units
-#. 3.4->settings-schema.json->icon-padding->units
-msgid "px"
-msgstr "px"
-
-#. 2.8->settings-schema.json->show-thumbnails->description
-#. 3.4->settings-schema.json->show-thumbnails->description
-msgid "Show thumbnails"
-msgstr "Afficher les miniatures"
-
-#. 2.8->settings-schema.json->show-thumbnails->tooltip
-#. 3.4->settings-schema.json->show-thumbnails->tooltip
-msgid "Show window thumbnails when hovering over an app button."
-msgstr "Afficher la fenêtre en miniature au survol du bouton de l'application"
-
-#. 2.8->settings-schema.json->icon-size->description
-#. 3.4->settings-schema.json->icon-size->description
-msgid "Icon size"
-msgstr "Taille des icônes"
-
-#. 2.8->settings-schema.json->icon-size->tooltip
-#. 3.4->settings-schema.json->icon-size->tooltip
-msgid "Set icon size"
-msgstr "Ajustez la taille des icônes (indépendamment de la taille du panneau)"
-
-#. 2.8->settings-schema.json->hover-peek-time->description
-#. 3.4->settings-schema.json->hover-peek-time->description
-msgid "Window fade time"
-msgstr "Durée de l'animation"
-
-#. 2.8->settings-schema.json->hover-peek-time->tooltip
-#. 3.4->settings-schema.json->hover-peek-time->tooltip
-msgid "Controls how quickly a window will fade on hover."
-msgstr "Contrôle la vitesse à laquelle une fenêtre s'estompera après survol de la souris."
-
-#. 2.8->settings-schema.json->hover-peek-time->units
-#. 2.8->settings-schema.json->thumbnail-timeout->units
-#. 2.8->settings-schema.json->show-apps-order-timeout->units
-#. 3.4->settings-schema.json->hover-peek-time->units
-#. 3.4->settings-schema.json->thumbnail-timeout->units
-#. 3.4->settings-schema.json->show-apps-order-timeout->units
-msgid "milliseconds"
-msgstr "millisecondes"
-
-#. 2.8->settings-schema.json->close-button-style->description
-msgid "Allow themes to control the thumbnail close button"
-msgstr "Autoriser les thèmes à contrôler l'aspect du bouton de fermeture des miniatures"
-
-#. 2.8->settings-schema.json->close-button-style->tooltip
-msgid "Controls whether or not the theme controls the window thumbnail's close button."
-msgstr "Indique si oui ou non le thème peut contrôler l'aspect du bouton de fermeture dans la miniature d'une fenêtre."
-
-#. 2.8->settings-schema.json->title-display->description
-#. 3.4->settings-schema.json->title-display->description
-msgid "Title display"
-msgstr "Affichage du libellé de l'application"
-
-#. 2.8->settings-schema.json->title-display->tooltip
-#. 3.4->settings-schema.json->title-display->tooltip
-msgid "focused: show focused window title, title: display the window title, app: diplay app name, none: don't display anything"
-msgstr "Désactivé : N'affiche aucun libellé. Application: Affiche le nom de l'application. Active: Affiche le titre de l'application active. Titre: Affiche le titre de l'application."
-
-#. 2.8->settings-schema.json->title-display->options
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-#. 3.4->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->middle-click-action->options
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "None"
-msgstr "Désactivé"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Focused"
-msgstr "Active"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "App"
-msgstr "Application"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Title"
-msgstr "Titre"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->description
-#. 3.4->settings-schema.json->hoverPseudoClass->description
-msgid "App button hover pseudo class"
-msgstr "Effet désiré sur le bouton d'une application lorsque celui-ci est survolé"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
-#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons on hover."
-msgstr "Remplace l'effet standard appliqué au bouton d'une application lorsqu'il est survolé"
-
-#. 2.8->settings-schema.json->show-alerts->description
-#. 3.4->settings-schema.json->show-alerts->description
-msgid "Show app alerts and notifications"
-msgstr "Afficher les alertes et notifications des applications"
-
-#. 2.8->settings-schema.json->show-alerts->tooltip
-#. 3.4->settings-schema.json->show-alerts->tooltip
-msgid "If enabled, notifications and alerts will appear."
-msgstr "Activer cette option permet d'afficher des notifications et des alertes."
-
-#. 2.8->settings-schema.json->pinOnDrag->description
-#. 2.8->settings-schema.json->pinOnDrag->tooltip
-#. 3.4->settings-schema.json->pinOnDrag->description
-#. 3.4->settings-schema.json->pinOnDrag->tooltip
-msgid "Pin apps when dragged to a new position"
-msgstr "Épingler les applications déplacées vers une nouvelle position"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->description
-#. 3.4->settings-schema.json->show-apps-order-hotkey->description
-msgid "Global hotkey to show the order of apps"
-msgstr "Touche de raccourci pour afficher l'ordre des applications"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
-#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
-msgid "When triggered, the window count label will be replaced with its order in the app list temporarily."
-msgstr "Si ceci est coché, l'étiquette du compteur de fenêtres sera remplacée temporairement par son ordre dans la liste des applications."
-
-#. 2.8->settings-schema.json->menuItemType->description
-#. 3.4->settings-schema.json->menuItemType->description
-msgid "Menu item type"
-msgstr "Type d'élément de menu"
-
-#. 2.8->settings-schema.json->menuItemType->tooltip
-#. 3.4->settings-schema.json->menuItemType->tooltip
-msgid "Determines whether menu item icons are symbolic, non-symbolic, or not shown."
-msgstr "Détermine si les icônes des éléments de menu sont symboliques, non symboliques ou non affichées."
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Symbolic icons"
-msgstr "Icônes symboliques"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "No icons"
-msgstr "Aucune icône"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Non-symbolic icons"
-msgstr "Icônes non symboliques"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->description
-#. 3.4->settings-schema.json->hover-peek-opacity->description
-msgid "Window opacity"
-msgstr "Opacité des fenêtres non survolées par la souris"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
-#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
-msgid "Opacity of the windows on hover."
-msgstr "Opacité des fenêtres au survol de la souris."
-
-#. 2.8->settings-schema.json->hover-peek-opacity->units
-#. 3.4->settings-schema.json->hover-peek-opacity->units
-msgid "percent"
-msgstr "%"
-
-#. 2.8->settings-schema.json->enable-hover-peek->description
-#. 3.4->settings-schema.json->enable-hover-peek->description
-msgid "Show windows when hovered over"
-msgstr "Afficher la fenêtre dont la miniature est survolée"
-
-#. 2.8->settings-schema.json->enable-hover-peek->tooltip
-#. 3.4->settings-schema.json->enable-hover-peek->tooltip
-msgid "Controls whether or not windows display when hovered over."
-msgstr "Contrôle si la fenêtre s'affiche ou non lorsque sa miniature est survolée."
-
-#. 2.8->settings-schema.json->activePseudoClass->description
-#. 3.4->settings-schema.json->activePseudoClass->description
-msgid "App button active pseudo class"
-msgstr "Effet désiré sur le bouton d'une application active"
-
-#. 2.8->settings-schema.json->activePseudoClass->tooltip
-#. 3.4->settings-schema.json->activePseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons when they are active."
-msgstr "Remplace l'effet standard appliqué au bouton d'une application active."
-
-#. 2.8->settings-schema.json->animate-thumbnails->description
-#. 3.4->settings-schema.json->animate-thumbnails->description
-msgid "Animate thumbnails"
-msgstr "Animer les miniatures"
-
-#. 2.8->settings-schema.json->animate-thumbnails->tooltip
-#. 3.4->settings-schema.json->animate-thumbnails->tooltip
-msgid "If enabled, thumbnails will animate when appearing and disappearing."
-msgstr "Si cette option est activée, les miniatures s'animeront avec effet lors de leur apparition ou disparition."
-
-#. 2.8->settings-schema.json->autostart-menu-item->description
-#. 3.4->settings-schema.json->autostart-menu-item->description
-msgid "Show autostart option"
-msgstr "Afficher l'option de démarrage automatique"
-
-#. 2.8->settings-schema.json->autostart-menu-item->tooltip
-#. 3.4->settings-schema.json->autostart-menu-item->tooltip
-msgid "Shows the autostart toggle option in an app's context menu."
-msgstr "Affiche l'option de basculement Démarrage Automatique dans le menu contextuel d'une application."
-
-#. 2.8->settings-schema.json->show-pinned->description
-#. 3.4->settings-schema.json->show-pinned->description
-msgid "Show pinned apps"
-msgstr "Afficher les applications épinglées"
-
-#. 2.8->settings-schema.json->show-pinned->tooltip
-#. 3.4->settings-schema.json->show-pinned->tooltip
-msgid "Controls whether or not the pinned apps appear in the panel if they are not open."
-msgstr "Contrôle si les applications épinglées apparaissent dans le panneau lorsqu'elles ne sont pas ouvertes."
-
-#. 2.8->settings-schema.json->useSystemTooltips->description
-msgid "Use system tooltips for closed apps"
-msgstr "Utiliser les info-bulles système pour les applications fermées"
-
-#. 2.8->settings-schema.json->useSystemTooltips->tooltip
-msgid "Controls whether or not system tooltips are in use when hovering over closed pinned apps."
-msgstr "Contrôle si les info-bulles du système sont utilisées lors du survol des applications fermées."
-
-#. 2.8->settings-schema.json->WindowList->description
-msgid "Window List Settings"
-msgstr "Paramètres de la liste des applications"
-
-#. 2.8->settings-schema.json->AppMenu->description
-msgid "Context Menu Settings"
-msgstr "Paramètres du menu contextuel"
-
-#. 2.8->settings-schema.json->Thumbnails->description
-msgid "Thumbnail Settings"
-msgstr "Paramètres des miniatures"
-
-#. 2.8->settings-schema.json->show-recent->description
-#. 3.4->settings-schema.json->show-recent->description
-msgid "Show recent items"
-msgstr "Afficher les emplacements récents dans le menu"
-
-#. 2.8->settings-schema.json->show-recent->tooltip
-#. 3.4->settings-schema.json->show-recent->tooltip
-msgid "Controls whether recent items will appear in the context menu."
-msgstr "Contrôle si les éléments récents apparaissent dans le menu contextuel."
-
-#. 2.8->settings-schema.json->vertical-thumbnails->description
-#. 3.4->settings-schema.json->vertical-thumbnails->description
-msgid "Enable vertical thumbnails"
-msgstr "Afficher verticalement les miniatures"
-
-#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
-#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
-msgid "If enabled, thumbnails will stack vertically."
-msgstr "Lorsque cette option est activée, les miniatures s'empilent verticalement."
-
-#. 2.8->settings-schema.json->thumbnail-timeout->description
-#. 3.4->settings-schema.json->thumbnail-timeout->description
-msgid "Thumbnail timeout"
-msgstr "Durée d'affichage des miniatures"
-
-#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
-#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
-msgid "Controls how quickly an app's set of window thumbnails will fade out when the mouse leaves the app button."
-msgstr "Contrôle la vitesse à laquelle l'ensemble des miniatures de fenêtre d'une application disparaîtra lorsque la souris quittera le bouton de l'application."
-
-#. 2.8->settings-schema.json->ThemeSettings->description
-msgid "Theme Settings"
-msgstr "Préférences de thème"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->description
-#. 3.4->settings-schema.json->onclick-thumbnails->description
-msgid "Open thumbnails on click"
-msgstr "Ouvrir les miniatures via un clic de souris"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
-#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
-msgid "Open the thumbnails on click if there is more than one window open."
-msgstr "Ouvrir les miniatures via un clic de souris, si il y a plus d'une fenêtre ouverte"
-
-#. 2.8->settings-schema.json->panelLauncherClass->description
-msgid "Use the panel launcher class for pinned apps"
-msgstr "Utiliser la classe de lanceur de panneau pour les applications épinglées"
-
-#. 2.8->settings-schema.json->panelLauncherClass->tooltip
-msgid "Enabling this helps with certain themes."
-msgstr "L'activation de cette fonction peut aider avec certains thèmes."
-
-#. 2.8->settings-schema.json->include-all-windows->description
-#. 3.4->settings-schema.json->include-all-windows->description
-msgid "Include all app windows"
-msgstr "Inclure toutes les fenêtres de l'application"
-
-#. 2.8->settings-schema.json->include-all-windows->tooltip
-#. 3.4->settings-schema.json->include-all-windows->tooltip
-msgid "Controls whether or not thumbnails for smalller child windows, such as exit confirmations and file dialogues will be included in the thumbnail list."
-msgstr "Contrôle si les miniatures des sous-fenêtres, telles que les confirmations de sortie et les dialogues de fichiers, seront incluses dans la liste des vignettes."
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->description
-#. 3.4->settings-schema.json->cycleMenusHotkey->description
-msgid "Global hotkey for cycling through thumbnail menus"
-msgstr "Touche de raccourci pour parcourir les menus de miniatures"
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
-#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
-msgid "This allows you to cycle through the menus without activating a window."
-msgstr "Cela vous permet de faire défiler les menus sans activer de fenêtre."
-
-#. 2.8->settings-schema.json->enable-iconSize->description
-#. 3.4->settings-schema.json->enable-iconSize->description
-msgid "Adjust icon size"
-msgstr "Ajuster la taille de l'icône"
-
-#. 2.8->settings-schema.json->enable-iconSize->tooltip
-#. 3.4->settings-schema.json->enable-iconSize->tooltip
-msgid "Adjust icon size independent of Cinnamon's panel scaling."
-msgstr "Ajustez la taille de l'icône indépendamment de la mise à l'échelle du panneau Cinnamon."
-
-#. 2.8->settings-schema.json->number-display->description
-#. 3.4->settings-schema.json->number-display->description
-msgid "Number display"
-msgstr "Affichage du nombre d'instances"
-
-#. 2.8->settings-schema.json->number-display->tooltip
-#. 3.4->settings-schema.json->number-display->tooltip
-msgid "normal: display window number, smart: display window number if more than one window, none: don't display number, all: display window number for favorites too"
-msgstr "Intelligent : Afficher le nombre d'instances d'une application si au moins deux instances existent. Normal : Afficher le nombre d'instances d'une application si au moins une instance existe. Désactivé : Ne pas afficher le nombre d'instances d'une application. Toujours : Toujours afficher le nombre d'instances d'une application."
-
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "All"
-msgstr "Toujours"
-
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Smart"
-msgstr "Intelligent"
-
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Normal"
-msgstr "Normal"
+#. metadata.json->description
+msgid "Window list with app grouping and thumbnails"
+msgstr "Liste de fenêtres avec regroupements d'applications et miniatures"
+
+#. metadata.json->name
+msgid "Icing Task Manager"
+msgstr ""
 
 #. 2.8->settings-schema.json->ITM->description
 msgid "ITM Settings"
 msgstr "Paramètres ITM"
 
-#. 2.8->settings-schema.json->HoverPeek->description
-msgid "Hover Peek Settings"
-msgstr "Paramètres de la mise en évidence des applications"
+#. 2.8->settings-schema.json->WindowList->description
+msgid "Window List Settings"
+msgstr "Paramètres de la liste des applications"
 
-#. 2.8->settings-schema.json->icon-padding->description
-#. 3.4->settings-schema.json->icon-padding->description
-msgid "Icon padding"
-msgstr "Espace supplémentaire entre les icônes"
+#. 2.8->settings-schema.json->number-display->description
+#. 3.8->settings-schema.json->number-display->description
+#. 3.4->settings-schema.json->number-display->description
+msgid "Number display"
+msgstr "Affichage du nombre d'instances"
 
-#. 2.8->settings-schema.json->icon-padding->tooltip
-#. 3.4->settings-schema.json->icon-padding->tooltip
-msgid "Controls how much horizontal padding is inside the app buttons. Padding is only applied to instances of this applet on horizontal panels."
-msgstr "Contrôle la quantité de rembourrage horizontal à l'intérieur des boutons de l'application. Le rembourrage est uniquement appliqué aux instances de cette applet sur des panneaux horizontaux."
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Smart"
+msgstr "Intelligent"
 
-#. 2.8->settings-schema.json->middle-click-action->description
-msgid "Middle clicking app buttons creates new app instances"
-msgstr "Un clic central sur les boutons d'application crée de nouvelles instances d'application"
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Normal"
+msgstr "Normal"
 
-#. 2.8->settings-schema.json->middle-click-action->tooltip
-msgid "Determines the behavior of middle mouse button clicks on app buttons. Setting this to false will close the last focused window from the app group on middle click."
-msgstr "Détermine le comportement des clics de bouton du milieu de la souris sur les boutons de l'application. Si vous définissez cette option sur false, la dernière fenêtre ciblée du groupe d'applications sera clôturée."
+#. 2.8->settings-schema.json->number-display->options
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "None"
+msgstr "Désactivé"
 
-#. 2.8->settings-schema.json->firefox-menu->description
-#. 3.4->settings-schema.json->firefox-menu->description
-msgid "Firefox context menu"
-msgstr "Affichage des sites dans le menu de l'application Firefox"
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "All"
+msgstr "Toujours"
 
-#. 2.8->settings-schema.json->firefox-menu->tooltip
-#. 3.4->settings-schema.json->firefox-menu->tooltip
-msgid "Most Visited: show the sites you visit most, Recent History: display the the last pages you visited, Bookmarks: show your favorite bookmarks."
-msgstr "Les plus visités : affiche les sites que vous visitez le plus. Les derniers visités : affiche les derniers sites que vous avez visité. Marque-pages : affiche vos marque-pages."
+#. 2.8->settings-schema.json->number-display->tooltip
+#. 3.8->settings-schema.json->number-display->tooltip
+#. 3.4->settings-schema.json->number-display->tooltip
+msgid ""
+"normal: display window number, smart: display window number if more than one "
+"window, none: don't display number, all: display window number for favorites "
+"too"
+msgstr ""
+"Intelligent : Afficher le nombre d'instances d'une application si au moins "
+"deux instances existent. Normal : Afficher le nombre d'instances d'une "
+"application si au moins une instance existe. Désactivé : Ne pas afficher le "
+"nombre d'instances d'une application. Toujours : Toujours afficher le nombre "
+"d'instances d'une application."
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Bookmarks"
-msgstr "Signets web"
+#. 2.8->settings-schema.json->title-display->description
+#. 3.8->settings-schema.json->title-display->description
+#. 3.4->settings-schema.json->title-display->description
+msgid "Title display"
+msgstr "Affichage du libellé de l'application"
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Most Visited"
-msgstr "Les plus visités"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "App"
+msgstr "Application"
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Recent History"
-msgstr "Historique récent"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Title"
+msgstr "Titre"
 
-#. 2.8->settings-schema.json->themePadding->description
-msgid "Use theme padding to center button icons"
-msgstr "Utiliser le rembourrage du thème pour les icônes de bouton central"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Focused"
+msgstr "Active"
 
-#. 2.8->settings-schema.json->themePadding->tooltip
-msgid "If button icons look off-centered, toggling this may help."
-msgstr "Si les icônes des boutons sont désaxées, la modification de cette option peut vous aider."
+#. 2.8->settings-schema.json->title-display->tooltip
+#. 3.8->settings-schema.json->title-display->tooltip
+#. 3.4->settings-schema.json->title-display->tooltip
+msgid ""
+"focused: show focused window title, title: display the window title, app: "
+"diplay app name, none: don't display anything"
+msgstr ""
+"Désactivé : N'affiche aucun libellé. Application: Affiche le nom de "
+"l'application. Active: Affiche le titre de l'application active. Titre: "
+"Affiche le titre de l'application."
 
 #. 2.8->settings-schema.json->group-apps->description
+#. 3.8->settings-schema.json->group-apps->description
 #. 3.4->settings-schema.json->group-apps->description
 msgid "Group apps"
 msgstr "Regrouper les applications"
 
 #. 2.8->settings-schema.json->group-apps->tooltip
+#. 3.8->settings-schema.json->group-apps->tooltip
 #. 3.4->settings-schema.json->group-apps->tooltip
 msgid "Group each app's set of windows."
 msgstr "Regroupez l'ensemble des fenêtres de chaque application."
 
-#. 2.8->settings-schema.json->show-active->description
-#. 3.4->settings-schema.json->show-active->description
-msgid "Show active app indicators"
-msgstr "Afficher les indicateurs d'applications actives"
+#. 2.8->settings-schema.json->show-alerts->description
+#. 3.8->settings-schema.json->show-alerts->description
+#. 3.4->settings-schema.json->show-alerts->description
+msgid "Show app alerts and notifications"
+msgstr "Afficher les alertes et notifications des applications"
 
-#. 2.8->settings-schema.json->show-active->tooltip
-#. 3.4->settings-schema.json->show-active->tooltip
-msgid "Active app styling will indicate if an app is active."
-msgstr "Le style de l'application active indique si une application est active."
+#. 2.8->settings-schema.json->show-alerts->tooltip
+#. 3.8->settings-schema.json->show-alerts->tooltip
+#. 3.4->settings-schema.json->show-alerts->tooltip
+msgid "If enabled, notifications and alerts will appear."
+msgstr ""
+"Activer cette option permet d'afficher des notifications et des alertes."
 
-#. 2.8->settings-schema.json->show-apps-order-timeout->description
-#. 3.4->settings-schema.json->show-apps-order-timeout->description
-msgid "Duration of the apps order display on hotkey press"
-msgstr "Durée de l'affichage des commandes d'applications en appuyant sur la touche de raccourci"
+#. 2.8->settings-schema.json->show-pinned->description
+#. 3.8->settings-schema.json->show-pinned->description
+#. 3.4->settings-schema.json->show-pinned->description
+msgid "Show pinned apps"
+msgstr "Afficher les applications épinglées"
 
-#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
-#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
-msgid "Determines the duration the window count labels are replaced with the app's order number."
-msgstr "Détermine la durée pendant laquelle les étiquettes de comptage de fenêtre sont remplacées par le numéro de commande de l'application."
+#. 2.8->settings-schema.json->show-pinned->tooltip
+#. 3.8->settings-schema.json->show-pinned->tooltip
+#. 3.4->settings-schema.json->show-pinned->tooltip
+msgid ""
+"Controls whether or not the pinned apps appear in the panel if they are not "
+"open."
+msgstr ""
+"Contrôle si les applications épinglées apparaissent dans le panneau "
+"lorsqu'elles ne sont pas ouvertes."
 
 #. 2.8->settings-schema.json->arrange-pinnedApps->description
 msgid "Arrange pinned apps"
@@ -648,250 +327,937 @@ msgstr "Pouvoir modifier l'ordre des applications"
 msgid "Arrange pinned apps into a different order."
 msgstr "Pouvoir modifier l'ordre des applications"
 
-#. 2.8->settings-schema.json->monitor-move-all-windows->description
-#. 3.4->settings-schema.json->monitor-move-all-windows->description
-msgid "Apply the monitor move option to all windows"
-msgstr "Appliquer le changement de moniteur à toutes les fenêtres de l'application"
+#. 2.8->settings-schema.json->pinOnDrag->description
+#. 2.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.8->settings-schema.json->pinOnDrag->description
+#. 3.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.4->settings-schema.json->pinOnDrag->description
+#. 3.4->settings-schema.json->pinOnDrag->tooltip
+msgid "Pin apps when dragged to a new position"
+msgstr "Épingler les applications déplacées vers une nouvelle position"
 
-#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
-#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
-msgid "When clicking \"Move to monitor\" in the context menu, this option will move all of an app's windows instead of just the last focused window from the app."
-msgstr "Lorsque vous cliquez sur \"Déplacer vers le moniteur\" dans le menu contextuel, cette option va déplacer toutes les fenêtres d'une application au lieu de la seule dernière fenêtre active de l'application."
+#. 2.8->settings-schema.json->middle-click-action->description
+msgid "Middle clicking app buttons creates new app instances"
+msgstr ""
+"Un clic central sur les boutons d'application crée de nouvelles instances "
+"d'application"
+
+#. 2.8->settings-schema.json->middle-click-action->tooltip
+msgid ""
+"Determines the behavior of middle mouse button clicks on app buttons. "
+"Setting this to false will close the last focused window from the app group "
+"on middle click."
+msgstr ""
+"Détermine le comportement des clics de bouton du milieu de la souris sur les "
+"boutons de l'application. Si vous définissez cette option sur false, la "
+"dernière fenêtre ciblée du groupe d'applications sera clôturée."
+
+#. 2.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.4->settings-schema.json->cycleMenusHotkey->description
+msgid "Global hotkey for cycling through thumbnail menus"
+msgstr "Touche de raccourci pour parcourir les menus de miniatures"
+
+#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
+msgid "This allows you to cycle through the menus without activating a window."
+msgstr "Cela vous permet de faire défiler les menus sans activer de fenêtre."
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.4->settings-schema.json->show-apps-order-hotkey->description
+msgid "Global hotkey to show the order of apps"
+msgstr "Touche de raccourci pour afficher l'ordre des applications"
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
+msgid ""
+"When triggered, the window count label will be replaced with its order in "
+"the app list temporarily."
+msgstr ""
+"Si ceci est coché, l'étiquette du compteur de fenêtres sera remplacée "
+"temporairement par son ordre dans la liste des applications."
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->units
+#. 2.8->settings-schema.json->thumbnail-timeout->units
+#. 2.8->settings-schema.json->hover-peek-time->units
+#. 3.8->settings-schema.json->show-apps-order-timeout->units
+#. 3.8->settings-schema.json->thumbnail-timeout->units
+#. 3.8->settings-schema.json->hover-peek-time->units
+#. 3.4->settings-schema.json->show-apps-order-timeout->units
+#. 3.4->settings-schema.json->thumbnail-timeout->units
+#. 3.4->settings-schema.json->hover-peek-time->units
+msgid "milliseconds"
+msgstr "millisecondes"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.4->settings-schema.json->show-apps-order-timeout->description
+msgid "Duration of the apps order display on hotkey press"
+msgstr ""
+"Durée de l'affichage des commandes d'applications en appuyant sur la touche "
+"de raccourci"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
+msgid ""
+"Determines the duration the window count labels are replaced with the app's "
+"order number."
+msgstr ""
+"Détermine la durée pendant laquelle les étiquettes de comptage de fenêtre "
+"sont remplacées par le numéro de commande de l'application."
+
+#. 2.8->settings-schema.json->Thumbnails->description
+msgid "Thumbnail Settings"
+msgstr "Paramètres des miniatures"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->description
+#. 3.8->settings-schema.json->thumbnail-timeout->description
+#. 3.4->settings-schema.json->thumbnail-timeout->description
+msgid "Thumbnail timeout"
+msgstr "Durée d'affichage des miniatures"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
+msgid ""
+"Controls how quickly an app's set of window thumbnails will fade out when "
+"the mouse leaves the app button."
+msgstr ""
+"Contrôle la vitesse à laquelle l'ensemble des miniatures de fenêtre d'une "
+"application disparaîtra lorsque la souris quittera le bouton de "
+"l'application."
+
+#. 2.8->settings-schema.json->thumbnail-size->units
+#. 3.8->settings-schema.json->thumbnail-size->units
+#. 3.4->settings-schema.json->thumbnail-size->units
+msgid "size"
+msgstr "taille"
+
+#. 2.8->settings-schema.json->thumbnail-size->description
+#. 3.8->settings-schema.json->thumbnail-size->description
+#. 3.4->settings-schema.json->thumbnail-size->description
+msgid "Thumbnail size"
+msgstr "Taille des miniatures"
+
+#. 2.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-size->tooltip
+msgid "Controls the size of the thumbnails."
+msgstr "Contrôle la taille des miniatures."
+
+#. 2.8->settings-schema.json->show-thumbnails->description
+#. 3.8->settings-schema.json->show-thumbnails->description
+#. 3.4->settings-schema.json->show-thumbnails->description
+msgid "Show thumbnails"
+msgstr "Afficher les miniatures"
+
+#. 2.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.4->settings-schema.json->show-thumbnails->tooltip
+msgid "Show window thumbnails when hovering over an app button."
+msgstr "Afficher la fenêtre en miniature au survol du bouton de l'application"
+
+#. 2.8->settings-schema.json->animate-thumbnails->description
+#. 3.8->settings-schema.json->animate-thumbnails->description
+#. 3.4->settings-schema.json->animate-thumbnails->description
+msgid "Animate thumbnails"
+msgstr "Animer les miniatures"
+
+#. 2.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.4->settings-schema.json->animate-thumbnails->tooltip
+msgid "If enabled, thumbnails will animate when appearing and disappearing."
+msgstr ""
+"Si cette option est activée, les miniatures s'animeront avec effet lors de "
+"leur apparition ou disparition."
+
+#. 2.8->settings-schema.json->vertical-thumbnails->description
+#. 3.8->settings-schema.json->vertical-thumbnails->description
+#. 3.4->settings-schema.json->vertical-thumbnails->description
+msgid "Enable vertical thumbnails"
+msgstr "Afficher verticalement les miniatures"
+
+#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
+msgid "If enabled, thumbnails will stack vertically."
+msgstr ""
+"Lorsque cette option est activée, les miniatures s'empilent verticalement."
 
 #. 2.8->settings-schema.json->sort-thumbnails->description
+#. 3.8->settings-schema.json->sort-thumbnails->description
 #. 3.4->settings-schema.json->sort-thumbnails->description
 msgid "Sort windows for each app by last focused"
-msgstr "Trier les fenêtres en mettant en premier les dernières applications actives"
+msgstr ""
+"Trier les fenêtres en mettant en premier les dernières applications actives"
 
 #. 2.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.8->settings-schema.json->sort-thumbnails->tooltip
 #. 3.4->settings-schema.json->sort-thumbnails->tooltip
-msgid "Controls whether the order windows appear for an app is by last focused, or the order they were opened."
-msgstr "Détermine si les fenêtres d'une application apparaissent dans l'ordre décroissant de leur utilisation, ou dans l'ordre dans lequel elles ont été ouvertes."
+msgid ""
+"Controls whether the order windows appear for an app is by last focused, or "
+"the order they were opened."
+msgstr ""
+"Détermine si les fenêtres d'une application apparaissent dans l'ordre "
+"décroissant de leur utilisation, ou dans l'ordre dans lequel elles ont été "
+"ouvertes."
 
-#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->onclick-thumbnails->description
+#. 3.8->settings-schema.json->onclick-thumbnails->description
+#. 3.4->settings-schema.json->onclick-thumbnails->description
+msgid "Open thumbnails on click"
+msgstr "Ouvrir les miniatures via un clic de souris"
+
+#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
+msgid "Open the thumbnails on click if there is more than one window open."
+msgstr ""
+"Ouvrir les miniatures via un clic de souris, si il y a plus d'une fenêtre "
+"ouverte"
+
+#. 2.8->settings-schema.json->include-all-windows->description
+#. 3.8->settings-schema.json->include-all-windows->description
+#. 3.4->settings-schema.json->include-all-windows->description
+msgid "Include all app windows"
+msgstr "Inclure toutes les fenêtres de l'application"
+
+#. 2.8->settings-schema.json->include-all-windows->tooltip
+#. 3.8->settings-schema.json->include-all-windows->tooltip
+#. 3.4->settings-schema.json->include-all-windows->tooltip
+msgid ""
+"Controls whether or not thumbnails for smalller child windows, such as exit "
+"confirmations and file dialogues will be included in the thumbnail list."
+msgstr ""
+"Contrôle si les miniatures des sous-fenêtres, telles que les confirmations "
+"de sortie et les dialogues de fichiers, seront incluses dans la liste des "
+"vignettes."
+
+#. 2.8->settings-schema.json->AppMenu->description
+msgid "Context Menu Settings"
+msgstr "Paramètres du menu contextuel"
+
+#. 2.8->settings-schema.json->show-recent->description
+#. 3.8->settings-schema.json->show-recent->description
+#. 3.4->settings-schema.json->show-recent->description
+msgid "Show recent items"
+msgstr "Afficher les emplacements récents dans le menu"
+
+#. 2.8->settings-schema.json->show-recent->tooltip
+#. 3.8->settings-schema.json->show-recent->tooltip
+#. 3.4->settings-schema.json->show-recent->tooltip
+msgid "Controls whether recent items will appear in the context menu."
+msgstr "Contrôle si les éléments récents apparaissent dans le menu contextuel."
+
+#. 2.8->settings-schema.json->menuItemType->description
+#. 3.8->settings-schema.json->menuItemType->description
+#. 3.4->settings-schema.json->menuItemType->description
+msgid "Menu item type"
+msgstr "Type d'élément de menu"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Symbolic icons"
+msgstr "Icônes symboliques"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Non-symbolic icons"
+msgstr "Icônes non symboliques"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "No icons"
+msgstr "Aucune icône"
+
+#. 2.8->settings-schema.json->menuItemType->tooltip
+#. 3.8->settings-schema.json->menuItemType->tooltip
+#. 3.4->settings-schema.json->menuItemType->tooltip
+msgid ""
+"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
+msgstr ""
+"Détermine si les icônes des éléments de menu sont symboliques, non "
+"symboliques ou non affichées."
+
+#. 2.8->settings-schema.json->firefox-menu->description
+#. 3.8->settings-schema.json->firefox-menu->description
+#. 3.4->settings-schema.json->firefox-menu->description
+msgid "Firefox context menu"
+msgstr "Affichage des sites dans le menu de l'application Firefox"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Most Visited"
+msgstr "Les plus visités"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Recent History"
+msgstr "Historique récent"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Bookmarks"
+msgstr "Signets web"
+
+#. 2.8->settings-schema.json->firefox-menu->tooltip
+#. 3.8->settings-schema.json->firefox-menu->tooltip
+#. 3.4->settings-schema.json->firefox-menu->tooltip
+msgid ""
+"Most Visited: show the sites you visit most, Recent History: display the the "
+"last pages you visited, Bookmarks: show your favorite bookmarks."
+msgstr ""
+"Les plus visités : affiche les sites que vous visitez le plus. Les derniers "
+"visités : affiche les derniers sites que vous avez visité. Marque-pages : "
+"affiche vos marque-pages."
+
+#. 2.8->settings-schema.json->autostart-menu-item->description
+#. 3.8->settings-schema.json->autostart-menu-item->description
+#. 3.4->settings-schema.json->autostart-menu-item->description
+msgid "Show autostart option"
+msgstr "Afficher l'option de démarrage automatique"
+
+#. 2.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.4->settings-schema.json->autostart-menu-item->tooltip
+msgid "Shows the autostart toggle option in an app's context menu."
+msgstr ""
+"Affiche l'option de basculement Démarrage Automatique dans le menu "
+"contextuel d'une application."
+
+#. 2.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.4->settings-schema.json->monitor-move-all-windows->description
+msgid "Apply the monitor move option to all windows"
+msgstr ""
+"Appliquer le changement de moniteur à toutes les fenêtres de l'application"
+
+#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
+msgid ""
+"When clicking \"Move to monitor\" in the context menu, this option will move "
+"all of an app's windows instead of just the last focused window from the app."
+msgstr ""
+"Lorsque vous cliquez sur \"Déplacer vers le moniteur\" dans le menu "
+"contextuel, cette option va déplacer toutes les fenêtres d'une application "
+"au lieu de la seule dernière fenêtre active de l'application."
+
+#. 2.8->settings-schema.json->HoverPeek->description
+msgid "Hover Peek Settings"
+msgstr "Paramètres de la mise en évidence des applications"
+
+#. 2.8->settings-schema.json->enable-hover-peek->description
+#. 3.8->settings-schema.json->enable-hover-peek->description
+#. 3.4->settings-schema.json->enable-hover-peek->description
+msgid "Show windows when hovered over"
+msgstr "Afficher la fenêtre dont la miniature est survolée"
+
+#. 2.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.4->settings-schema.json->enable-hover-peek->tooltip
+msgid "Controls whether or not windows display when hovered over."
+msgstr ""
+"Contrôle si la fenêtre s'affiche ou non lorsque sa miniature est survolée."
+
+#. 2.8->settings-schema.json->hover-peek-time->description
+#. 3.8->settings-schema.json->hover-peek-time->description
+#. 3.4->settings-schema.json->hover-peek-time->description
+msgid "Window fade time"
+msgstr "Durée de l'animation"
+
+#. 2.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.4->settings-schema.json->hover-peek-time->tooltip
+msgid "Controls how quickly a window will fade on hover."
+msgstr ""
+"Contrôle la vitesse à laquelle une fenêtre s'estompera après survol de la "
+"souris."
+
+#. 2.8->settings-schema.json->hover-peek-opacity->units
+#. 3.8->settings-schema.json->hover-peek-opacity->units
+#. 3.4->settings-schema.json->hover-peek-opacity->units
+msgid "percent"
+msgstr "%"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->description
+#. 3.8->settings-schema.json->hover-peek-opacity->description
+#. 3.4->settings-schema.json->hover-peek-opacity->description
+msgid "Window opacity"
+msgstr "Opacité des fenêtres non survolées par la souris"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
+msgid "Opacity of the windows on hover."
+msgstr "Opacité des fenêtres au survol de la souris."
+
+#. 2.8->settings-schema.json->ThemeSettings->description
+msgid "Theme Settings"
+msgstr "Préférences de thème"
+
+#. 2.8->settings-schema.json->show-active->description
+#. 3.8->settings-schema.json->show-active->description
+#. 3.4->settings-schema.json->show-active->description
+msgid "Show active app indicators"
+msgstr "Afficher les indicateurs d'applications actives"
+
+#. 2.8->settings-schema.json->show-active->tooltip
+#. 3.8->settings-schema.json->show-active->tooltip
+#. 3.4->settings-schema.json->show-active->tooltip
+msgid "Active app styling will indicate if an app is active."
+msgstr ""
+"Le style de l'application active indique si une application est active."
+
+#. 2.8->settings-schema.json->icon-spacing->units
+#. 2.8->settings-schema.json->icon-padding->units
+#. 2.8->settings-schema.json->icon-size->units
+#. 3.8->settings-schema.json->app-button-width->units
+#. 3.8->settings-schema.json->thumbnail-close-button-size->units
+#. 3.8->settings-schema.json->thumbnail-padding->units
+#. 3.8->settings-schema.json->icon-spacing->units
+#. 3.8->settings-schema.json->icon-padding->units
+#. 3.8->settings-schema.json->icon-size->units
+#. 3.4->settings-schema.json->app-button-width->units
+#. 3.4->settings-schema.json->thumbnail-close-button-size->units
+#. 3.4->settings-schema.json->thumbnail-padding->units
+#. 3.4->settings-schema.json->icon-spacing->units
+#. 3.4->settings-schema.json->icon-padding->units
+#. 3.4->settings-schema.json->icon-size->units
+msgid "px"
+msgstr "px"
+
+#. 2.8->settings-schema.json->icon-spacing->description
+#. 3.8->settings-schema.json->icon-spacing->description
+#. 3.4->settings-schema.json->icon-spacing->description
+msgid "Icon spacing"
+msgstr "Espacement des icônes"
+
+#. 2.8->settings-schema.json->icon-spacing->tooltip
+#. 3.8->settings-schema.json->icon-spacing->tooltip
+#. 3.4->settings-schema.json->icon-spacing->tooltip
+msgid "Controls how much space is between the icons."
+msgstr "Contrôle l'espace entre les icônes."
+
+#. 2.8->settings-schema.json->icon-padding->description
+#. 3.8->settings-schema.json->icon-padding->description
+#. 3.4->settings-schema.json->icon-padding->description
+msgid "Icon padding"
+msgstr "Espace supplémentaire entre les icônes"
+
+#. 2.8->settings-schema.json->icon-padding->tooltip
+#. 3.8->settings-schema.json->icon-padding->tooltip
+#. 3.4->settings-schema.json->icon-padding->tooltip
+msgid ""
+"Controls how much horizontal padding is inside the app buttons. Padding is "
+"only applied to instances of this applet on horizontal panels."
+msgstr ""
+"Contrôle la quantité de rembourrage horizontal à l'intérieur des boutons de "
+"l'application. Le rembourrage est uniquement appliqué aux instances de cette "
+"applet sur des panneaux horizontaux."
+
+#. 2.8->settings-schema.json->themePadding->description
+msgid "Use theme padding to center button icons"
+msgstr "Utiliser le rembourrage du thème pour les icônes de bouton central"
+
+#. 2.8->settings-schema.json->themePadding->tooltip
+msgid "If button icons look off-centered, toggling this may help."
+msgstr ""
+"Si les icônes des boutons sont désaxées, la modification de cette option "
+"peut vous aider."
+
+#. 2.8->settings-schema.json->enable-iconSize->description
+#. 3.8->settings-schema.json->enable-iconSize->description
+#. 3.4->settings-schema.json->enable-iconSize->description
+msgid "Adjust icon size"
+msgstr "Ajuster la taille de l'icône"
+
+#. 2.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.4->settings-schema.json->enable-iconSize->tooltip
+msgid "Adjust icon size independent of Cinnamon's panel scaling."
+msgstr ""
+"Ajustez la taille de l'icône indépendamment de la mise à l'échelle du "
+"panneau Cinnamon."
+
+#. 2.8->settings-schema.json->icon-size->description
+#. 3.8->settings-schema.json->icon-size->description
+#. 3.4->settings-schema.json->icon-size->description
+msgid "Icon size"
+msgstr "Taille des icônes"
+
+#. 2.8->settings-schema.json->icon-size->tooltip
+#. 3.8->settings-schema.json->icon-size->tooltip
+#. 3.4->settings-schema.json->icon-size->tooltip
+msgid "Set icon size"
+msgstr "Ajustez la taille des icônes (indépendamment de la taille du panneau)"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->description
+#. 3.8->settings-schema.json->hoverPseudoClass->description
+#. 3.4->settings-schema.json->hoverPseudoClass->description
+msgid "App button hover pseudo class"
+msgstr ""
+"Effet désiré sur le bouton d'une application lorsque celui-ci est survolé"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
 #. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
 #. 3.4->settings-schema.json->activePseudoClass->options
-msgid "checked"
-msgstr "coché"
+msgid "hover"
+msgstr "flottant"
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
-msgid "Highlight the last focused window within an app group"
-msgstr "Éclairer davantage la dernière fenêtre utilisée dans le groupe d'une application"
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "focus"
+msgstr "focus"
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
-msgid "When enabled, the last window that was interacted with will be indicated."
-msgstr "Lorsque cette option est activée, la dernière fenêtre qui a interagi avec l'utilisateur sera indiquée par un sur-éclairage."
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "active"
+msgstr "active"
 
-#. 3.4->settings-schema.json->app-button-transition-duration->description
-msgid "App button transition duration"
-msgstr "Durée de l'animation d'un bouton d'application"
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "outlined"
+msgstr "souligné"
 
-#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
-msgid "Overrides the theme's animation time for app buttons. If set to zero, the theme's transition duration will be used."
-msgstr "Remplace le temps d'animation des boutons d'application indiqué dans le thème. Si c'est zéro, le temps d'animation par défaut (celui du thème) sera utilisé."
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "selected"
+msgstr "sélectionné"
 
-#. 3.4->settings-schema.json->app-button-transition-duration->units
-msgid "ms"
-msgstr "ms"
+#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons on hover."
+msgstr ""
+"Remplace l'effet standard appliqué au bouton d'une application lorsqu'il est "
+"survolé"
 
-#. 3.4->settings-schema.json->thumbnail-padding->description
-msgid "Thumbnail padding"
-msgstr "Espace autour des miniatures"
+#. 2.8->settings-schema.json->focusPseudoClass->description
+#. 3.8->settings-schema.json->focusPseudoClass->description
+#. 3.4->settings-schema.json->focusPseudoClass->description
+msgid "App button focus pseudo class"
+msgstr ""
+"Effet désiré sur le bouton d'une application lorsque celui-ci est cliqué"
 
-#. 3.4->settings-schema.json->thumbnail-padding->tooltip
-msgid "Controls how much space will be around the window preview thumbnails."
-msgstr "Contrôle la largeur de l'espace autour des miniatures de fenêtres."
+#. 2.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.4->settings-schema.json->focusPseudoClass->tooltip
+msgid "Overrides the pseudo class for app button on focus."
+msgstr ""
+"Remplace l'effet standard appliqué au bouton d'une application sur lequel on "
+"clique."
 
-#. 3.4->settings-schema.json->system-favorites->description
-msgid "Use system favorites for pinned apps"
-msgstr "Épingler les applications favorites indiquées dans le système"
+#. 2.8->settings-schema.json->activePseudoClass->description
+#. 3.8->settings-schema.json->activePseudoClass->description
+#. 3.4->settings-schema.json->activePseudoClass->description
+msgid "App button active pseudo class"
+msgstr "Effet désiré sur le bouton d'une application active"
 
-#. 3.4->settings-schema.json->system-favorites->tooltip
-msgid "Controls whether or not pinned apps consist of the system favorites list."
-msgstr "Contrôle si oui ou non vos applications favorites sont épinglées."
+#. 2.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.4->settings-schema.json->activePseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons when they are active."
+msgstr "Remplace l'effet standard appliqué au bouton d'une application active."
 
-#. 3.4->settings-schema.json->generalSection->title
-msgid "Behavior"
-msgstr "Comportement"
+#. 2.8->settings-schema.json->panelLauncherClass->description
+msgid "Use the panel launcher class for pinned apps"
+msgstr ""
+"Utiliser la classe de lanceur de panneau pour les applications épinglées"
 
+#. 2.8->settings-schema.json->panelLauncherClass->tooltip
+msgid "Enabling this helps with certain themes."
+msgstr "L'activation de cette fonction peut aider avec certains thèmes."
+
+#. 2.8->settings-schema.json->close-button-style->description
+msgid "Allow themes to control the thumbnail close button"
+msgstr ""
+"Autoriser les thèmes à contrôler l'aspect du bouton de fermeture des "
+"miniatures"
+
+#. 2.8->settings-schema.json->close-button-style->tooltip
+msgid ""
+"Controls whether or not the theme controls the window thumbnail's close "
+"button."
+msgstr ""
+"Indique si oui ou non le thème peut contrôler l'aspect du bouton de "
+"fermeture dans la miniature d'une fenêtre."
+
+#. 2.8->settings-schema.json->useSystemTooltips->description
+msgid "Use system tooltips for closed apps"
+msgstr "Utiliser les info-bulles système pour les applications fermées"
+
+#. 2.8->settings-schema.json->useSystemTooltips->tooltip
+msgid ""
+"Controls whether or not system tooltips are in use when hovering over closed "
+"pinned apps."
+msgstr ""
+"Contrôle si les info-bulles du système sont utilisées lors du survol des "
+"applications fermées."
+
+#. 3.8->settings-schema.json->generalPage->title
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr "Général"
+
+#. 3.8->settings-schema.json->panelPage->title
+#. 3.4->settings-schema.json->panelPage->title
+msgid "Panel"
+msgstr "Tableau de bord"
+
+#. 3.8->settings-schema.json->thumbnailsPage->title
+#. 3.8->settings-schema.json->thumbnailsSection->title
 #. 3.4->settings-schema.json->thumbnailsPage->title
 #. 3.4->settings-schema.json->thumbnailsSection->title
 msgid "Thumbnails"
 msgstr "Miniatures"
 
-#. 3.4->settings-schema.json->presetSection->title
-msgid "Recommended Presets"
-msgstr "Réglages recommandés"
-
-#. 3.4->settings-schema.json->appButtonsSection->title
-msgid "App Buttons"
-msgstr "Boutons d'applications"
-
-#. 3.4->settings-schema.json->generalPage->title
-msgid "General"
-msgstr "Général"
-
-#. 3.4->settings-schema.json->hoverPeekSection->title
-msgid "Hover Peek"
-msgstr "Aperçu par survol de la souris"
-
-#. 3.4->settings-schema.json->panelPage->title
-msgid "Panel"
-msgstr "Tableau de bord"
-
-#. 3.4->settings-schema.json->iconSection->title
-msgid "Icons"
-msgstr "Icônes"
-
-#. 3.4->settings-schema.json->hotKeysSection->title
-msgid "Hot Keys"
-msgstr "Raccourcis-clavier"
-
-#. 3.4->settings-schema.json->stylingSection->title
-msgid "Styling"
-msgstr "Style"
-
+#. 3.8->settings-schema.json->contextMenuPage->title
 #. 3.4->settings-schema.json->contextMenuPage->title
 msgid "Context Menu"
 msgstr "Menu contextuel"
 
+#. 3.8->settings-schema.json->themePage->title
 #. 3.4->settings-schema.json->themePage->title
 msgid "Theming"
 msgstr "Thème"
 
-#. 3.4->settings-schema.json->mintYPreset->description
-#. 3.4->settings-schema.json->mintYPreset->tooltip
-msgid "Mint Y and Variants"
-msgstr "Mint Y et ses variantes"
+#. 3.8->settings-schema.json->generalSection->title
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr "Comportement"
 
-#. 3.4->settings-schema.json->show-icons->description
-msgid "Show icons"
-msgstr "Afficher l'icône à côté du titre"
+#. 3.8->settings-schema.json->appButtonsSection->title
+#. 3.4->settings-schema.json->appButtonsSection->title
+msgid "App Buttons"
+msgstr "Boutons d'applications"
 
-#. 3.4->settings-schema.json->show-icons->tooltip
-msgid "Show the window's icon next to the title."
-msgstr "Si activé, l'icône de la fenêtre est affichée à côté de son titre. Sinon, seul le titre est affiché."
+#. 3.8->settings-schema.json->hotKeysSection->title
+#. 3.4->settings-schema.json->hotKeysSection->title
+msgid "Hot Keys"
+msgstr "Raccourcis-clavier"
 
-#. 3.4->settings-schema.json->enable-app-button-dragging->description
-#. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
-msgid "Enable app button dragging"
-msgstr "Rendre possible le déplacement des boutons"
+#. 3.8->settings-schema.json->hoverPeekSection->title
+#. 3.4->settings-schema.json->hoverPeekSection->title
+msgid "Hover Peek"
+msgstr "Aperçu par survol de la souris"
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
-msgid "Show new window option"
-msgstr "Faire apparaître l'option Nouvelle fenêtre"
+#. 3.8->settings-schema.json->stylingSection->title
+#. 3.4->settings-schema.json->stylingSection->title
+msgid "Styling"
+msgstr "Style"
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
-msgid "Shows the \"New Window\" option in an app's context menu if it doesn't already have one from the app's own action menu items."
-msgstr "Affiche l'option \"Nouvelle fenêtre\" dans le menu contextuel de l'application, si cette option n'existe pas déjà parmi celles de l'application."
+#. 3.8->settings-schema.json->iconSection->title
+#. 3.4->settings-schema.json->iconSection->title
+msgid "Icons"
+msgstr "Icônes"
 
-#. 3.4->settings-schema.json->app-button-width->description
-msgid "App button width"
-msgstr "Largeur d'un bouton d'application"
+#. 3.8->settings-schema.json->presetSection->title
+#. 3.4->settings-schema.json->presetSection->title
+msgid "Recommended Presets"
+msgstr "Réglages recommandés"
 
-#. 3.4->settings-schema.json->app-button-width->tooltip
-msgid "Controls the width of the application button. This option only works for horizontal panels."
-msgstr "Contrôle la largeur du bouton d'une application. Cette option n'est valable que pour les panneaux horizontaux."
-
-#. 3.4->settings-schema.json->mintXPreset->description
-#. 3.4->settings-schema.json->mintXPreset->tooltip
-msgid "Mint X, Linux Mint, and Variants"
-msgstr "Mint X, Linux Mint, et variantes"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->description
-msgid "Launcher animation effect"
-msgstr "Effet d'animation du lanceur"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
-#. 3.4->settings-schema.json->left-click-action->description
-#. 3.4->settings-schema.json->left-click-action->tooltip
-msgid "Left click action"
-msgstr "Action du clic gauche"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Scale"
-msgstr "Graduel"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Fade"
-msgstr "Estompement"
-
-#. 3.4->settings-schema.json->enable-app-button-width->description
-msgid "Use a custom width for app buttons"
-msgstr "Utiliser une largeur personnalisée pour les boutons d'applications"
-
-#. 3.4->settings-schema.json->enable-app-button-width->tooltip
-msgid "When disabled, the app button width is determined by the panel height."
-msgstr "Quand cette option est déactivée, la largeur des boutons est déterminée par celle du panneau."
-
-#. 3.4->settings-schema.json->list-monitor-windows->description
-msgid "Only list windows from the monitor displaying this instance"
-msgstr "Ne lister que les applications présentes sur cet écran"
-
-#. 3.4->settings-schema.json->list-monitor-windows->tooltip
-msgid "This option will only come into effect for monitors displaying an ITM instance."
-msgstr "Cette option n'aura d'effet que sur les écrans tactiles."
-
-#. 3.4->settings-schema.json->thumbnail-close-button-size->description
-msgid "Close button size"
-msgstr "Taille du bouton de fermeture"
-
-#. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
-msgid "Controls how large the thumbnail close button is."
-msgstr "Contrôle la taille du bouton de fermeture de la miniature et de sa fenêtre correspondante."
-
-#. 3.4->settings-schema.json->middle-click-action->description
-#. 3.4->settings-schema.json->middle-click-action->tooltip
-msgid "Middle click action"
-msgstr "Action du clic sur la molette"
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Launch new app instance"
-msgstr "Lancer une autre instance de la même application"
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Close last focused window in group"
-msgstr "Fermer la dernière fenêtre active du groupe"
-
+#. 3.8->settings-schema.json->scroll-behavior->description
 #. 3.4->settings-schema.json->scroll-behavior->description
 msgid "Mouse wheel scroll behavior"
 msgstr "Rôle du défilement de la molette"
 
-#. 3.4->settings-schema.json->scroll-behavior->tooltip
-msgid "Choose if scrolling the mouse wheel cycles running apps, an app button's windows on hover, or is disabled."
-msgstr "Choisir si le défilement de la molette fait s'afficher de façon cyclique toutes les applications, ou bien seulement les fenêtres de l'application survolée, ou bien est désactivé."
-
+#. 3.8->settings-schema.json->scroll-behavior->options
 #. 3.4->settings-schema.json->scroll-behavior->options
 msgid "Cycle apps"
 msgstr "Cycle des applications"
 
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
 #. 3.4->settings-schema.json->scroll-behavior->options
 #. 3.4->settings-schema.json->left-click-action->options
 msgid "Cycle windows"
 msgstr "Cycle des fenêtres"
 
+#. 3.8->settings-schema.json->scroll-behavior->tooltip
+#. 3.4->settings-schema.json->scroll-behavior->tooltip
+msgid ""
+"Choose if scrolling the mouse wheel cycles running apps, an app button's "
+"windows on hover, or is disabled."
+msgstr ""
+"Choisir si le défilement de la molette fait s'afficher de façon cyclique "
+"toutes les applications, ou bien seulement les fenêtres de l'application "
+"survolée, ou bien est désactivé."
+
+#. 3.8->settings-schema.json->left-click-action->description
+#. 3.8->settings-schema.json->left-click-action->tooltip
+#. 3.8->settings-schema.json->launcher-animation-effect->tooltip
+#. 3.4->settings-schema.json->left-click-action->description
+#. 3.4->settings-schema.json->left-click-action->tooltip
+#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
+msgid "Left click action"
+msgstr "Action du clic gauche"
+
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->left-click-action->options
+msgid "Toggle activation of last focused window"
+msgstr "Afficher/Cacher la dernière fenêtre active"
+
+#. 3.8->settings-schema.json->middle-click-action->description
+#. 3.8->settings-schema.json->middle-click-action->tooltip
+#. 3.4->settings-schema.json->middle-click-action->description
+#. 3.4->settings-schema.json->middle-click-action->tooltip
+msgid "Middle click action"
+msgstr "Action du clic sur la molette"
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Launch new app instance"
+msgstr "Lancer une autre instance de la même application"
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Close last focused window in group"
+msgstr "Fermer la dernière fenêtre active du groupe"
+
+#. 3.8->settings-schema.json->system-favorites->description
+#. 3.4->settings-schema.json->system-favorites->description
+msgid "Use system favorites for pinned apps"
+msgstr "Épingler les applications favorites indiquées dans le système"
+
+#. 3.8->settings-schema.json->system-favorites->tooltip
+#. 3.4->settings-schema.json->system-favorites->tooltip
+msgid ""
+"Controls whether or not pinned apps consist of the system favorites list."
+msgstr "Contrôle si oui ou non vos applications favorites sont épinglées."
+
+#. 3.8->settings-schema.json->show-all-workspaces->description
+#. 3.8->settings-schema.json->show-all-workspaces->tooltip
 #. 3.4->settings-schema.json->show-all-workspaces->description
 #. 3.4->settings-schema.json->show-all-workspaces->tooltip
 msgid "Show windows from all workspaces"
 msgstr "Afficher les fenêtres de tous les espaces de travail"
 
+#. 3.8->settings-schema.json->enable-app-button-dragging->description
+#. 3.8->settings-schema.json->enable-app-button-dragging->tooltip
+#. 3.4->settings-schema.json->enable-app-button-dragging->description
+#. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
+msgid "Enable app button dragging"
+msgstr "Rendre possible le déplacement des boutons"
+
+#. 3.8->settings-schema.json->launcher-animation-effect->description
+#. 3.4->settings-schema.json->launcher-animation-effect->description
+msgid "Launcher animation effect"
+msgstr "Effet d'animation du lanceur"
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Fade"
+msgstr "Estompement"
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Scale"
+msgstr "Graduel"
+
+#. 3.8->settings-schema.json->list-monitor-windows->description
+#. 3.4->settings-schema.json->list-monitor-windows->description
+msgid "Only list windows from the monitor displaying this instance"
+msgstr "Ne lister que les applications présentes sur cet écran"
+
+#. 3.8->settings-schema.json->list-monitor-windows->tooltip
+#. 3.4->settings-schema.json->list-monitor-windows->tooltip
+msgid ""
+"This option will only come into effect for monitors displaying an ITM "
+"instance."
+msgstr "Cette option n'aura d'effet que sur les écrans tactiles."
+
+#. 3.8->settings-schema.json->enable-app-button-width->description
+#. 3.4->settings-schema.json->enable-app-button-width->description
+msgid "Use a custom width for app buttons"
+msgstr "Utiliser une largeur personnalisée pour les boutons d'applications"
+
+#. 3.8->settings-schema.json->enable-app-button-width->tooltip
+#. 3.4->settings-schema.json->enable-app-button-width->tooltip
+msgid "When disabled, the app button width is determined by the panel height."
+msgstr ""
+"Quand cette option est déactivée, la largeur des boutons est déterminée par "
+"celle du panneau."
+
+#. 3.8->settings-schema.json->app-button-width->description
+#. 3.4->settings-schema.json->app-button-width->description
+msgid "App button width"
+msgstr "Largeur d'un bouton d'application"
+
+#. 3.8->settings-schema.json->app-button-width->tooltip
+#. 3.4->settings-schema.json->app-button-width->tooltip
+msgid ""
+"Controls the width of the application button. This option only works for "
+"horizontal panels."
+msgstr ""
+"Contrôle la largeur du bouton d'une application. Cette option n'est valable "
+"que pour les panneaux horizontaux."
+
+#. 3.8->settings-schema.json->thumbnail-close-button-size->description
+#. 3.4->settings-schema.json->thumbnail-close-button-size->description
+msgid "Close button size"
+msgstr "Taille du bouton de fermeture"
+
+#. 3.8->settings-schema.json->thumbnail-close-button-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
+msgid "Controls how large the thumbnail close button is."
+msgstr ""
+"Contrôle la taille du bouton de fermeture de la miniature et de sa fenêtre "
+"correspondante."
+
+#. 3.8->settings-schema.json->thumbnail-padding->description
+#. 3.4->settings-schema.json->thumbnail-padding->description
+msgid "Thumbnail padding"
+msgstr "Espace autour des miniatures"
+
+#. 3.8->settings-schema.json->thumbnail-padding->tooltip
+#. 3.4->settings-schema.json->thumbnail-padding->tooltip
+msgid "Controls how much space will be around the window preview thumbnails."
+msgstr "Contrôle la largeur de l'espace autour des miniatures de fenêtres."
+
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->description
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
 msgid "Cycle windows on mouse wheel scroll"
 msgstr "Afficher cycliquement les fenêtres lors du défilement de la molette"
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->tooltip
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
-msgid "Choose whether or not scrolling the mouse wheel cycles windows when hovering over a thumbnail menu."
-msgstr "Choisissez si oui ou non le défilement de la roulette de la souris fait défiler les fenêtres lorsque vous passez la souris sur un menu de miniatures."
-
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "Toggle activation of last focused window"
-msgstr "Afficher/Cacher la dernière fenêtre active"
-
-#. IcingTaskManager@json->metadata.json->name
-msgid "Icing Task Manager"
+msgid ""
+"Choose whether or not scrolling the mouse wheel cycles windows when hovering "
+"over a thumbnail menu."
 msgstr ""
+"Choisissez si oui ou non le défilement de la roulette de la souris fait "
+"défiler les fenêtres lorsque vous passez la souris sur un menu de miniatures."
 
-#. IcingTaskManager@json->metadata.json->description
-msgid "Window list with app grouping and thumbnails"
-msgstr "Liste de fenêtres avec regroupements d'applications et miniatures"
+#. 3.8->settings-schema.json->show-icons->description
+#. 3.4->settings-schema.json->show-icons->description
+msgid "Show icons"
+msgstr "Afficher l'icône à côté du titre"
 
+#. 3.8->settings-schema.json->show-icons->tooltip
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr ""
+"Si activé, l'icône de la fenêtre est affichée à côté de son titre. Sinon, "
+"seul le titre est affiché."
+
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->description
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
+msgid "Highlight the last focused window within an app group"
+msgstr ""
+"Éclairer davantage la dernière fenêtre utilisée dans le groupe d'une "
+"application"
+
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+msgid ""
+"When enabled, the last window that was interacted with will be indicated."
+msgstr ""
+"Lorsque cette option est activée, la dernière fenêtre qui a interagi avec "
+"l'utilisateur sera indiquée par un sur-éclairage."
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->description
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+msgid "Show new window option"
+msgstr "Faire apparaître l'option Nouvelle fenêtre"
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->tooltip
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+"Affiche l'option \"Nouvelle fenêtre\" dans le menu contextuel de "
+"l'application, si cette option n'existe pas déjà parmi celles de "
+"l'application."
+
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr "coché"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->units
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr "ms"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->description
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr "Durée de l'animation d'un bouton d'application"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->tooltip
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+"Remplace le temps d'animation des boutons d'application indiqué dans le "
+"thème. Si c'est zéro, le temps d'animation par défaut (celui du thème) sera "
+"utilisé."
+
+#. 3.8->settings-schema.json->mintYPreset->description
+#. 3.8->settings-schema.json->mintYPreset->tooltip
+#. 3.4->settings-schema.json->mintYPreset->description
+#. 3.4->settings-schema.json->mintYPreset->tooltip
+msgid "Mint Y and Variants"
+msgstr "Mint Y et ses variantes"
+
+#. 3.8->settings-schema.json->mintXPreset->description
+#. 3.8->settings-schema.json->mintXPreset->tooltip
+#. 3.4->settings-schema.json->mintXPreset->description
+#. 3.4->settings-schema.json->mintXPreset->tooltip
+msgid "Mint X, Linux Mint, and Variants"
+msgstr "Mint X, Linux Mint, et variantes"
+
+#. 3.8->settings-schema.json->migrationButton->description
+msgid "Migrate Pinned Apps to Grouped Window List"
+msgstr ""

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/he.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/he.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-10 00:43-0600\n"
+"POT-Creation-Date: 2018-12-13 18:37-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Pandiora <Pandiora@github.com>\n"
 "Language-Team: \n"
@@ -13,53 +13,53 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: 3.8/applet.js:471
-msgid "Icing Task Manager is now Grouped Window List"
-msgstr ""
+#: 3.8/applet.js:476
+#, fuzzy
+msgid "Icing Task Manager is deprecated"
+msgstr "Icing Task Manager"
 
-#: 3.8/applet.js:472
+#: 3.8/applet.js:477
 msgid ""
-"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
-"Window List\". "
+"Please upgrade to Grouped Window List for a more stable, bug-free experience."
 msgstr ""
 
-#: 3.8/applet.js:473
+#: 3.8/applet.js:478
 msgid ""
-"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
-"List."
+"Add GWL to your panel, open the applet's settings and click \"Migrate Pinned "
+"Apps to Grouped Window List\"."
 msgstr ""
 
-#: 3.8/applet.js:485
-msgid "Migration can only be performed on Cinnamon 4.0."
+#: 3.8/applet.js:490
+msgid "Migration can only be performed on Cinnamon 4.0+."
 msgstr ""
 
-#: 3.8/applet.js:496
+#: 3.8/applet.js:501
 msgid ""
 "Please add Grouped Window List to a panel before proceeding with the "
 "migration."
 msgstr ""
 
-#: 3.8/applet.js:504
+#: 3.8/applet.js:509
 msgid "ITM settings directory could not be found!"
 msgstr ""
 
-#: 3.8/applet.js:534
+#: 3.8/applet.js:539
 msgid "System favorites enabled - no migration is needed."
 msgstr ""
 
-#: 3.8/applet.js:577
+#: 3.8/applet.js:582
 msgid "Unable to find a suitable ITM settings file to migrate."
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid "Migration complete. "
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid " settings file(s) could not be migrated."
 msgstr ""
 
-#: 3.8/applet.js:592
+#: 3.8/applet.js:597
 msgid "Migration was successful."
 msgstr ""
 
@@ -1210,6 +1210,10 @@ msgstr ""
 #. 3.8->settings-schema.json->migrationButton->description
 msgid "Migrate Pinned Apps to Grouped Window List"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Icing Task Manager is deprecated - please use Grouped Window List"
+#~ msgstr "Icing Task Manager"
 
 # Should not be set, just leave it blank by setting one white-space character
 #~ msgid "number"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/he.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/he.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-23 21:32-0600\n"
+"POT-Creation-Date: 2018-12-10 00:43-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Pandiora <Pandiora@github.com>\n"
 "Language-Team: \n"
@@ -13,553 +13,228 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/applet.js:471
+msgid "Icing Task Manager is now Grouped Window List"
+msgstr ""
+
+#: 3.8/applet.js:472
+msgid ""
+"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
+"Window List\". "
+msgstr ""
+
+#: 3.8/applet.js:473
+msgid ""
+"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
+"List."
+msgstr ""
+
+#: 3.8/applet.js:485
+msgid "Migration can only be performed on Cinnamon 4.0."
+msgstr ""
+
+#: 3.8/applet.js:496
+msgid ""
+"Please add Grouped Window List to a panel before proceeding with the "
+"migration."
+msgstr ""
+
+#: 3.8/applet.js:504
+msgid "ITM settings directory could not be found!"
+msgstr ""
+
+#: 3.8/applet.js:534
+msgid "System favorites enabled - no migration is needed."
+msgstr ""
+
+#: 3.8/applet.js:577
+msgid "Unable to find a suitable ITM settings file to migrate."
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid "Migration complete. "
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid " settings file(s) could not be migrated."
+msgstr ""
+
+#: 3.8/applet.js:592
+msgid "Migration was successful."
+msgstr ""
+
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 #, fuzzy
 msgid "Move to the other monitor"
 msgstr "העבר לשולחן עבודה %d"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 #, fuzzy
 msgid "Move to monitor "
 msgstr "העבר לשולחן עבודה %d"
 
-#: 3.4/specialMenus.js:126
+#: 3.8/specialMenus.js:98 3.4/specialMenus.js:126
 msgid "Only on this workspace"
 msgstr "רק בשולחן העבודה הזה"
 
-#: 3.4/specialMenus.js:133
+#: 3.8/specialMenus.js:105 3.4/specialMenus.js:133
 #, fuzzy
 msgid "Visible on all workspaces"
 msgstr "רק בשולחן העבודה הזה"
 
-#: 3.4/specialMenus.js:140
+#: 3.8/specialMenus.js:112 3.4/specialMenus.js:140
 #, fuzzy
 msgid "Move to another workspace"
 msgstr "העבר לשולחן עבודה השמאלי"
 
-#: 3.4/specialMenus.js:168
+#: 3.8/specialMenus.js:140 3.4/specialMenus.js:168
 msgid "Places"
 msgstr ""
 
-#: 3.4/specialMenus.js:207
+#: 3.8/specialMenus.js:179 3.4/specialMenus.js:207
 msgid "Bookmarks/History requires gir1.2-gda-5.0"
 msgstr ""
 
-#: 3.4/specialMenus.js:227
+#: 3.8/specialMenus.js:199 3.4/specialMenus.js:227
 #, fuzzy
 msgid "Recent"
 msgstr "אחוזים"
 
-#: 3.4/specialMenus.js:246
+#: 3.8/specialMenus.js:218 3.4/specialMenus.js:246
 msgid "Preferences"
 msgstr ""
 
-#: 3.4/specialMenus.js:249
+#: 3.8/specialMenus.js:221 3.4/specialMenus.js:249
 msgid "About..."
 msgstr ""
 
-#: 3.4/specialMenus.js:253
+#: 3.8/specialMenus.js:225 3.4/specialMenus.js:253
 msgid "Configure..."
 msgstr ""
 
-#: 3.4/specialMenus.js:257
+#: 3.8/specialMenus.js:229 3.4/specialMenus.js:257
 msgid "Remove"
 msgstr ""
 
-#: 3.4/specialMenus.js:287
+#: 3.8/specialMenus.js:259 3.4/specialMenus.js:287
 #, fuzzy
 msgid "New Window"
 msgstr "כלול את כל חלונות האפליקציה"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Unpin from Panel"
 msgstr "בטל את ההצמדה מהשורת משימות"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Pin to Panel"
 msgstr "הצמד לשורת משימות"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Remove from Autostart"
 msgstr "הסר Autostart"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Add to Autostart"
 msgstr "הוסף Autostart"
 
-#: 3.4/specialMenus.js:318
+#: 3.8/specialMenus.js:290 3.4/specialMenus.js:318
 msgid "Create Shortcut"
 msgstr "צור קיצור דרך"
 
-#: 3.4/specialMenus.js:329
+#: 3.8/specialMenus.js:301 3.4/specialMenus.js:329
 msgid "Restore to full opacity"
 msgstr ""
 
-#: 3.4/specialMenus.js:337
+#: 3.8/specialMenus.js:309 3.4/specialMenus.js:337
 msgid "Restore"
 msgstr "שחזר"
 
-#: 3.4/specialMenus.js:342
+#: 3.8/specialMenus.js:314 3.4/specialMenus.js:342
 msgid "Minimize"
 msgstr "מזער"
 
-#: 3.4/specialMenus.js:350
+#: 3.8/specialMenus.js:322 3.4/specialMenus.js:350
 msgid "Unmaximize"
 msgstr "הקטן חלון"
 
-#: 3.4/specialMenus.js:355
+#: 3.8/specialMenus.js:327 3.4/specialMenus.js:355
 msgid "Maximize"
 msgstr "הגדל"
 
-#: 3.4/specialMenus.js:365
+#: 3.8/specialMenus.js:337 3.4/specialMenus.js:365
 msgid "Close others"
 msgstr ""
 
-#: 3.4/specialMenus.js:375
+#: 3.8/specialMenus.js:347 3.4/specialMenus.js:375
 #, fuzzy
 msgid "Close all"
 msgstr "סגור הכל"
 
-#: 3.4/specialMenus.js:385
+#: 3.8/specialMenus.js:357 3.4/specialMenus.js:385
 msgid "Close"
 msgstr "סגור"
 
-#. 2.8->settings-schema.json->thumbnail-size->description
-#. 3.4->settings-schema.json->thumbnail-size->description
-msgid "Thumbnail size"
-msgstr "גודל תמונה ממוזערת"
-
-#. 2.8->settings-schema.json->thumbnail-size->tooltip
-#. 3.4->settings-schema.json->thumbnail-size->tooltip
-msgid "Controls the size of the thumbnails."
-msgstr "שולט בגודל של התמונות הממוזערות."
-
-# should not be set, just leave it blank and insert one white-space character
-#. 2.8->settings-schema.json->thumbnail-size->units
-#. 3.4->settings-schema.json->thumbnail-size->units
-msgid "size"
-msgstr " "
-
-#. 2.8->settings-schema.json->focusPseudoClass->description
-#. 3.4->settings-schema.json->focusPseudoClass->description
-msgid "App button focus pseudo class"
-msgstr "בכיתה פסאודו מוקד אפליקציה '"
-
-#. 2.8->settings-schema.json->focusPseudoClass->tooltip
-#. 3.4->settings-schema.json->focusPseudoClass->tooltip
-msgid "Overrides the pseudo class for app button on focus."
-msgstr "עוקף את הכיתה פסאודו עבור כפתור האפליקציה על המוקד."
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "active"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "outlined"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "hover"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
+#. metadata.json->description
 #, fuzzy
-msgid "focus"
-msgstr "רק בחלון שבפוקוס"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "selected"
+msgid "Window list with app grouping and thumbnails"
 msgstr ""
+"שורת משימות עם קיבוץ אפליקציות והצגת חלונות ממוזערים תכלס - כמו בווינדוס"
 
-#. 2.8->settings-schema.json->icon-spacing->description
-#. 3.4->settings-schema.json->icon-spacing->description
-msgid "Icon spacing"
-msgstr "מרווח אייקון"
+#. metadata.json->name
+msgid "Icing Task Manager"
+msgstr "Icing Task Manager"
 
-#. 2.8->settings-schema.json->icon-spacing->tooltip
-#. 3.4->settings-schema.json->icon-spacing->tooltip
-msgid "Controls how much space is between the icons."
-msgstr "בקרת כמה מקום הוא בין הסמלים."
-
-#. 2.8->settings-schema.json->icon-spacing->units
-#. 2.8->settings-schema.json->icon-size->units
-#. 2.8->settings-schema.json->icon-padding->units
-#. 3.4->settings-schema.json->icon-spacing->units
-#. 3.4->settings-schema.json->thumbnail-padding->units
-#. 3.4->settings-schema.json->icon-size->units
-#. 3.4->settings-schema.json->app-button-width->units
-#. 3.4->settings-schema.json->thumbnail-close-button-size->units
-#. 3.4->settings-schema.json->icon-padding->units
-msgid "px"
-msgstr ""
-
-#. 2.8->settings-schema.json->show-thumbnails->description
-#. 3.4->settings-schema.json->show-thumbnails->description
-msgid "Show thumbnails"
-msgstr "הראה תמונה ממוזערת"
-
-#. 2.8->settings-schema.json->show-thumbnails->tooltip
-#. 3.4->settings-schema.json->show-thumbnails->tooltip
-msgid "Show window thumbnails when hovering over an app button."
-msgstr "הראה תמונה ממוזערת של חלון פתוח בעת נגיעה בסמל שלו"
-
-#. 2.8->settings-schema.json->icon-size->description
-#. 3.4->settings-schema.json->icon-size->description
-msgid "Icon size"
-msgstr "גודל אייקון"
-
-#. 2.8->settings-schema.json->icon-size->tooltip
-#. 3.4->settings-schema.json->icon-size->tooltip
-msgid "Set icon size"
-msgstr "גודל גדר סמל"
-
-#. 2.8->settings-schema.json->hover-peek-time->description
-#. 3.4->settings-schema.json->hover-peek-time->description
-msgid "Window fade time"
-msgstr "זמן לאפקט"
-
-#. 2.8->settings-schema.json->hover-peek-time->tooltip
-#. 3.4->settings-schema.json->hover-peek-time->tooltip
-msgid "Controls how quickly a window will fade on hover."
-msgstr "תוך כמה זמן מהנגיעה בתמונה הממוזערת תופעל תצוגה מקדימה"
-
-#. 2.8->settings-schema.json->hover-peek-time->units
-#. 2.8->settings-schema.json->thumbnail-timeout->units
-#. 2.8->settings-schema.json->show-apps-order-timeout->units
-#. 3.4->settings-schema.json->hover-peek-time->units
-#. 3.4->settings-schema.json->thumbnail-timeout->units
-#. 3.4->settings-schema.json->show-apps-order-timeout->units
-msgid "milliseconds"
-msgstr "מילישניות"
-
-#. 2.8->settings-schema.json->close-button-style->description
-msgid "Allow themes to control the thumbnail close button"
-msgstr "אפשר נושאים לשלוט על לחצן התמונה הממוזערת קרוב"
-
-#. 2.8->settings-schema.json->close-button-style->tooltip
-msgid ""
-"Controls whether or not the theme controls the window thumbnail's close "
-"button."
-msgstr "קובע אם לאו הנושא שולט לחצן הסגירה של החלון הממוזער."
-
-#. 2.8->settings-schema.json->title-display->description
-#. 3.4->settings-schema.json->title-display->description
-msgid "Title display"
-msgstr "הצגת כותרת"
-
-#. 2.8->settings-schema.json->title-display->tooltip
-#. 3.4->settings-schema.json->title-display->tooltip
-msgid ""
-"focused: show focused window title, title: display the window title, app: "
-"diplay app name, none: don't display anything"
-msgstr ""
-"ממוקדת: תכנית ממוקדת כותרת החלון, הכותרת: להציג את כותרת החלון, האפליקציה: "
-"שם יישום תצוגה, בבול: לא יציג דבר"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-#. 3.4->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->middle-click-action->options
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "None"
-msgstr "הסתר כותרת"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Focused"
-msgstr "רק בחלון שבפוקוס"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "App"
-msgstr "אפליקציה"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Title"
-msgstr "כותרת"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->description
-#. 3.4->settings-schema.json->hoverPseudoClass->description
-msgid "App button hover pseudo class"
-msgstr "בכיתה פסאודו לרחף אפליקציה '"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
-#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons on hover."
-msgstr "עוקף את הכיתה פסאודו לכפתורי אפליקציה על לרחף."
-
-#. 2.8->settings-schema.json->show-alerts->description
-#. 3.4->settings-schema.json->show-alerts->description
-msgid "Show app alerts and notifications"
-msgstr "צג התראות אפליקציה והודעות"
-
-#. 2.8->settings-schema.json->show-alerts->tooltip
-#. 3.4->settings-schema.json->show-alerts->tooltip
-msgid "If enabled, notifications and alerts will appear."
-msgstr "אם מאופשר, הודעות והתראות תופענה."
-
-#. 2.8->settings-schema.json->pinOnDrag->description
-#. 2.8->settings-schema.json->pinOnDrag->tooltip
-#. 3.4->settings-schema.json->pinOnDrag->description
-#. 3.4->settings-schema.json->pinOnDrag->tooltip
-msgid "Pin apps when dragged to a new position"
-msgstr "הצמד את היישומים כאשר גררו למיקום חדש"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->description
-#. 3.4->settings-schema.json->show-apps-order-hotkey->description
-msgid "Global hotkey to show the order of apps"
-msgstr "מקשי קיצור דרך עולמיים להראות את סדר האפליקציות"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
-#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
-msgid ""
-"When triggered, the window count label will be replaced with its order in "
-"the app list temporarily."
-msgstr ""
-"כאשר מופעל, התווית חלון הספירה תוחלף מהזמנתו ברשימת היישומים באופן זמני."
-
-#. 2.8->settings-schema.json->menuItemType->description
-#. 3.4->settings-schema.json->menuItemType->description
-msgid "Menu item type"
-msgstr "סוג פריט בתפריט"
-
-#. 2.8->settings-schema.json->menuItemType->tooltip
-#. 3.4->settings-schema.json->menuItemType->tooltip
-msgid ""
-"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
-msgstr "קובע אם סמלי פריט בתפריט הם סמליים, הלא סמליים, או לא לראות."
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Symbolic icons"
-msgstr "סמלים סמליים"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "No icons"
-msgstr "לא נמצאו סמלים"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Non-symbolic icons"
-msgstr "סמלים ללא סמלי"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->description
-#. 3.4->settings-schema.json->hover-peek-opacity->description
-msgid "Window opacity"
-msgstr "שקיפות החלון"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
-#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
-msgid "Opacity of the windows on hover."
-msgstr "שקיפות החלון בתצוגה מקדימה"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->units
-#. 3.4->settings-schema.json->hover-peek-opacity->units
-msgid "percent"
-msgstr "אחוזים"
-
-#. 2.8->settings-schema.json->enable-hover-peek->description
-#. 3.4->settings-schema.json->enable-hover-peek->description
-msgid "Show windows when hovered over"
-msgstr "הצג חלונות כאשר ריחפה מעל"
-
-#. 2.8->settings-schema.json->enable-hover-peek->tooltip
-#. 3.4->settings-schema.json->enable-hover-peek->tooltip
-msgid "Controls whether or not windows display when hovered over."
-msgstr "הגדרה זו קובעת אם או לא להציג חלונות כאשר ריחפה מעל."
-
-#. 2.8->settings-schema.json->activePseudoClass->description
-#. 3.4->settings-schema.json->activePseudoClass->description
-msgid "App button active pseudo class"
-msgstr "App כפתור בכיתה פסאודו פעילה"
-
-#. 2.8->settings-schema.json->activePseudoClass->tooltip
-#. 3.4->settings-schema.json->activePseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons when they are active."
-msgstr "עוקף את הכיתה פסאודו לכפתורי אפליקציה כאשר הם פעילים."
-
-#. 2.8->settings-schema.json->animate-thumbnails->description
-#. 3.4->settings-schema.json->animate-thumbnails->description
-msgid "Animate thumbnails"
-msgstr "הנפשת תמונות ממוזערות"
-
-#. 2.8->settings-schema.json->animate-thumbnails->tooltip
-#. 3.4->settings-schema.json->animate-thumbnails->tooltip
-msgid "If enabled, thumbnails will animate when appearing and disappearing."
-msgstr "אם מאופשר, תמונות ממוזערות יהיה להנפיש כאשר מופיעה ונעלמת."
-
-#. 2.8->settings-schema.json->autostart-menu-item->description
-#. 3.4->settings-schema.json->autostart-menu-item->description
-msgid "Show autostart option"
-msgstr "אפשרות autostart צג"
-
-#. 2.8->settings-schema.json->autostart-menu-item->tooltip
-#. 3.4->settings-schema.json->autostart-menu-item->tooltip
-msgid "Shows the autostart toggle option in an app's context menu."
-msgstr "מציג את האפשרות לעבור autostart ב תפריט ההקשר של יישום."
-
-#. 2.8->settings-schema.json->show-pinned->description
-#. 3.4->settings-schema.json->show-pinned->description
-msgid "Show pinned apps"
-msgstr "הראה אפליקציות צמודות (שאינן פועלות)"
-
-#. 2.8->settings-schema.json->show-pinned->tooltip
-#. 3.4->settings-schema.json->show-pinned->tooltip
-msgid ""
-"Controls whether or not the pinned apps appear in the panel if they are not "
-"open."
-msgstr "קובע אם לאו היישומים המוצמדים מופיעים בלוח אם הם אינם פתוחים."
-
-#. 2.8->settings-schema.json->useSystemTooltips->description
-msgid "Use system tooltips for closed apps"
-msgstr "השתמש ובטיפי מערכת עבור יישומים סגורים"
-
-#. 2.8->settings-schema.json->useSystemTooltips->tooltip
-msgid ""
-"Controls whether or not system tooltips are in use when hovering over closed "
-"pinned apps."
-msgstr ""
-"הגדרה זו קובע אם ובטיפי מערכת או לא נמצאים בשימוש כאשר מרחפים מעל יישומים "
-"מוצמדים סגורים."
+#. 2.8->settings-schema.json->ITM->description
+msgid "ITM Settings"
+msgstr "הגדרות ITM"
 
 #. 2.8->settings-schema.json->WindowList->description
 msgid "Window List Settings"
 msgstr "הגדרות של רשימת החלונות"
 
-#. 2.8->settings-schema.json->AppMenu->description
-msgid "Context Menu Settings"
-msgstr "הגדרות תפריט ההקשר"
-
-#. 2.8->settings-schema.json->Thumbnails->description
-msgid "Thumbnail Settings"
-msgstr "הגדרת התמונה ממוצערת"
-
-#. 2.8->settings-schema.json->show-recent->description
-#. 3.4->settings-schema.json->show-recent->description
-msgid "Show recent items"
-msgstr "הצג את הפריטים האחרונים"
-
-#. 2.8->settings-schema.json->show-recent->tooltip
-#. 3.4->settings-schema.json->show-recent->tooltip
-msgid "Controls whether recent items will appear in the context menu."
-msgstr "קובע אם הפריטים האחרונים יופיעו בתפריט ההקשר."
-
-#. 2.8->settings-schema.json->vertical-thumbnails->description
-#. 3.4->settings-schema.json->vertical-thumbnails->description
-msgid "Enable vertical thumbnails"
-msgstr "אפשר תמונות ממוזערות אנכיות"
-
-#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
-#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
-msgid "If enabled, thumbnails will stack vertically."
-msgstr "אם מאופשר, תמונות ממוזערות תהיינה מחסנית אנכית."
-
-#. 2.8->settings-schema.json->thumbnail-timeout->description
-#. 3.4->settings-schema.json->thumbnail-timeout->description
-msgid "Thumbnail timeout"
-msgstr "פסק זמן של תמונה ממוזערת"
-
-#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
-#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
-msgid ""
-"Controls how quickly an app's set of window thumbnails will fade out when "
-"the mouse leaves the app button."
-msgstr ""
-"כיצד הסט של אפליקציה במהירות של תמונות ממוזערות חלון יהיה לדהות כאשר העכבר "
-"עוזב את כפתור האפליקציה."
-
-#. 2.8->settings-schema.json->ThemeSettings->description
-msgid "Theme Settings"
-msgstr "הגדרות נושא"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->description
-#. 3.4->settings-schema.json->onclick-thumbnails->description
-msgid "Open thumbnails on click"
-msgstr "תמונות ממוזערות דף בלחיצה"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
-#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
-msgid "Open the thumbnails on click if there is more than one window open."
-msgstr "פתח את התמונות הממוזערות על קליק אם יש יותר מאחד חלון פתוח."
-
-#. 2.8->settings-schema.json->panelLauncherClass->description
-msgid "Use the panel launcher class for pinned apps"
-msgstr "השתמש בכיתה משגר לוח עבור יישומים המוצמדים"
-
-#. 2.8->settings-schema.json->panelLauncherClass->tooltip
-msgid "Enabling this helps with certain themes."
-msgstr "הפעלת המדיניות הזו מסייעת עם נושאים מסוימים."
-
-#. 2.8->settings-schema.json->include-all-windows->description
-#. 3.4->settings-schema.json->include-all-windows->description
-msgid "Include all app windows"
-msgstr "כלול את כל חלונות האפליקציה"
-
-#. 2.8->settings-schema.json->include-all-windows->tooltip
-#. 3.4->settings-schema.json->include-all-windows->tooltip
-msgid ""
-"Controls whether or not thumbnails for smalller child windows, such as exit "
-"confirmations and file dialogues will be included in the thumbnail list."
-msgstr ""
-"הגדרה זו קובעת אם או לא תמונות ממוזערות עבור חלונות ילד קטן, כגון אישורי "
-"יציאה ודיאלוגים קובץ ייכלל ברשימת ממוזערת."
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->description
-#. 3.4->settings-schema.json->cycleMenusHotkey->description
-msgid "Global hotkey for cycling through thumbnail menus"
-msgstr "מקשי קיצור דרך עולמיים לרכיבה על אופניים דרך תפריטים ממוזערים"
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
-#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
-msgid "This allows you to cycle through the menus without activating a window."
-msgstr "זה מאפשר לך לעבור בין התפריטים ללא הפעלת חלון."
-
-#. 2.8->settings-schema.json->enable-iconSize->description
-#. 3.4->settings-schema.json->enable-iconSize->description
-msgid "Adjust icon size"
-msgstr "התאם גודל סמל"
-
-#. 2.8->settings-schema.json->enable-iconSize->tooltip
-#. 3.4->settings-schema.json->enable-iconSize->tooltip
-msgid "Adjust icon size independent of Cinnamon's panel scaling."
-msgstr "התאם גודל סמל עצמאי של אבנית הלוח של הקינמון."
-
 #. 2.8->settings-schema.json->number-display->description
+#. 3.8->settings-schema.json->number-display->description
 #. 3.4->settings-schema.json->number-display->description
 msgid "Number display"
 msgstr "מספר שולחנות עבודה"
 
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Smart"
+msgstr "חכם"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Normal"
+msgstr "רגיל"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "None"
+msgstr "הסתר כותרת"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "All"
+msgstr "הכל"
+
 #. 2.8->settings-schema.json->number-display->tooltip
+#. 3.8->settings-schema.json->number-display->tooltip
 #. 3.4->settings-schema.json->number-display->tooltip
 msgid ""
 "normal: display window number, smart: display window number if more than one "
@@ -569,42 +244,94 @@ msgstr ""
 "רגיל: הראה מספר חלון, חכם: הראה מספר חלון אם יש יותר מחלון חכם, כלום: אל "
 "תראה מספר חלון, הכל: הראה מספר חלון למועדפים"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "All"
-msgstr "הכל"
+#. 2.8->settings-schema.json->title-display->description
+#. 3.8->settings-schema.json->title-display->description
+#. 3.4->settings-schema.json->title-display->description
+msgid "Title display"
+msgstr "הצגת כותרת"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Smart"
-msgstr "חכם"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "App"
+msgstr "אפליקציה"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Normal"
-msgstr "רגיל"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Title"
+msgstr "כותרת"
 
-#. 2.8->settings-schema.json->ITM->description
-msgid "ITM Settings"
-msgstr "הגדרות ITM"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Focused"
+msgstr "רק בחלון שבפוקוס"
 
-#. 2.8->settings-schema.json->HoverPeek->description
-msgid "Hover Peek Settings"
-msgstr "הגדרות תצוגה מקדימה בנגיעה"
-
-#. 2.8->settings-schema.json->icon-padding->description
-#. 3.4->settings-schema.json->icon-padding->description
-msgid "Icon padding"
-msgstr "רווח מצדדי האיקונים"
-
-#. 2.8->settings-schema.json->icon-padding->tooltip
-#. 3.4->settings-schema.json->icon-padding->tooltip
+#. 2.8->settings-schema.json->title-display->tooltip
+#. 3.8->settings-schema.json->title-display->tooltip
+#. 3.4->settings-schema.json->title-display->tooltip
 msgid ""
-"Controls how much horizontal padding is inside the app buttons. Padding is "
-"only applied to instances of this applet on horizontal panels."
+"focused: show focused window title, title: display the window title, app: "
+"diplay app name, none: don't display anything"
 msgstr ""
-"Controls כמה ריפוד אופקי הוא בתוך כפתורי האפליקציה. ריפוד מוחל רק על מקרים "
-"של יישומון זה על לוחות אופקיים."
+"ממוקדת: תכנית ממוקדת כותרת החלון, הכותרת: להציג את כותרת החלון, האפליקציה: "
+"שם יישום תצוגה, בבול: לא יציג דבר"
+
+#. 2.8->settings-schema.json->group-apps->description
+#. 3.8->settings-schema.json->group-apps->description
+#. 3.4->settings-schema.json->group-apps->description
+msgid "Group apps"
+msgstr "אפליקציות קבוצה"
+
+#. 2.8->settings-schema.json->group-apps->tooltip
+#. 3.8->settings-schema.json->group-apps->tooltip
+#. 3.4->settings-schema.json->group-apps->tooltip
+msgid "Group each app's set of windows."
+msgstr "קבוצה כל קבוצה של חלונות של האפליקציה."
+
+#. 2.8->settings-schema.json->show-alerts->description
+#. 3.8->settings-schema.json->show-alerts->description
+#. 3.4->settings-schema.json->show-alerts->description
+msgid "Show app alerts and notifications"
+msgstr "צג התראות אפליקציה והודעות"
+
+#. 2.8->settings-schema.json->show-alerts->tooltip
+#. 3.8->settings-schema.json->show-alerts->tooltip
+#. 3.4->settings-schema.json->show-alerts->tooltip
+msgid "If enabled, notifications and alerts will appear."
+msgstr "אם מאופשר, הודעות והתראות תופענה."
+
+#. 2.8->settings-schema.json->show-pinned->description
+#. 3.8->settings-schema.json->show-pinned->description
+#. 3.4->settings-schema.json->show-pinned->description
+msgid "Show pinned apps"
+msgstr "הראה אפליקציות צמודות (שאינן פועלות)"
+
+#. 2.8->settings-schema.json->show-pinned->tooltip
+#. 3.8->settings-schema.json->show-pinned->tooltip
+#. 3.4->settings-schema.json->show-pinned->tooltip
+msgid ""
+"Controls whether or not the pinned apps appear in the panel if they are not "
+"open."
+msgstr "קובע אם לאו היישומים המוצמדים מופיעים בלוח אם הם אינם פתוחים."
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->description
+msgid "Arrange pinned apps"
+msgstr "הזז אפליקציות צמודות"
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
+msgid "Arrange pinned apps into a different order."
+msgstr "שנה את סדר האפליקציות הצמודות."
+
+#. 2.8->settings-schema.json->pinOnDrag->description
+#. 2.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.8->settings-schema.json->pinOnDrag->description
+#. 3.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.4->settings-schema.json->pinOnDrag->description
+#. 3.4->settings-schema.json->pinOnDrag->tooltip
+msgid "Pin apps when dragged to a new position"
+msgstr "הצמד את היישומים כאשר גררו למיקום חדש"
 
 #. 2.8->settings-schema.json->middle-click-action->description
 msgid "Middle clicking app buttons creates new app instances"
@@ -619,12 +346,252 @@ msgstr ""
 "קובע את ההתנהגות של לחיצות כפתור עכבר אמצעי על כפתורי אפליקציה. ההגדרה הזו "
 "השווא תסגור את החלון האחרון ממוקד מקבוצת האפליקציה בלחיצה באמצע."
 
+#. 2.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.4->settings-schema.json->cycleMenusHotkey->description
+msgid "Global hotkey for cycling through thumbnail menus"
+msgstr "מקשי קיצור דרך עולמיים לרכיבה על אופניים דרך תפריטים ממוזערים"
+
+#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
+msgid "This allows you to cycle through the menus without activating a window."
+msgstr "זה מאפשר לך לעבור בין התפריטים ללא הפעלת חלון."
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.4->settings-schema.json->show-apps-order-hotkey->description
+msgid "Global hotkey to show the order of apps"
+msgstr "מקשי קיצור דרך עולמיים להראות את סדר האפליקציות"
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
+msgid ""
+"When triggered, the window count label will be replaced with its order in "
+"the app list temporarily."
+msgstr ""
+"כאשר מופעל, התווית חלון הספירה תוחלף מהזמנתו ברשימת היישומים באופן זמני."
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->units
+#. 2.8->settings-schema.json->thumbnail-timeout->units
+#. 2.8->settings-schema.json->hover-peek-time->units
+#. 3.8->settings-schema.json->show-apps-order-timeout->units
+#. 3.8->settings-schema.json->thumbnail-timeout->units
+#. 3.8->settings-schema.json->hover-peek-time->units
+#. 3.4->settings-schema.json->show-apps-order-timeout->units
+#. 3.4->settings-schema.json->thumbnail-timeout->units
+#. 3.4->settings-schema.json->hover-peek-time->units
+msgid "milliseconds"
+msgstr "מילישניות"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.4->settings-schema.json->show-apps-order-timeout->description
+msgid "Duration of the apps order display on hotkey press"
+msgstr "משך אפליקציות סדר תצוגה על עיתונות hotkey"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
+msgid ""
+"Determines the duration the window count labels are replaced with the app's "
+"order number."
+msgstr ""
+"קובע את המשך זמן תוויות ספירת חלון מוחלפות עם מספר ההזמנה של האפליקציה."
+
+#. 2.8->settings-schema.json->Thumbnails->description
+msgid "Thumbnail Settings"
+msgstr "הגדרת התמונה ממוצערת"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->description
+#. 3.8->settings-schema.json->thumbnail-timeout->description
+#. 3.4->settings-schema.json->thumbnail-timeout->description
+msgid "Thumbnail timeout"
+msgstr "פסק זמן של תמונה ממוזערת"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
+msgid ""
+"Controls how quickly an app's set of window thumbnails will fade out when "
+"the mouse leaves the app button."
+msgstr ""
+"כיצד הסט של אפליקציה במהירות של תמונות ממוזערות חלון יהיה לדהות כאשר העכבר "
+"עוזב את כפתור האפליקציה."
+
+# should not be set, just leave it blank and insert one white-space character
+#. 2.8->settings-schema.json->thumbnail-size->units
+#. 3.8->settings-schema.json->thumbnail-size->units
+#. 3.4->settings-schema.json->thumbnail-size->units
+msgid "size"
+msgstr " "
+
+#. 2.8->settings-schema.json->thumbnail-size->description
+#. 3.8->settings-schema.json->thumbnail-size->description
+#. 3.4->settings-schema.json->thumbnail-size->description
+msgid "Thumbnail size"
+msgstr "גודל תמונה ממוזערת"
+
+#. 2.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-size->tooltip
+msgid "Controls the size of the thumbnails."
+msgstr "שולט בגודל של התמונות הממוזערות."
+
+#. 2.8->settings-schema.json->show-thumbnails->description
+#. 3.8->settings-schema.json->show-thumbnails->description
+#. 3.4->settings-schema.json->show-thumbnails->description
+msgid "Show thumbnails"
+msgstr "הראה תמונה ממוזערת"
+
+#. 2.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.4->settings-schema.json->show-thumbnails->tooltip
+msgid "Show window thumbnails when hovering over an app button."
+msgstr "הראה תמונה ממוזערת של חלון פתוח בעת נגיעה בסמל שלו"
+
+#. 2.8->settings-schema.json->animate-thumbnails->description
+#. 3.8->settings-schema.json->animate-thumbnails->description
+#. 3.4->settings-schema.json->animate-thumbnails->description
+msgid "Animate thumbnails"
+msgstr "הנפשת תמונות ממוזערות"
+
+#. 2.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.4->settings-schema.json->animate-thumbnails->tooltip
+msgid "If enabled, thumbnails will animate when appearing and disappearing."
+msgstr "אם מאופשר, תמונות ממוזערות יהיה להנפיש כאשר מופיעה ונעלמת."
+
+#. 2.8->settings-schema.json->vertical-thumbnails->description
+#. 3.8->settings-schema.json->vertical-thumbnails->description
+#. 3.4->settings-schema.json->vertical-thumbnails->description
+msgid "Enable vertical thumbnails"
+msgstr "אפשר תמונות ממוזערות אנכיות"
+
+#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
+msgid "If enabled, thumbnails will stack vertically."
+msgstr "אם מאופשר, תמונות ממוזערות תהיינה מחסנית אנכית."
+
+#. 2.8->settings-schema.json->sort-thumbnails->description
+#. 3.8->settings-schema.json->sort-thumbnails->description
+#. 3.4->settings-schema.json->sort-thumbnails->description
+msgid "Sort windows for each app by last focused"
+msgstr "חלונות מיין עבור כל יישום על ידי ממוקד האחרון"
+
+#. 2.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.4->settings-schema.json->sort-thumbnails->tooltip
+msgid ""
+"Controls whether the order windows appear for an app is by last focused, or "
+"the order they were opened."
+msgstr ""
+"הגדרה זו קובע אם ההסדר חלונות להופיע על אפליקציה הוא ממוקד האחרון, או בסדר "
+"פתיחתם."
+
+#. 2.8->settings-schema.json->onclick-thumbnails->description
+#. 3.8->settings-schema.json->onclick-thumbnails->description
+#. 3.4->settings-schema.json->onclick-thumbnails->description
+msgid "Open thumbnails on click"
+msgstr "תמונות ממוזערות דף בלחיצה"
+
+#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
+msgid "Open the thumbnails on click if there is more than one window open."
+msgstr "פתח את התמונות הממוזערות על קליק אם יש יותר מאחד חלון פתוח."
+
+#. 2.8->settings-schema.json->include-all-windows->description
+#. 3.8->settings-schema.json->include-all-windows->description
+#. 3.4->settings-schema.json->include-all-windows->description
+msgid "Include all app windows"
+msgstr "כלול את כל חלונות האפליקציה"
+
+#. 2.8->settings-schema.json->include-all-windows->tooltip
+#. 3.8->settings-schema.json->include-all-windows->tooltip
+#. 3.4->settings-schema.json->include-all-windows->tooltip
+msgid ""
+"Controls whether or not thumbnails for smalller child windows, such as exit "
+"confirmations and file dialogues will be included in the thumbnail list."
+msgstr ""
+"הגדרה זו קובעת אם או לא תמונות ממוזערות עבור חלונות ילד קטן, כגון אישורי "
+"יציאה ודיאלוגים קובץ ייכלל ברשימת ממוזערת."
+
+#. 2.8->settings-schema.json->AppMenu->description
+msgid "Context Menu Settings"
+msgstr "הגדרות תפריט ההקשר"
+
+#. 2.8->settings-schema.json->show-recent->description
+#. 3.8->settings-schema.json->show-recent->description
+#. 3.4->settings-schema.json->show-recent->description
+msgid "Show recent items"
+msgstr "הצג את הפריטים האחרונים"
+
+#. 2.8->settings-schema.json->show-recent->tooltip
+#. 3.8->settings-schema.json->show-recent->tooltip
+#. 3.4->settings-schema.json->show-recent->tooltip
+msgid "Controls whether recent items will appear in the context menu."
+msgstr "קובע אם הפריטים האחרונים יופיעו בתפריט ההקשר."
+
+#. 2.8->settings-schema.json->menuItemType->description
+#. 3.8->settings-schema.json->menuItemType->description
+#. 3.4->settings-schema.json->menuItemType->description
+msgid "Menu item type"
+msgstr "סוג פריט בתפריט"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Symbolic icons"
+msgstr "סמלים סמליים"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Non-symbolic icons"
+msgstr "סמלים ללא סמלי"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "No icons"
+msgstr "לא נמצאו סמלים"
+
+#. 2.8->settings-schema.json->menuItemType->tooltip
+#. 3.8->settings-schema.json->menuItemType->tooltip
+#. 3.4->settings-schema.json->menuItemType->tooltip
+msgid ""
+"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
+msgstr "קובע אם סמלי פריט בתפריט הם סמליים, הלא סמליים, או לא לראות."
+
 #. 2.8->settings-schema.json->firefox-menu->description
+#. 3.8->settings-schema.json->firefox-menu->description
 #. 3.4->settings-schema.json->firefox-menu->description
 msgid "Firefox context menu"
 msgstr "תפריט ההקשר פיירפוקס"
 
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Most Visited"
+msgstr "הכי מבוקרים"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Recent History"
+msgstr "דפים אחרונים"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Bookmarks"
+msgstr "מועדפים"
+
 #. 2.8->settings-schema.json->firefox-menu->tooltip
+#. 3.8->settings-schema.json->firefox-menu->tooltip
 #. 3.4->settings-schema.json->firefox-menu->tooltip
 msgid ""
 "Most Visited: show the sites you visit most, Recent History: display the the "
@@ -633,20 +600,141 @@ msgstr ""
 "המבוקרים ביותר - האתרים שביקרת בהם הכי הרבה, האחרונים - האתרים האחרונים "
 "שביקרת בהם, מועדפים - מראה את המועדפים"
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Bookmarks"
-msgstr "מועדפים"
+#. 2.8->settings-schema.json->autostart-menu-item->description
+#. 3.8->settings-schema.json->autostart-menu-item->description
+#. 3.4->settings-schema.json->autostart-menu-item->description
+msgid "Show autostart option"
+msgstr "אפשרות autostart צג"
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Most Visited"
-msgstr "הכי מבוקרים"
+#. 2.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.4->settings-schema.json->autostart-menu-item->tooltip
+msgid "Shows the autostart toggle option in an app's context menu."
+msgstr "מציג את האפשרות לעבור autostart ב תפריט ההקשר של יישום."
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Recent History"
-msgstr "דפים אחרונים"
+#. 2.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.4->settings-schema.json->monitor-move-all-windows->description
+msgid "Apply the monitor move option to all windows"
+msgstr "החל את אפשרות המעבר לפקח על כל החלונות"
+
+#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
+msgid ""
+"When clicking \"Move to monitor\" in the context menu, this option will move "
+"all of an app's windows instead of just the last focused window from the app."
+msgstr ""
+"כאשר לחיצה \"הזז לפקח \" בתפריט ההקשר, אפשרות זו יעביר את כל חלונות של "
+"אפליקציה במקום רק את הממוקד האחרון חלון מהאפליקציה."
+
+#. 2.8->settings-schema.json->HoverPeek->description
+msgid "Hover Peek Settings"
+msgstr "הגדרות תצוגה מקדימה בנגיעה"
+
+#. 2.8->settings-schema.json->enable-hover-peek->description
+#. 3.8->settings-schema.json->enable-hover-peek->description
+#. 3.4->settings-schema.json->enable-hover-peek->description
+msgid "Show windows when hovered over"
+msgstr "הצג חלונות כאשר ריחפה מעל"
+
+#. 2.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.4->settings-schema.json->enable-hover-peek->tooltip
+msgid "Controls whether or not windows display when hovered over."
+msgstr "הגדרה זו קובעת אם או לא להציג חלונות כאשר ריחפה מעל."
+
+#. 2.8->settings-schema.json->hover-peek-time->description
+#. 3.8->settings-schema.json->hover-peek-time->description
+#. 3.4->settings-schema.json->hover-peek-time->description
+msgid "Window fade time"
+msgstr "זמן לאפקט"
+
+#. 2.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.4->settings-schema.json->hover-peek-time->tooltip
+msgid "Controls how quickly a window will fade on hover."
+msgstr "תוך כמה זמן מהנגיעה בתמונה הממוזערת תופעל תצוגה מקדימה"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->units
+#. 3.8->settings-schema.json->hover-peek-opacity->units
+#. 3.4->settings-schema.json->hover-peek-opacity->units
+msgid "percent"
+msgstr "אחוזים"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->description
+#. 3.8->settings-schema.json->hover-peek-opacity->description
+#. 3.4->settings-schema.json->hover-peek-opacity->description
+msgid "Window opacity"
+msgstr "שקיפות החלון"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
+msgid "Opacity of the windows on hover."
+msgstr "שקיפות החלון בתצוגה מקדימה"
+
+#. 2.8->settings-schema.json->ThemeSettings->description
+msgid "Theme Settings"
+msgstr "הגדרות נושא"
+
+#. 2.8->settings-schema.json->show-active->description
+#. 3.8->settings-schema.json->show-active->description
+#. 3.4->settings-schema.json->show-active->description
+msgid "Show active app indicators"
+msgstr "צג מחווני אפליקציה פעילים"
+
+#. 2.8->settings-schema.json->show-active->tooltip
+#. 3.8->settings-schema.json->show-active->tooltip
+#. 3.4->settings-schema.json->show-active->tooltip
+msgid "Active app styling will indicate if an app is active."
+msgstr "סטיילינג אפליקציות הפעיל יציין אם אפליקציה פעילה."
+
+#. 2.8->settings-schema.json->icon-spacing->units
+#. 2.8->settings-schema.json->icon-padding->units
+#. 2.8->settings-schema.json->icon-size->units
+#. 3.8->settings-schema.json->app-button-width->units
+#. 3.8->settings-schema.json->thumbnail-close-button-size->units
+#. 3.8->settings-schema.json->thumbnail-padding->units
+#. 3.8->settings-schema.json->icon-spacing->units
+#. 3.8->settings-schema.json->icon-padding->units
+#. 3.8->settings-schema.json->icon-size->units
+#. 3.4->settings-schema.json->app-button-width->units
+#. 3.4->settings-schema.json->thumbnail-close-button-size->units
+#. 3.4->settings-schema.json->thumbnail-padding->units
+#. 3.4->settings-schema.json->icon-spacing->units
+#. 3.4->settings-schema.json->icon-padding->units
+#. 3.4->settings-schema.json->icon-size->units
+msgid "px"
+msgstr ""
+
+#. 2.8->settings-schema.json->icon-spacing->description
+#. 3.8->settings-schema.json->icon-spacing->description
+#. 3.4->settings-schema.json->icon-spacing->description
+msgid "Icon spacing"
+msgstr "מרווח אייקון"
+
+#. 2.8->settings-schema.json->icon-spacing->tooltip
+#. 3.8->settings-schema.json->icon-spacing->tooltip
+#. 3.4->settings-schema.json->icon-spacing->tooltip
+msgid "Controls how much space is between the icons."
+msgstr "בקרת כמה מקום הוא בין הסמלים."
+
+#. 2.8->settings-schema.json->icon-padding->description
+#. 3.8->settings-schema.json->icon-padding->description
+#. 3.4->settings-schema.json->icon-padding->description
+msgid "Icon padding"
+msgstr "רווח מצדדי האיקונים"
+
+#. 2.8->settings-schema.json->icon-padding->tooltip
+#. 3.8->settings-schema.json->icon-padding->tooltip
+#. 3.4->settings-schema.json->icon-padding->tooltip
+msgid ""
+"Controls how much horizontal padding is inside the app buttons. Padding is "
+"only applied to instances of this applet on horizontal panels."
+msgstr ""
+"Controls כמה ריפוד אופקי הוא בתוך כפתורי האפליקציה. ריפוד מוחל רק על מקרים "
+"של יישומון זה על לוחות אופקיים."
 
 #. 2.8->settings-schema.json->themePadding->description
 msgid "Use theme padding to center button icons"
@@ -656,213 +744,351 @@ msgstr "השתמש ריפוד נושא למרכז סמלים כפתור"
 msgid "If button icons look off-centered, toggling this may help."
 msgstr "אם סמלים כפתורים נראים מחוץ מרוכזים, החלפה זה עשויה לעזור."
 
-#. 2.8->settings-schema.json->group-apps->description
-#. 3.4->settings-schema.json->group-apps->description
-msgid "Group apps"
-msgstr "אפליקציות קבוצה"
+#. 2.8->settings-schema.json->enable-iconSize->description
+#. 3.8->settings-schema.json->enable-iconSize->description
+#. 3.4->settings-schema.json->enable-iconSize->description
+msgid "Adjust icon size"
+msgstr "התאם גודל סמל"
 
-#. 2.8->settings-schema.json->group-apps->tooltip
-#. 3.4->settings-schema.json->group-apps->tooltip
-msgid "Group each app's set of windows."
-msgstr "קבוצה כל קבוצה של חלונות של האפליקציה."
+#. 2.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.4->settings-schema.json->enable-iconSize->tooltip
+msgid "Adjust icon size independent of Cinnamon's panel scaling."
+msgstr "התאם גודל סמל עצמאי של אבנית הלוח של הקינמון."
 
-#. 2.8->settings-schema.json->show-active->description
-#. 3.4->settings-schema.json->show-active->description
-msgid "Show active app indicators"
-msgstr "צג מחווני אפליקציה פעילים"
+#. 2.8->settings-schema.json->icon-size->description
+#. 3.8->settings-schema.json->icon-size->description
+#. 3.4->settings-schema.json->icon-size->description
+msgid "Icon size"
+msgstr "גודל אייקון"
 
-#. 2.8->settings-schema.json->show-active->tooltip
-#. 3.4->settings-schema.json->show-active->tooltip
-msgid "Active app styling will indicate if an app is active."
-msgstr "סטיילינג אפליקציות הפעיל יציין אם אפליקציה פעילה."
+#. 2.8->settings-schema.json->icon-size->tooltip
+#. 3.8->settings-schema.json->icon-size->tooltip
+#. 3.4->settings-schema.json->icon-size->tooltip
+msgid "Set icon size"
+msgstr "גודל גדר סמל"
 
-#. 2.8->settings-schema.json->show-apps-order-timeout->description
-#. 3.4->settings-schema.json->show-apps-order-timeout->description
-msgid "Duration of the apps order display on hotkey press"
-msgstr "משך אפליקציות סדר תצוגה על עיתונות hotkey"
+#. 2.8->settings-schema.json->hoverPseudoClass->description
+#. 3.8->settings-schema.json->hoverPseudoClass->description
+#. 3.4->settings-schema.json->hoverPseudoClass->description
+msgid "App button hover pseudo class"
+msgstr "בכיתה פסאודו לרחף אפליקציה '"
 
-#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
-#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
-msgid ""
-"Determines the duration the window count labels are replaced with the app's "
-"order number."
-msgstr ""
-"קובע את המשך זמן תוויות ספירת חלון מוחלפות עם מספר ההזמנה של האפליקציה."
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->description
-msgid "Arrange pinned apps"
-msgstr "הזז אפליקציות צמודות"
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
-msgid "Arrange pinned apps into a different order."
-msgstr "שנה את סדר האפליקציות הצמודות."
-
-#. 2.8->settings-schema.json->monitor-move-all-windows->description
-#. 3.4->settings-schema.json->monitor-move-all-windows->description
-msgid "Apply the monitor move option to all windows"
-msgstr "החל את אפשרות המעבר לפקח על כל החלונות"
-
-#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
-#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
-msgid ""
-"When clicking \"Move to monitor\" in the context menu, this option will move "
-"all of an app's windows instead of just the last focused window from the app."
-msgstr ""
-"כאשר לחיצה \"הזז לפקח \" בתפריט ההקשר, אפשרות זו יעביר את כל חלונות של "
-"אפליקציה במקום רק את הממוקד האחרון חלון מהאפליקציה."
-
-#. 2.8->settings-schema.json->sort-thumbnails->description
-#. 3.4->settings-schema.json->sort-thumbnails->description
-msgid "Sort windows for each app by last focused"
-msgstr "חלונות מיין עבור כל יישום על ידי ממוקד האחרון"
-
-#. 2.8->settings-schema.json->sort-thumbnails->tooltip
-#. 3.4->settings-schema.json->sort-thumbnails->tooltip
-msgid ""
-"Controls whether the order windows appear for an app is by last focused, or "
-"the order they were opened."
-msgstr ""
-"הגדרה זו קובע אם ההסדר חלונות להופיע על אפליקציה הוא ממוקד האחרון, או בסדר "
-"פתיחתם."
-
-#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
 #. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
 #. 3.4->settings-schema.json->activePseudoClass->options
-msgid "checked"
+msgid "hover"
 msgstr ""
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
-msgid "Highlight the last focused window within an app group"
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+#, fuzzy
+msgid "focus"
+msgstr "רק בחלון שבפוקוס"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "active"
 msgstr ""
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "outlined"
+msgstr ""
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "selected"
+msgstr ""
+
+#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons on hover."
+msgstr "עוקף את הכיתה פסאודו לכפתורי אפליקציה על לרחף."
+
+#. 2.8->settings-schema.json->focusPseudoClass->description
+#. 3.8->settings-schema.json->focusPseudoClass->description
+#. 3.4->settings-schema.json->focusPseudoClass->description
+msgid "App button focus pseudo class"
+msgstr "בכיתה פסאודו מוקד אפליקציה '"
+
+#. 2.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.4->settings-schema.json->focusPseudoClass->tooltip
+msgid "Overrides the pseudo class for app button on focus."
+msgstr "עוקף את הכיתה פסאודו עבור כפתור האפליקציה על המוקד."
+
+#. 2.8->settings-schema.json->activePseudoClass->description
+#. 3.8->settings-schema.json->activePseudoClass->description
+#. 3.4->settings-schema.json->activePseudoClass->description
+msgid "App button active pseudo class"
+msgstr "App כפתור בכיתה פסאודו פעילה"
+
+#. 2.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.4->settings-schema.json->activePseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons when they are active."
+msgstr "עוקף את הכיתה פסאודו לכפתורי אפליקציה כאשר הם פעילים."
+
+#. 2.8->settings-schema.json->panelLauncherClass->description
+msgid "Use the panel launcher class for pinned apps"
+msgstr "השתמש בכיתה משגר לוח עבור יישומים המוצמדים"
+
+#. 2.8->settings-schema.json->panelLauncherClass->tooltip
+msgid "Enabling this helps with certain themes."
+msgstr "הפעלת המדיניות הזו מסייעת עם נושאים מסוימים."
+
+#. 2.8->settings-schema.json->close-button-style->description
+msgid "Allow themes to control the thumbnail close button"
+msgstr "אפשר נושאים לשלוט על לחצן התמונה הממוזערת קרוב"
+
+#. 2.8->settings-schema.json->close-button-style->tooltip
 msgid ""
-"When enabled, the last window that was interacted with will be indicated."
-msgstr ""
+"Controls whether or not the theme controls the window thumbnail's close "
+"button."
+msgstr "קובע אם לאו הנושא שולט לחצן הסגירה של החלון הממוזער."
 
-#. 3.4->settings-schema.json->app-button-transition-duration->description
-msgid "App button transition duration"
-msgstr ""
-
-#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
-msgid ""
-"Overrides the theme's animation time for app buttons. If set to zero, the "
-"theme's transition duration will be used."
-msgstr ""
-
-#. 3.4->settings-schema.json->app-button-transition-duration->units
-msgid "ms"
-msgstr ""
-
-#. 3.4->settings-schema.json->thumbnail-padding->description
-#, fuzzy
-msgid "Thumbnail padding"
-msgstr "הגדרת התמונה ממוצערת"
-
-#. 3.4->settings-schema.json->thumbnail-padding->tooltip
-#, fuzzy
-msgid "Controls how much space will be around the window preview thumbnails."
-msgstr "בקרת כמה מקום הוא בין הסמלים."
-
-#. 3.4->settings-schema.json->system-favorites->description
-#, fuzzy
-msgid "Use system favorites for pinned apps"
+#. 2.8->settings-schema.json->useSystemTooltips->description
+msgid "Use system tooltips for closed apps"
 msgstr "השתמש ובטיפי מערכת עבור יישומים סגורים"
 
-#. 3.4->settings-schema.json->system-favorites->tooltip
-#, fuzzy
+#. 2.8->settings-schema.json->useSystemTooltips->tooltip
 msgid ""
-"Controls whether or not pinned apps consist of the system favorites list."
-msgstr "קובע אם לאו היישומים המוצמדים מופיעים בלוח אם הם אינם פתוחים."
+"Controls whether or not system tooltips are in use when hovering over closed "
+"pinned apps."
+msgstr ""
+"הגדרה זו קובע אם ובטיפי מערכת או לא נמצאים בשימוש כאשר מרחפים מעל יישומים "
+"מוצמדים סגורים."
 
-#. 3.4->settings-schema.json->generalSection->title
-msgid "Behavior"
+#. 3.8->settings-schema.json->generalPage->title
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
 msgstr ""
 
+#. 3.8->settings-schema.json->panelPage->title
+#. 3.4->settings-schema.json->panelPage->title
+msgid "Panel"
+msgstr ""
+
+#. 3.8->settings-schema.json->thumbnailsPage->title
+#. 3.8->settings-schema.json->thumbnailsSection->title
 #. 3.4->settings-schema.json->thumbnailsPage->title
 #. 3.4->settings-schema.json->thumbnailsSection->title
 #, fuzzy
 msgid "Thumbnails"
 msgstr "גודל תמונה ממוזערת"
 
-#. 3.4->settings-schema.json->presetSection->title
-msgid "Recommended Presets"
-msgstr ""
-
-#. 3.4->settings-schema.json->appButtonsSection->title
-msgid "App Buttons"
-msgstr ""
-
-#. 3.4->settings-schema.json->generalPage->title
-msgid "General"
-msgstr ""
-
-#. 3.4->settings-schema.json->hoverPeekSection->title
-#, fuzzy
-msgid "Hover Peek"
-msgstr "הגדרות תצוגה מקדימה בנגיעה"
-
-#. 3.4->settings-schema.json->panelPage->title
-msgid "Panel"
-msgstr ""
-
-#. 3.4->settings-schema.json->iconSection->title
-#, fuzzy
-msgid "Icons"
-msgstr "גודל אייקון"
-
-#. 3.4->settings-schema.json->hotKeysSection->title
-msgid "Hot Keys"
-msgstr ""
-
-#. 3.4->settings-schema.json->stylingSection->title
-msgid "Styling"
-msgstr ""
-
+#. 3.8->settings-schema.json->contextMenuPage->title
 #. 3.4->settings-schema.json->contextMenuPage->title
 #, fuzzy
 msgid "Context Menu"
 msgstr "הגדרות תפריט ההקשר"
 
+#. 3.8->settings-schema.json->themePage->title
 #. 3.4->settings-schema.json->themePage->title
 #, fuzzy
 msgid "Theming"
 msgstr "הגדרות נושא"
 
-#. 3.4->settings-schema.json->mintYPreset->description
-#. 3.4->settings-schema.json->mintYPreset->tooltip
-msgid "Mint Y and Variants"
+#. 3.8->settings-schema.json->generalSection->title
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
 msgstr ""
 
-#. 3.4->settings-schema.json->show-icons->description
+#. 3.8->settings-schema.json->appButtonsSection->title
+#. 3.4->settings-schema.json->appButtonsSection->title
+msgid "App Buttons"
+msgstr ""
+
+#. 3.8->settings-schema.json->hotKeysSection->title
+#. 3.4->settings-schema.json->hotKeysSection->title
+msgid "Hot Keys"
+msgstr ""
+
+#. 3.8->settings-schema.json->hoverPeekSection->title
+#. 3.4->settings-schema.json->hoverPeekSection->title
 #, fuzzy
-msgid "Show icons"
-msgstr "לא נמצאו סמלים"
+msgid "Hover Peek"
+msgstr "הגדרות תצוגה מקדימה בנגיעה"
 
-#. 3.4->settings-schema.json->show-icons->tooltip
-msgid "Show the window's icon next to the title."
+#. 3.8->settings-schema.json->stylingSection->title
+#. 3.4->settings-schema.json->stylingSection->title
+msgid "Styling"
 msgstr ""
 
+#. 3.8->settings-schema.json->iconSection->title
+#. 3.4->settings-schema.json->iconSection->title
+#, fuzzy
+msgid "Icons"
+msgstr "גודל אייקון"
+
+#. 3.8->settings-schema.json->presetSection->title
+#. 3.4->settings-schema.json->presetSection->title
+msgid "Recommended Presets"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->description
+#. 3.4->settings-schema.json->scroll-behavior->description
+msgid "Mouse wheel scroll behavior"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+msgid "Cycle apps"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#, fuzzy
+msgid "Cycle windows"
+msgstr "כלול את כל חלונות האפליקציה"
+
+#. 3.8->settings-schema.json->scroll-behavior->tooltip
+#. 3.4->settings-schema.json->scroll-behavior->tooltip
+msgid ""
+"Choose if scrolling the mouse wheel cycles running apps, an app button's "
+"windows on hover, or is disabled."
+msgstr ""
+
+#. 3.8->settings-schema.json->left-click-action->description
+#. 3.8->settings-schema.json->left-click-action->tooltip
+#. 3.8->settings-schema.json->launcher-animation-effect->tooltip
+#. 3.4->settings-schema.json->left-click-action->description
+#. 3.4->settings-schema.json->left-click-action->tooltip
+#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
+msgid "Left click action"
+msgstr ""
+
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->left-click-action->options
+msgid "Toggle activation of last focused window"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->description
+#. 3.8->settings-schema.json->middle-click-action->tooltip
+#. 3.4->settings-schema.json->middle-click-action->description
+#. 3.4->settings-schema.json->middle-click-action->tooltip
+msgid "Middle click action"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Launch new app instance"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Close last focused window in group"
+msgstr ""
+
+#. 3.8->settings-schema.json->system-favorites->description
+#. 3.4->settings-schema.json->system-favorites->description
+#, fuzzy
+msgid "Use system favorites for pinned apps"
+msgstr "השתמש ובטיפי מערכת עבור יישומים סגורים"
+
+#. 3.8->settings-schema.json->system-favorites->tooltip
+#. 3.4->settings-schema.json->system-favorites->tooltip
+#, fuzzy
+msgid ""
+"Controls whether or not pinned apps consist of the system favorites list."
+msgstr "קובע אם לאו היישומים המוצמדים מופיעים בלוח אם הם אינם פתוחים."
+
+#. 3.8->settings-schema.json->show-all-workspaces->description
+#. 3.8->settings-schema.json->show-all-workspaces->tooltip
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#, fuzzy
+msgid "Show windows from all workspaces"
+msgstr "רק בשולחן העבודה הזה"
+
+#. 3.8->settings-schema.json->enable-app-button-dragging->description
+#. 3.8->settings-schema.json->enable-app-button-dragging->tooltip
 #. 3.4->settings-schema.json->enable-app-button-dragging->description
 #. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
 msgid "Enable app button dragging"
 msgstr ""
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
-#, fuzzy
-msgid "Show new window option"
-msgstr "אפשרות autostart צג"
-
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
-msgid ""
-"Shows the \"New Window\" option in an app's context menu if it doesn't "
-"already have one from the app's own action menu items."
+#. 3.8->settings-schema.json->launcher-animation-effect->description
+#. 3.4->settings-schema.json->launcher-animation-effect->description
+msgid "Launcher animation effect"
 msgstr ""
 
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Fade"
+msgstr ""
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Scale"
+msgstr ""
+
+#. 3.8->settings-schema.json->list-monitor-windows->description
+#. 3.4->settings-schema.json->list-monitor-windows->description
+msgid "Only list windows from the monitor displaying this instance"
+msgstr ""
+
+#. 3.8->settings-schema.json->list-monitor-windows->tooltip
+#. 3.4->settings-schema.json->list-monitor-windows->tooltip
+msgid ""
+"This option will only come into effect for monitors displaying an ITM "
+"instance."
+msgstr ""
+
+#. 3.8->settings-schema.json->enable-app-button-width->description
+#. 3.4->settings-schema.json->enable-app-button-width->description
+msgid "Use a custom width for app buttons"
+msgstr ""
+
+#. 3.8->settings-schema.json->enable-app-button-width->tooltip
+#. 3.4->settings-schema.json->enable-app-button-width->tooltip
+msgid "When disabled, the app button width is determined by the panel height."
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-width->description
 #. 3.4->settings-schema.json->app-button-width->description
 msgid "App button width"
 msgstr ""
 
+#. 3.8->settings-schema.json->app-button-width->tooltip
 #. 3.4->settings-schema.json->app-button-width->tooltip
 #, fuzzy
 msgid ""
@@ -870,119 +1096,120 @@ msgid ""
 "horizontal panels."
 msgstr "שולט בגודל של התמונות הממוזערות."
 
-#. 3.4->settings-schema.json->mintXPreset->description
-#. 3.4->settings-schema.json->mintXPreset->tooltip
-msgid "Mint X, Linux Mint, and Variants"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->description
-msgid "Launcher animation effect"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
-#. 3.4->settings-schema.json->left-click-action->description
-#. 3.4->settings-schema.json->left-click-action->tooltip
-msgid "Left click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Scale"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Fade"
-msgstr ""
-
-#. 3.4->settings-schema.json->enable-app-button-width->description
-msgid "Use a custom width for app buttons"
-msgstr ""
-
-#. 3.4->settings-schema.json->enable-app-button-width->tooltip
-msgid "When disabled, the app button width is determined by the panel height."
-msgstr ""
-
-#. 3.4->settings-schema.json->list-monitor-windows->description
-msgid "Only list windows from the monitor displaying this instance"
-msgstr ""
-
-#. 3.4->settings-schema.json->list-monitor-windows->tooltip
-msgid ""
-"This option will only come into effect for monitors displaying an ITM "
-"instance."
-msgstr ""
-
+#. 3.8->settings-schema.json->thumbnail-close-button-size->description
 #. 3.4->settings-schema.json->thumbnail-close-button-size->description
 #, fuzzy
 msgid "Close button size"
 msgstr "גודל גדר סמל"
 
+#. 3.8->settings-schema.json->thumbnail-close-button-size->tooltip
 #. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
 #, fuzzy
 msgid "Controls how large the thumbnail close button is."
 msgstr "אפשר נושאים לשלוט על לחצן התמונה הממוזערת קרוב"
 
-#. 3.4->settings-schema.json->middle-click-action->description
-#. 3.4->settings-schema.json->middle-click-action->tooltip
-msgid "Middle click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Launch new app instance"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Close last focused window in group"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->description
-msgid "Mouse wheel scroll behavior"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->tooltip
-msgid ""
-"Choose if scrolling the mouse wheel cycles running apps, an app button's "
-"windows on hover, or is disabled."
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->options
-msgid "Cycle apps"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->thumbnail-padding->description
+#. 3.4->settings-schema.json->thumbnail-padding->description
 #, fuzzy
-msgid "Cycle windows"
-msgstr "כלול את כל חלונות האפליקציה"
+msgid "Thumbnail padding"
+msgstr "הגדרת התמונה ממוצערת"
 
-#. 3.4->settings-schema.json->show-all-workspaces->description
-#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#. 3.8->settings-schema.json->thumbnail-padding->tooltip
+#. 3.4->settings-schema.json->thumbnail-padding->tooltip
 #, fuzzy
-msgid "Show windows from all workspaces"
-msgstr "רק בשולחן העבודה הזה"
+msgid "Controls how much space will be around the window preview thumbnails."
+msgstr "בקרת כמה מקום הוא בין הסמלים."
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->description
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
 msgid "Cycle windows on mouse wheel scroll"
 msgstr ""
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->tooltip
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
 msgid ""
 "Choose whether or not scrolling the mouse wheel cycles windows when hovering "
 "over a thumbnail menu."
 msgstr ""
 
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "Toggle activation of last focused window"
-msgstr ""
-
-#. IcingTaskManager@json->metadata.json->name
-msgid "Icing Task Manager"
-msgstr "Icing Task Manager"
-
-#. IcingTaskManager@json->metadata.json->description
+#. 3.8->settings-schema.json->show-icons->description
+#. 3.4->settings-schema.json->show-icons->description
 #, fuzzy
-msgid "Window list with app grouping and thumbnails"
+msgid "Show icons"
+msgstr "לא נמצאו סמלים"
+
+#. 3.8->settings-schema.json->show-icons->tooltip
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
 msgstr ""
-"שורת משימות עם קיבוץ אפליקציות והצגת חלונות ממוזערים תכלס - כמו בווינדוס"
+
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->description
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
+msgid "Highlight the last focused window within an app group"
+msgstr ""
+
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+msgid ""
+"When enabled, the last window that was interacted with will be indicated."
+msgstr ""
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->description
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "אפשרות autostart צג"
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->tooltip
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->units
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->description
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->tooltip
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.8->settings-schema.json->mintYPreset->description
+#. 3.8->settings-schema.json->mintYPreset->tooltip
+#. 3.4->settings-schema.json->mintYPreset->description
+#. 3.4->settings-schema.json->mintYPreset->tooltip
+msgid "Mint Y and Variants"
+msgstr ""
+
+#. 3.8->settings-schema.json->mintXPreset->description
+#. 3.8->settings-schema.json->mintXPreset->tooltip
+#. 3.4->settings-schema.json->mintXPreset->description
+#. 3.4->settings-schema.json->mintXPreset->tooltip
+msgid "Mint X, Linux Mint, and Variants"
+msgstr ""
+
+#. 3.8->settings-schema.json->migrationButton->description
+msgid "Migrate Pinned Apps to Grouped Window List"
+msgstr ""
 
 # Should not be set, just leave it blank by setting one white-space character
 #~ msgid "number"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/hr.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/hr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Icing Task Manager 4.3.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-23 21:32-0600\n"
+"POT-Creation-Date: 2018-12-10 00:43-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian <hr@li.org>\n"
@@ -14,557 +14,226 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/applet.js:471
+msgid "Icing Task Manager is now Grouped Window List"
+msgstr ""
+
+#: 3.8/applet.js:472
+msgid ""
+"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
+"Window List\". "
+msgstr ""
+
+#: 3.8/applet.js:473
+msgid ""
+"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
+"List."
+msgstr ""
+
+#: 3.8/applet.js:485
+msgid "Migration can only be performed on Cinnamon 4.0."
+msgstr ""
+
+#: 3.8/applet.js:496
+msgid ""
+"Please add Grouped Window List to a panel before proceeding with the "
+"migration."
+msgstr ""
+
+#: 3.8/applet.js:504
+msgid "ITM settings directory could not be found!"
+msgstr ""
+
+#: 3.8/applet.js:534
+msgid "System favorites enabled - no migration is needed."
+msgstr ""
+
+#: 3.8/applet.js:577
+msgid "Unable to find a suitable ITM settings file to migrate."
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid "Migration complete. "
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid " settings file(s) could not be migrated."
+msgstr ""
+
+#: 3.8/applet.js:592
+msgid "Migration was successful."
+msgstr ""
+
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 #, fuzzy
 msgid "Move to the other monitor"
 msgstr "Premjesti na zaslon"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 #, fuzzy
 msgid "Move to monitor "
 msgstr "Premjesti na zaslon"
 
-#: 3.4/specialMenus.js:126
+#: 3.8/specialMenus.js:98 3.4/specialMenus.js:126
 msgid "Only on this workspace"
 msgstr "Samo na ovom radnom prostoru"
 
-#: 3.4/specialMenus.js:133
+#: 3.8/specialMenus.js:105 3.4/specialMenus.js:133
 msgid "Visible on all workspaces"
 msgstr "Vidljivo na svim radnim prostorima"
 
-#: 3.4/specialMenus.js:140
+#: 3.8/specialMenus.js:112 3.4/specialMenus.js:140
 #, fuzzy
 msgid "Move to another workspace"
 msgstr "Premjesti na lijevi radni prostor"
 
-#: 3.4/specialMenus.js:168
+#: 3.8/specialMenus.js:140 3.4/specialMenus.js:168
 msgid "Places"
 msgstr ""
 
-#: 3.4/specialMenus.js:207
+#: 3.8/specialMenus.js:179 3.4/specialMenus.js:207
 msgid "Bookmarks/History requires gir1.2-gda-5.0"
 msgstr ""
 
-#: 3.4/specialMenus.js:227
+#: 3.8/specialMenus.js:199 3.4/specialMenus.js:227
 #, fuzzy
 msgid "Recent"
 msgstr "postoci"
 
-#: 3.4/specialMenus.js:246
+#: 3.8/specialMenus.js:218 3.4/specialMenus.js:246
 msgid "Preferences"
 msgstr ""
 
-#: 3.4/specialMenus.js:249
+#: 3.8/specialMenus.js:221 3.4/specialMenus.js:249
 msgid "About..."
 msgstr ""
 
-#: 3.4/specialMenus.js:253
+#: 3.8/specialMenus.js:225 3.4/specialMenus.js:253
 msgid "Configure..."
 msgstr ""
 
-#: 3.4/specialMenus.js:257
+#: 3.8/specialMenus.js:229 3.4/specialMenus.js:257
 msgid "Remove"
 msgstr ""
 
-#: 3.4/specialMenus.js:287
+#: 3.8/specialMenus.js:259 3.4/specialMenus.js:287
 #, fuzzy
 msgid "New Window"
 msgstr "Uključi sve prozore"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Unpin from Panel"
 msgstr "Ukloni s panela"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Pin to Panel"
 msgstr "Pričvrsti na panel"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Remove from Autostart"
 msgstr "Ukloni iz automatskog pokretanja"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Add to Autostart"
 msgstr "Dodaj u automatsko pokretanje"
 
-#: 3.4/specialMenus.js:318
+#: 3.8/specialMenus.js:290 3.4/specialMenus.js:318
 msgid "Create Shortcut"
 msgstr "Stvori prečac"
 
-#: 3.4/specialMenus.js:329
+#: 3.8/specialMenus.js:301 3.4/specialMenus.js:329
 msgid "Restore to full opacity"
 msgstr ""
 
-#: 3.4/specialMenus.js:337
+#: 3.8/specialMenus.js:309 3.4/specialMenus.js:337
 msgid "Restore"
 msgstr "Vrati"
 
-#: 3.4/specialMenus.js:342
+#: 3.8/specialMenus.js:314 3.4/specialMenus.js:342
 msgid "Minimize"
 msgstr "Smanji"
 
-#: 3.4/specialMenus.js:350
+#: 3.8/specialMenus.js:322 3.4/specialMenus.js:350
 msgid "Unmaximize"
 msgstr "Prikaži u prozoru"
 
-#: 3.4/specialMenus.js:355
+#: 3.8/specialMenus.js:327 3.4/specialMenus.js:355
 msgid "Maximize"
 msgstr "Uvećaj"
 
-#: 3.4/specialMenus.js:365
+#: 3.8/specialMenus.js:337 3.4/specialMenus.js:365
 msgid "Close others"
 msgstr ""
 
-#: 3.4/specialMenus.js:375
+#: 3.8/specialMenus.js:347 3.4/specialMenus.js:375
 #, fuzzy
 msgid "Close all"
 msgstr "Zatvori sve"
 
-#: 3.4/specialMenus.js:385
+#: 3.8/specialMenus.js:357 3.4/specialMenus.js:385
 msgid "Close"
 msgstr "Zatvori"
 
-#. 2.8->settings-schema.json->thumbnail-size->description
-#. 3.4->settings-schema.json->thumbnail-size->description
-msgid "Thumbnail size"
-msgstr "Veličina minijatura"
-
-#. 2.8->settings-schema.json->thumbnail-size->tooltip
-#. 3.4->settings-schema.json->thumbnail-size->tooltip
-msgid "Controls the size of the thumbnails."
-msgstr "Upravlja veličinom minijatura."
-
-#. 2.8->settings-schema.json->thumbnail-size->units
-#. 3.4->settings-schema.json->thumbnail-size->units
-msgid "size"
-msgstr "veličina"
-
-#. 2.8->settings-schema.json->focusPseudoClass->description
-#. 3.4->settings-schema.json->focusPseudoClass->description
-msgid "App button focus pseudo class"
-msgstr "Pseudo klasa tipke fokusa aplikacije"
-
-#. 2.8->settings-schema.json->focusPseudoClass->tooltip
-#. 3.4->settings-schema.json->focusPseudoClass->tooltip
-msgid "Overrides the pseudo class for app button on focus."
-msgstr "Zaobilazi pseudo klasu tipke fokusa aplikacije."
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "active"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "outlined"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "hover"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
+#. metadata.json->description
 #, fuzzy
-msgid "focus"
-msgstr "Fokusiran"
+msgid "Window list with app grouping and thumbnails"
+msgstr "Popis prozora s grupiranjem aplikacija i minijaturama prozora"
 
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "selected"
-msgstr ""
+#. metadata.json->name
+msgid "Icing Task Manager"
+msgstr "Icing upravitelj zadataka"
 
-#. 2.8->settings-schema.json->icon-spacing->description
-#. 3.4->settings-schema.json->icon-spacing->description
-msgid "Icon spacing"
-msgstr "Razmak ikona"
-
-#. 2.8->settings-schema.json->icon-spacing->tooltip
-#. 3.4->settings-schema.json->icon-spacing->tooltip
-msgid "Controls how much space is between the icons."
-msgstr "Upravlja razmakom između ikona."
-
-#. 2.8->settings-schema.json->icon-spacing->units
-#. 2.8->settings-schema.json->icon-size->units
-#. 2.8->settings-schema.json->icon-padding->units
-#. 3.4->settings-schema.json->icon-spacing->units
-#. 3.4->settings-schema.json->thumbnail-padding->units
-#. 3.4->settings-schema.json->icon-size->units
-#. 3.4->settings-schema.json->app-button-width->units
-#. 3.4->settings-schema.json->thumbnail-close-button-size->units
-#. 3.4->settings-schema.json->icon-padding->units
-msgid "px"
-msgstr "pikseli"
-
-#. 2.8->settings-schema.json->show-thumbnails->description
-#. 3.4->settings-schema.json->show-thumbnails->description
-msgid "Show thumbnails"
-msgstr "Prikaži minijature"
-
-#. 2.8->settings-schema.json->show-thumbnails->tooltip
-#. 3.4->settings-schema.json->show-thumbnails->tooltip
-msgid "Show window thumbnails when hovering over an app button."
-msgstr "Prikazuje minijature prozora pri prijelazu preko tipke aplikacije."
-
-#. 2.8->settings-schema.json->icon-size->description
-#. 3.4->settings-schema.json->icon-size->description
-msgid "Icon size"
-msgstr "Veličina ikone"
-
-#. 2.8->settings-schema.json->icon-size->tooltip
-#. 3.4->settings-schema.json->icon-size->tooltip
-msgid "Set icon size"
-msgstr "Postavi veličinu ikone"
-
-#. 2.8->settings-schema.json->hover-peek-time->description
-#. 3.4->settings-schema.json->hover-peek-time->description
-msgid "Window fade time"
-msgstr "Vrijeme isčezavanja prozora"
-
-#. 2.8->settings-schema.json->hover-peek-time->tooltip
-#. 3.4->settings-schema.json->hover-peek-time->tooltip
-msgid "Controls how quickly a window will fade on hover."
-msgstr "Upravlja iščezavanjem prozora pri prijelazu pokazivačem miša."
-
-#. 2.8->settings-schema.json->hover-peek-time->units
-#. 2.8->settings-schema.json->thumbnail-timeout->units
-#. 2.8->settings-schema.json->show-apps-order-timeout->units
-#. 3.4->settings-schema.json->hover-peek-time->units
-#. 3.4->settings-schema.json->thumbnail-timeout->units
-#. 3.4->settings-schema.json->show-apps-order-timeout->units
-msgid "milliseconds"
-msgstr "milisekundi"
-
-#. 2.8->settings-schema.json->close-button-style->description
-msgid "Allow themes to control the thumbnail close button"
-msgstr "Dopusti temi upravljanje tipkom zatvaranja minijature"
-
-#. 2.8->settings-schema.json->close-button-style->tooltip
-msgid ""
-"Controls whether or not the theme controls the window thumbnail's close "
-"button."
-msgstr "Tema upravlja tipkom zatvaranja minijature."
-
-#. 2.8->settings-schema.json->title-display->description
-#. 3.4->settings-schema.json->title-display->description
-msgid "Title display"
-msgstr "Prikaz naslova"
-
-#. 2.8->settings-schema.json->title-display->tooltip
-#. 3.4->settings-schema.json->title-display->tooltip
-msgid ""
-"focused: show focused window title, title: display the window title, app: "
-"diplay app name, none: don't display anything"
-msgstr ""
-"fokusiran: prikaži fokusirane naslove prozora, naslov: prikaži naslov "
-"prozora, aplikacija: prikaži naziv aplikacije, nijedan: prikazuj ništa"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-#. 3.4->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->middle-click-action->options
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "None"
-msgstr "Nijedan"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Focused"
-msgstr "Fokusiran"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "App"
-msgstr "Aplikacija"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Title"
-msgstr "Naslov"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->description
-#. 3.4->settings-schema.json->hoverPseudoClass->description
-msgid "App button hover pseudo class"
-msgstr "Pseudo klasa tipke prijelaza aplikacije"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
-#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons on hover."
-msgstr "Zaobilazi pseudo klasu tipke prijelaza aplikacije."
-
-#. 2.8->settings-schema.json->show-alerts->description
-#. 3.4->settings-schema.json->show-alerts->description
-msgid "Show app alerts and notifications"
-msgstr "Prikaži upozorenje aplikacije i obavijest"
-
-#. 2.8->settings-schema.json->show-alerts->tooltip
-#. 3.4->settings-schema.json->show-alerts->tooltip
-msgid "If enabled, notifications and alerts will appear."
-msgstr "Ako je omogućeno, prikazivat će se obavijesti i upozorenja aplikacije."
-
-#. 2.8->settings-schema.json->pinOnDrag->description
-#. 2.8->settings-schema.json->pinOnDrag->tooltip
-#. 3.4->settings-schema.json->pinOnDrag->description
-#. 3.4->settings-schema.json->pinOnDrag->tooltip
-msgid "Pin apps when dragged to a new position"
-msgstr "Pin aplikacije Kada odvukao na novu poziciju"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->description
-#. 3.4->settings-schema.json->show-apps-order-hotkey->description
-msgid "Global hotkey to show the order of apps"
-msgstr "Globalni prečaci tipkovnice za prikaz poredka aplikacija"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
-#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
-msgid ""
-"When triggered, the window count label will be replaced with its order in "
-"the app list temporarily."
-msgstr ""
-"Kada je pokrenuto, broj naslova prozora će biti privremeno zamijenjen s "
-"poredkom u popisu aplikacija."
-
-#. 2.8->settings-schema.json->menuItemType->description
-#. 3.4->settings-schema.json->menuItemType->description
-msgid "Menu item type"
-msgstr "Vrsta unosa izbornika"
-
-#. 2.8->settings-schema.json->menuItemType->tooltip
-#. 3.4->settings-schema.json->menuItemType->tooltip
-msgid ""
-"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
-msgstr ""
-"Određuje je li ikona stavke izbornika simbolička, nesimbolička ili nije "
-"prikazana."
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Symbolic icons"
-msgstr "Simboličke ikona"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "No icons"
-msgstr "Bez ikona"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Non-symbolic icons"
-msgstr "Nesimboličke ikona"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->description
-#. 3.4->settings-schema.json->hover-peek-opacity->description
-msgid "Window opacity"
-msgstr "Prozirnost prozora"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
-#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
-msgid "Opacity of the windows on hover."
-msgstr "Prozirnost prozora pri prijelazu pokazivača miša."
-
-#. 2.8->settings-schema.json->hover-peek-opacity->units
-#. 3.4->settings-schema.json->hover-peek-opacity->units
-msgid "percent"
-msgstr "postoci"
-
-#. 2.8->settings-schema.json->enable-hover-peek->description
-#. 3.4->settings-schema.json->enable-hover-peek->description
-msgid "Show windows when hovered over"
-msgstr "Prikaži prozor kada se prijeđe pokazivačem miša"
-
-#. 2.8->settings-schema.json->enable-hover-peek->tooltip
-#. 3.4->settings-schema.json->enable-hover-peek->tooltip
-msgid "Controls whether or not windows display when hovered over."
-msgstr "Upravlja prikazom prozora kada se prijeđe preko pokazivačem miša."
-
-#. 2.8->settings-schema.json->activePseudoClass->description
-#. 3.4->settings-schema.json->activePseudoClass->description
-msgid "App button active pseudo class"
-msgstr "Pseudo klasa tipke aktivacije aplikacije"
-
-#. 2.8->settings-schema.json->activePseudoClass->tooltip
-#. 3.4->settings-schema.json->activePseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons when they are active."
-msgstr "Zaobilazi pseudo klasu tipke aktivacije aplikacije."
-
-#. 2.8->settings-schema.json->animate-thumbnails->description
-#. 3.4->settings-schema.json->animate-thumbnails->description
-msgid "Animate thumbnails"
-msgstr "Animiraj minijature"
-
-#. 2.8->settings-schema.json->animate-thumbnails->tooltip
-#. 3.4->settings-schema.json->animate-thumbnails->tooltip
-msgid "If enabled, thumbnails will animate when appearing and disappearing."
-msgstr ""
-"Ako je omogućeno, minijature će se animirati pri pojavljivanju i nestajanju."
-
-#. 2.8->settings-schema.json->autostart-menu-item->description
-#. 3.4->settings-schema.json->autostart-menu-item->description
-msgid "Show autostart option"
-msgstr "Prikaži mogućnosti automatskog pokretanja"
-
-#. 2.8->settings-schema.json->autostart-menu-item->tooltip
-#. 3.4->settings-schema.json->autostart-menu-item->tooltip
-msgid "Shows the autostart toggle option in an app's context menu."
-msgstr "Prikazuje preklopnu tipku u izborniku aplikacije."
-
-#. 2.8->settings-schema.json->show-pinned->description
-#. 3.4->settings-schema.json->show-pinned->description
-msgid "Show pinned apps"
-msgstr "Prikaži pričvršćene aplikacije"
-
-#. 2.8->settings-schema.json->show-pinned->tooltip
-#. 3.4->settings-schema.json->show-pinned->tooltip
-msgid ""
-"Controls whether or not the pinned apps appear in the panel if they are not "
-"open."
-msgstr ""
-"Upravlja pojavljivanjem pričvršćenih aplikacija u panelu ako one nisu "
-"otvorene."
-
-#. 2.8->settings-schema.json->useSystemTooltips->description
-msgid "Use system tooltips for closed apps"
-msgstr "Koristi napomene sustava za zatvorene aplikacije"
-
-#. 2.8->settings-schema.json->useSystemTooltips->tooltip
-msgid ""
-"Controls whether or not system tooltips are in use when hovering over closed "
-"pinned apps."
-msgstr ""
-"Upravlja napomena sustava kada se prelazi preko zatvorenih pričvršćenih "
-"aplikacija."
+#. 2.8->settings-schema.json->ITM->description
+msgid "ITM Settings"
+msgstr "IUZ Postavke"
 
 #. 2.8->settings-schema.json->WindowList->description
 msgid "Window List Settings"
 msgstr "Postavke popisa prozora"
 
-#. 2.8->settings-schema.json->AppMenu->description
-msgid "Context Menu Settings"
-msgstr "Postavke izbornika"
-
-#. 2.8->settings-schema.json->Thumbnails->description
-msgid "Thumbnail Settings"
-msgstr "Postavke minijatura"
-
-#. 2.8->settings-schema.json->show-recent->description
-#. 3.4->settings-schema.json->show-recent->description
-msgid "Show recent items"
-msgstr "Prikaži nedavne stavke"
-
-#. 2.8->settings-schema.json->show-recent->tooltip
-#. 3.4->settings-schema.json->show-recent->tooltip
-msgid "Controls whether recent items will appear in the context menu."
-msgstr "Upravlja pojavljivanjem nedavnih stavki u izborniku."
-
-#. 2.8->settings-schema.json->vertical-thumbnails->description
-#. 3.4->settings-schema.json->vertical-thumbnails->description
-msgid "Enable vertical thumbnails"
-msgstr "Omogući okomite minijature"
-
-#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
-#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
-msgid "If enabled, thumbnails will stack vertically."
-msgstr "Ako je omogućeno, minijature će se slagati okomito."
-
-#. 2.8->settings-schema.json->thumbnail-timeout->description
-#. 3.4->settings-schema.json->thumbnail-timeout->description
-msgid "Thumbnail timeout"
-msgstr "Istek minijatura"
-
-#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
-#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
-msgid ""
-"Controls how quickly an app's set of window thumbnails will fade out when "
-"the mouse leaves the app button."
-msgstr ""
-"Upravlja brzinom postavljanja iščezavanja minijature prozora aplikacije kada "
-"pokazivač miša napusti tipku aplikacije."
-
-#. 2.8->settings-schema.json->ThemeSettings->description
-msgid "Theme Settings"
-msgstr "Postavke teme"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->description
-#. 3.4->settings-schema.json->onclick-thumbnails->description
-msgid "Open thumbnails on click"
-msgstr "Otvori minijaturu pri kliku"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
-#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
-msgid "Open the thumbnails on click if there is more than one window open."
-msgstr "Otvori minijaturu pri kliku ako je otvoren više od jednog prozora."
-
-#. 2.8->settings-schema.json->panelLauncherClass->description
-msgid "Use the panel launcher class for pinned apps"
-msgstr "Koristi klasu panela pokretača za pričvršćene aplikacije"
-
-#. 2.8->settings-schema.json->panelLauncherClass->tooltip
-msgid "Enabling this helps with certain themes."
-msgstr "Ovo omogućavanje pomaže u određenim temama."
-
-#. 2.8->settings-schema.json->include-all-windows->description
-#. 3.4->settings-schema.json->include-all-windows->description
-msgid "Include all app windows"
-msgstr "Uključi sve prozore"
-
-#. 2.8->settings-schema.json->include-all-windows->tooltip
-#. 3.4->settings-schema.json->include-all-windows->tooltip
-msgid ""
-"Controls whether or not thumbnails for smalller child windows, such as exit "
-"confirmations and file dialogues will be included in the thumbnail list."
-msgstr ""
-"Određuje postojanje minijatura za manje prozore aplikacije, poput prikaza "
-"dijaloga zatvaranja i dijaloga datoteke."
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->description
-#. 3.4->settings-schema.json->cycleMenusHotkey->description
-msgid "Global hotkey for cycling through thumbnail menus"
-msgstr "Globalni prečaci tipkovnice za kruženje kroz izbornike minijatura"
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
-#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
-msgid "This allows you to cycle through the menus without activating a window."
-msgstr "Ovo vam omogućuje kruženje kroz izbornike bez aktivacije prozora."
-
-#. 2.8->settings-schema.json->enable-iconSize->description
-#. 3.4->settings-schema.json->enable-iconSize->description
-msgid "Adjust icon size"
-msgstr "Prilagodi veličinu ikone"
-
-#. 2.8->settings-schema.json->enable-iconSize->tooltip
-#. 3.4->settings-schema.json->enable-iconSize->tooltip
-msgid "Adjust icon size independent of Cinnamon's panel scaling."
-msgstr "Prilagodi veličinu ikone neovisno o veličini Cinnamon panela."
-
 #. 2.8->settings-schema.json->number-display->description
+#. 3.8->settings-schema.json->number-display->description
 #. 3.4->settings-schema.json->number-display->description
 msgid "Number display"
 msgstr "Prikaz broja"
 
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Smart"
+msgstr "Pametan"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Normal"
+msgstr "Normalan"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "None"
+msgstr "Nijedan"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "All"
+msgstr "Sve"
+
 #. 2.8->settings-schema.json->number-display->tooltip
+#. 3.8->settings-schema.json->number-display->tooltip
 #. 3.4->settings-schema.json->number-display->tooltip
 msgid ""
 "normal: display window number, smart: display window number if more than one "
@@ -575,43 +244,96 @@ msgstr ""
 "postoji više od jednog prozora, nijedan: ne prikazuj broj, sve: prikazuj "
 "broj prozora i za omiljene"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "All"
-msgstr "Sve"
+#. 2.8->settings-schema.json->title-display->description
+#. 3.8->settings-schema.json->title-display->description
+#. 3.4->settings-schema.json->title-display->description
+msgid "Title display"
+msgstr "Prikaz naslova"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Smart"
-msgstr "Pametan"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "App"
+msgstr "Aplikacija"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Normal"
-msgstr "Normalan"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Title"
+msgstr "Naslov"
 
-#. 2.8->settings-schema.json->ITM->description
-msgid "ITM Settings"
-msgstr "IUZ Postavke"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Focused"
+msgstr "Fokusiran"
 
-#. 2.8->settings-schema.json->HoverPeek->description
-msgid "Hover Peek Settings"
-msgstr "Postavke virenja i prijelaza"
-
-#. 2.8->settings-schema.json->icon-padding->description
-#. 3.4->settings-schema.json->icon-padding->description
-msgid "Icon padding"
-msgstr "Popunjavanje ikone"
-
-#. 2.8->settings-schema.json->icon-padding->tooltip
-#. 3.4->settings-schema.json->icon-padding->tooltip
+#. 2.8->settings-schema.json->title-display->tooltip
+#. 3.8->settings-schema.json->title-display->tooltip
+#. 3.4->settings-schema.json->title-display->tooltip
 msgid ""
-"Controls how much horizontal padding is inside the app buttons. Padding is "
-"only applied to instances of this applet on horizontal panels."
+"focused: show focused window title, title: display the window title, app: "
+"diplay app name, none: don't display anything"
 msgstr ""
-"Upravlja koliko je vodoravnog popunjavanja unutar tipke aplikacije. "
-"Popunjavanje se samo primijenjuje na primjerke ovog apleta na vodoravnom "
-"panelu."
+"fokusiran: prikaži fokusirane naslove prozora, naslov: prikaži naslov "
+"prozora, aplikacija: prikaži naziv aplikacije, nijedan: prikazuj ništa"
+
+#. 2.8->settings-schema.json->group-apps->description
+#. 3.8->settings-schema.json->group-apps->description
+#. 3.4->settings-schema.json->group-apps->description
+msgid "Group apps"
+msgstr "Grupiraj aplikacije"
+
+#. 2.8->settings-schema.json->group-apps->tooltip
+#. 3.8->settings-schema.json->group-apps->tooltip
+#. 3.4->settings-schema.json->group-apps->tooltip
+msgid "Group each app's set of windows."
+msgstr "Grupiraj svaku skupinu prozora aplikacije."
+
+#. 2.8->settings-schema.json->show-alerts->description
+#. 3.8->settings-schema.json->show-alerts->description
+#. 3.4->settings-schema.json->show-alerts->description
+msgid "Show app alerts and notifications"
+msgstr "Prikaži upozorenje aplikacije i obavijest"
+
+#. 2.8->settings-schema.json->show-alerts->tooltip
+#. 3.8->settings-schema.json->show-alerts->tooltip
+#. 3.4->settings-schema.json->show-alerts->tooltip
+msgid "If enabled, notifications and alerts will appear."
+msgstr "Ako je omogućeno, prikazivat će se obavijesti i upozorenja aplikacije."
+
+#. 2.8->settings-schema.json->show-pinned->description
+#. 3.8->settings-schema.json->show-pinned->description
+#. 3.4->settings-schema.json->show-pinned->description
+msgid "Show pinned apps"
+msgstr "Prikaži pričvršćene aplikacije"
+
+#. 2.8->settings-schema.json->show-pinned->tooltip
+#. 3.8->settings-schema.json->show-pinned->tooltip
+#. 3.4->settings-schema.json->show-pinned->tooltip
+msgid ""
+"Controls whether or not the pinned apps appear in the panel if they are not "
+"open."
+msgstr ""
+"Upravlja pojavljivanjem pričvršćenih aplikacija u panelu ako one nisu "
+"otvorene."
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->description
+msgid "Arrange pinned apps"
+msgstr "Rasporedi pričvršćene aplikacije"
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
+msgid "Arrange pinned apps into a different order."
+msgstr "Rasporedi pričvršćene aplikacije u drugačiji poredak."
+
+#. 2.8->settings-schema.json->pinOnDrag->description
+#. 2.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.8->settings-schema.json->pinOnDrag->description
+#. 3.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.4->settings-schema.json->pinOnDrag->description
+#. 3.4->settings-schema.json->pinOnDrag->tooltip
+msgid "Pin apps when dragged to a new position"
+msgstr "Pin aplikacije Kada odvukao na novu poziciju"
 
 #. 2.8->settings-schema.json->middle-click-action->description
 msgid "Middle clicking app buttons creates new app instances"
@@ -627,12 +349,256 @@ msgstr ""
 "Postavljanje na false će se zatvoriti posljednje fokusirane prozor iz "
 "skupine aplikacija na srednji klik."
 
+#. 2.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.4->settings-schema.json->cycleMenusHotkey->description
+msgid "Global hotkey for cycling through thumbnail menus"
+msgstr "Globalni prečaci tipkovnice za kruženje kroz izbornike minijatura"
+
+#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
+msgid "This allows you to cycle through the menus without activating a window."
+msgstr "Ovo vam omogućuje kruženje kroz izbornike bez aktivacije prozora."
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.4->settings-schema.json->show-apps-order-hotkey->description
+msgid "Global hotkey to show the order of apps"
+msgstr "Globalni prečaci tipkovnice za prikaz poredka aplikacija"
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
+msgid ""
+"When triggered, the window count label will be replaced with its order in "
+"the app list temporarily."
+msgstr ""
+"Kada je pokrenuto, broj naslova prozora će biti privremeno zamijenjen s "
+"poredkom u popisu aplikacija."
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->units
+#. 2.8->settings-schema.json->thumbnail-timeout->units
+#. 2.8->settings-schema.json->hover-peek-time->units
+#. 3.8->settings-schema.json->show-apps-order-timeout->units
+#. 3.8->settings-schema.json->thumbnail-timeout->units
+#. 3.8->settings-schema.json->hover-peek-time->units
+#. 3.4->settings-schema.json->show-apps-order-timeout->units
+#. 3.4->settings-schema.json->thumbnail-timeout->units
+#. 3.4->settings-schema.json->hover-peek-time->units
+msgid "milliseconds"
+msgstr "milisekundi"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.4->settings-schema.json->show-apps-order-timeout->description
+msgid "Duration of the apps order display on hotkey press"
+msgstr "Trajanje prikaza poredka aplikacija pri pritisku tipke prečaca"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
+msgid ""
+"Determines the duration the window count labels are replaced with the app's "
+"order number."
+msgstr ""
+"Određuje trajanje zamjene broja naslova prozora s poredkom u popisu "
+"aplikacija."
+
+#. 2.8->settings-schema.json->Thumbnails->description
+msgid "Thumbnail Settings"
+msgstr "Postavke minijatura"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->description
+#. 3.8->settings-schema.json->thumbnail-timeout->description
+#. 3.4->settings-schema.json->thumbnail-timeout->description
+msgid "Thumbnail timeout"
+msgstr "Istek minijatura"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
+msgid ""
+"Controls how quickly an app's set of window thumbnails will fade out when "
+"the mouse leaves the app button."
+msgstr ""
+"Upravlja brzinom postavljanja iščezavanja minijature prozora aplikacije kada "
+"pokazivač miša napusti tipku aplikacije."
+
+#. 2.8->settings-schema.json->thumbnail-size->units
+#. 3.8->settings-schema.json->thumbnail-size->units
+#. 3.4->settings-schema.json->thumbnail-size->units
+msgid "size"
+msgstr "veličina"
+
+#. 2.8->settings-schema.json->thumbnail-size->description
+#. 3.8->settings-schema.json->thumbnail-size->description
+#. 3.4->settings-schema.json->thumbnail-size->description
+msgid "Thumbnail size"
+msgstr "Veličina minijatura"
+
+#. 2.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-size->tooltip
+msgid "Controls the size of the thumbnails."
+msgstr "Upravlja veličinom minijatura."
+
+#. 2.8->settings-schema.json->show-thumbnails->description
+#. 3.8->settings-schema.json->show-thumbnails->description
+#. 3.4->settings-schema.json->show-thumbnails->description
+msgid "Show thumbnails"
+msgstr "Prikaži minijature"
+
+#. 2.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.4->settings-schema.json->show-thumbnails->tooltip
+msgid "Show window thumbnails when hovering over an app button."
+msgstr "Prikazuje minijature prozora pri prijelazu preko tipke aplikacije."
+
+#. 2.8->settings-schema.json->animate-thumbnails->description
+#. 3.8->settings-schema.json->animate-thumbnails->description
+#. 3.4->settings-schema.json->animate-thumbnails->description
+msgid "Animate thumbnails"
+msgstr "Animiraj minijature"
+
+#. 2.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.4->settings-schema.json->animate-thumbnails->tooltip
+msgid "If enabled, thumbnails will animate when appearing and disappearing."
+msgstr ""
+"Ako je omogućeno, minijature će se animirati pri pojavljivanju i nestajanju."
+
+#. 2.8->settings-schema.json->vertical-thumbnails->description
+#. 3.8->settings-schema.json->vertical-thumbnails->description
+#. 3.4->settings-schema.json->vertical-thumbnails->description
+msgid "Enable vertical thumbnails"
+msgstr "Omogući okomite minijature"
+
+#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
+msgid "If enabled, thumbnails will stack vertically."
+msgstr "Ako je omogućeno, minijature će se slagati okomito."
+
+#. 2.8->settings-schema.json->sort-thumbnails->description
+#. 3.8->settings-schema.json->sort-thumbnails->description
+#. 3.4->settings-schema.json->sort-thumbnails->description
+msgid "Sort windows for each app by last focused"
+msgstr "Razvrstaj prozor za svaku aplikaciju prema posljednjem fokusiranju"
+
+#. 2.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.4->settings-schema.json->sort-thumbnails->tooltip
+msgid ""
+"Controls whether the order windows appear for an app is by last focused, or "
+"the order they were opened."
+msgstr ""
+"Upravlja pojavljivanjem poredka prozora za aplikaciju prema posljednjem "
+"fokusu, ili poredkom prema kojem su otvoreni."
+
+#. 2.8->settings-schema.json->onclick-thumbnails->description
+#. 3.8->settings-schema.json->onclick-thumbnails->description
+#. 3.4->settings-schema.json->onclick-thumbnails->description
+msgid "Open thumbnails on click"
+msgstr "Otvori minijaturu pri kliku"
+
+#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
+msgid "Open the thumbnails on click if there is more than one window open."
+msgstr "Otvori minijaturu pri kliku ako je otvoren više od jednog prozora."
+
+#. 2.8->settings-schema.json->include-all-windows->description
+#. 3.8->settings-schema.json->include-all-windows->description
+#. 3.4->settings-schema.json->include-all-windows->description
+msgid "Include all app windows"
+msgstr "Uključi sve prozore"
+
+#. 2.8->settings-schema.json->include-all-windows->tooltip
+#. 3.8->settings-schema.json->include-all-windows->tooltip
+#. 3.4->settings-schema.json->include-all-windows->tooltip
+msgid ""
+"Controls whether or not thumbnails for smalller child windows, such as exit "
+"confirmations and file dialogues will be included in the thumbnail list."
+msgstr ""
+"Određuje postojanje minijatura za manje prozore aplikacije, poput prikaza "
+"dijaloga zatvaranja i dijaloga datoteke."
+
+#. 2.8->settings-schema.json->AppMenu->description
+msgid "Context Menu Settings"
+msgstr "Postavke izbornika"
+
+#. 2.8->settings-schema.json->show-recent->description
+#. 3.8->settings-schema.json->show-recent->description
+#. 3.4->settings-schema.json->show-recent->description
+msgid "Show recent items"
+msgstr "Prikaži nedavne stavke"
+
+#. 2.8->settings-schema.json->show-recent->tooltip
+#. 3.8->settings-schema.json->show-recent->tooltip
+#. 3.4->settings-schema.json->show-recent->tooltip
+msgid "Controls whether recent items will appear in the context menu."
+msgstr "Upravlja pojavljivanjem nedavnih stavki u izborniku."
+
+#. 2.8->settings-schema.json->menuItemType->description
+#. 3.8->settings-schema.json->menuItemType->description
+#. 3.4->settings-schema.json->menuItemType->description
+msgid "Menu item type"
+msgstr "Vrsta unosa izbornika"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Symbolic icons"
+msgstr "Simboličke ikona"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Non-symbolic icons"
+msgstr "Nesimboličke ikona"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "No icons"
+msgstr "Bez ikona"
+
+#. 2.8->settings-schema.json->menuItemType->tooltip
+#. 3.8->settings-schema.json->menuItemType->tooltip
+#. 3.4->settings-schema.json->menuItemType->tooltip
+msgid ""
+"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
+msgstr ""
+"Određuje je li ikona stavke izbornika simbolička, nesimbolička ili nije "
+"prikazana."
+
 #. 2.8->settings-schema.json->firefox-menu->description
+#. 3.8->settings-schema.json->firefox-menu->description
 #. 3.4->settings-schema.json->firefox-menu->description
 msgid "Firefox context menu"
 msgstr "Firefox izbornik"
 
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Most Visited"
+msgstr "Najposjećenije"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Recent History"
+msgstr "Nedavna povijest"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Bookmarks"
+msgstr "Zabilješke"
+
 #. 2.8->settings-schema.json->firefox-menu->tooltip
+#. 3.8->settings-schema.json->firefox-menu->tooltip
 #. 3.4->settings-schema.json->firefox-menu->tooltip
 msgid ""
 "Most Visited: show the sites you visit most, Recent History: display the the "
@@ -642,77 +608,26 @@ msgstr ""
 "povijest: prikazuje posljednje posjećene stranice, Zabilješke: prikazuje "
 "vaše omiljene zabilješke."
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Bookmarks"
-msgstr "Zabilješke"
+#. 2.8->settings-schema.json->autostart-menu-item->description
+#. 3.8->settings-schema.json->autostart-menu-item->description
+#. 3.4->settings-schema.json->autostart-menu-item->description
+msgid "Show autostart option"
+msgstr "Prikaži mogućnosti automatskog pokretanja"
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Most Visited"
-msgstr "Najposjećenije"
-
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Recent History"
-msgstr "Nedavna povijest"
-
-#. 2.8->settings-schema.json->themePadding->description
-msgid "Use theme padding to center button icons"
-msgstr "Koristi popunjavanje teme za postavljanje sredine ikona tipke"
-
-#. 2.8->settings-schema.json->themePadding->tooltip
-msgid "If button icons look off-centered, toggling this may help."
-msgstr "Ako ikone tipke nisu u sredini, ovo aktiviranje bi moglo pomoći."
-
-#. 2.8->settings-schema.json->group-apps->description
-#. 3.4->settings-schema.json->group-apps->description
-msgid "Group apps"
-msgstr "Grupiraj aplikacije"
-
-#. 2.8->settings-schema.json->group-apps->tooltip
-#. 3.4->settings-schema.json->group-apps->tooltip
-msgid "Group each app's set of windows."
-msgstr "Grupiraj svaku skupinu prozora aplikacije."
-
-#. 2.8->settings-schema.json->show-active->description
-#. 3.4->settings-schema.json->show-active->description
-msgid "Show active app indicators"
-msgstr "Prikaži naglašavanje aktivne aplikacije"
-
-#. 2.8->settings-schema.json->show-active->tooltip
-#. 3.4->settings-schema.json->show-active->tooltip
-msgid "Active app styling will indicate if an app is active."
-msgstr "Izgled aktivne aplikacije će se naglasiti ako je aplikacija aktivna."
-
-#. 2.8->settings-schema.json->show-apps-order-timeout->description
-#. 3.4->settings-schema.json->show-apps-order-timeout->description
-msgid "Duration of the apps order display on hotkey press"
-msgstr "Trajanje prikaza poredka aplikacija pri pritisku tipke prečaca"
-
-#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
-#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
-msgid ""
-"Determines the duration the window count labels are replaced with the app's "
-"order number."
-msgstr ""
-"Određuje trajanje zamjene broja naslova prozora s poredkom u popisu "
-"aplikacija."
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->description
-msgid "Arrange pinned apps"
-msgstr "Rasporedi pričvršćene aplikacije"
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
-msgid "Arrange pinned apps into a different order."
-msgstr "Rasporedi pričvršćene aplikacije u drugačiji poredak."
+#. 2.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.4->settings-schema.json->autostart-menu-item->tooltip
+msgid "Shows the autostart toggle option in an app's context menu."
+msgstr "Prikazuje preklopnu tipku u izborniku aplikacije."
 
 #. 2.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.8->settings-schema.json->monitor-move-all-windows->description
 #. 3.4->settings-schema.json->monitor-move-all-windows->description
 msgid "Apply the monitor move option to all windows"
 msgstr "Primijeni potez premještanja na sve prozore"
 
 #. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.8->settings-schema.json->monitor-move-all-windows->tooltip
 #. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
 msgid ""
 "When clicking \"Move to monitor\" in the context menu, this option will move "
@@ -722,64 +637,404 @@ msgstr ""
 "premjestiti sve prozore aplikacija umjesto samo posljednjeg fokusiranog "
 "prozora aplikacije."
 
-#. 2.8->settings-schema.json->sort-thumbnails->description
-#. 3.4->settings-schema.json->sort-thumbnails->description
-msgid "Sort windows for each app by last focused"
-msgstr "Razvrstaj prozor za svaku aplikaciju prema posljednjem fokusiranju"
+#. 2.8->settings-schema.json->HoverPeek->description
+msgid "Hover Peek Settings"
+msgstr "Postavke virenja i prijelaza"
 
-#. 2.8->settings-schema.json->sort-thumbnails->tooltip
-#. 3.4->settings-schema.json->sort-thumbnails->tooltip
-msgid ""
-"Controls whether the order windows appear for an app is by last focused, or "
-"the order they were opened."
-msgstr ""
-"Upravlja pojavljivanjem poredka prozora za aplikaciju prema posljednjem "
-"fokusu, ili poredkom prema kojem su otvoreni."
+#. 2.8->settings-schema.json->enable-hover-peek->description
+#. 3.8->settings-schema.json->enable-hover-peek->description
+#. 3.4->settings-schema.json->enable-hover-peek->description
+msgid "Show windows when hovered over"
+msgstr "Prikaži prozor kada se prijeđe pokazivačem miša"
 
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "checked"
-msgstr ""
+#. 2.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.4->settings-schema.json->enable-hover-peek->tooltip
+msgid "Controls whether or not windows display when hovered over."
+msgstr "Upravlja prikazom prozora kada se prijeđe preko pokazivačem miša."
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
-msgid "Highlight the last focused window within an app group"
-msgstr ""
+#. 2.8->settings-schema.json->hover-peek-time->description
+#. 3.8->settings-schema.json->hover-peek-time->description
+#. 3.4->settings-schema.json->hover-peek-time->description
+msgid "Window fade time"
+msgstr "Vrijeme isčezavanja prozora"
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
-msgid ""
-"When enabled, the last window that was interacted with will be indicated."
-msgstr ""
+#. 2.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.4->settings-schema.json->hover-peek-time->tooltip
+msgid "Controls how quickly a window will fade on hover."
+msgstr "Upravlja iščezavanjem prozora pri prijelazu pokazivačem miša."
 
-#. 3.4->settings-schema.json->app-button-transition-duration->description
-msgid "App button transition duration"
-msgstr ""
+#. 2.8->settings-schema.json->hover-peek-opacity->units
+#. 3.8->settings-schema.json->hover-peek-opacity->units
+#. 3.4->settings-schema.json->hover-peek-opacity->units
+msgid "percent"
+msgstr "postoci"
 
-#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
-msgid ""
-"Overrides the theme's animation time for app buttons. If set to zero, the "
-"theme's transition duration will be used."
-msgstr ""
+#. 2.8->settings-schema.json->hover-peek-opacity->description
+#. 3.8->settings-schema.json->hover-peek-opacity->description
+#. 3.4->settings-schema.json->hover-peek-opacity->description
+msgid "Window opacity"
+msgstr "Prozirnost prozora"
 
-#. 3.4->settings-schema.json->app-button-transition-duration->units
-msgid "ms"
-msgstr ""
+#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
+msgid "Opacity of the windows on hover."
+msgstr "Prozirnost prozora pri prijelazu pokazivača miša."
 
-#. 3.4->settings-schema.json->thumbnail-padding->description
-#, fuzzy
-msgid "Thumbnail padding"
-msgstr "Postavke minijatura"
+#. 2.8->settings-schema.json->ThemeSettings->description
+msgid "Theme Settings"
+msgstr "Postavke teme"
 
-#. 3.4->settings-schema.json->thumbnail-padding->tooltip
-#, fuzzy
-msgid "Controls how much space will be around the window preview thumbnails."
+#. 2.8->settings-schema.json->show-active->description
+#. 3.8->settings-schema.json->show-active->description
+#. 3.4->settings-schema.json->show-active->description
+msgid "Show active app indicators"
+msgstr "Prikaži naglašavanje aktivne aplikacije"
+
+#. 2.8->settings-schema.json->show-active->tooltip
+#. 3.8->settings-schema.json->show-active->tooltip
+#. 3.4->settings-schema.json->show-active->tooltip
+msgid "Active app styling will indicate if an app is active."
+msgstr "Izgled aktivne aplikacije će se naglasiti ako je aplikacija aktivna."
+
+#. 2.8->settings-schema.json->icon-spacing->units
+#. 2.8->settings-schema.json->icon-padding->units
+#. 2.8->settings-schema.json->icon-size->units
+#. 3.8->settings-schema.json->app-button-width->units
+#. 3.8->settings-schema.json->thumbnail-close-button-size->units
+#. 3.8->settings-schema.json->thumbnail-padding->units
+#. 3.8->settings-schema.json->icon-spacing->units
+#. 3.8->settings-schema.json->icon-padding->units
+#. 3.8->settings-schema.json->icon-size->units
+#. 3.4->settings-schema.json->app-button-width->units
+#. 3.4->settings-schema.json->thumbnail-close-button-size->units
+#. 3.4->settings-schema.json->thumbnail-padding->units
+#. 3.4->settings-schema.json->icon-spacing->units
+#. 3.4->settings-schema.json->icon-padding->units
+#. 3.4->settings-schema.json->icon-size->units
+msgid "px"
+msgstr "pikseli"
+
+#. 2.8->settings-schema.json->icon-spacing->description
+#. 3.8->settings-schema.json->icon-spacing->description
+#. 3.4->settings-schema.json->icon-spacing->description
+msgid "Icon spacing"
+msgstr "Razmak ikona"
+
+#. 2.8->settings-schema.json->icon-spacing->tooltip
+#. 3.8->settings-schema.json->icon-spacing->tooltip
+#. 3.4->settings-schema.json->icon-spacing->tooltip
+msgid "Controls how much space is between the icons."
 msgstr "Upravlja razmakom između ikona."
 
+#. 2.8->settings-schema.json->icon-padding->description
+#. 3.8->settings-schema.json->icon-padding->description
+#. 3.4->settings-schema.json->icon-padding->description
+msgid "Icon padding"
+msgstr "Popunjavanje ikone"
+
+#. 2.8->settings-schema.json->icon-padding->tooltip
+#. 3.8->settings-schema.json->icon-padding->tooltip
+#. 3.4->settings-schema.json->icon-padding->tooltip
+msgid ""
+"Controls how much horizontal padding is inside the app buttons. Padding is "
+"only applied to instances of this applet on horizontal panels."
+msgstr ""
+"Upravlja koliko je vodoravnog popunjavanja unutar tipke aplikacije. "
+"Popunjavanje se samo primijenjuje na primjerke ovog apleta na vodoravnom "
+"panelu."
+
+#. 2.8->settings-schema.json->themePadding->description
+msgid "Use theme padding to center button icons"
+msgstr "Koristi popunjavanje teme za postavljanje sredine ikona tipke"
+
+#. 2.8->settings-schema.json->themePadding->tooltip
+msgid "If button icons look off-centered, toggling this may help."
+msgstr "Ako ikone tipke nisu u sredini, ovo aktiviranje bi moglo pomoći."
+
+#. 2.8->settings-schema.json->enable-iconSize->description
+#. 3.8->settings-schema.json->enable-iconSize->description
+#. 3.4->settings-schema.json->enable-iconSize->description
+msgid "Adjust icon size"
+msgstr "Prilagodi veličinu ikone"
+
+#. 2.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.4->settings-schema.json->enable-iconSize->tooltip
+msgid "Adjust icon size independent of Cinnamon's panel scaling."
+msgstr "Prilagodi veličinu ikone neovisno o veličini Cinnamon panela."
+
+#. 2.8->settings-schema.json->icon-size->description
+#. 3.8->settings-schema.json->icon-size->description
+#. 3.4->settings-schema.json->icon-size->description
+msgid "Icon size"
+msgstr "Veličina ikone"
+
+#. 2.8->settings-schema.json->icon-size->tooltip
+#. 3.8->settings-schema.json->icon-size->tooltip
+#. 3.4->settings-schema.json->icon-size->tooltip
+msgid "Set icon size"
+msgstr "Postavi veličinu ikone"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->description
+#. 3.8->settings-schema.json->hoverPseudoClass->description
+#. 3.4->settings-schema.json->hoverPseudoClass->description
+msgid "App button hover pseudo class"
+msgstr "Pseudo klasa tipke prijelaza aplikacije"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "hover"
+msgstr ""
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+#, fuzzy
+msgid "focus"
+msgstr "Fokusiran"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "active"
+msgstr ""
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "outlined"
+msgstr ""
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "selected"
+msgstr ""
+
+#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons on hover."
+msgstr "Zaobilazi pseudo klasu tipke prijelaza aplikacije."
+
+#. 2.8->settings-schema.json->focusPseudoClass->description
+#. 3.8->settings-schema.json->focusPseudoClass->description
+#. 3.4->settings-schema.json->focusPseudoClass->description
+msgid "App button focus pseudo class"
+msgstr "Pseudo klasa tipke fokusa aplikacije"
+
+#. 2.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.4->settings-schema.json->focusPseudoClass->tooltip
+msgid "Overrides the pseudo class for app button on focus."
+msgstr "Zaobilazi pseudo klasu tipke fokusa aplikacije."
+
+#. 2.8->settings-schema.json->activePseudoClass->description
+#. 3.8->settings-schema.json->activePseudoClass->description
+#. 3.4->settings-schema.json->activePseudoClass->description
+msgid "App button active pseudo class"
+msgstr "Pseudo klasa tipke aktivacije aplikacije"
+
+#. 2.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.4->settings-schema.json->activePseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons when they are active."
+msgstr "Zaobilazi pseudo klasu tipke aktivacije aplikacije."
+
+#. 2.8->settings-schema.json->panelLauncherClass->description
+msgid "Use the panel launcher class for pinned apps"
+msgstr "Koristi klasu panela pokretača za pričvršćene aplikacije"
+
+#. 2.8->settings-schema.json->panelLauncherClass->tooltip
+msgid "Enabling this helps with certain themes."
+msgstr "Ovo omogućavanje pomaže u određenim temama."
+
+#. 2.8->settings-schema.json->close-button-style->description
+msgid "Allow themes to control the thumbnail close button"
+msgstr "Dopusti temi upravljanje tipkom zatvaranja minijature"
+
+#. 2.8->settings-schema.json->close-button-style->tooltip
+msgid ""
+"Controls whether or not the theme controls the window thumbnail's close "
+"button."
+msgstr "Tema upravlja tipkom zatvaranja minijature."
+
+#. 2.8->settings-schema.json->useSystemTooltips->description
+msgid "Use system tooltips for closed apps"
+msgstr "Koristi napomene sustava za zatvorene aplikacije"
+
+#. 2.8->settings-schema.json->useSystemTooltips->tooltip
+msgid ""
+"Controls whether or not system tooltips are in use when hovering over closed "
+"pinned apps."
+msgstr ""
+"Upravlja napomena sustava kada se prelazi preko zatvorenih pričvršćenih "
+"aplikacija."
+
+#. 3.8->settings-schema.json->generalPage->title
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr ""
+
+#. 3.8->settings-schema.json->panelPage->title
+#. 3.4->settings-schema.json->panelPage->title
+msgid "Panel"
+msgstr ""
+
+#. 3.8->settings-schema.json->thumbnailsPage->title
+#. 3.8->settings-schema.json->thumbnailsSection->title
+#. 3.4->settings-schema.json->thumbnailsPage->title
+#. 3.4->settings-schema.json->thumbnailsSection->title
+#, fuzzy
+msgid "Thumbnails"
+msgstr "Veličina minijatura"
+
+#. 3.8->settings-schema.json->contextMenuPage->title
+#. 3.4->settings-schema.json->contextMenuPage->title
+#, fuzzy
+msgid "Context Menu"
+msgstr "Postavke izbornika"
+
+#. 3.8->settings-schema.json->themePage->title
+#. 3.4->settings-schema.json->themePage->title
+#, fuzzy
+msgid "Theming"
+msgstr "Postavke teme"
+
+#. 3.8->settings-schema.json->generalSection->title
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.8->settings-schema.json->appButtonsSection->title
+#. 3.4->settings-schema.json->appButtonsSection->title
+msgid "App Buttons"
+msgstr ""
+
+#. 3.8->settings-schema.json->hotKeysSection->title
+#. 3.4->settings-schema.json->hotKeysSection->title
+msgid "Hot Keys"
+msgstr ""
+
+#. 3.8->settings-schema.json->hoverPeekSection->title
+#. 3.4->settings-schema.json->hoverPeekSection->title
+#, fuzzy
+msgid "Hover Peek"
+msgstr "Prijeđi za virenje"
+
+#. 3.8->settings-schema.json->stylingSection->title
+#. 3.4->settings-schema.json->stylingSection->title
+msgid "Styling"
+msgstr ""
+
+#. 3.8->settings-schema.json->iconSection->title
+#. 3.4->settings-schema.json->iconSection->title
+#, fuzzy
+msgid "Icons"
+msgstr "Veličina ikone"
+
+#. 3.8->settings-schema.json->presetSection->title
+#. 3.4->settings-schema.json->presetSection->title
+msgid "Recommended Presets"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->description
+#. 3.4->settings-schema.json->scroll-behavior->description
+msgid "Mouse wheel scroll behavior"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+msgid "Cycle apps"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#, fuzzy
+msgid "Cycle windows"
+msgstr "Uključi sve prozore"
+
+#. 3.8->settings-schema.json->scroll-behavior->tooltip
+#. 3.4->settings-schema.json->scroll-behavior->tooltip
+msgid ""
+"Choose if scrolling the mouse wheel cycles running apps, an app button's "
+"windows on hover, or is disabled."
+msgstr ""
+
+#. 3.8->settings-schema.json->left-click-action->description
+#. 3.8->settings-schema.json->left-click-action->tooltip
+#. 3.8->settings-schema.json->launcher-animation-effect->tooltip
+#. 3.4->settings-schema.json->left-click-action->description
+#. 3.4->settings-schema.json->left-click-action->tooltip
+#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
+msgid "Left click action"
+msgstr ""
+
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->left-click-action->options
+msgid "Toggle activation of last focused window"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->description
+#. 3.8->settings-schema.json->middle-click-action->tooltip
+#. 3.4->settings-schema.json->middle-click-action->description
+#. 3.4->settings-schema.json->middle-click-action->tooltip
+msgid "Middle click action"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Launch new app instance"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Close last focused window in group"
+msgstr ""
+
+#. 3.8->settings-schema.json->system-favorites->description
 #. 3.4->settings-schema.json->system-favorites->description
 #, fuzzy
 msgid "Use system favorites for pinned apps"
 msgstr "Koristi napomene sustava za zatvorene aplikacije"
 
+#. 3.8->settings-schema.json->system-favorites->tooltip
 #. 3.4->settings-schema.json->system-favorites->tooltip
 #, fuzzy
 msgid ""
@@ -788,94 +1043,64 @@ msgstr ""
 "Upravlja pojavljivanjem pričvršćenih aplikacija u panelu ako one nisu "
 "otvorene."
 
-#. 3.4->settings-schema.json->generalSection->title
-msgid "Behavior"
-msgstr ""
-
-#. 3.4->settings-schema.json->thumbnailsPage->title
-#. 3.4->settings-schema.json->thumbnailsSection->title
+#. 3.8->settings-schema.json->show-all-workspaces->description
+#. 3.8->settings-schema.json->show-all-workspaces->tooltip
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
 #, fuzzy
-msgid "Thumbnails"
-msgstr "Veličina minijatura"
+msgid "Show windows from all workspaces"
+msgstr "Vidljivo na svim radnim prostorima"
 
-#. 3.4->settings-schema.json->presetSection->title
-msgid "Recommended Presets"
-msgstr ""
-
-#. 3.4->settings-schema.json->appButtonsSection->title
-msgid "App Buttons"
-msgstr ""
-
-#. 3.4->settings-schema.json->generalPage->title
-msgid "General"
-msgstr ""
-
-#. 3.4->settings-schema.json->hoverPeekSection->title
-#, fuzzy
-msgid "Hover Peek"
-msgstr "Prijeđi za virenje"
-
-#. 3.4->settings-schema.json->panelPage->title
-msgid "Panel"
-msgstr ""
-
-#. 3.4->settings-schema.json->iconSection->title
-#, fuzzy
-msgid "Icons"
-msgstr "Veličina ikone"
-
-#. 3.4->settings-schema.json->hotKeysSection->title
-msgid "Hot Keys"
-msgstr ""
-
-#. 3.4->settings-schema.json->stylingSection->title
-msgid "Styling"
-msgstr ""
-
-#. 3.4->settings-schema.json->contextMenuPage->title
-#, fuzzy
-msgid "Context Menu"
-msgstr "Postavke izbornika"
-
-#. 3.4->settings-schema.json->themePage->title
-#, fuzzy
-msgid "Theming"
-msgstr "Postavke teme"
-
-#. 3.4->settings-schema.json->mintYPreset->description
-#. 3.4->settings-schema.json->mintYPreset->tooltip
-msgid "Mint Y and Variants"
-msgstr ""
-
-#. 3.4->settings-schema.json->show-icons->description
-#, fuzzy
-msgid "Show icons"
-msgstr "Bez ikona"
-
-#. 3.4->settings-schema.json->show-icons->tooltip
-msgid "Show the window's icon next to the title."
-msgstr ""
-
+#. 3.8->settings-schema.json->enable-app-button-dragging->description
+#. 3.8->settings-schema.json->enable-app-button-dragging->tooltip
 #. 3.4->settings-schema.json->enable-app-button-dragging->description
 #. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
 msgid "Enable app button dragging"
 msgstr ""
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
-#, fuzzy
-msgid "Show new window option"
-msgstr "Prikaži mogućnosti automatskog pokretanja"
-
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
-msgid ""
-"Shows the \"New Window\" option in an app's context menu if it doesn't "
-"already have one from the app's own action menu items."
+#. 3.8->settings-schema.json->launcher-animation-effect->description
+#. 3.4->settings-schema.json->launcher-animation-effect->description
+msgid "Launcher animation effect"
 msgstr ""
 
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Fade"
+msgstr ""
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Scale"
+msgstr ""
+
+#. 3.8->settings-schema.json->list-monitor-windows->description
+#. 3.4->settings-schema.json->list-monitor-windows->description
+msgid "Only list windows from the monitor displaying this instance"
+msgstr ""
+
+#. 3.8->settings-schema.json->list-monitor-windows->tooltip
+#. 3.4->settings-schema.json->list-monitor-windows->tooltip
+msgid ""
+"This option will only come into effect for monitors displaying an ITM "
+"instance."
+msgstr ""
+
+#. 3.8->settings-schema.json->enable-app-button-width->description
+#. 3.4->settings-schema.json->enable-app-button-width->description
+msgid "Use a custom width for app buttons"
+msgstr ""
+
+#. 3.8->settings-schema.json->enable-app-button-width->tooltip
+#. 3.4->settings-schema.json->enable-app-button-width->tooltip
+msgid "When disabled, the app button width is determined by the panel height."
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-width->description
 #. 3.4->settings-schema.json->app-button-width->description
 msgid "App button width"
 msgstr ""
 
+#. 3.8->settings-schema.json->app-button-width->tooltip
 #. 3.4->settings-schema.json->app-button-width->tooltip
 #, fuzzy
 msgid ""
@@ -883,118 +1108,120 @@ msgid ""
 "horizontal panels."
 msgstr "Upravlja veličinom minijatura."
 
-#. 3.4->settings-schema.json->mintXPreset->description
-#. 3.4->settings-schema.json->mintXPreset->tooltip
-msgid "Mint X, Linux Mint, and Variants"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->description
-msgid "Launcher animation effect"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
-#. 3.4->settings-schema.json->left-click-action->description
-#. 3.4->settings-schema.json->left-click-action->tooltip
-msgid "Left click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Scale"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Fade"
-msgstr ""
-
-#. 3.4->settings-schema.json->enable-app-button-width->description
-msgid "Use a custom width for app buttons"
-msgstr ""
-
-#. 3.4->settings-schema.json->enable-app-button-width->tooltip
-msgid "When disabled, the app button width is determined by the panel height."
-msgstr ""
-
-#. 3.4->settings-schema.json->list-monitor-windows->description
-msgid "Only list windows from the monitor displaying this instance"
-msgstr ""
-
-#. 3.4->settings-schema.json->list-monitor-windows->tooltip
-msgid ""
-"This option will only come into effect for monitors displaying an ITM "
-"instance."
-msgstr ""
-
+#. 3.8->settings-schema.json->thumbnail-close-button-size->description
 #. 3.4->settings-schema.json->thumbnail-close-button-size->description
 #, fuzzy
 msgid "Close button size"
 msgstr "Postavi veličinu ikone"
 
+#. 3.8->settings-schema.json->thumbnail-close-button-size->tooltip
 #. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
 #, fuzzy
 msgid "Controls how large the thumbnail close button is."
 msgstr "Dopusti temi upravljanje tipkom zatvaranja minijature"
 
-#. 3.4->settings-schema.json->middle-click-action->description
-#. 3.4->settings-schema.json->middle-click-action->tooltip
-msgid "Middle click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Launch new app instance"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Close last focused window in group"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->description
-msgid "Mouse wheel scroll behavior"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->tooltip
-msgid ""
-"Choose if scrolling the mouse wheel cycles running apps, an app button's "
-"windows on hover, or is disabled."
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->options
-msgid "Cycle apps"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->thumbnail-padding->description
+#. 3.4->settings-schema.json->thumbnail-padding->description
 #, fuzzy
-msgid "Cycle windows"
-msgstr "Uključi sve prozore"
+msgid "Thumbnail padding"
+msgstr "Postavke minijatura"
 
-#. 3.4->settings-schema.json->show-all-workspaces->description
-#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#. 3.8->settings-schema.json->thumbnail-padding->tooltip
+#. 3.4->settings-schema.json->thumbnail-padding->tooltip
 #, fuzzy
-msgid "Show windows from all workspaces"
-msgstr "Vidljivo na svim radnim prostorima"
+msgid "Controls how much space will be around the window preview thumbnails."
+msgstr "Upravlja razmakom između ikona."
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->description
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
 msgid "Cycle windows on mouse wheel scroll"
 msgstr ""
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->tooltip
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
 msgid ""
 "Choose whether or not scrolling the mouse wheel cycles windows when hovering "
 "over a thumbnail menu."
 msgstr ""
 
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "Toggle activation of last focused window"
+#. 3.8->settings-schema.json->show-icons->description
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "Bez ikona"
+
+#. 3.8->settings-schema.json->show-icons->tooltip
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
 msgstr ""
 
-#. IcingTaskManager@json->metadata.json->name
-msgid "Icing Task Manager"
-msgstr "Icing upravitelj zadataka"
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->description
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
+msgid "Highlight the last focused window within an app group"
+msgstr ""
 
-#. IcingTaskManager@json->metadata.json->description
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+msgid ""
+"When enabled, the last window that was interacted with will be indicated."
+msgstr ""
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->description
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
 #, fuzzy
-msgid "Window list with app grouping and thumbnails"
-msgstr "Popis prozora s grupiranjem aplikacija i minijaturama prozora"
+msgid "Show new window option"
+msgstr "Prikaži mogućnosti automatskog pokretanja"
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->tooltip
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->units
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->description
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->tooltip
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.8->settings-schema.json->mintYPreset->description
+#. 3.8->settings-schema.json->mintYPreset->tooltip
+#. 3.4->settings-schema.json->mintYPreset->description
+#. 3.4->settings-schema.json->mintYPreset->tooltip
+msgid "Mint Y and Variants"
+msgstr ""
+
+#. 3.8->settings-schema.json->mintXPreset->description
+#. 3.8->settings-schema.json->mintXPreset->tooltip
+#. 3.4->settings-schema.json->mintXPreset->description
+#. 3.4->settings-schema.json->mintXPreset->tooltip
+msgid "Mint X, Linux Mint, and Variants"
+msgstr ""
+
+#. 3.8->settings-schema.json->migrationButton->description
+msgid "Migrate Pinned Apps to Grouped Window List"
+msgstr ""
 
 #~ msgid "number"
 #~ msgstr "broj"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/hr.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/hr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Icing Task Manager 4.3.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-10 00:43-0600\n"
+"POT-Creation-Date: 2018-12-13 18:37-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian <hr@li.org>\n"
@@ -14,53 +14,53 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: 3.8/applet.js:471
-msgid "Icing Task Manager is now Grouped Window List"
-msgstr ""
+#: 3.8/applet.js:476
+#, fuzzy
+msgid "Icing Task Manager is deprecated"
+msgstr "Icing upravitelj zadataka"
 
-#: 3.8/applet.js:472
+#: 3.8/applet.js:477
 msgid ""
-"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
-"Window List\". "
+"Please upgrade to Grouped Window List for a more stable, bug-free experience."
 msgstr ""
 
-#: 3.8/applet.js:473
+#: 3.8/applet.js:478
 msgid ""
-"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
-"List."
+"Add GWL to your panel, open the applet's settings and click \"Migrate Pinned "
+"Apps to Grouped Window List\"."
 msgstr ""
 
-#: 3.8/applet.js:485
-msgid "Migration can only be performed on Cinnamon 4.0."
+#: 3.8/applet.js:490
+msgid "Migration can only be performed on Cinnamon 4.0+."
 msgstr ""
 
-#: 3.8/applet.js:496
+#: 3.8/applet.js:501
 msgid ""
 "Please add Grouped Window List to a panel before proceeding with the "
 "migration."
 msgstr ""
 
-#: 3.8/applet.js:504
+#: 3.8/applet.js:509
 msgid "ITM settings directory could not be found!"
 msgstr ""
 
-#: 3.8/applet.js:534
+#: 3.8/applet.js:539
 msgid "System favorites enabled - no migration is needed."
 msgstr ""
 
-#: 3.8/applet.js:577
+#: 3.8/applet.js:582
 msgid "Unable to find a suitable ITM settings file to migrate."
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid "Migration complete. "
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid " settings file(s) could not be migrated."
 msgstr ""
 
-#: 3.8/applet.js:592
+#: 3.8/applet.js:597
 msgid "Migration was successful."
 msgstr ""
 
@@ -1222,6 +1222,10 @@ msgstr ""
 #. 3.8->settings-schema.json->migrationButton->description
 msgid "Migrate Pinned Apps to Grouped Window List"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Icing Task Manager is deprecated - please use Grouped Window List"
+#~ msgstr "Icing upravitelj zadataka"
 
 #~ msgid "number"
 #~ msgstr "broj"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/hu.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/hu.po
@@ -7,588 +7,323 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-23 21:33-0600\n"
+"POT-Creation-Date: 2018-12-10 00:43-0600\n"
 "PO-Revision-Date: 2018-04-25 14:13+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Last-Translator: \n"
-"Language-Team: \n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/applet.js:471
+msgid "Icing Task Manager is now Grouped Window List"
+msgstr ""
+
+#: 3.8/applet.js:472
+msgid ""
+"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
+"Window List\". "
+msgstr ""
+
+#: 3.8/applet.js:473
+msgid ""
+"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
+"List."
+msgstr ""
+
+#: 3.8/applet.js:485
+msgid "Migration can only be performed on Cinnamon 4.0."
+msgstr ""
+
+#: 3.8/applet.js:496
+msgid ""
+"Please add Grouped Window List to a panel before proceeding with the "
+"migration."
+msgstr ""
+
+#: 3.8/applet.js:504
+msgid "ITM settings directory could not be found!"
+msgstr ""
+
+#: 3.8/applet.js:534
+msgid "System favorites enabled - no migration is needed."
+msgstr ""
+
+#: 3.8/applet.js:577
+msgid "Unable to find a suitable ITM settings file to migrate."
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid "Migration complete. "
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid " settings file(s) could not be migrated."
+msgstr ""
+
+#: 3.8/applet.js:592
+msgid "Migration was successful."
+msgstr ""
+
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to the other monitor"
 msgstr "Áthelyezés a másik kijelzőre"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to monitor "
 msgstr "Áthelyezés kijelzőre"
 
-#: 3.4/specialMenus.js:126
+#: 3.8/specialMenus.js:98 3.4/specialMenus.js:126
 msgid "Only on this workspace"
 msgstr "Csak ezen a munkaterületen"
 
-#: 3.4/specialMenus.js:133
+#: 3.8/specialMenus.js:105 3.4/specialMenus.js:133
 msgid "Visible on all workspaces"
 msgstr "Minden munkaterületen látható"
 
-#: 3.4/specialMenus.js:140
+#: 3.8/specialMenus.js:112 3.4/specialMenus.js:140
 msgid "Move to another workspace"
 msgstr "Áthelyezés másik munkaterületre"
 
-#: 3.4/specialMenus.js:168
+#: 3.8/specialMenus.js:140 3.4/specialMenus.js:168
 msgid "Places"
 msgstr "Helyek"
 
-#: 3.4/specialMenus.js:207
+#: 3.8/specialMenus.js:179 3.4/specialMenus.js:207
 msgid "Bookmarks/History requires gir1.2-gda-5.0"
 msgstr ""
 "A könyvjelzők és előzmények használatához szükség van a gir1.2-gda-5.0 "
 "csomagra"
 
-#: 3.4/specialMenus.js:227
+#: 3.8/specialMenus.js:199 3.4/specialMenus.js:227
 msgid "Recent"
 msgstr "Legutóbbi"
 
-#: 3.4/specialMenus.js:246
+#: 3.8/specialMenus.js:218 3.4/specialMenus.js:246
 msgid "Preferences"
 msgstr "Beállítások"
 
-#: 3.4/specialMenus.js:249
+#: 3.8/specialMenus.js:221 3.4/specialMenus.js:249
 msgid "About..."
 msgstr "Névjegy…"
 
-#: 3.4/specialMenus.js:253
+#: 3.8/specialMenus.js:225 3.4/specialMenus.js:253
 msgid "Configure..."
 msgstr "Beállítások…"
 
-#: 3.4/specialMenus.js:257
+#: 3.8/specialMenus.js:229 3.4/specialMenus.js:257
 msgid "Remove"
 msgstr "Eltávolítás"
 
-#: 3.4/specialMenus.js:287
+#: 3.8/specialMenus.js:259 3.4/specialMenus.js:287
 msgid "New Window"
 msgstr "Új ablak"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Unpin from Panel"
 msgstr "Feloldás a panelról"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Pin to Panel"
 msgstr "Rögzítés a panelra"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Remove from Autostart"
 msgstr "Automatikus indítás tiltása"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Add to Autostart"
 msgstr "Automatikus indítás engedélyezése"
 
-#: 3.4/specialMenus.js:318
+#: 3.8/specialMenus.js:290 3.4/specialMenus.js:318
 msgid "Create Shortcut"
 msgstr "Gyorsbillentyű"
 
-#: 3.4/specialMenus.js:329
+#: 3.8/specialMenus.js:301 3.4/specialMenus.js:329
 msgid "Restore to full opacity"
 msgstr "Teljes átlátszatlanság visszaállítása"
 
-#: 3.4/specialMenus.js:337
+#: 3.8/specialMenus.js:309 3.4/specialMenus.js:337
 msgid "Restore"
 msgstr "Visszaállítás"
 
-#: 3.4/specialMenus.js:342
+#: 3.8/specialMenus.js:314 3.4/specialMenus.js:342
 msgid "Minimize"
 msgstr "Minimalizálás"
 
-#: 3.4/specialMenus.js:350
+#: 3.8/specialMenus.js:322 3.4/specialMenus.js:350
 msgid "Unmaximize"
 msgstr "Eredeti méret"
 
-#: 3.4/specialMenus.js:355
+#: 3.8/specialMenus.js:327 3.4/specialMenus.js:355
 msgid "Maximize"
 msgstr "Maximalizálás"
 
-#: 3.4/specialMenus.js:365
+#: 3.8/specialMenus.js:337 3.4/specialMenus.js:365
 msgid "Close others"
 msgstr "Többi bezárása"
 
-#: 3.4/specialMenus.js:375
+#: 3.8/specialMenus.js:347 3.4/specialMenus.js:375
 msgid "Close all"
 msgstr "Minden bezárása"
 
-#: 3.4/specialMenus.js:385
+#: 3.8/specialMenus.js:357 3.4/specialMenus.js:385
 msgid "Close"
 msgstr "Bezár"
 
-#. 2.8->settings-schema.json->thumbnail-size->description
-#. 3.4->settings-schema.json->thumbnail-size->description
-msgid "Thumbnail size"
-msgstr "Előnézet mérete"
+#. metadata.json->description
+msgid "Window list with app grouping and thumbnails"
+msgstr "Ablaklista az alkalmazások csoportosításával és előnézetével"
 
-#. 2.8->settings-schema.json->thumbnail-size->tooltip
-#. 3.4->settings-schema.json->thumbnail-size->tooltip
-msgid "Controls the size of the thumbnails."
-msgstr "Megadja az előnézet méretét."
+#. metadata.json->name
+msgid "Icing Task Manager"
+msgstr "Icing alkalmazásváltó"
 
-#. 2.8->settings-schema.json->thumbnail-size->units
-#. 3.4->settings-schema.json->thumbnail-size->units
-msgid "size"
-msgstr "méret"
-
-#. 2.8->settings-schema.json->focusPseudoClass->description
-#. 3.4->settings-schema.json->focusPseudoClass->description
-msgid "App button focus pseudo class"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->tooltip
-#. 3.4->settings-schema.json->focusPseudoClass->tooltip
-msgid "Overrides the pseudo class for app button on focus."
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "active"
-msgstr "aktív"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "outlined"
-msgstr "körvonal"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "hover"
-msgstr "rámutat"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "focus"
-msgstr "fókusz"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "selected"
-msgstr "kiválasztott"
-
-#. 2.8->settings-schema.json->icon-spacing->description
-#. 3.4->settings-schema.json->icon-spacing->description
-msgid "Icon spacing"
-msgstr "Ikon térköz"
-
-#. 2.8->settings-schema.json->icon-spacing->tooltip
-#. 3.4->settings-schema.json->icon-spacing->tooltip
-msgid "Controls how much space is between the icons."
-msgstr "Megadja az ikonok közötti távolságot."
-
-#. 2.8->settings-schema.json->icon-spacing->units
-#. 2.8->settings-schema.json->icon-size->units
-#. 2.8->settings-schema.json->icon-padding->units
-#. 3.4->settings-schema.json->icon-spacing->units
-#. 3.4->settings-schema.json->thumbnail-padding->units
-#. 3.4->settings-schema.json->icon-size->units
-#. 3.4->settings-schema.json->app-button-width->units
-#. 3.4->settings-schema.json->thumbnail-close-button-size->units
-#. 3.4->settings-schema.json->icon-padding->units
-msgid "px"
-msgstr "px"
-
-#. 2.8->settings-schema.json->show-thumbnails->description
-#. 3.4->settings-schema.json->show-thumbnails->description
-msgid "Show thumbnails"
-msgstr "Előnézet megjelenítése"
-
-#. 2.8->settings-schema.json->show-thumbnails->tooltip
-#. 3.4->settings-schema.json->show-thumbnails->tooltip
-msgid "Show window thumbnails when hovering over an app button."
-msgstr ""
-
-#. 2.8->settings-schema.json->icon-size->description
-#. 3.4->settings-schema.json->icon-size->description
-msgid "Icon size"
-msgstr "Ikonméret"
-
-#. 2.8->settings-schema.json->icon-size->tooltip
-#. 3.4->settings-schema.json->icon-size->tooltip
-msgid "Set icon size"
-msgstr "Ikonméret beállítása"
-
-#. 2.8->settings-schema.json->hover-peek-time->description
-#. 3.4->settings-schema.json->hover-peek-time->description
-msgid "Window fade time"
-msgstr "Ablak elhalványítás késleltetése"
-
-#. 2.8->settings-schema.json->hover-peek-time->tooltip
-#. 3.4->settings-schema.json->hover-peek-time->tooltip
-msgid "Controls how quickly a window will fade on hover."
-msgstr ""
-
-#. 2.8->settings-schema.json->hover-peek-time->units
-#. 2.8->settings-schema.json->thumbnail-timeout->units
-#. 2.8->settings-schema.json->show-apps-order-timeout->units
-#. 3.4->settings-schema.json->hover-peek-time->units
-#. 3.4->settings-schema.json->thumbnail-timeout->units
-#. 3.4->settings-schema.json->show-apps-order-timeout->units
-msgid "milliseconds"
-msgstr "ezredmásodperc"
-
-#. 2.8->settings-schema.json->close-button-style->description
-msgid "Allow themes to control the thumbnail close button"
-msgstr ""
-
-#. 2.8->settings-schema.json->close-button-style->tooltip
-msgid ""
-"Controls whether or not the theme controls the window thumbnail's close "
-"button."
-msgstr ""
-
-#. 2.8->settings-schema.json->title-display->description
-#. 3.4->settings-schema.json->title-display->description
-msgid "Title display"
-msgstr "Cím megjelenítés"
-
-#. 2.8->settings-schema.json->title-display->tooltip
-#. 3.4->settings-schema.json->title-display->tooltip
-msgid ""
-"focused: show focused window title, title: display the window title, app: "
-"diplay app name, none: don't display anything"
-msgstr ""
-
-#. 2.8->settings-schema.json->title-display->options
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-#. 3.4->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->middle-click-action->options
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "None"
-msgstr "Nincs"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Focused"
-msgstr "Fókuszt kapott"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "App"
-msgstr "Alkalmazás"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Title"
-msgstr "Cím"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->description
-#. 3.4->settings-schema.json->hoverPseudoClass->description
-msgid "App button hover pseudo class"
-msgstr ""
-
-#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
-#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons on hover."
-msgstr ""
-
-#. 2.8->settings-schema.json->show-alerts->description
-#. 3.4->settings-schema.json->show-alerts->description
-msgid "Show app alerts and notifications"
-msgstr ""
-
-#. 2.8->settings-schema.json->show-alerts->tooltip
-#. 3.4->settings-schema.json->show-alerts->tooltip
-msgid "If enabled, notifications and alerts will appear."
-msgstr ""
-
-#. 2.8->settings-schema.json->pinOnDrag->description
-#. 2.8->settings-schema.json->pinOnDrag->tooltip
-#. 3.4->settings-schema.json->pinOnDrag->description
-#. 3.4->settings-schema.json->pinOnDrag->tooltip
-msgid "Pin apps when dragged to a new position"
-msgstr ""
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->description
-#. 3.4->settings-schema.json->show-apps-order-hotkey->description
-msgid "Global hotkey to show the order of apps"
-msgstr ""
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
-#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
-msgid ""
-"When triggered, the window count label will be replaced with its order in "
-"the app list temporarily."
-msgstr ""
-
-#. 2.8->settings-schema.json->menuItemType->description
-#. 3.4->settings-schema.json->menuItemType->description
-msgid "Menu item type"
-msgstr ""
-
-#. 2.8->settings-schema.json->menuItemType->tooltip
-#. 3.4->settings-schema.json->menuItemType->tooltip
-msgid ""
-"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
-msgstr ""
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Symbolic icons"
-msgstr "Szimbolikus ikonok"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "No icons"
-msgstr "Nincsenek ikonok"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Non-symbolic icons"
-msgstr "Nem szimbolikus ikonok"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->description
-#. 3.4->settings-schema.json->hover-peek-opacity->description
-msgid "Window opacity"
-msgstr "Ablak átlátszatlanság"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
-#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
-msgid "Opacity of the windows on hover."
-msgstr ""
-
-#. 2.8->settings-schema.json->hover-peek-opacity->units
-#. 3.4->settings-schema.json->hover-peek-opacity->units
-msgid "percent"
-msgstr "százalék"
-
-#. 2.8->settings-schema.json->enable-hover-peek->description
-#. 3.4->settings-schema.json->enable-hover-peek->description
-msgid "Show windows when hovered over"
-msgstr ""
-
-#. 2.8->settings-schema.json->enable-hover-peek->tooltip
-#. 3.4->settings-schema.json->enable-hover-peek->tooltip
-msgid "Controls whether or not windows display when hovered over."
-msgstr ""
-
-#. 2.8->settings-schema.json->activePseudoClass->description
-#. 3.4->settings-schema.json->activePseudoClass->description
-msgid "App button active pseudo class"
-msgstr ""
-
-#. 2.8->settings-schema.json->activePseudoClass->tooltip
-#. 3.4->settings-schema.json->activePseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons when they are active."
-msgstr ""
-
-#. 2.8->settings-schema.json->animate-thumbnails->description
-#. 3.4->settings-schema.json->animate-thumbnails->description
-msgid "Animate thumbnails"
-msgstr "Mozgó előnézet"
-
-#. 2.8->settings-schema.json->animate-thumbnails->tooltip
-#. 3.4->settings-schema.json->animate-thumbnails->tooltip
-msgid "If enabled, thumbnails will animate when appearing and disappearing."
-msgstr ""
-
-#. 2.8->settings-schema.json->autostart-menu-item->description
-#. 3.4->settings-schema.json->autostart-menu-item->description
-msgid "Show autostart option"
-msgstr "Automatikus indítási lehetőségek megjelenítése"
-
-#. 2.8->settings-schema.json->autostart-menu-item->tooltip
-#. 3.4->settings-schema.json->autostart-menu-item->tooltip
-msgid "Shows the autostart toggle option in an app's context menu."
-msgstr ""
-
-#. 2.8->settings-schema.json->show-pinned->description
-#. 3.4->settings-schema.json->show-pinned->description
-msgid "Show pinned apps"
-msgstr "Rögzített alkalmazások megjelenítése"
-
-#. 2.8->settings-schema.json->show-pinned->tooltip
-#. 3.4->settings-schema.json->show-pinned->tooltip
-msgid ""
-"Controls whether or not the pinned apps appear in the panel if they are not "
-"open."
-msgstr ""
-
-#. 2.8->settings-schema.json->useSystemTooltips->description
-msgid "Use system tooltips for closed apps"
-msgstr ""
-
-#. 2.8->settings-schema.json->useSystemTooltips->tooltip
-msgid ""
-"Controls whether or not system tooltips are in use when hovering over "
-"closed pinned apps."
+#. 2.8->settings-schema.json->ITM->description
+msgid "ITM Settings"
 msgstr ""
 
 #. 2.8->settings-schema.json->WindowList->description
 msgid "Window List Settings"
 msgstr ""
 
-#. 2.8->settings-schema.json->AppMenu->description
-msgid "Context Menu Settings"
-msgstr ""
-
-#. 2.8->settings-schema.json->Thumbnails->description
-msgid "Thumbnail Settings"
-msgstr ""
-
-#. 2.8->settings-schema.json->show-recent->description
-#. 3.4->settings-schema.json->show-recent->description
-msgid "Show recent items"
-msgstr ""
-
-#. 2.8->settings-schema.json->show-recent->tooltip
-#. 3.4->settings-schema.json->show-recent->tooltip
-msgid "Controls whether recent items will appear in the context menu."
-msgstr ""
-
-#. 2.8->settings-schema.json->vertical-thumbnails->description
-#. 3.4->settings-schema.json->vertical-thumbnails->description
-msgid "Enable vertical thumbnails"
-msgstr ""
-
-#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
-#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
-msgid "If enabled, thumbnails will stack vertically."
-msgstr ""
-
-#. 2.8->settings-schema.json->thumbnail-timeout->description
-#. 3.4->settings-schema.json->thumbnail-timeout->description
-msgid "Thumbnail timeout"
-msgstr ""
-
-#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
-#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
-msgid ""
-"Controls how quickly an app's set of window thumbnails will fade out when "
-"the mouse leaves the app button."
-msgstr ""
-
-#. 2.8->settings-schema.json->ThemeSettings->description
-msgid "Theme Settings"
-msgstr ""
-
-#. 2.8->settings-schema.json->onclick-thumbnails->description
-#. 3.4->settings-schema.json->onclick-thumbnails->description
-msgid "Open thumbnails on click"
-msgstr ""
-
-#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
-#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
-msgid "Open the thumbnails on click if there is more than one window open."
-msgstr ""
-
-#. 2.8->settings-schema.json->panelLauncherClass->description
-msgid "Use the panel launcher class for pinned apps"
-msgstr ""
-
-#. 2.8->settings-schema.json->panelLauncherClass->tooltip
-msgid "Enabling this helps with certain themes."
-msgstr ""
-
-#. 2.8->settings-schema.json->include-all-windows->description
-#. 3.4->settings-schema.json->include-all-windows->description
-msgid "Include all app windows"
-msgstr ""
-
-#. 2.8->settings-schema.json->include-all-windows->tooltip
-#. 3.4->settings-schema.json->include-all-windows->tooltip
-msgid ""
-"Controls whether or not thumbnails for smalller child windows, such as exit "
-"confirmations and file dialogues will be included in the thumbnail list."
-msgstr ""
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->description
-#. 3.4->settings-schema.json->cycleMenusHotkey->description
-msgid "Global hotkey for cycling through thumbnail menus"
-msgstr ""
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
-#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
-msgid ""
-"This allows you to cycle through the menus without activating a window."
-msgstr ""
-
-#. 2.8->settings-schema.json->enable-iconSize->description
-#. 3.4->settings-schema.json->enable-iconSize->description
-msgid "Adjust icon size"
-msgstr ""
-
-#. 2.8->settings-schema.json->enable-iconSize->tooltip
-#. 3.4->settings-schema.json->enable-iconSize->tooltip
-msgid "Adjust icon size independent of Cinnamon's panel scaling."
-msgstr ""
-
 #. 2.8->settings-schema.json->number-display->description
+#. 3.8->settings-schema.json->number-display->description
 #. 3.4->settings-schema.json->number-display->description
 msgid "Number display"
 msgstr ""
 
-#. 2.8->settings-schema.json->number-display->tooltip
-#. 3.4->settings-schema.json->number-display->tooltip
-msgid ""
-"normal: display window number, smart: display window number if more than "
-"one window, none: don't display number, all: display window number for "
-"favorites too"
-msgstr ""
-
 #. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "All"
-msgstr "Minden"
-
-#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
 #. 3.4->settings-schema.json->number-display->options
 msgid "Smart"
 msgstr ""
 
 #. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
 #. 3.4->settings-schema.json->number-display->options
 msgid "Normal"
 msgstr "Normál"
 
-#. 2.8->settings-schema.json->ITM->description
-msgid "ITM Settings"
-msgstr ""
+#. 2.8->settings-schema.json->number-display->options
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "None"
+msgstr "Nincs"
 
-#. 2.8->settings-schema.json->HoverPeek->description
-msgid "Hover Peek Settings"
-msgstr ""
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "All"
+msgstr "Minden"
 
-#. 2.8->settings-schema.json->icon-padding->description
-#. 3.4->settings-schema.json->icon-padding->description
-msgid "Icon padding"
-msgstr ""
-
-#. 2.8->settings-schema.json->icon-padding->tooltip
-#. 3.4->settings-schema.json->icon-padding->tooltip
+#. 2.8->settings-schema.json->number-display->tooltip
+#. 3.8->settings-schema.json->number-display->tooltip
+#. 3.4->settings-schema.json->number-display->tooltip
 msgid ""
-"Controls how much horizontal padding is inside the app buttons. Padding is "
-"only applied to instances of this applet on horizontal panels."
+"normal: display window number, smart: display window number if more than one "
+"window, none: don't display number, all: display window number for favorites "
+"too"
+msgstr ""
+
+#. 2.8->settings-schema.json->title-display->description
+#. 3.8->settings-schema.json->title-display->description
+#. 3.4->settings-schema.json->title-display->description
+msgid "Title display"
+msgstr "Cím megjelenítés"
+
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "App"
+msgstr "Alkalmazás"
+
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Title"
+msgstr "Cím"
+
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Focused"
+msgstr "Fókuszt kapott"
+
+#. 2.8->settings-schema.json->title-display->tooltip
+#. 3.8->settings-schema.json->title-display->tooltip
+#. 3.4->settings-schema.json->title-display->tooltip
+msgid ""
+"focused: show focused window title, title: display the window title, app: "
+"diplay app name, none: don't display anything"
+msgstr ""
+
+#. 2.8->settings-schema.json->group-apps->description
+#. 3.8->settings-schema.json->group-apps->description
+#. 3.4->settings-schema.json->group-apps->description
+msgid "Group apps"
+msgstr ""
+
+#. 2.8->settings-schema.json->group-apps->tooltip
+#. 3.8->settings-schema.json->group-apps->tooltip
+#. 3.4->settings-schema.json->group-apps->tooltip
+msgid "Group each app's set of windows."
+msgstr ""
+
+#. 2.8->settings-schema.json->show-alerts->description
+#. 3.8->settings-schema.json->show-alerts->description
+#. 3.4->settings-schema.json->show-alerts->description
+msgid "Show app alerts and notifications"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-alerts->tooltip
+#. 3.8->settings-schema.json->show-alerts->tooltip
+#. 3.4->settings-schema.json->show-alerts->tooltip
+msgid "If enabled, notifications and alerts will appear."
+msgstr ""
+
+#. 2.8->settings-schema.json->show-pinned->description
+#. 3.8->settings-schema.json->show-pinned->description
+#. 3.4->settings-schema.json->show-pinned->description
+msgid "Show pinned apps"
+msgstr "Rögzített alkalmazások megjelenítése"
+
+#. 2.8->settings-schema.json->show-pinned->tooltip
+#. 3.8->settings-schema.json->show-pinned->tooltip
+#. 3.4->settings-schema.json->show-pinned->tooltip
+msgid ""
+"Controls whether or not the pinned apps appear in the panel if they are not "
+"open."
+msgstr ""
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->description
+msgid "Arrange pinned apps"
+msgstr ""
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
+msgid "Arrange pinned apps into a different order."
+msgstr ""
+
+#. 2.8->settings-schema.json->pinOnDrag->description
+#. 2.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.8->settings-schema.json->pinOnDrag->description
+#. 3.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.4->settings-schema.json->pinOnDrag->description
+#. 3.4->settings-schema.json->pinOnDrag->tooltip
+msgid "Pin apps when dragged to a new position"
 msgstr ""
 
 #. 2.8->settings-schema.json->middle-click-action->description
@@ -602,31 +337,379 @@ msgid ""
 "on middle click."
 msgstr ""
 
+#. 2.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.4->settings-schema.json->cycleMenusHotkey->description
+msgid "Global hotkey for cycling through thumbnail menus"
+msgstr ""
+
+#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
+msgid "This allows you to cycle through the menus without activating a window."
+msgstr ""
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.4->settings-schema.json->show-apps-order-hotkey->description
+msgid "Global hotkey to show the order of apps"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
+msgid ""
+"When triggered, the window count label will be replaced with its order in "
+"the app list temporarily."
+msgstr ""
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->units
+#. 2.8->settings-schema.json->thumbnail-timeout->units
+#. 2.8->settings-schema.json->hover-peek-time->units
+#. 3.8->settings-schema.json->show-apps-order-timeout->units
+#. 3.8->settings-schema.json->thumbnail-timeout->units
+#. 3.8->settings-schema.json->hover-peek-time->units
+#. 3.4->settings-schema.json->show-apps-order-timeout->units
+#. 3.4->settings-schema.json->thumbnail-timeout->units
+#. 3.4->settings-schema.json->hover-peek-time->units
+msgid "milliseconds"
+msgstr "ezredmásodperc"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.4->settings-schema.json->show-apps-order-timeout->description
+msgid "Duration of the apps order display on hotkey press"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
+msgid ""
+"Determines the duration the window count labels are replaced with the app's "
+"order number."
+msgstr ""
+
+#. 2.8->settings-schema.json->Thumbnails->description
+msgid "Thumbnail Settings"
+msgstr ""
+
+#. 2.8->settings-schema.json->thumbnail-timeout->description
+#. 3.8->settings-schema.json->thumbnail-timeout->description
+#. 3.4->settings-schema.json->thumbnail-timeout->description
+msgid "Thumbnail timeout"
+msgstr ""
+
+#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
+msgid ""
+"Controls how quickly an app's set of window thumbnails will fade out when "
+"the mouse leaves the app button."
+msgstr ""
+
+#. 2.8->settings-schema.json->thumbnail-size->units
+#. 3.8->settings-schema.json->thumbnail-size->units
+#. 3.4->settings-schema.json->thumbnail-size->units
+msgid "size"
+msgstr "méret"
+
+#. 2.8->settings-schema.json->thumbnail-size->description
+#. 3.8->settings-schema.json->thumbnail-size->description
+#. 3.4->settings-schema.json->thumbnail-size->description
+msgid "Thumbnail size"
+msgstr "Előnézet mérete"
+
+#. 2.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-size->tooltip
+msgid "Controls the size of the thumbnails."
+msgstr "Megadja az előnézet méretét."
+
+#. 2.8->settings-schema.json->show-thumbnails->description
+#. 3.8->settings-schema.json->show-thumbnails->description
+#. 3.4->settings-schema.json->show-thumbnails->description
+msgid "Show thumbnails"
+msgstr "Előnézet megjelenítése"
+
+#. 2.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.4->settings-schema.json->show-thumbnails->tooltip
+msgid "Show window thumbnails when hovering over an app button."
+msgstr ""
+
+#. 2.8->settings-schema.json->animate-thumbnails->description
+#. 3.8->settings-schema.json->animate-thumbnails->description
+#. 3.4->settings-schema.json->animate-thumbnails->description
+msgid "Animate thumbnails"
+msgstr "Mozgó előnézet"
+
+#. 2.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.4->settings-schema.json->animate-thumbnails->tooltip
+msgid "If enabled, thumbnails will animate when appearing and disappearing."
+msgstr ""
+
+#. 2.8->settings-schema.json->vertical-thumbnails->description
+#. 3.8->settings-schema.json->vertical-thumbnails->description
+#. 3.4->settings-schema.json->vertical-thumbnails->description
+msgid "Enable vertical thumbnails"
+msgstr ""
+
+#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
+msgid "If enabled, thumbnails will stack vertically."
+msgstr ""
+
+#. 2.8->settings-schema.json->sort-thumbnails->description
+#. 3.8->settings-schema.json->sort-thumbnails->description
+#. 3.4->settings-schema.json->sort-thumbnails->description
+msgid "Sort windows for each app by last focused"
+msgstr ""
+
+#. 2.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.4->settings-schema.json->sort-thumbnails->tooltip
+msgid ""
+"Controls whether the order windows appear for an app is by last focused, or "
+"the order they were opened."
+msgstr ""
+
+#. 2.8->settings-schema.json->onclick-thumbnails->description
+#. 3.8->settings-schema.json->onclick-thumbnails->description
+#. 3.4->settings-schema.json->onclick-thumbnails->description
+msgid "Open thumbnails on click"
+msgstr ""
+
+#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
+msgid "Open the thumbnails on click if there is more than one window open."
+msgstr ""
+
+#. 2.8->settings-schema.json->include-all-windows->description
+#. 3.8->settings-schema.json->include-all-windows->description
+#. 3.4->settings-schema.json->include-all-windows->description
+msgid "Include all app windows"
+msgstr ""
+
+#. 2.8->settings-schema.json->include-all-windows->tooltip
+#. 3.8->settings-schema.json->include-all-windows->tooltip
+#. 3.4->settings-schema.json->include-all-windows->tooltip
+msgid ""
+"Controls whether or not thumbnails for smalller child windows, such as exit "
+"confirmations and file dialogues will be included in the thumbnail list."
+msgstr ""
+
+#. 2.8->settings-schema.json->AppMenu->description
+msgid "Context Menu Settings"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-recent->description
+#. 3.8->settings-schema.json->show-recent->description
+#. 3.4->settings-schema.json->show-recent->description
+msgid "Show recent items"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-recent->tooltip
+#. 3.8->settings-schema.json->show-recent->tooltip
+#. 3.4->settings-schema.json->show-recent->tooltip
+msgid "Controls whether recent items will appear in the context menu."
+msgstr ""
+
+#. 2.8->settings-schema.json->menuItemType->description
+#. 3.8->settings-schema.json->menuItemType->description
+#. 3.4->settings-schema.json->menuItemType->description
+msgid "Menu item type"
+msgstr ""
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Symbolic icons"
+msgstr "Szimbolikus ikonok"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Non-symbolic icons"
+msgstr "Nem szimbolikus ikonok"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "No icons"
+msgstr "Nincsenek ikonok"
+
+#. 2.8->settings-schema.json->menuItemType->tooltip
+#. 3.8->settings-schema.json->menuItemType->tooltip
+#. 3.4->settings-schema.json->menuItemType->tooltip
+msgid ""
+"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
+msgstr ""
+
 #. 2.8->settings-schema.json->firefox-menu->description
+#. 3.8->settings-schema.json->firefox-menu->description
 #. 3.4->settings-schema.json->firefox-menu->description
 msgid "Firefox context menu"
 msgstr ""
 
-#. 2.8->settings-schema.json->firefox-menu->tooltip
-#. 3.4->settings-schema.json->firefox-menu->tooltip
-msgid ""
-"Most Visited: show the sites you visit most, Recent History: display the "
-"the last pages you visited, Bookmarks: show your favorite bookmarks."
-msgstr ""
-
 #. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Bookmarks"
-msgstr "Könyvjelzők"
-
-#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
 #. 3.4->settings-schema.json->firefox-menu->options
 msgid "Most Visited"
 msgstr ""
 
 #. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
 #. 3.4->settings-schema.json->firefox-menu->options
 msgid "Recent History"
+msgstr ""
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Bookmarks"
+msgstr "Könyvjelzők"
+
+#. 2.8->settings-schema.json->firefox-menu->tooltip
+#. 3.8->settings-schema.json->firefox-menu->tooltip
+#. 3.4->settings-schema.json->firefox-menu->tooltip
+msgid ""
+"Most Visited: show the sites you visit most, Recent History: display the the "
+"last pages you visited, Bookmarks: show your favorite bookmarks."
+msgstr ""
+
+#. 2.8->settings-schema.json->autostart-menu-item->description
+#. 3.8->settings-schema.json->autostart-menu-item->description
+#. 3.4->settings-schema.json->autostart-menu-item->description
+msgid "Show autostart option"
+msgstr "Automatikus indítási lehetőségek megjelenítése"
+
+#. 2.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.4->settings-schema.json->autostart-menu-item->tooltip
+msgid "Shows the autostart toggle option in an app's context menu."
+msgstr ""
+
+#. 2.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.4->settings-schema.json->monitor-move-all-windows->description
+msgid "Apply the monitor move option to all windows"
+msgstr ""
+
+#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
+msgid ""
+"When clicking \"Move to monitor\" in the context menu, this option will move "
+"all of an app's windows instead of just the last focused window from the app."
+msgstr ""
+
+#. 2.8->settings-schema.json->HoverPeek->description
+msgid "Hover Peek Settings"
+msgstr ""
+
+#. 2.8->settings-schema.json->enable-hover-peek->description
+#. 3.8->settings-schema.json->enable-hover-peek->description
+#. 3.4->settings-schema.json->enable-hover-peek->description
+msgid "Show windows when hovered over"
+msgstr ""
+
+#. 2.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.4->settings-schema.json->enable-hover-peek->tooltip
+msgid "Controls whether or not windows display when hovered over."
+msgstr ""
+
+#. 2.8->settings-schema.json->hover-peek-time->description
+#. 3.8->settings-schema.json->hover-peek-time->description
+#. 3.4->settings-schema.json->hover-peek-time->description
+msgid "Window fade time"
+msgstr "Ablak elhalványítás késleltetése"
+
+#. 2.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.4->settings-schema.json->hover-peek-time->tooltip
+msgid "Controls how quickly a window will fade on hover."
+msgstr ""
+
+#. 2.8->settings-schema.json->hover-peek-opacity->units
+#. 3.8->settings-schema.json->hover-peek-opacity->units
+#. 3.4->settings-schema.json->hover-peek-opacity->units
+msgid "percent"
+msgstr "százalék"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->description
+#. 3.8->settings-schema.json->hover-peek-opacity->description
+#. 3.4->settings-schema.json->hover-peek-opacity->description
+msgid "Window opacity"
+msgstr "Ablak átlátszatlanság"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
+msgid "Opacity of the windows on hover."
+msgstr ""
+
+#. 2.8->settings-schema.json->ThemeSettings->description
+msgid "Theme Settings"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-active->description
+#. 3.8->settings-schema.json->show-active->description
+#. 3.4->settings-schema.json->show-active->description
+msgid "Show active app indicators"
+msgstr ""
+
+#. 2.8->settings-schema.json->show-active->tooltip
+#. 3.8->settings-schema.json->show-active->tooltip
+#. 3.4->settings-schema.json->show-active->tooltip
+msgid "Active app styling will indicate if an app is active."
+msgstr ""
+
+#. 2.8->settings-schema.json->icon-spacing->units
+#. 2.8->settings-schema.json->icon-padding->units
+#. 2.8->settings-schema.json->icon-size->units
+#. 3.8->settings-schema.json->app-button-width->units
+#. 3.8->settings-schema.json->thumbnail-close-button-size->units
+#. 3.8->settings-schema.json->thumbnail-padding->units
+#. 3.8->settings-schema.json->icon-spacing->units
+#. 3.8->settings-schema.json->icon-padding->units
+#. 3.8->settings-schema.json->icon-size->units
+#. 3.4->settings-schema.json->app-button-width->units
+#. 3.4->settings-schema.json->thumbnail-close-button-size->units
+#. 3.4->settings-schema.json->thumbnail-padding->units
+#. 3.4->settings-schema.json->icon-spacing->units
+#. 3.4->settings-schema.json->icon-padding->units
+#. 3.4->settings-schema.json->icon-size->units
+msgid "px"
+msgstr "px"
+
+#. 2.8->settings-schema.json->icon-spacing->description
+#. 3.8->settings-schema.json->icon-spacing->description
+#. 3.4->settings-schema.json->icon-spacing->description
+msgid "Icon spacing"
+msgstr "Ikon térköz"
+
+#. 2.8->settings-schema.json->icon-spacing->tooltip
+#. 3.8->settings-schema.json->icon-spacing->tooltip
+#. 3.4->settings-schema.json->icon-spacing->tooltip
+msgid "Controls how much space is between the icons."
+msgstr "Megadja az ikonok közötti távolságot."
+
+#. 2.8->settings-schema.json->icon-padding->description
+#. 3.8->settings-schema.json->icon-padding->description
+#. 3.4->settings-schema.json->icon-padding->description
+msgid "Icon padding"
+msgstr ""
+
+#. 2.8->settings-schema.json->icon-padding->tooltip
+#. 3.8->settings-schema.json->icon-padding->tooltip
+#. 3.4->settings-schema.json->icon-padding->tooltip
+msgid ""
+"Controls how much horizontal padding is inside the app buttons. Padding is "
+"only applied to instances of this applet on horizontal panels."
 msgstr ""
 
 #. 2.8->settings-schema.json->themePadding->description
@@ -637,308 +720,450 @@ msgstr ""
 msgid "If button icons look off-centered, toggling this may help."
 msgstr ""
 
-#. 2.8->settings-schema.json->group-apps->description
-#. 3.4->settings-schema.json->group-apps->description
-msgid "Group apps"
+#. 2.8->settings-schema.json->enable-iconSize->description
+#. 3.8->settings-schema.json->enable-iconSize->description
+#. 3.4->settings-schema.json->enable-iconSize->description
+msgid "Adjust icon size"
 msgstr ""
 
-#. 2.8->settings-schema.json->group-apps->tooltip
-#. 3.4->settings-schema.json->group-apps->tooltip
-msgid "Group each app's set of windows."
+#. 2.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.4->settings-schema.json->enable-iconSize->tooltip
+msgid "Adjust icon size independent of Cinnamon's panel scaling."
 msgstr ""
 
-#. 2.8->settings-schema.json->show-active->description
-#. 3.4->settings-schema.json->show-active->description
-msgid "Show active app indicators"
+#. 2.8->settings-schema.json->icon-size->description
+#. 3.8->settings-schema.json->icon-size->description
+#. 3.4->settings-schema.json->icon-size->description
+msgid "Icon size"
+msgstr "Ikonméret"
+
+#. 2.8->settings-schema.json->icon-size->tooltip
+#. 3.8->settings-schema.json->icon-size->tooltip
+#. 3.4->settings-schema.json->icon-size->tooltip
+msgid "Set icon size"
+msgstr "Ikonméret beállítása"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->description
+#. 3.8->settings-schema.json->hoverPseudoClass->description
+#. 3.4->settings-schema.json->hoverPseudoClass->description
+msgid "App button hover pseudo class"
 msgstr ""
 
-#. 2.8->settings-schema.json->show-active->tooltip
-#. 3.4->settings-schema.json->show-active->tooltip
-msgid "Active app styling will indicate if an app is active."
-msgstr ""
-
-#. 2.8->settings-schema.json->show-apps-order-timeout->description
-#. 3.4->settings-schema.json->show-apps-order-timeout->description
-msgid "Duration of the apps order display on hotkey press"
-msgstr ""
-
-#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
-#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
-msgid ""
-"Determines the duration the window count labels are replaced with the app's "
-"order number."
-msgstr ""
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->description
-msgid "Arrange pinned apps"
-msgstr ""
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
-msgid "Arrange pinned apps into a different order."
-msgstr ""
-
-#. 2.8->settings-schema.json->monitor-move-all-windows->description
-#. 3.4->settings-schema.json->monitor-move-all-windows->description
-msgid "Apply the monitor move option to all windows"
-msgstr ""
-
-#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
-#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
-msgid ""
-"When clicking \"Move to monitor\" in the context menu, this option will "
-"move all of an app's windows instead of just the last focused window from "
-"the app."
-msgstr ""
-
-#. 2.8->settings-schema.json->sort-thumbnails->description
-#. 3.4->settings-schema.json->sort-thumbnails->description
-msgid "Sort windows for each app by last focused"
-msgstr ""
-
-#. 2.8->settings-schema.json->sort-thumbnails->tooltip
-#. 3.4->settings-schema.json->sort-thumbnails->tooltip
-msgid ""
-"Controls whether the order windows appear for an app is by last focused, or "
-"the order they were opened."
-msgstr ""
-
-#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
 #. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
 #. 3.4->settings-schema.json->activePseudoClass->options
-msgid "checked"
+msgid "hover"
+msgstr "rámutat"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "focus"
+msgstr "fókusz"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "active"
+msgstr "aktív"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "outlined"
+msgstr "körvonal"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "selected"
+msgstr "kiválasztott"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons on hover."
 msgstr ""
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
-msgid "Highlight the last focused window within an app group"
+#. 2.8->settings-schema.json->focusPseudoClass->description
+#. 3.8->settings-schema.json->focusPseudoClass->description
+#. 3.4->settings-schema.json->focusPseudoClass->description
+msgid "App button focus pseudo class"
 msgstr ""
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 2.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.4->settings-schema.json->focusPseudoClass->tooltip
+msgid "Overrides the pseudo class for app button on focus."
+msgstr ""
+
+#. 2.8->settings-schema.json->activePseudoClass->description
+#. 3.8->settings-schema.json->activePseudoClass->description
+#. 3.4->settings-schema.json->activePseudoClass->description
+msgid "App button active pseudo class"
+msgstr ""
+
+#. 2.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.4->settings-schema.json->activePseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons when they are active."
+msgstr ""
+
+#. 2.8->settings-schema.json->panelLauncherClass->description
+msgid "Use the panel launcher class for pinned apps"
+msgstr ""
+
+#. 2.8->settings-schema.json->panelLauncherClass->tooltip
+msgid "Enabling this helps with certain themes."
+msgstr ""
+
+#. 2.8->settings-schema.json->close-button-style->description
+msgid "Allow themes to control the thumbnail close button"
+msgstr ""
+
+#. 2.8->settings-schema.json->close-button-style->tooltip
 msgid ""
-"When enabled, the last window that was interacted with will be indicated."
+"Controls whether or not the theme controls the window thumbnail's close "
+"button."
 msgstr ""
 
-#. 3.4->settings-schema.json->app-button-transition-duration->description
-msgid "App button transition duration"
+#. 2.8->settings-schema.json->useSystemTooltips->description
+msgid "Use system tooltips for closed apps"
 msgstr ""
 
-#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+#. 2.8->settings-schema.json->useSystemTooltips->tooltip
 msgid ""
-"Overrides the theme's animation time for app buttons. If set to zero, the "
-"theme's transition duration will be used."
+"Controls whether or not system tooltips are in use when hovering over closed "
+"pinned apps."
 msgstr ""
 
-#. 3.4->settings-schema.json->app-button-transition-duration->units
-msgid "ms"
-msgstr "ms"
+#. 3.8->settings-schema.json->generalPage->title
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr "Általános"
 
-#. 3.4->settings-schema.json->thumbnail-padding->description
-msgid "Thumbnail padding"
-msgstr ""
+#. 3.8->settings-schema.json->panelPage->title
+#. 3.4->settings-schema.json->panelPage->title
+msgid "Panel"
+msgstr "Panel"
 
-#. 3.4->settings-schema.json->thumbnail-padding->tooltip
-msgid "Controls how much space will be around the window preview thumbnails."
-msgstr ""
-
-#. 3.4->settings-schema.json->system-favorites->description
-msgid "Use system favorites for pinned apps"
-msgstr ""
-
-#. 3.4->settings-schema.json->system-favorites->tooltip
-msgid ""
-"Controls whether or not pinned apps consist of the system favorites list."
-msgstr ""
-
-#. 3.4->settings-schema.json->generalSection->title
-msgid "Behavior"
-msgstr "Viselkedés"
-
+#. 3.8->settings-schema.json->thumbnailsPage->title
+#. 3.8->settings-schema.json->thumbnailsSection->title
 #. 3.4->settings-schema.json->thumbnailsPage->title
 #. 3.4->settings-schema.json->thumbnailsSection->title
 msgid "Thumbnails"
 msgstr "Előnézet"
 
-#. 3.4->settings-schema.json->presetSection->title
-msgid "Recommended Presets"
-msgstr ""
-
-#. 3.4->settings-schema.json->appButtonsSection->title
-msgid "App Buttons"
-msgstr ""
-
-#. 3.4->settings-schema.json->generalPage->title
-msgid "General"
-msgstr "Általános"
-
-#. 3.4->settings-schema.json->hoverPeekSection->title
-msgid "Hover Peek"
-msgstr ""
-
-#. 3.4->settings-schema.json->panelPage->title
-msgid "Panel"
-msgstr "Panel"
-
-#. 3.4->settings-schema.json->iconSection->title
-msgid "Icons"
-msgstr "Csak ikonok"
-
-#. 3.4->settings-schema.json->hotKeysSection->title
-msgid "Hot Keys"
-msgstr ""
-
-#. 3.4->settings-schema.json->stylingSection->title
-msgid "Styling"
-msgstr ""
-
+#. 3.8->settings-schema.json->contextMenuPage->title
 #. 3.4->settings-schema.json->contextMenuPage->title
 msgid "Context Menu"
 msgstr ""
 
+#. 3.8->settings-schema.json->themePage->title
 #. 3.4->settings-schema.json->themePage->title
 msgid "Theming"
 msgstr ""
 
-#. 3.4->settings-schema.json->mintYPreset->description
-#. 3.4->settings-schema.json->mintYPreset->tooltip
-msgid "Mint Y and Variants"
+#. 3.8->settings-schema.json->generalSection->title
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr "Viselkedés"
+
+#. 3.8->settings-schema.json->appButtonsSection->title
+#. 3.4->settings-schema.json->appButtonsSection->title
+msgid "App Buttons"
 msgstr ""
 
-#. 3.4->settings-schema.json->show-icons->description
-msgid "Show icons"
+#. 3.8->settings-schema.json->hotKeysSection->title
+#. 3.4->settings-schema.json->hotKeysSection->title
+msgid "Hot Keys"
 msgstr ""
 
-#. 3.4->settings-schema.json->show-icons->tooltip
-msgid "Show the window's icon next to the title."
+#. 3.8->settings-schema.json->hoverPeekSection->title
+#. 3.4->settings-schema.json->hoverPeekSection->title
+msgid "Hover Peek"
 msgstr ""
 
-#. 3.4->settings-schema.json->enable-app-button-dragging->description
-#. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
-msgid "Enable app button dragging"
+#. 3.8->settings-schema.json->stylingSection->title
+#. 3.4->settings-schema.json->stylingSection->title
+msgid "Styling"
 msgstr ""
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
-msgid "Show new window option"
+#. 3.8->settings-schema.json->iconSection->title
+#. 3.4->settings-schema.json->iconSection->title
+msgid "Icons"
+msgstr "Csak ikonok"
+
+#. 3.8->settings-schema.json->presetSection->title
+#. 3.4->settings-schema.json->presetSection->title
+msgid "Recommended Presets"
 msgstr ""
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
-msgid ""
-"Shows the \"New Window\" option in an app's context menu if it doesn't "
-"already have one from the app's own action menu items."
-msgstr ""
-
-#. 3.4->settings-schema.json->app-button-width->description
-msgid "App button width"
-msgstr ""
-
-#. 3.4->settings-schema.json->app-button-width->tooltip
-msgid ""
-"Controls the width of the application button. This option only works for "
-"horizontal panels."
-msgstr ""
-
-#. 3.4->settings-schema.json->mintXPreset->description
-#. 3.4->settings-schema.json->mintXPreset->tooltip
-msgid "Mint X, Linux Mint, and Variants"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->description
-msgid "Launcher animation effect"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
-#. 3.4->settings-schema.json->left-click-action->description
-#. 3.4->settings-schema.json->left-click-action->tooltip
-msgid "Left click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Scale"
-msgstr "Áttekintő"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Fade"
-msgstr "Elhalványodás"
-
-#. 3.4->settings-schema.json->enable-app-button-width->description
-msgid "Use a custom width for app buttons"
-msgstr ""
-
-#. 3.4->settings-schema.json->enable-app-button-width->tooltip
-msgid "When disabled, the app button width is determined by the panel height."
-msgstr ""
-
-#. 3.4->settings-schema.json->list-monitor-windows->description
-msgid "Only list windows from the monitor displaying this instance"
-msgstr ""
-
-#. 3.4->settings-schema.json->list-monitor-windows->tooltip
-msgid ""
-"This option will only come into effect for monitors displaying an ITM "
-"instance."
-msgstr ""
-
-#. 3.4->settings-schema.json->thumbnail-close-button-size->description
-msgid "Close button size"
-msgstr ""
-
-#. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
-msgid "Controls how large the thumbnail close button is."
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->description
-#. 3.4->settings-schema.json->middle-click-action->tooltip
-msgid "Middle click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Launch new app instance"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Close last focused window in group"
-msgstr ""
-
+#. 3.8->settings-schema.json->scroll-behavior->description
 #. 3.4->settings-schema.json->scroll-behavior->description
 msgid "Mouse wheel scroll behavior"
 msgstr ""
 
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+msgid "Cycle apps"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+msgid "Cycle windows"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->tooltip
 #. 3.4->settings-schema.json->scroll-behavior->tooltip
 msgid ""
 "Choose if scrolling the mouse wheel cycles running apps, an app button's "
 "windows on hover, or is disabled."
 msgstr ""
 
-#. 3.4->settings-schema.json->scroll-behavior->options
-msgid "Cycle apps"
+#. 3.8->settings-schema.json->left-click-action->description
+#. 3.8->settings-schema.json->left-click-action->tooltip
+#. 3.8->settings-schema.json->launcher-animation-effect->tooltip
+#. 3.4->settings-schema.json->left-click-action->description
+#. 3.4->settings-schema.json->left-click-action->tooltip
+#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
+msgid "Left click action"
 msgstr ""
 
-#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
 #. 3.4->settings-schema.json->left-click-action->options
-msgid "Cycle windows"
+msgid "Toggle activation of last focused window"
 msgstr ""
 
+#. 3.8->settings-schema.json->middle-click-action->description
+#. 3.8->settings-schema.json->middle-click-action->tooltip
+#. 3.4->settings-schema.json->middle-click-action->description
+#. 3.4->settings-schema.json->middle-click-action->tooltip
+msgid "Middle click action"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Launch new app instance"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Close last focused window in group"
+msgstr ""
+
+#. 3.8->settings-schema.json->system-favorites->description
+#. 3.4->settings-schema.json->system-favorites->description
+msgid "Use system favorites for pinned apps"
+msgstr ""
+
+#. 3.8->settings-schema.json->system-favorites->tooltip
+#. 3.4->settings-schema.json->system-favorites->tooltip
+msgid ""
+"Controls whether or not pinned apps consist of the system favorites list."
+msgstr ""
+
+#. 3.8->settings-schema.json->show-all-workspaces->description
+#. 3.8->settings-schema.json->show-all-workspaces->tooltip
 #. 3.4->settings-schema.json->show-all-workspaces->description
 #. 3.4->settings-schema.json->show-all-workspaces->tooltip
 msgid "Show windows from all workspaces"
 msgstr "Ablakok megjelenítése minden munkaterületről"
 
+#. 3.8->settings-schema.json->enable-app-button-dragging->description
+#. 3.8->settings-schema.json->enable-app-button-dragging->tooltip
+#. 3.4->settings-schema.json->enable-app-button-dragging->description
+#. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
+msgid "Enable app button dragging"
+msgstr ""
+
+#. 3.8->settings-schema.json->launcher-animation-effect->description
+#. 3.4->settings-schema.json->launcher-animation-effect->description
+msgid "Launcher animation effect"
+msgstr ""
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Fade"
+msgstr "Elhalványodás"
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Scale"
+msgstr "Áttekintő"
+
+#. 3.8->settings-schema.json->list-monitor-windows->description
+#. 3.4->settings-schema.json->list-monitor-windows->description
+msgid "Only list windows from the monitor displaying this instance"
+msgstr ""
+
+#. 3.8->settings-schema.json->list-monitor-windows->tooltip
+#. 3.4->settings-schema.json->list-monitor-windows->tooltip
+msgid ""
+"This option will only come into effect for monitors displaying an ITM "
+"instance."
+msgstr ""
+
+#. 3.8->settings-schema.json->enable-app-button-width->description
+#. 3.4->settings-schema.json->enable-app-button-width->description
+msgid "Use a custom width for app buttons"
+msgstr ""
+
+#. 3.8->settings-schema.json->enable-app-button-width->tooltip
+#. 3.4->settings-schema.json->enable-app-button-width->tooltip
+msgid "When disabled, the app button width is determined by the panel height."
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-width->description
+#. 3.4->settings-schema.json->app-button-width->description
+msgid "App button width"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-width->tooltip
+#. 3.4->settings-schema.json->app-button-width->tooltip
+msgid ""
+"Controls the width of the application button. This option only works for "
+"horizontal panels."
+msgstr ""
+
+#. 3.8->settings-schema.json->thumbnail-close-button-size->description
+#. 3.4->settings-schema.json->thumbnail-close-button-size->description
+msgid "Close button size"
+msgstr ""
+
+#. 3.8->settings-schema.json->thumbnail-close-button-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
+msgid "Controls how large the thumbnail close button is."
+msgstr ""
+
+#. 3.8->settings-schema.json->thumbnail-padding->description
+#. 3.4->settings-schema.json->thumbnail-padding->description
+msgid "Thumbnail padding"
+msgstr ""
+
+#. 3.8->settings-schema.json->thumbnail-padding->tooltip
+#. 3.4->settings-schema.json->thumbnail-padding->tooltip
+msgid "Controls how much space will be around the window preview thumbnails."
+msgstr ""
+
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->description
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
 msgid "Cycle windows on mouse wheel scroll"
 msgstr ""
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->tooltip
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
 msgid ""
-"Choose whether or not scrolling the mouse wheel cycles windows when "
-"hovering over a thumbnail menu."
+"Choose whether or not scrolling the mouse wheel cycles windows when hovering "
+"over a thumbnail menu."
 msgstr ""
 
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "Toggle activation of last focused window"
+#. 3.8->settings-schema.json->show-icons->description
+#. 3.4->settings-schema.json->show-icons->description
+msgid "Show icons"
 msgstr ""
 
-#. IcingTaskManager@json->metadata.json->name
-msgid "Icing Task Manager"
-msgstr "Icing alkalmazásváltó"
+#. 3.8->settings-schema.json->show-icons->tooltip
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr ""
 
-#. IcingTaskManager@json->metadata.json->description
-msgid "Window list with app grouping and thumbnails"
-msgstr "Ablaklista az alkalmazások csoportosításával és előnézetével"
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->description
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
+msgid "Highlight the last focused window within an app group"
+msgstr ""
+
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+msgid ""
+"When enabled, the last window that was interacted with will be indicated."
+msgstr ""
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->description
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+msgid "Show new window option"
+msgstr ""
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->tooltip
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->units
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr "ms"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->description
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->tooltip
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.8->settings-schema.json->mintYPreset->description
+#. 3.8->settings-schema.json->mintYPreset->tooltip
+#. 3.4->settings-schema.json->mintYPreset->description
+#. 3.4->settings-schema.json->mintYPreset->tooltip
+msgid "Mint Y and Variants"
+msgstr ""
+
+#. 3.8->settings-schema.json->mintXPreset->description
+#. 3.8->settings-schema.json->mintXPreset->tooltip
+#. 3.4->settings-schema.json->mintXPreset->description
+#. 3.4->settings-schema.json->mintXPreset->tooltip
+msgid "Mint X, Linux Mint, and Variants"
+msgstr ""
+
+#. 3.8->settings-schema.json->migrationButton->description
+msgid "Migrate Pinned Apps to Grouped Window List"
+msgstr ""

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/hu.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-10 00:43-0600\n"
+"POT-Creation-Date: 2018-12-13 18:37-0600\n"
 "PO-Revision-Date: 2018-04-25 14:13+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,53 +17,53 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-#: 3.8/applet.js:471
-msgid "Icing Task Manager is now Grouped Window List"
-msgstr ""
+#: 3.8/applet.js:476
+#, fuzzy
+msgid "Icing Task Manager is deprecated"
+msgstr "Icing alkalmazásváltó"
 
-#: 3.8/applet.js:472
+#: 3.8/applet.js:477
 msgid ""
-"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
-"Window List\". "
+"Please upgrade to Grouped Window List for a more stable, bug-free experience."
 msgstr ""
 
-#: 3.8/applet.js:473
+#: 3.8/applet.js:478
 msgid ""
-"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
-"List."
+"Add GWL to your panel, open the applet's settings and click \"Migrate Pinned "
+"Apps to Grouped Window List\"."
 msgstr ""
 
-#: 3.8/applet.js:485
-msgid "Migration can only be performed on Cinnamon 4.0."
+#: 3.8/applet.js:490
+msgid "Migration can only be performed on Cinnamon 4.0+."
 msgstr ""
 
-#: 3.8/applet.js:496
+#: 3.8/applet.js:501
 msgid ""
 "Please add Grouped Window List to a panel before proceeding with the "
 "migration."
 msgstr ""
 
-#: 3.8/applet.js:504
+#: 3.8/applet.js:509
 msgid "ITM settings directory could not be found!"
 msgstr ""
 
-#: 3.8/applet.js:534
+#: 3.8/applet.js:539
 msgid "System favorites enabled - no migration is needed."
 msgstr ""
 
-#: 3.8/applet.js:577
+#: 3.8/applet.js:582
 msgid "Unable to find a suitable ITM settings file to migrate."
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid "Migration complete. "
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid " settings file(s) could not be migrated."
 msgstr ""
 
-#: 3.8/applet.js:592
+#: 3.8/applet.js:597
 msgid "Migration was successful."
 msgstr ""
 
@@ -1167,3 +1167,7 @@ msgstr ""
 #. 3.8->settings-schema.json->migrationButton->description
 msgid "Migrate Pinned Apps to Grouped Window List"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Icing Task Manager is deprecated - please use Grouped Window List"
+#~ msgstr "Icing alkalmazásváltó"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/pl.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/pl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-23 21:32-0600\n"
+"POT-Creation-Date: 2018-12-10 00:43-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: mariachini\n"
 "Language-Team: \n"
@@ -13,554 +13,219 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/applet.js:471
+msgid "Icing Task Manager is now Grouped Window List"
+msgstr ""
+
+#: 3.8/applet.js:472
+msgid ""
+"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
+"Window List\". "
+msgstr ""
+
+#: 3.8/applet.js:473
+msgid ""
+"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
+"List."
+msgstr ""
+
+#: 3.8/applet.js:485
+msgid "Migration can only be performed on Cinnamon 4.0."
+msgstr ""
+
+#: 3.8/applet.js:496
+msgid ""
+"Please add Grouped Window List to a panel before proceeding with the "
+"migration."
+msgstr ""
+
+#: 3.8/applet.js:504
+msgid "ITM settings directory could not be found!"
+msgstr ""
+
+#: 3.8/applet.js:534
+msgid "System favorites enabled - no migration is needed."
+msgstr ""
+
+#: 3.8/applet.js:577
+msgid "Unable to find a suitable ITM settings file to migrate."
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid "Migration complete. "
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid " settings file(s) could not be migrated."
+msgstr ""
+
+#: 3.8/applet.js:592
+msgid "Migration was successful."
+msgstr ""
+
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to the other monitor"
 msgstr "Przesuń na inny monitor"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to monitor "
 msgstr "Przesuń na monitor"
 
-#: 3.4/specialMenus.js:126
+#: 3.8/specialMenus.js:98 3.4/specialMenus.js:126
 msgid "Only on this workspace"
 msgstr "Tylko na tym obszarze roboczym"
 
-#: 3.4/specialMenus.js:133
+#: 3.8/specialMenus.js:105 3.4/specialMenus.js:133
 msgid "Visible on all workspaces"
 msgstr "Widoczne na wszystkich obszarach roboczych"
 
-#: 3.4/specialMenus.js:140
+#: 3.8/specialMenus.js:112 3.4/specialMenus.js:140
 msgid "Move to another workspace"
 msgstr "Przesuń na inny obszar roboczy"
 
-#: 3.4/specialMenus.js:168
+#: 3.8/specialMenus.js:140 3.4/specialMenus.js:168
 msgid "Places"
 msgstr "Miejsca"
 
-#: 3.4/specialMenus.js:207
+#: 3.8/specialMenus.js:179 3.4/specialMenus.js:207
 msgid "Bookmarks/History requires gir1.2-gda-5.0"
 msgstr "Zakładki/Historia wymagają gir1.2-gda-5.0"
 
-#: 3.4/specialMenus.js:227
+#: 3.8/specialMenus.js:199 3.4/specialMenus.js:227
 msgid "Recent"
 msgstr "Ostatnie"
 
-#: 3.4/specialMenus.js:246
+#: 3.8/specialMenus.js:218 3.4/specialMenus.js:246
 msgid "Preferences"
 msgstr "Ustawienia"
 
-#: 3.4/specialMenus.js:249
+#: 3.8/specialMenus.js:221 3.4/specialMenus.js:249
 msgid "About..."
 msgstr "O programie..."
 
-#: 3.4/specialMenus.js:253
+#: 3.8/specialMenus.js:225 3.4/specialMenus.js:253
 msgid "Configure..."
 msgstr "Konfiguruj..."
 
-#: 3.4/specialMenus.js:257
+#: 3.8/specialMenus.js:229 3.4/specialMenus.js:257
 msgid "Remove"
 msgstr "Usuń"
 
-#: 3.4/specialMenus.js:287
+#: 3.8/specialMenus.js:259 3.4/specialMenus.js:287
 msgid "New Window"
 msgstr "Nowe okno"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Unpin from Panel"
 msgstr "Odepnij od panelu"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Pin to Panel"
 msgstr "Przypnij do panelu"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Remove from Autostart"
 msgstr "Usuń z autostartu"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Add to Autostart"
 msgstr "Dodaj do autostartu"
 
-#: 3.4/specialMenus.js:318
+#: 3.8/specialMenus.js:290 3.4/specialMenus.js:318
 msgid "Create Shortcut"
 msgstr "Utwórz skrót"
 
-#: 3.4/specialMenus.js:329
+#: 3.8/specialMenus.js:301 3.4/specialMenus.js:329
 msgid "Restore to full opacity"
 msgstr "Przywróć pełną nieprzezroczystość"
 
-#: 3.4/specialMenus.js:337
+#: 3.8/specialMenus.js:309 3.4/specialMenus.js:337
 msgid "Restore"
 msgstr "Przywróć"
 
-#: 3.4/specialMenus.js:342
+#: 3.8/specialMenus.js:314 3.4/specialMenus.js:342
 msgid "Minimize"
 msgstr "Minimalizuj"
 
-#: 3.4/specialMenus.js:350
+#: 3.8/specialMenus.js:322 3.4/specialMenus.js:350
 msgid "Unmaximize"
 msgstr "Zmniejszenie"
 
-#: 3.4/specialMenus.js:355
+#: 3.8/specialMenus.js:327 3.4/specialMenus.js:355
 msgid "Maximize"
 msgstr "Maksymalizuj"
 
-#: 3.4/specialMenus.js:365
+#: 3.8/specialMenus.js:337 3.4/specialMenus.js:365
 msgid "Close others"
 msgstr "Zamknij pozostałe"
 
-#: 3.4/specialMenus.js:375
+#: 3.8/specialMenus.js:347 3.4/specialMenus.js:375
 msgid "Close all"
 msgstr "Zamknij wszystkie"
 
-#: 3.4/specialMenus.js:385
+#: 3.8/specialMenus.js:357 3.4/specialMenus.js:385
 msgid "Close"
 msgstr "Zamknij"
 
-#. 2.8->settings-schema.json->thumbnail-size->description
-#. 3.4->settings-schema.json->thumbnail-size->description
-msgid "Thumbnail size"
-msgstr "Wielkość miniaturki"
+#. metadata.json->description
+msgid "Window list with app grouping and thumbnails"
+msgstr "Lista okien z grupowaniem aplikacji i miniaturkami"
 
-#. 2.8->settings-schema.json->thumbnail-size->tooltip
-#. 3.4->settings-schema.json->thumbnail-size->tooltip
-msgid "Controls the size of the thumbnails."
-msgstr "Kontroluje wielkość miniaturek"
+#. metadata.json->name
+msgid "Icing Task Manager"
+msgstr "Icing Task Manager"
 
-#. 2.8->settings-schema.json->thumbnail-size->units
-#. 3.4->settings-schema.json->thumbnail-size->units
-msgid "size"
-msgstr "rozmiar"
-
-#. 2.8->settings-schema.json->focusPseudoClass->description
-#. 3.4->settings-schema.json->focusPseudoClass->description
-msgid "App button focus pseudo class"
-msgstr "Pseudo klasa dla przycisku aktywnego okna aplikacji"
-
-#. 2.8->settings-schema.json->focusPseudoClass->tooltip
-#. 3.4->settings-schema.json->focusPseudoClass->tooltip
-msgid "Overrides the pseudo class for app button on focus."
-msgstr ""
-"Nadpisuje pseudo klasę dla przycisku aplikacji przy wybraniu aktywnego okna."
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "active"
-msgstr "aktywne"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "outlined"
-msgstr "opisane"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "hover"
-msgstr "najedź"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "focus"
-msgstr "skup"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "selected"
-msgstr "zaznaczone"
-
-#. 2.8->settings-schema.json->icon-spacing->description
-#. 3.4->settings-schema.json->icon-spacing->description
-msgid "Icon spacing"
-msgstr "Rozstaw ikon"
-
-#. 2.8->settings-schema.json->icon-spacing->tooltip
-#. 3.4->settings-schema.json->icon-spacing->tooltip
-msgid "Controls how much space is between the icons."
-msgstr "Kontroluje ile miejsca jest między ikonami."
-
-#. 2.8->settings-schema.json->icon-spacing->units
-#. 2.8->settings-schema.json->icon-size->units
-#. 2.8->settings-schema.json->icon-padding->units
-#. 3.4->settings-schema.json->icon-spacing->units
-#. 3.4->settings-schema.json->thumbnail-padding->units
-#. 3.4->settings-schema.json->icon-size->units
-#. 3.4->settings-schema.json->app-button-width->units
-#. 3.4->settings-schema.json->thumbnail-close-button-size->units
-#. 3.4->settings-schema.json->icon-padding->units
-msgid "px"
-msgstr "px"
-
-#. 2.8->settings-schema.json->show-thumbnails->description
-#. 3.4->settings-schema.json->show-thumbnails->description
-msgid "Show thumbnails"
-msgstr "Pokaż miniaturki"
-
-#. 2.8->settings-schema.json->show-thumbnails->tooltip
-#. 3.4->settings-schema.json->show-thumbnails->tooltip
-msgid "Show window thumbnails when hovering over an app button."
-msgstr "Pokazuj miniaturki po najechaniu na przycisk aplikacji"
-
-#. 2.8->settings-schema.json->icon-size->description
-#. 3.4->settings-schema.json->icon-size->description
-msgid "Icon size"
-msgstr "Wielkość ikony"
-
-#. 2.8->settings-schema.json->icon-size->tooltip
-#. 3.4->settings-schema.json->icon-size->tooltip
-msgid "Set icon size"
-msgstr "Ustaw wielkość ikony"
-
-#. 2.8->settings-schema.json->hover-peek-time->description
-#. 3.4->settings-schema.json->hover-peek-time->description
-msgid "Window fade time"
-msgstr "Czas zanikania okna"
-
-#. 2.8->settings-schema.json->hover-peek-time->tooltip
-#. 3.4->settings-schema.json->hover-peek-time->tooltip
-msgid "Controls how quickly a window will fade on hover."
-msgstr "Kontroluje jak szybko zaniknie okno po najechaniu na nie."
-
-#. 2.8->settings-schema.json->hover-peek-time->units
-#. 2.8->settings-schema.json->thumbnail-timeout->units
-#. 2.8->settings-schema.json->show-apps-order-timeout->units
-#. 3.4->settings-schema.json->hover-peek-time->units
-#. 3.4->settings-schema.json->thumbnail-timeout->units
-#. 3.4->settings-schema.json->show-apps-order-timeout->units
-msgid "milliseconds"
-msgstr "milisekundy"
-
-#. 2.8->settings-schema.json->close-button-style->description
-msgid "Allow themes to control the thumbnail close button"
-msgstr "Pozwalaj motywom kontrolować przycisk zamykania miniaturek"
-
-#. 2.8->settings-schema.json->close-button-style->tooltip
-msgid ""
-"Controls whether or not the theme controls the window thumbnail's close "
-"button."
-msgstr ""
-"Kontroluje czy motywy będą mogły kontrolować przycisk zamykania miniaturek."
-
-#. 2.8->settings-schema.json->title-display->description
-#. 3.4->settings-schema.json->title-display->description
-msgid "Title display"
-msgstr "Wyświetlany tytuł"
-
-#. 2.8->settings-schema.json->title-display->tooltip
-#. 3.4->settings-schema.json->title-display->tooltip
-msgid ""
-"focused: show focused window title, title: display the window title, app: "
-"diplay app name, none: don't display anything"
-msgstr ""
-"aktywne okno: pokaż tytuł aktywnego okna, tytuł: pokaż tytuł okna, "
-"aplikacja: pokaż nazwę aplikacji, brak: niczego nie wyświetlaj"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-#. 3.4->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->middle-click-action->options
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "None"
-msgstr "Brak"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Focused"
-msgstr "Aktywne okno"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "App"
-msgstr "Aplikacja"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Title"
-msgstr "Tytuł"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->description
-#. 3.4->settings-schema.json->hoverPseudoClass->description
-msgid "App button hover pseudo class"
-msgstr "Pseudo klasa dla przycisku aplikacji po najechaniu"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
-#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons on hover."
-msgstr "Nadpisuje pseudo klasę dla przycisków aplikacji po najechaniu na nią."
-
-#. 2.8->settings-schema.json->show-alerts->description
-#. 3.4->settings-schema.json->show-alerts->description
-msgid "Show app alerts and notifications"
-msgstr "Pokazuj alerty aplikacji i powiadomienia"
-
-#. 2.8->settings-schema.json->show-alerts->tooltip
-#. 3.4->settings-schema.json->show-alerts->tooltip
-msgid "If enabled, notifications and alerts will appear."
-msgstr "Jeśli aktywne, powiadomienia i alerty będą się pojawiać."
-
-#. 2.8->settings-schema.json->pinOnDrag->description
-#. 2.8->settings-schema.json->pinOnDrag->tooltip
-#. 3.4->settings-schema.json->pinOnDrag->description
-#. 3.4->settings-schema.json->pinOnDrag->tooltip
-msgid "Pin apps when dragged to a new position"
-msgstr "Przypnij aplikacje gdy przeciągnięte są do nowej pozycji"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->description
-#. 3.4->settings-schema.json->show-apps-order-hotkey->description
-msgid "Global hotkey to show the order of apps"
-msgstr "Globalny skrót klawiszowy do pokazania posortowanych aplikacji"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
-#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
-msgid ""
-"When triggered, the window count label will be replaced with its order in "
-"the app list temporarily."
-msgstr ""
-"Po włączeniu, etykieta z ilością okien będzie zastąpiona tymczasową "
-"kolejnością na liście aplikacji."
-
-#. 2.8->settings-schema.json->menuItemType->description
-#. 3.4->settings-schema.json->menuItemType->description
-msgid "Menu item type"
-msgstr "Typ elementów menu"
-
-#. 2.8->settings-schema.json->menuItemType->tooltip
-#. 3.4->settings-schema.json->menuItemType->tooltip
-msgid ""
-"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
-msgstr ""
-"Określa, czy elementy menu ikon są symboliczne, niesymboliczne, czy też nie "
-"są pokazane."
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Symbolic icons"
-msgstr "Ikony symboliczne"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "No icons"
-msgstr "Bez ikon"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Non-symbolic icons"
-msgstr "Ikony niesymboliczne"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->description
-#. 3.4->settings-schema.json->hover-peek-opacity->description
-msgid "Window opacity"
-msgstr "Krycie okien"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
-#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
-msgid "Opacity of the windows on hover."
-msgstr "Krycie okien po najechaniu na nie."
-
-#. 2.8->settings-schema.json->hover-peek-opacity->units
-#. 3.4->settings-schema.json->hover-peek-opacity->units
-msgid "percent"
-msgstr "procent"
-
-#. 2.8->settings-schema.json->enable-hover-peek->description
-#. 3.4->settings-schema.json->enable-hover-peek->description
-msgid "Show windows when hovered over"
-msgstr "Pokaż okna po najechaniu na nie"
-
-#. 2.8->settings-schema.json->enable-hover-peek->tooltip
-#. 3.4->settings-schema.json->enable-hover-peek->tooltip
-msgid "Controls whether or not windows display when hovered over."
-msgstr "Kontroluje czy pojawi się okno po najechaniu na nie."
-
-#. 2.8->settings-schema.json->activePseudoClass->description
-#. 3.4->settings-schema.json->activePseudoClass->description
-msgid "App button active pseudo class"
-msgstr "Pseudo klasa dla przycisku aplikacji gdy aktywny"
-
-#. 2.8->settings-schema.json->activePseudoClass->tooltip
-#. 3.4->settings-schema.json->activePseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons when they are active."
-msgstr "Nadpisuje pseudo klasę dla przycisków aplikacji kiedy są aktywne."
-
-#. 2.8->settings-schema.json->animate-thumbnails->description
-#. 3.4->settings-schema.json->animate-thumbnails->description
-msgid "Animate thumbnails"
-msgstr "Animowane miniaturki"
-
-#. 2.8->settings-schema.json->animate-thumbnails->tooltip
-#. 3.4->settings-schema.json->animate-thumbnails->tooltip
-msgid "If enabled, thumbnails will animate when appearing and disappearing."
-msgstr ""
-"Jeśli aktywne, miniaturki będą animowane podczas ich pojawiania się i "
-"zanikania."
-
-#. 2.8->settings-schema.json->autostart-menu-item->description
-#. 3.4->settings-schema.json->autostart-menu-item->description
-msgid "Show autostart option"
-msgstr "Pokazuj opcję autostartu"
-
-#. 2.8->settings-schema.json->autostart-menu-item->tooltip
-#. 3.4->settings-schema.json->autostart-menu-item->tooltip
-msgid "Shows the autostart toggle option in an app's context menu."
-msgstr "Pokazuje opcję autostartu w menu kontekstowym dla danej aplikacji."
-
-#. 2.8->settings-schema.json->show-pinned->description
-#. 3.4->settings-schema.json->show-pinned->description
-msgid "Show pinned apps"
-msgstr "Pokaż przypięte aplikacje"
-
-#. 2.8->settings-schema.json->show-pinned->tooltip
-#. 3.4->settings-schema.json->show-pinned->tooltip
-msgid ""
-"Controls whether or not the pinned apps appear in the panel if they are not "
-"open."
-msgstr ""
-"Kontroluje czy przypięte aplikacje będą pojawiać się w panelu niezależnie od "
-"tego czy są otwarte."
-
-#. 2.8->settings-schema.json->useSystemTooltips->description
-msgid "Use system tooltips for closed apps"
-msgstr "Użyj systemowych podpowiedzi dla zamkniętych aplikacji"
-
-#. 2.8->settings-schema.json->useSystemTooltips->tooltip
-msgid ""
-"Controls whether or not system tooltips are in use when hovering over closed "
-"pinned apps."
-msgstr ""
-"Kontroluje czy systemowe tooltipy będą w użyciu podczas najeżdżania na "
-"zamknięte przypięte aplikacje."
+#. 2.8->settings-schema.json->ITM->description
+msgid "ITM Settings"
+msgstr "Ustawienia ITM"
 
 #. 2.8->settings-schema.json->WindowList->description
 msgid "Window List Settings"
 msgstr "Ustawienia listy okien"
 
-#. 2.8->settings-schema.json->AppMenu->description
-msgid "Context Menu Settings"
-msgstr "Ustawienia menu kontekstowego"
-
-#. 2.8->settings-schema.json->Thumbnails->description
-msgid "Thumbnail Settings"
-msgstr "Ustawienia miniaturek"
-
-#. 2.8->settings-schema.json->show-recent->description
-#. 3.4->settings-schema.json->show-recent->description
-msgid "Show recent items"
-msgstr "Pokaż ostatnie pozycje"
-
-#. 2.8->settings-schema.json->show-recent->tooltip
-#. 3.4->settings-schema.json->show-recent->tooltip
-msgid "Controls whether recent items will appear in the context menu."
-msgstr "Kontroluje czy ostatnie pozycje pojawią się w menu kontekstowym."
-
-#. 2.8->settings-schema.json->vertical-thumbnails->description
-#. 3.4->settings-schema.json->vertical-thumbnails->description
-msgid "Enable vertical thumbnails"
-msgstr "Włącz pionowe miniaturki"
-
-#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
-#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
-msgid "If enabled, thumbnails will stack vertically."
-msgstr "Jeśli aktywne, miniaturki będą przylegać do siebie pionowo."
-
-#. 2.8->settings-schema.json->thumbnail-timeout->description
-#. 3.4->settings-schema.json->thumbnail-timeout->description
-msgid "Thumbnail timeout"
-msgstr "Opóźnienie miniaturek"
-
-#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
-#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
-msgid ""
-"Controls how quickly an app's set of window thumbnails will fade out when "
-"the mouse leaves the app button."
-msgstr ""
-"Kontroluje jak szybko miniaturki okien aplikacji będą zanikać, gdy myszka "
-"opuści przycisk aplikacji."
-
-#. 2.8->settings-schema.json->ThemeSettings->description
-msgid "Theme Settings"
-msgstr "Ustawienia stylu"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->description
-#. 3.4->settings-schema.json->onclick-thumbnails->description
-msgid "Open thumbnails on click"
-msgstr "Otwórz miniaturki kliknięciem"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
-#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
-msgid "Open the thumbnails on click if there is more than one window open."
-msgstr ""
-"Otwórz miniaturkę klikając w nią jeśli jest więcej niż jedno otwarte okno."
-
-#. 2.8->settings-schema.json->panelLauncherClass->description
-msgid "Use the panel launcher class for pinned apps"
-msgstr "Używaj klasy panelu uruchamiania dla przypiętych aplikacji"
-
-#. 2.8->settings-schema.json->panelLauncherClass->tooltip
-msgid "Enabling this helps with certain themes."
-msgstr "Włączenie tego pomaga przy różnych motywach."
-
-#. 2.8->settings-schema.json->include-all-windows->description
-#. 3.4->settings-schema.json->include-all-windows->description
-msgid "Include all app windows"
-msgstr "Uwzględnij wszystkie okna aplikacji"
-
-#. 2.8->settings-schema.json->include-all-windows->tooltip
-#. 3.4->settings-schema.json->include-all-windows->tooltip
-msgid ""
-"Controls whether or not thumbnails for smalller child windows, such as exit "
-"confirmations and file dialogues will be included in the thumbnail list."
-msgstr ""
-"Kontroluje czy miniaturki małych okien, takich jak potwierdzenia wyjścia czy "
-"dialogi przenoszenia pliku, będą pojawiać się na liście miniaturek."
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->description
-#. 3.4->settings-schema.json->cycleMenusHotkey->description
-msgid "Global hotkey for cycling through thumbnail menus"
-msgstr "Globalny skrót klawiszowy do przechodzenia pomiędzy miniaturkami menu"
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
-#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
-msgid "This allows you to cycle through the menus without activating a window."
-msgstr "To pozwoli ci na przechodzenie po menu bez aktywowania okna."
-
-#. 2.8->settings-schema.json->enable-iconSize->description
-#. 3.4->settings-schema.json->enable-iconSize->description
-msgid "Adjust icon size"
-msgstr "Dostosuj rozmiar ikon"
-
-#. 2.8->settings-schema.json->enable-iconSize->tooltip
-#. 3.4->settings-schema.json->enable-iconSize->tooltip
-msgid "Adjust icon size independent of Cinnamon's panel scaling."
-msgstr "Dostosuj rozmiar ikon niezależnie od skalowania panelu przez Cinnamona"
-
 #. 2.8->settings-schema.json->number-display->description
+#. 3.8->settings-schema.json->number-display->description
 #. 3.4->settings-schema.json->number-display->description
 msgid "Number display"
 msgstr "Wyświetlany numer"
 
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Smart"
+msgstr "Sprytne"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Normal"
+msgstr "Normalne"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "None"
+msgstr "Brak"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "All"
+msgstr "Wszystko"
+
 #. 2.8->settings-schema.json->number-display->tooltip
+#. 3.8->settings-schema.json->number-display->tooltip
 #. 3.4->settings-schema.json->number-display->tooltip
 msgid ""
 "normal: display window number, smart: display window number if more than one "
@@ -571,43 +236,96 @@ msgstr ""
 "otwarte więcej niż jedno okno, brak: nie wyświetlaj liczby okien, wszystko: "
 "wyświetl liczbę okien także dla ulubionych"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "All"
-msgstr "Wszystko"
+#. 2.8->settings-schema.json->title-display->description
+#. 3.8->settings-schema.json->title-display->description
+#. 3.4->settings-schema.json->title-display->description
+msgid "Title display"
+msgstr "Wyświetlany tytuł"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Smart"
-msgstr "Sprytne"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "App"
+msgstr "Aplikacja"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Normal"
-msgstr "Normalne"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Title"
+msgstr "Tytuł"
 
-#. 2.8->settings-schema.json->ITM->description
-msgid "ITM Settings"
-msgstr "Ustawienia ITM"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Focused"
+msgstr "Aktywne okno"
 
-#. 2.8->settings-schema.json->HoverPeek->description
-msgid "Hover Peek Settings"
-msgstr "Ustawienia podglądu podczas najechania"
-
-#. 2.8->settings-schema.json->icon-padding->description
-#. 3.4->settings-schema.json->icon-padding->description
-msgid "Icon padding"
-msgstr "Przestrzeń wokół ikony"
-
-#. 2.8->settings-schema.json->icon-padding->tooltip
-#. 3.4->settings-schema.json->icon-padding->tooltip
+#. 2.8->settings-schema.json->title-display->tooltip
+#. 3.8->settings-schema.json->title-display->tooltip
+#. 3.4->settings-schema.json->title-display->tooltip
 msgid ""
-"Controls how much horizontal padding is inside the app buttons. Padding is "
-"only applied to instances of this applet on horizontal panels."
+"focused: show focused window title, title: display the window title, app: "
+"diplay app name, none: don't display anything"
 msgstr ""
-"Kontroluje ile poziomej przestrzeni znajduje się w przyciskach aplikacji. "
-"Przestrzeń ta dotyczy jedynie tych instancji w tym aplecie dla panelów "
-"poziomych."
+"aktywne okno: pokaż tytuł aktywnego okna, tytuł: pokaż tytuł okna, "
+"aplikacja: pokaż nazwę aplikacji, brak: niczego nie wyświetlaj"
+
+#. 2.8->settings-schema.json->group-apps->description
+#. 3.8->settings-schema.json->group-apps->description
+#. 3.4->settings-schema.json->group-apps->description
+msgid "Group apps"
+msgstr "Grupuj aplikacje"
+
+#. 2.8->settings-schema.json->group-apps->tooltip
+#. 3.8->settings-schema.json->group-apps->tooltip
+#. 3.4->settings-schema.json->group-apps->tooltip
+msgid "Group each app's set of windows."
+msgstr "Grupuj każdy zestaw okien aplikacji."
+
+#. 2.8->settings-schema.json->show-alerts->description
+#. 3.8->settings-schema.json->show-alerts->description
+#. 3.4->settings-schema.json->show-alerts->description
+msgid "Show app alerts and notifications"
+msgstr "Pokazuj alerty aplikacji i powiadomienia"
+
+#. 2.8->settings-schema.json->show-alerts->tooltip
+#. 3.8->settings-schema.json->show-alerts->tooltip
+#. 3.4->settings-schema.json->show-alerts->tooltip
+msgid "If enabled, notifications and alerts will appear."
+msgstr "Jeśli aktywne, powiadomienia i alerty będą się pojawiać."
+
+#. 2.8->settings-schema.json->show-pinned->description
+#. 3.8->settings-schema.json->show-pinned->description
+#. 3.4->settings-schema.json->show-pinned->description
+msgid "Show pinned apps"
+msgstr "Pokaż przypięte aplikacje"
+
+#. 2.8->settings-schema.json->show-pinned->tooltip
+#. 3.8->settings-schema.json->show-pinned->tooltip
+#. 3.4->settings-schema.json->show-pinned->tooltip
+msgid ""
+"Controls whether or not the pinned apps appear in the panel if they are not "
+"open."
+msgstr ""
+"Kontroluje czy przypięte aplikacje będą pojawiać się w panelu niezależnie od "
+"tego czy są otwarte."
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->description
+msgid "Arrange pinned apps"
+msgstr "Rozmieść przypięte aplikacje"
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
+msgid "Arrange pinned apps into a different order."
+msgstr "Rozmieść przypięte aplikacje w zmienionej kolejności."
+
+#. 2.8->settings-schema.json->pinOnDrag->description
+#. 2.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.8->settings-schema.json->pinOnDrag->description
+#. 3.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.4->settings-schema.json->pinOnDrag->description
+#. 3.4->settings-schema.json->pinOnDrag->tooltip
+msgid "Pin apps when dragged to a new position"
+msgstr "Przypnij aplikacje gdy przeciągnięte są do nowej pozycji"
 
 #. 2.8->settings-schema.json->middle-click-action->description
 msgid "Middle clicking app buttons creates new app instances"
@@ -623,12 +341,261 @@ msgstr ""
 "Ustawienie na false spowoduje zamknięcie ostatniego okna skupiony z grupy "
 "aplikacji na środkowym kliknięcia."
 
+#. 2.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.4->settings-schema.json->cycleMenusHotkey->description
+msgid "Global hotkey for cycling through thumbnail menus"
+msgstr "Globalny skrót klawiszowy do przechodzenia pomiędzy miniaturkami menu"
+
+#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
+msgid "This allows you to cycle through the menus without activating a window."
+msgstr "To pozwoli ci na przechodzenie po menu bez aktywowania okna."
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.4->settings-schema.json->show-apps-order-hotkey->description
+msgid "Global hotkey to show the order of apps"
+msgstr "Globalny skrót klawiszowy do pokazania posortowanych aplikacji"
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
+msgid ""
+"When triggered, the window count label will be replaced with its order in "
+"the app list temporarily."
+msgstr ""
+"Po włączeniu, etykieta z ilością okien będzie zastąpiona tymczasową "
+"kolejnością na liście aplikacji."
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->units
+#. 2.8->settings-schema.json->thumbnail-timeout->units
+#. 2.8->settings-schema.json->hover-peek-time->units
+#. 3.8->settings-schema.json->show-apps-order-timeout->units
+#. 3.8->settings-schema.json->thumbnail-timeout->units
+#. 3.8->settings-schema.json->hover-peek-time->units
+#. 3.4->settings-schema.json->show-apps-order-timeout->units
+#. 3.4->settings-schema.json->thumbnail-timeout->units
+#. 3.4->settings-schema.json->hover-peek-time->units
+msgid "milliseconds"
+msgstr "milisekundy"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.4->settings-schema.json->show-apps-order-timeout->description
+msgid "Duration of the apps order display on hotkey press"
+msgstr ""
+"Czas od ukazania się posortowanych aplikacji w momencie wciśnięcia "
+"globalnego skrótu klawiatury"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
+msgid ""
+"Determines the duration the window count labels are replaced with the app's "
+"order number."
+msgstr ""
+"Określa czas po którym etykieta z ilością okien będzie zastąpiona numerem "
+"kolejności aplikacji."
+
+#. 2.8->settings-schema.json->Thumbnails->description
+msgid "Thumbnail Settings"
+msgstr "Ustawienia miniaturek"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->description
+#. 3.8->settings-schema.json->thumbnail-timeout->description
+#. 3.4->settings-schema.json->thumbnail-timeout->description
+msgid "Thumbnail timeout"
+msgstr "Opóźnienie miniaturek"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
+msgid ""
+"Controls how quickly an app's set of window thumbnails will fade out when "
+"the mouse leaves the app button."
+msgstr ""
+"Kontroluje jak szybko miniaturki okien aplikacji będą zanikać, gdy myszka "
+"opuści przycisk aplikacji."
+
+#. 2.8->settings-schema.json->thumbnail-size->units
+#. 3.8->settings-schema.json->thumbnail-size->units
+#. 3.4->settings-schema.json->thumbnail-size->units
+msgid "size"
+msgstr "rozmiar"
+
+#. 2.8->settings-schema.json->thumbnail-size->description
+#. 3.8->settings-schema.json->thumbnail-size->description
+#. 3.4->settings-schema.json->thumbnail-size->description
+msgid "Thumbnail size"
+msgstr "Wielkość miniaturki"
+
+#. 2.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-size->tooltip
+msgid "Controls the size of the thumbnails."
+msgstr "Kontroluje wielkość miniaturek"
+
+#. 2.8->settings-schema.json->show-thumbnails->description
+#. 3.8->settings-schema.json->show-thumbnails->description
+#. 3.4->settings-schema.json->show-thumbnails->description
+msgid "Show thumbnails"
+msgstr "Pokaż miniaturki"
+
+#. 2.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.4->settings-schema.json->show-thumbnails->tooltip
+msgid "Show window thumbnails when hovering over an app button."
+msgstr "Pokazuj miniaturki po najechaniu na przycisk aplikacji"
+
+#. 2.8->settings-schema.json->animate-thumbnails->description
+#. 3.8->settings-schema.json->animate-thumbnails->description
+#. 3.4->settings-schema.json->animate-thumbnails->description
+msgid "Animate thumbnails"
+msgstr "Animowane miniaturki"
+
+#. 2.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.4->settings-schema.json->animate-thumbnails->tooltip
+msgid "If enabled, thumbnails will animate when appearing and disappearing."
+msgstr ""
+"Jeśli aktywne, miniaturki będą animowane podczas ich pojawiania się i "
+"zanikania."
+
+#. 2.8->settings-schema.json->vertical-thumbnails->description
+#. 3.8->settings-schema.json->vertical-thumbnails->description
+#. 3.4->settings-schema.json->vertical-thumbnails->description
+msgid "Enable vertical thumbnails"
+msgstr "Włącz pionowe miniaturki"
+
+#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
+msgid "If enabled, thumbnails will stack vertically."
+msgstr "Jeśli aktywne, miniaturki będą przylegać do siebie pionowo."
+
+#. 2.8->settings-schema.json->sort-thumbnails->description
+#. 3.8->settings-schema.json->sort-thumbnails->description
+#. 3.4->settings-schema.json->sort-thumbnails->description
+msgid "Sort windows for each app by last focused"
+msgstr ""
+"Sortuj okna dla każdej aplikacji na podstawie ostatniego aktywnego okna"
+
+#. 2.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.4->settings-schema.json->sort-thumbnails->tooltip
+msgid ""
+"Controls whether the order windows appear for an app is by last focused, or "
+"the order they were opened."
+msgstr ""
+"Kontroluje czy kolejność pojawiania się okien aplikacji będzie zależeć od "
+"ostatniego aktywnego okna czy od kolejności jego otworzenia."
+
+#. 2.8->settings-schema.json->onclick-thumbnails->description
+#. 3.8->settings-schema.json->onclick-thumbnails->description
+#. 3.4->settings-schema.json->onclick-thumbnails->description
+msgid "Open thumbnails on click"
+msgstr "Otwórz miniaturki kliknięciem"
+
+#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
+msgid "Open the thumbnails on click if there is more than one window open."
+msgstr ""
+"Otwórz miniaturkę klikając w nią jeśli jest więcej niż jedno otwarte okno."
+
+#. 2.8->settings-schema.json->include-all-windows->description
+#. 3.8->settings-schema.json->include-all-windows->description
+#. 3.4->settings-schema.json->include-all-windows->description
+msgid "Include all app windows"
+msgstr "Uwzględnij wszystkie okna aplikacji"
+
+#. 2.8->settings-schema.json->include-all-windows->tooltip
+#. 3.8->settings-schema.json->include-all-windows->tooltip
+#. 3.4->settings-schema.json->include-all-windows->tooltip
+msgid ""
+"Controls whether or not thumbnails for smalller child windows, such as exit "
+"confirmations and file dialogues will be included in the thumbnail list."
+msgstr ""
+"Kontroluje czy miniaturki małych okien, takich jak potwierdzenia wyjścia czy "
+"dialogi przenoszenia pliku, będą pojawiać się na liście miniaturek."
+
+#. 2.8->settings-schema.json->AppMenu->description
+msgid "Context Menu Settings"
+msgstr "Ustawienia menu kontekstowego"
+
+#. 2.8->settings-schema.json->show-recent->description
+#. 3.8->settings-schema.json->show-recent->description
+#. 3.4->settings-schema.json->show-recent->description
+msgid "Show recent items"
+msgstr "Pokaż ostatnie pozycje"
+
+#. 2.8->settings-schema.json->show-recent->tooltip
+#. 3.8->settings-schema.json->show-recent->tooltip
+#. 3.4->settings-schema.json->show-recent->tooltip
+msgid "Controls whether recent items will appear in the context menu."
+msgstr "Kontroluje czy ostatnie pozycje pojawią się w menu kontekstowym."
+
+#. 2.8->settings-schema.json->menuItemType->description
+#. 3.8->settings-schema.json->menuItemType->description
+#. 3.4->settings-schema.json->menuItemType->description
+msgid "Menu item type"
+msgstr "Typ elementów menu"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Symbolic icons"
+msgstr "Ikony symboliczne"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Non-symbolic icons"
+msgstr "Ikony niesymboliczne"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "No icons"
+msgstr "Bez ikon"
+
+#. 2.8->settings-schema.json->menuItemType->tooltip
+#. 3.8->settings-schema.json->menuItemType->tooltip
+#. 3.4->settings-schema.json->menuItemType->tooltip
+msgid ""
+"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
+msgstr ""
+"Określa, czy elementy menu ikon są symboliczne, niesymboliczne, czy też nie "
+"są pokazane."
+
 #. 2.8->settings-schema.json->firefox-menu->description
+#. 3.8->settings-schema.json->firefox-menu->description
 #. 3.4->settings-schema.json->firefox-menu->description
 msgid "Firefox context menu"
 msgstr "Menu kontekstowe Firefox"
 
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Most Visited"
+msgstr "Najczęściej odwiedzane"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Recent History"
+msgstr "Ostatnia historia"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Bookmarks"
+msgstr "Ulubione"
+
 #. 2.8->settings-schema.json->firefox-menu->tooltip
+#. 3.8->settings-schema.json->firefox-menu->tooltip
 #. 3.4->settings-schema.json->firefox-menu->tooltip
 msgid ""
 "Most Visited: show the sites you visit most, Recent History: display the the "
@@ -638,20 +605,142 @@ msgstr ""
 "Ostatnia historia: wyświetl ostatnio odwiedzoną stronę, Zakładki: pokaż "
 "ulubione zakładki."
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Bookmarks"
-msgstr "Ulubione"
+#. 2.8->settings-schema.json->autostart-menu-item->description
+#. 3.8->settings-schema.json->autostart-menu-item->description
+#. 3.4->settings-schema.json->autostart-menu-item->description
+msgid "Show autostart option"
+msgstr "Pokazuj opcję autostartu"
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Most Visited"
-msgstr "Najczęściej odwiedzane"
+#. 2.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.4->settings-schema.json->autostart-menu-item->tooltip
+msgid "Shows the autostart toggle option in an app's context menu."
+msgstr "Pokazuje opcję autostartu w menu kontekstowym dla danej aplikacji."
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Recent History"
-msgstr "Ostatnia historia"
+#. 2.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.4->settings-schema.json->monitor-move-all-windows->description
+msgid "Apply the monitor move option to all windows"
+msgstr "Aktywuj opcję przemieszczanie monitora na wszystkie okna"
+
+#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
+msgid ""
+"When clicking \"Move to monitor\" in the context menu, this option will move "
+"all of an app's windows instead of just the last focused window from the app."
+msgstr ""
+"Podczas kliknięcia na \"Przenieś na monitor\" w menu kontekstowym, opcja te "
+"przeniesie wszystkie okna zamiast tylko ostatniego, aktywnego okna aplikacji."
+
+#. 2.8->settings-schema.json->HoverPeek->description
+msgid "Hover Peek Settings"
+msgstr "Ustawienia podglądu podczas najechania"
+
+#. 2.8->settings-schema.json->enable-hover-peek->description
+#. 3.8->settings-schema.json->enable-hover-peek->description
+#. 3.4->settings-schema.json->enable-hover-peek->description
+msgid "Show windows when hovered over"
+msgstr "Pokaż okna po najechaniu na nie"
+
+#. 2.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.4->settings-schema.json->enable-hover-peek->tooltip
+msgid "Controls whether or not windows display when hovered over."
+msgstr "Kontroluje czy pojawi się okno po najechaniu na nie."
+
+#. 2.8->settings-schema.json->hover-peek-time->description
+#. 3.8->settings-schema.json->hover-peek-time->description
+#. 3.4->settings-schema.json->hover-peek-time->description
+msgid "Window fade time"
+msgstr "Czas zanikania okna"
+
+#. 2.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.4->settings-schema.json->hover-peek-time->tooltip
+msgid "Controls how quickly a window will fade on hover."
+msgstr "Kontroluje jak szybko zaniknie okno po najechaniu na nie."
+
+#. 2.8->settings-schema.json->hover-peek-opacity->units
+#. 3.8->settings-schema.json->hover-peek-opacity->units
+#. 3.4->settings-schema.json->hover-peek-opacity->units
+msgid "percent"
+msgstr "procent"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->description
+#. 3.8->settings-schema.json->hover-peek-opacity->description
+#. 3.4->settings-schema.json->hover-peek-opacity->description
+msgid "Window opacity"
+msgstr "Krycie okien"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
+msgid "Opacity of the windows on hover."
+msgstr "Krycie okien po najechaniu na nie."
+
+#. 2.8->settings-schema.json->ThemeSettings->description
+msgid "Theme Settings"
+msgstr "Ustawienia stylu"
+
+#. 2.8->settings-schema.json->show-active->description
+#. 3.8->settings-schema.json->show-active->description
+#. 3.4->settings-schema.json->show-active->description
+msgid "Show active app indicators"
+msgstr "Pokaż aktywne wskaźniki aplikacji"
+
+#. 2.8->settings-schema.json->show-active->tooltip
+#. 3.8->settings-schema.json->show-active->tooltip
+#. 3.4->settings-schema.json->show-active->tooltip
+msgid "Active app styling will indicate if an app is active."
+msgstr "Styl aktywnej aplikacji wskaże, czy aplikacja jest aktywna."
+
+#. 2.8->settings-schema.json->icon-spacing->units
+#. 2.8->settings-schema.json->icon-padding->units
+#. 2.8->settings-schema.json->icon-size->units
+#. 3.8->settings-schema.json->app-button-width->units
+#. 3.8->settings-schema.json->thumbnail-close-button-size->units
+#. 3.8->settings-schema.json->thumbnail-padding->units
+#. 3.8->settings-schema.json->icon-spacing->units
+#. 3.8->settings-schema.json->icon-padding->units
+#. 3.8->settings-schema.json->icon-size->units
+#. 3.4->settings-schema.json->app-button-width->units
+#. 3.4->settings-schema.json->thumbnail-close-button-size->units
+#. 3.4->settings-schema.json->thumbnail-padding->units
+#. 3.4->settings-schema.json->icon-spacing->units
+#. 3.4->settings-schema.json->icon-padding->units
+#. 3.4->settings-schema.json->icon-size->units
+msgid "px"
+msgstr "px"
+
+#. 2.8->settings-schema.json->icon-spacing->description
+#. 3.8->settings-schema.json->icon-spacing->description
+#. 3.4->settings-schema.json->icon-spacing->description
+msgid "Icon spacing"
+msgstr "Rozstaw ikon"
+
+#. 2.8->settings-schema.json->icon-spacing->tooltip
+#. 3.8->settings-schema.json->icon-spacing->tooltip
+#. 3.4->settings-schema.json->icon-spacing->tooltip
+msgid "Controls how much space is between the icons."
+msgstr "Kontroluje ile miejsca jest między ikonami."
+
+#. 2.8->settings-schema.json->icon-padding->description
+#. 3.8->settings-schema.json->icon-padding->description
+#. 3.4->settings-schema.json->icon-padding->description
+msgid "Icon padding"
+msgstr "Przestrzeń wokół ikony"
+
+#. 2.8->settings-schema.json->icon-padding->tooltip
+#. 3.8->settings-schema.json->icon-padding->tooltip
+#. 3.4->settings-schema.json->icon-padding->tooltip
+msgid ""
+"Controls how much horizontal padding is inside the app buttons. Padding is "
+"only applied to instances of this applet on horizontal panels."
+msgstr ""
+"Kontroluje ile poziomej przestrzeni znajduje się w przyciskach aplikacji. "
+"Przestrzeń ta dotyczy jedynie tych instancji w tym aplecie dla panelów "
+"poziomych."
 
 #. 2.8->settings-schema.json->themePadding->description
 msgid "Use theme padding to center button icons"
@@ -663,120 +752,283 @@ msgstr ""
 "Jeśli wygląd przycisków ikon jest nie do końca wyśrodkowany, przełączenie "
 "tego spróbuje pomóc."
 
-#. 2.8->settings-schema.json->group-apps->description
-#. 3.4->settings-schema.json->group-apps->description
-msgid "Group apps"
-msgstr "Grupuj aplikacje"
+#. 2.8->settings-schema.json->enable-iconSize->description
+#. 3.8->settings-schema.json->enable-iconSize->description
+#. 3.4->settings-schema.json->enable-iconSize->description
+msgid "Adjust icon size"
+msgstr "Dostosuj rozmiar ikon"
 
-#. 2.8->settings-schema.json->group-apps->tooltip
-#. 3.4->settings-schema.json->group-apps->tooltip
-msgid "Group each app's set of windows."
-msgstr "Grupuj każdy zestaw okien aplikacji."
+#. 2.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.4->settings-schema.json->enable-iconSize->tooltip
+msgid "Adjust icon size independent of Cinnamon's panel scaling."
+msgstr "Dostosuj rozmiar ikon niezależnie od skalowania panelu przez Cinnamona"
 
-#. 2.8->settings-schema.json->show-active->description
-#. 3.4->settings-schema.json->show-active->description
-msgid "Show active app indicators"
-msgstr "Pokaż aktywne wskaźniki aplikacji"
+#. 2.8->settings-schema.json->icon-size->description
+#. 3.8->settings-schema.json->icon-size->description
+#. 3.4->settings-schema.json->icon-size->description
+msgid "Icon size"
+msgstr "Wielkość ikony"
 
-#. 2.8->settings-schema.json->show-active->tooltip
-#. 3.4->settings-schema.json->show-active->tooltip
-msgid "Active app styling will indicate if an app is active."
-msgstr "Styl aktywnej aplikacji wskaże, czy aplikacja jest aktywna."
+#. 2.8->settings-schema.json->icon-size->tooltip
+#. 3.8->settings-schema.json->icon-size->tooltip
+#. 3.4->settings-schema.json->icon-size->tooltip
+msgid "Set icon size"
+msgstr "Ustaw wielkość ikony"
 
-#. 2.8->settings-schema.json->show-apps-order-timeout->description
-#. 3.4->settings-schema.json->show-apps-order-timeout->description
-msgid "Duration of the apps order display on hotkey press"
-msgstr ""
-"Czas od ukazania się posortowanych aplikacji w momencie wciśnięcia "
-"globalnego skrótu klawiatury"
+#. 2.8->settings-schema.json->hoverPseudoClass->description
+#. 3.8->settings-schema.json->hoverPseudoClass->description
+#. 3.4->settings-schema.json->hoverPseudoClass->description
+msgid "App button hover pseudo class"
+msgstr "Pseudo klasa dla przycisku aplikacji po najechaniu"
 
-#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
-#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
-msgid ""
-"Determines the duration the window count labels are replaced with the app's "
-"order number."
-msgstr ""
-"Określa czas po którym etykieta z ilością okien będzie zastąpiona numerem "
-"kolejności aplikacji."
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->description
-msgid "Arrange pinned apps"
-msgstr "Rozmieść przypięte aplikacje"
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
-msgid "Arrange pinned apps into a different order."
-msgstr "Rozmieść przypięte aplikacje w zmienionej kolejności."
-
-#. 2.8->settings-schema.json->monitor-move-all-windows->description
-#. 3.4->settings-schema.json->monitor-move-all-windows->description
-msgid "Apply the monitor move option to all windows"
-msgstr "Aktywuj opcję przemieszczanie monitora na wszystkie okna"
-
-#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
-#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
-msgid ""
-"When clicking \"Move to monitor\" in the context menu, this option will move "
-"all of an app's windows instead of just the last focused window from the app."
-msgstr ""
-"Podczas kliknięcia na \"Przenieś na monitor\" w menu kontekstowym, opcja te "
-"przeniesie wszystkie okna zamiast tylko ostatniego, aktywnego okna aplikacji."
-
-#. 2.8->settings-schema.json->sort-thumbnails->description
-#. 3.4->settings-schema.json->sort-thumbnails->description
-msgid "Sort windows for each app by last focused"
-msgstr ""
-"Sortuj okna dla każdej aplikacji na podstawie ostatniego aktywnego okna"
-
-#. 2.8->settings-schema.json->sort-thumbnails->tooltip
-#. 3.4->settings-schema.json->sort-thumbnails->tooltip
-msgid ""
-"Controls whether the order windows appear for an app is by last focused, or "
-"the order they were opened."
-msgstr ""
-"Kontroluje czy kolejność pojawiania się okien aplikacji będzie zależeć od "
-"ostatniego aktywnego okna czy od kolejności jego otworzenia."
-
-#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
 #. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
 #. 3.4->settings-schema.json->activePseudoClass->options
-msgid "checked"
+msgid "hover"
+msgstr "najedź"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "focus"
+msgstr "skup"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "active"
+msgstr "aktywne"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "outlined"
+msgstr "opisane"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "selected"
 msgstr "zaznaczone"
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
-msgid "Highlight the last focused window within an app group"
-msgstr "Podświetl ostatnio aktywne okno z grupy aplikacji"
+#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons on hover."
+msgstr "Nadpisuje pseudo klasę dla przycisków aplikacji po najechaniu na nią."
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 2.8->settings-schema.json->focusPseudoClass->description
+#. 3.8->settings-schema.json->focusPseudoClass->description
+#. 3.4->settings-schema.json->focusPseudoClass->description
+msgid "App button focus pseudo class"
+msgstr "Pseudo klasa dla przycisku aktywnego okna aplikacji"
+
+#. 2.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.4->settings-schema.json->focusPseudoClass->tooltip
+msgid "Overrides the pseudo class for app button on focus."
+msgstr ""
+"Nadpisuje pseudo klasę dla przycisku aplikacji przy wybraniu aktywnego okna."
+
+#. 2.8->settings-schema.json->activePseudoClass->description
+#. 3.8->settings-schema.json->activePseudoClass->description
+#. 3.4->settings-schema.json->activePseudoClass->description
+msgid "App button active pseudo class"
+msgstr "Pseudo klasa dla przycisku aplikacji gdy aktywny"
+
+#. 2.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.4->settings-schema.json->activePseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons when they are active."
+msgstr "Nadpisuje pseudo klasę dla przycisków aplikacji kiedy są aktywne."
+
+#. 2.8->settings-schema.json->panelLauncherClass->description
+msgid "Use the panel launcher class for pinned apps"
+msgstr "Używaj klasy panelu uruchamiania dla przypiętych aplikacji"
+
+#. 2.8->settings-schema.json->panelLauncherClass->tooltip
+msgid "Enabling this helps with certain themes."
+msgstr "Włączenie tego pomaga przy różnych motywach."
+
+#. 2.8->settings-schema.json->close-button-style->description
+msgid "Allow themes to control the thumbnail close button"
+msgstr "Pozwalaj motywom kontrolować przycisk zamykania miniaturek"
+
+#. 2.8->settings-schema.json->close-button-style->tooltip
 msgid ""
-"When enabled, the last window that was interacted with will be indicated."
-msgstr "Jeśli aktywne, ostatnio użyte okno będzie wskazane"
+"Controls whether or not the theme controls the window thumbnail's close "
+"button."
+msgstr ""
+"Kontroluje czy motywy będą mogły kontrolować przycisk zamykania miniaturek."
 
-#. 3.4->settings-schema.json->app-button-transition-duration->description
-msgid "App button transition duration"
-msgstr "Czas trwania przejścia na przycisku aplikacji"
+#. 2.8->settings-schema.json->useSystemTooltips->description
+msgid "Use system tooltips for closed apps"
+msgstr "Użyj systemowych podpowiedzi dla zamkniętych aplikacji"
 
-#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+#. 2.8->settings-schema.json->useSystemTooltips->tooltip
 msgid ""
-"Overrides the theme's animation time for app buttons. If set to zero, the "
-"theme's transition duration will be used."
+"Controls whether or not system tooltips are in use when hovering over closed "
+"pinned apps."
+msgstr ""
+"Kontroluje czy systemowe tooltipy będą w użyciu podczas najeżdżania na "
+"zamknięte przypięte aplikacje."
+
+#. 3.8->settings-schema.json->generalPage->title
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr "Ogólne"
+
+#. 3.8->settings-schema.json->panelPage->title
+#. 3.4->settings-schema.json->panelPage->title
+msgid "Panel"
+msgstr "Panel"
+
+#. 3.8->settings-schema.json->thumbnailsPage->title
+#. 3.8->settings-schema.json->thumbnailsSection->title
+#. 3.4->settings-schema.json->thumbnailsPage->title
+#. 3.4->settings-schema.json->thumbnailsSection->title
+msgid "Thumbnails"
+msgstr "Miniaturki"
+
+#. 3.8->settings-schema.json->contextMenuPage->title
+#. 3.4->settings-schema.json->contextMenuPage->title
+msgid "Context Menu"
+msgstr "Menu kontekstowe"
+
+#. 3.8->settings-schema.json->themePage->title
+#. 3.4->settings-schema.json->themePage->title
+msgid "Theming"
+msgstr "Ustawienia stylu"
+
+#. 3.8->settings-schema.json->generalSection->title
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr "Zachowanie"
+
+#. 3.8->settings-schema.json->appButtonsSection->title
+#. 3.4->settings-schema.json->appButtonsSection->title
+msgid "App Buttons"
+msgstr "Przyciski aplikacji"
+
+#. 3.8->settings-schema.json->hotKeysSection->title
+#. 3.4->settings-schema.json->hotKeysSection->title
+msgid "Hot Keys"
+msgstr "Skróty klawiszowe"
+
+#. 3.8->settings-schema.json->hoverPeekSection->title
+#. 3.4->settings-schema.json->hoverPeekSection->title
+msgid "Hover Peek"
+msgstr "Najedź w celu podglądu"
+
+#. 3.8->settings-schema.json->stylingSection->title
+#. 3.4->settings-schema.json->stylingSection->title
+msgid "Styling"
+msgstr "Styl"
+
+#. 3.8->settings-schema.json->iconSection->title
+#. 3.4->settings-schema.json->iconSection->title
+msgid "Icons"
+msgstr "Ikony"
+
+#. 3.8->settings-schema.json->presetSection->title
+#. 3.4->settings-schema.json->presetSection->title
+msgid "Recommended Presets"
+msgstr "Rekomendowane ustawienia"
+
+#. 3.8->settings-schema.json->scroll-behavior->description
+#. 3.4->settings-schema.json->scroll-behavior->description
+msgid "Mouse wheel scroll behavior"
+msgstr "Akcja rolki myszy"
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+msgid "Cycle apps"
 msgstr ""
 
-#. 3.4->settings-schema.json->app-button-transition-duration->units
-msgid "ms"
-msgstr "ms"
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#, fuzzy
+msgid "Cycle windows"
+msgstr "Uwzględnij wszystkie okna aplikacji"
 
-#. 3.4->settings-schema.json->thumbnail-padding->description
-msgid "Thumbnail padding"
-msgstr "Margines miniaturek"
+#. 3.8->settings-schema.json->scroll-behavior->tooltip
+#. 3.4->settings-schema.json->scroll-behavior->tooltip
+msgid ""
+"Choose if scrolling the mouse wheel cycles running apps, an app button's "
+"windows on hover, or is disabled."
+msgstr ""
 
-#. 3.4->settings-schema.json->thumbnail-padding->tooltip
-msgid "Controls how much space will be around the window preview thumbnails."
-msgstr "Kontroluje ile miejsca jest między ikonami."
+#. 3.8->settings-schema.json->left-click-action->description
+#. 3.8->settings-schema.json->left-click-action->tooltip
+#. 3.8->settings-schema.json->launcher-animation-effect->tooltip
+#. 3.4->settings-schema.json->left-click-action->description
+#. 3.4->settings-schema.json->left-click-action->tooltip
+#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
+msgid "Left click action"
+msgstr "Akcja lewego przycisku"
 
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->left-click-action->options
+msgid "Toggle activation of last focused window"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->description
+#. 3.8->settings-schema.json->middle-click-action->tooltip
+#. 3.4->settings-schema.json->middle-click-action->description
+#. 3.4->settings-schema.json->middle-click-action->tooltip
+msgid "Middle click action"
+msgstr "Akcja środkowego przycisku"
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Launch new app instance"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+#, fuzzy
+msgid "Close last focused window in group"
+msgstr "Podświetl ostatnio aktywne okno z grupy aplikacji"
+
+#. 3.8->settings-schema.json->system-favorites->description
 #. 3.4->settings-schema.json->system-favorites->description
 msgid "Use system favorites for pinned apps"
 msgstr "Użyj systemowych ulubionych dla przypiętych aplikacji"
 
+#. 3.8->settings-schema.json->system-favorites->tooltip
 #. 3.4->settings-schema.json->system-favorites->tooltip
 msgid ""
 "Controls whether or not pinned apps consist of the system favorites list."
@@ -784,89 +1036,66 @@ msgstr ""
 "Kontroluje czy przypięte aplikacje będą pojawiać się w panelu niezależnie od "
 "tego czy są otwarte."
 
-#. 3.4->settings-schema.json->generalSection->title
-msgid "Behavior"
-msgstr "Zachowanie"
-
-#. 3.4->settings-schema.json->thumbnailsPage->title
-#. 3.4->settings-schema.json->thumbnailsSection->title
-msgid "Thumbnails"
-msgstr "Miniaturki"
-
-#. 3.4->settings-schema.json->presetSection->title
-msgid "Recommended Presets"
-msgstr "Rekomendowane ustawienia"
-
-#. 3.4->settings-schema.json->appButtonsSection->title
-msgid "App Buttons"
-msgstr "Przyciski aplikacji"
-
-#. 3.4->settings-schema.json->generalPage->title
-msgid "General"
-msgstr "Ogólne"
-
-#. 3.4->settings-schema.json->hoverPeekSection->title
-msgid "Hover Peek"
-msgstr "Najedź w celu podglądu"
-
-#. 3.4->settings-schema.json->panelPage->title
-msgid "Panel"
-msgstr "Panel"
-
-#. 3.4->settings-schema.json->iconSection->title
-msgid "Icons"
-msgstr "Ikony"
-
-#. 3.4->settings-schema.json->hotKeysSection->title
-msgid "Hot Keys"
-msgstr "Skróty klawiszowe"
-
-#. 3.4->settings-schema.json->stylingSection->title
-msgid "Styling"
-msgstr "Styl"
-
-#. 3.4->settings-schema.json->contextMenuPage->title
-msgid "Context Menu"
-msgstr "Menu kontekstowe"
-
-#. 3.4->settings-schema.json->themePage->title
-msgid "Theming"
-msgstr "Ustawienia stylu"
-
-#. 3.4->settings-schema.json->mintYPreset->description
-#. 3.4->settings-schema.json->mintYPreset->tooltip
-msgid "Mint Y and Variants"
-msgstr "Mint Y i warianty"
-
-#. 3.4->settings-schema.json->show-icons->description
+#. 3.8->settings-schema.json->show-all-workspaces->description
+#. 3.8->settings-schema.json->show-all-workspaces->tooltip
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
 #, fuzzy
-msgid "Show icons"
-msgstr "Bez ikon"
+msgid "Show windows from all workspaces"
+msgstr "Widoczne na wszystkich obszarach roboczych"
 
-#. 3.4->settings-schema.json->show-icons->tooltip
-msgid "Show the window's icon next to the title."
-msgstr "Pokaż ikonę obok okna tytułu"
-
+#. 3.8->settings-schema.json->enable-app-button-dragging->description
+#. 3.8->settings-schema.json->enable-app-button-dragging->tooltip
 #. 3.4->settings-schema.json->enable-app-button-dragging->description
 #. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
 msgid "Enable app button dragging"
 msgstr "Włącz przeciąganie przycisków aplikacji"
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
-#, fuzzy
-msgid "Show new window option"
-msgstr "Pokazuj opcję autostartu"
-
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
-msgid ""
-"Shows the \"New Window\" option in an app's context menu if it doesn't "
-"already have one from the app's own action menu items."
+#. 3.8->settings-schema.json->launcher-animation-effect->description
+#. 3.4->settings-schema.json->launcher-animation-effect->description
+msgid "Launcher animation effect"
 msgstr ""
 
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Fade"
+msgstr ""
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Scale"
+msgstr "Skala"
+
+#. 3.8->settings-schema.json->list-monitor-windows->description
+#. 3.4->settings-schema.json->list-monitor-windows->description
+msgid "Only list windows from the monitor displaying this instance"
+msgstr "Tylko lista okien z monitora wyświetlającego tę instancję"
+
+#. 3.8->settings-schema.json->list-monitor-windows->tooltip
+#. 3.4->settings-schema.json->list-monitor-windows->tooltip
+msgid ""
+"This option will only come into effect for monitors displaying an ITM "
+"instance."
+msgstr "Ta opcja będzie aktywna dla monitorów wyświetlających instancję ITM."
+
+#. 3.8->settings-schema.json->enable-app-button-width->description
+#. 3.4->settings-schema.json->enable-app-button-width->description
+msgid "Use a custom width for app buttons"
+msgstr "Użyj własnej szerokości przycisków aplikacji"
+
+#. 3.8->settings-schema.json->enable-app-button-width->tooltip
+#. 3.4->settings-schema.json->enable-app-button-width->tooltip
+msgid "When disabled, the app button width is determined by the panel height."
+msgstr ""
+"Jeśli nieaktywne, szerokość przycisków aplikacji będzie ustalana poprzez "
+"wysokość panelu"
+
+#. 3.8->settings-schema.json->app-button-width->description
 #. 3.4->settings-schema.json->app-button-width->description
 msgid "App button width"
 msgstr "Szerokość przycisków aplikacji"
 
+#. 3.8->settings-schema.json->app-button-width->tooltip
 #. 3.4->settings-schema.json->app-button-width->tooltip
 msgid ""
 "Controls the width of the application button. This option only works for "
@@ -875,119 +1104,117 @@ msgstr ""
 "Kontroluje szerokość przycisków aplikacji. To ustawienie działa tylko z "
 "panelami poziomymi."
 
-#. 3.4->settings-schema.json->mintXPreset->description
-#. 3.4->settings-schema.json->mintXPreset->tooltip
-#, fuzzy
-msgid "Mint X, Linux Mint, and Variants"
-msgstr "Mint Y i warianty"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->description
-msgid "Launcher animation effect"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
-#. 3.4->settings-schema.json->left-click-action->description
-#. 3.4->settings-schema.json->left-click-action->tooltip
-msgid "Left click action"
-msgstr "Akcja lewego przycisku"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Scale"
-msgstr "Skala"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Fade"
-msgstr ""
-
-#. 3.4->settings-schema.json->enable-app-button-width->description
-msgid "Use a custom width for app buttons"
-msgstr "Użyj własnej szerokości przycisków aplikacji"
-
-#. 3.4->settings-schema.json->enable-app-button-width->tooltip
-msgid "When disabled, the app button width is determined by the panel height."
-msgstr ""
-"Jeśli nieaktywne, szerokość przycisków aplikacji będzie ustalana poprzez "
-"wysokość panelu"
-
-#. 3.4->settings-schema.json->list-monitor-windows->description
-msgid "Only list windows from the monitor displaying this instance"
-msgstr "Tylko lista okien z monitora wyświetlającego tę instancję"
-
-#. 3.4->settings-schema.json->list-monitor-windows->tooltip
-msgid ""
-"This option will only come into effect for monitors displaying an ITM "
-"instance."
-msgstr "Ta opcja będzie aktywna dla monitorów wyświetlających instancję ITM."
-
+#. 3.8->settings-schema.json->thumbnail-close-button-size->description
 #. 3.4->settings-schema.json->thumbnail-close-button-size->description
 msgid "Close button size"
 msgstr "Wielkość ikony zamykania"
 
+#. 3.8->settings-schema.json->thumbnail-close-button-size->tooltip
 #. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
 msgid "Controls how large the thumbnail close button is."
 msgstr "Pozwalaj motywom kontrolować przycisk zamykania miniaturek"
 
-#. 3.4->settings-schema.json->middle-click-action->description
-#. 3.4->settings-schema.json->middle-click-action->tooltip
-msgid "Middle click action"
-msgstr "Akcja środkowego przycisku"
+#. 3.8->settings-schema.json->thumbnail-padding->description
+#. 3.4->settings-schema.json->thumbnail-padding->description
+msgid "Thumbnail padding"
+msgstr "Margines miniaturek"
 
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Launch new app instance"
-msgstr ""
+#. 3.8->settings-schema.json->thumbnail-padding->tooltip
+#. 3.4->settings-schema.json->thumbnail-padding->tooltip
+msgid "Controls how much space will be around the window preview thumbnails."
+msgstr "Kontroluje ile miejsca jest między ikonami."
 
-#. 3.4->settings-schema.json->middle-click-action->options
-#, fuzzy
-msgid "Close last focused window in group"
-msgstr "Podświetl ostatnio aktywne okno z grupy aplikacji"
-
-#. 3.4->settings-schema.json->scroll-behavior->description
-msgid "Mouse wheel scroll behavior"
-msgstr "Akcja rolki myszy"
-
-#. 3.4->settings-schema.json->scroll-behavior->tooltip
-msgid ""
-"Choose if scrolling the mouse wheel cycles running apps, an app button's "
-"windows on hover, or is disabled."
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->options
-msgid "Cycle apps"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
-#, fuzzy
-msgid "Cycle windows"
-msgstr "Uwzględnij wszystkie okna aplikacji"
-
-#. 3.4->settings-schema.json->show-all-workspaces->description
-#. 3.4->settings-schema.json->show-all-workspaces->tooltip
-#, fuzzy
-msgid "Show windows from all workspaces"
-msgstr "Widoczne na wszystkich obszarach roboczych"
-
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->description
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
 msgid "Cycle windows on mouse wheel scroll"
 msgstr ""
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->tooltip
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
 msgid ""
 "Choose whether or not scrolling the mouse wheel cycles windows when hovering "
 "over a thumbnail menu."
 msgstr ""
 
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "Toggle activation of last focused window"
+#. 3.8->settings-schema.json->show-icons->description
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "Bez ikon"
+
+#. 3.8->settings-schema.json->show-icons->tooltip
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr "Pokaż ikonę obok okna tytułu"
+
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->description
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
+msgid "Highlight the last focused window within an app group"
+msgstr "Podświetl ostatnio aktywne okno z grupy aplikacji"
+
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+msgid ""
+"When enabled, the last window that was interacted with will be indicated."
+msgstr "Jeśli aktywne, ostatnio użyte okno będzie wskazane"
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->description
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "Pokazuj opcję autostartu"
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->tooltip
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
 msgstr ""
 
-#. IcingTaskManager@json->metadata.json->name
-msgid "Icing Task Manager"
-msgstr "Icing Task Manager"
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr "zaznaczone"
 
-#. IcingTaskManager@json->metadata.json->description
-msgid "Window list with app grouping and thumbnails"
-msgstr "Lista okien z grupowaniem aplikacji i miniaturkami"
+#. 3.8->settings-schema.json->app-button-transition-duration->units
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr "ms"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->description
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr "Czas trwania przejścia na przycisku aplikacji"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->tooltip
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.8->settings-schema.json->mintYPreset->description
+#. 3.8->settings-schema.json->mintYPreset->tooltip
+#. 3.4->settings-schema.json->mintYPreset->description
+#. 3.4->settings-schema.json->mintYPreset->tooltip
+msgid "Mint Y and Variants"
+msgstr "Mint Y i warianty"
+
+#. 3.8->settings-schema.json->mintXPreset->description
+#. 3.8->settings-schema.json->mintXPreset->tooltip
+#. 3.4->settings-schema.json->mintXPreset->description
+#. 3.4->settings-schema.json->mintXPreset->tooltip
+#, fuzzy
+msgid "Mint X, Linux Mint, and Variants"
+msgstr "Mint Y i warianty"
+
+#. 3.8->settings-schema.json->migrationButton->description
+msgid "Migrate Pinned Apps to Grouped Window List"
+msgstr ""
 
 #~ msgid "number"
 #~ msgstr "numer"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/pl.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/pl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-10 00:43-0600\n"
+"POT-Creation-Date: 2018-12-13 18:37-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: mariachini\n"
 "Language-Team: \n"
@@ -13,53 +13,53 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: 3.8/applet.js:471
-msgid "Icing Task Manager is now Grouped Window List"
-msgstr ""
+#: 3.8/applet.js:476
+#, fuzzy
+msgid "Icing Task Manager is deprecated"
+msgstr "Icing Task Manager"
 
-#: 3.8/applet.js:472
+#: 3.8/applet.js:477
 msgid ""
-"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
-"Window List\". "
+"Please upgrade to Grouped Window List for a more stable, bug-free experience."
 msgstr ""
 
-#: 3.8/applet.js:473
+#: 3.8/applet.js:478
 msgid ""
-"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
-"List."
+"Add GWL to your panel, open the applet's settings and click \"Migrate Pinned "
+"Apps to Grouped Window List\"."
 msgstr ""
 
-#: 3.8/applet.js:485
-msgid "Migration can only be performed on Cinnamon 4.0."
+#: 3.8/applet.js:490
+msgid "Migration can only be performed on Cinnamon 4.0+."
 msgstr ""
 
-#: 3.8/applet.js:496
+#: 3.8/applet.js:501
 msgid ""
 "Please add Grouped Window List to a panel before proceeding with the "
 "migration."
 msgstr ""
 
-#: 3.8/applet.js:504
+#: 3.8/applet.js:509
 msgid "ITM settings directory could not be found!"
 msgstr ""
 
-#: 3.8/applet.js:534
+#: 3.8/applet.js:539
 msgid "System favorites enabled - no migration is needed."
 msgstr ""
 
-#: 3.8/applet.js:577
+#: 3.8/applet.js:582
 msgid "Unable to find a suitable ITM settings file to migrate."
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid "Migration complete. "
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid " settings file(s) could not be migrated."
 msgstr ""
 
-#: 3.8/applet.js:592
+#: 3.8/applet.js:597
 msgid "Migration was successful."
 msgstr ""
 
@@ -1215,6 +1215,10 @@ msgstr "Mint Y i warianty"
 #. 3.8->settings-schema.json->migrationButton->description
 msgid "Migrate Pinned Apps to Grouped Window List"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Icing Task Manager is deprecated - please use Grouped Window List"
+#~ msgstr "Icing Task Manager"
 
 #~ msgid "number"
 #~ msgstr "numer"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/ru.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-14 21:32-0600\n"
+"POT-Creation-Date: 2018-12-10 00:43-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: ArionWT <arionwhiteac@gmail.com>\n"
 "Language-Team: \n"
@@ -14,557 +14,226 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/applet.js:471
+msgid "Icing Task Manager is now Grouped Window List"
+msgstr ""
+
+#: 3.8/applet.js:472
+msgid ""
+"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
+"Window List\". "
+msgstr ""
+
+#: 3.8/applet.js:473
+msgid ""
+"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
+"List."
+msgstr ""
+
+#: 3.8/applet.js:485
+msgid "Migration can only be performed on Cinnamon 4.0."
+msgstr ""
+
+#: 3.8/applet.js:496
+msgid ""
+"Please add Grouped Window List to a panel before proceeding with the "
+"migration."
+msgstr ""
+
+#: 3.8/applet.js:504
+msgid "ITM settings directory could not be found!"
+msgstr ""
+
+#: 3.8/applet.js:534
+msgid "System favorites enabled - no migration is needed."
+msgstr ""
+
+#: 3.8/applet.js:577
+msgid "Unable to find a suitable ITM settings file to migrate."
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid "Migration complete. "
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid " settings file(s) could not be migrated."
+msgstr ""
+
+#: 3.8/applet.js:592
+msgid "Migration was successful."
+msgstr ""
+
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 #, fuzzy
 msgid "Move to the other monitor"
 msgstr "Переместить на другой экран"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 #, fuzzy
 msgid "Move to monitor "
 msgstr "Переместить на экран "
 
-#: 3.4/specialMenus.js:126
+#: 3.8/specialMenus.js:98 3.4/specialMenus.js:126
 msgid "Only on this workspace"
 msgstr "Только на этом рабочем столе"
 
-#: 3.4/specialMenus.js:133
+#: 3.8/specialMenus.js:105 3.4/specialMenus.js:133
 msgid "Visible on all workspaces"
 msgstr "На всех рабочих столах"
 
-#: 3.4/specialMenus.js:140
+#: 3.8/specialMenus.js:112 3.4/specialMenus.js:140
 #, fuzzy
 msgid "Move to another workspace"
 msgstr "На рабочий стол слева"
 
-#: 3.4/specialMenus.js:168
+#: 3.8/specialMenus.js:140 3.4/specialMenus.js:168
 msgid "Places"
 msgstr "Места"
 
-#: 3.4/specialMenus.js:207
+#: 3.8/specialMenus.js:179 3.4/specialMenus.js:207
 msgid "Bookmarks/History requires gir1.2-gda-5.0"
 msgstr "Для Закладок и Истории требуется gir1.2-gda-5.0"
 
-#: 3.4/specialMenus.js:227
+#: 3.8/specialMenus.js:199 3.4/specialMenus.js:227
 #, fuzzy
 msgid "Recent"
 msgstr "проценты"
 
-#: 3.4/specialMenus.js:246
+#: 3.8/specialMenus.js:218 3.4/specialMenus.js:246
 msgid "Preferences"
 msgstr "Параметры"
 
-#: 3.4/specialMenus.js:249
+#: 3.8/specialMenus.js:221 3.4/specialMenus.js:249
 msgid "About..."
 msgstr "О модуле..."
 
-#: 3.4/specialMenus.js:253
+#: 3.8/specialMenus.js:225 3.4/specialMenus.js:253
 msgid "Configure..."
 msgstr "Настройка..."
 
-#: 3.4/specialMenus.js:257
+#: 3.8/specialMenus.js:229 3.4/specialMenus.js:257
 msgid "Remove"
 msgstr "Удалить"
 
-#: 3.4/specialMenus.js:287
+#: 3.8/specialMenus.js:259 3.4/specialMenus.js:287
 #, fuzzy
 msgid "New Window"
 msgstr "Новое окно"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Unpin from Panel"
 msgstr "Открепить"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Pin to Panel"
 msgstr "Прикрепить"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Remove from Autostart"
 msgstr "Удалить из автозагрузки"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Add to Autostart"
 msgstr "Добавить в автозагрузку"
 
-#: 3.4/specialMenus.js:318
+#: 3.8/specialMenus.js:290 3.4/specialMenus.js:318
 msgid "Create Shortcut"
 msgstr "Создать ярлык"
 
-#: 3.4/specialMenus.js:329
+#: 3.8/specialMenus.js:301 3.4/specialMenus.js:329
 msgid "Restore to full opacity"
 msgstr "Восстановить непрозрачность"
 
-#: 3.4/specialMenus.js:337
+#: 3.8/specialMenus.js:309 3.4/specialMenus.js:337
 msgid "Restore"
 msgstr "Восстановить"
 
-#: 3.4/specialMenus.js:342
+#: 3.8/specialMenus.js:314 3.4/specialMenus.js:342
 msgid "Minimize"
 msgstr "Свернуть"
 
-#: 3.4/specialMenus.js:350
+#: 3.8/specialMenus.js:322 3.4/specialMenus.js:350
 msgid "Unmaximize"
 msgstr "Вернуть размер"
 
-#: 3.4/specialMenus.js:355
+#: 3.8/specialMenus.js:327 3.4/specialMenus.js:355
 msgid "Maximize"
 msgstr "Развернуть"
 
-#: 3.4/specialMenus.js:365
+#: 3.8/specialMenus.js:337 3.4/specialMenus.js:365
 msgid "Close others"
 msgstr "Закрыть остальные"
 
-#: 3.4/specialMenus.js:375
+#: 3.8/specialMenus.js:347 3.4/specialMenus.js:375
 #, fuzzy
 msgid "Close all"
 msgstr "Закрыть все"
 
-#: 3.4/specialMenus.js:385
+#: 3.8/specialMenus.js:357 3.4/specialMenus.js:385
 msgid "Close"
 msgstr "Закрыть"
 
-#. 2.8->settings-schema.json->thumbnail-size->description
-#. 3.4->settings-schema.json->thumbnail-size->description
-msgid "Thumbnail size"
-msgstr "Размер миниатюры"
-
-#. 2.8->settings-schema.json->thumbnail-size->tooltip
-#. 3.4->settings-schema.json->thumbnail-size->tooltip
-msgid "Controls the size of the thumbnails."
-msgstr "Управляет размером миниатюры."
-
-# should not be set, just leave it blank and insert one white-space character
-#. 2.8->settings-schema.json->thumbnail-size->units
-#. 3.4->settings-schema.json->thumbnail-size->units
-msgid "size"
-msgstr "размер"
-
-#. 2.8->settings-schema.json->focusPseudoClass->description
-#. 3.4->settings-schema.json->focusPseudoClass->description
-msgid "App button focus pseudo class"
-msgstr "Вид кнопки в фокусе"
-
-#. 2.8->settings-schema.json->focusPseudoClass->tooltip
-#. 3.4->settings-schema.json->focusPseudoClass->tooltip
-msgid "Overrides the pseudo class for app button on focus."
-msgstr "Перезаписывает псевдокласс focus для кнопки."
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "active"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "outlined"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "hover"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
+#. metadata.json->description
 #, fuzzy
-msgid "focus"
-msgstr ""
+msgid "Window list with app grouping and thumbnails"
+msgstr "Список окон с группировкой и миниатюрами"
 
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "selected"
-msgstr ""
+#. metadata.json->name
+msgid "Icing Task Manager"
+msgstr "Icing Task Manager"
 
-#. 2.8->settings-schema.json->icon-spacing->description
-#. 3.4->settings-schema.json->icon-spacing->description
-msgid "Icon spacing"
-msgstr "Расстояние между иконками"
-
-#. 2.8->settings-schema.json->icon-spacing->tooltip
-#. 3.4->settings-schema.json->icon-spacing->tooltip
-msgid "Controls how much space is between the icons."
-msgstr "Устанавливает расстояние между иконками в пикселях."
-
-#. 2.8->settings-schema.json->icon-spacing->units
-#. 2.8->settings-schema.json->icon-size->units
-#. 2.8->settings-schema.json->icon-padding->units
-#. 3.4->settings-schema.json->icon-spacing->units
-#. 3.4->settings-schema.json->thumbnail-padding->units
-#. 3.4->settings-schema.json->icon-size->units
-#. 3.4->settings-schema.json->app-button-width->units
-#. 3.4->settings-schema.json->thumbnail-close-button-size->units
-#. 3.4->settings-schema.json->icon-padding->units
-msgid "px"
-msgstr "пиксели"
-
-#. 2.8->settings-schema.json->show-thumbnails->description
-#. 3.4->settings-schema.json->show-thumbnails->description
-msgid "Show thumbnails"
-msgstr "Показывать миниатюры"
-
-#. 2.8->settings-schema.json->show-thumbnails->tooltip
-#. 3.4->settings-schema.json->show-thumbnails->tooltip
-msgid "Show window thumbnails when hovering over an app button."
-msgstr "Показывать миниатюры открытых окон при наведении на кнопку."
-
-#. 2.8->settings-schema.json->icon-size->description
-#. 3.4->settings-schema.json->icon-size->description
-msgid "Icon size"
-msgstr "Размер иконки"
-
-#. 2.8->settings-schema.json->icon-size->tooltip
-#. 3.4->settings-schema.json->icon-size->tooltip
-msgid "Set icon size"
-msgstr "Установить размер иконки"
-
-#. 2.8->settings-schema.json->hover-peek-time->description
-#. 3.4->settings-schema.json->hover-peek-time->description
-msgid "Window fade time"
-msgstr "Скорость анимации"
-
-#. 2.8->settings-schema.json->hover-peek-time->tooltip
-#. 3.4->settings-schema.json->hover-peek-time->tooltip
-msgid "Controls how quickly a window will fade on hover."
-msgstr "Скорость исчезновения окна, миллисекунды"
-
-#. 2.8->settings-schema.json->hover-peek-time->units
-#. 2.8->settings-schema.json->thumbnail-timeout->units
-#. 2.8->settings-schema.json->show-apps-order-timeout->units
-#. 3.4->settings-schema.json->hover-peek-time->units
-#. 3.4->settings-schema.json->thumbnail-timeout->units
-#. 3.4->settings-schema.json->show-apps-order-timeout->units
-msgid "milliseconds"
-msgstr "миллисекунды"
-
-#. 2.8->settings-schema.json->close-button-style->description
-msgid "Allow themes to control the thumbnail close button"
-msgstr "Разрешить теме установить кнопку закрытия миниатюр"
-
-#. 2.8->settings-schema.json->close-button-style->tooltip
-msgid ""
-"Controls whether or not the theme controls the window thumbnail's close "
-"button."
-msgstr "Устанавливает кнопку закрытия миниатюр из темы."
-
-#. 2.8->settings-schema.json->title-display->description
-#. 3.4->settings-schema.json->title-display->description
-msgid "Title display"
-msgstr "Отображение заголовков"
-
-#. 2.8->settings-schema.json->title-display->tooltip
-#. 3.4->settings-schema.json->title-display->tooltip
-msgid ""
-"focused: show focused window title, title: display the window title, app: "
-"diplay app name, none: don't display anything"
-msgstr ""
-"Активное: показывать заголовок активного окна; Заголовок: показывать "
-"заголовок окна; Приложение: показывать название приложения, Ничего: не "
-"показывать ничего"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-#. 3.4->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->middle-click-action->options
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "None"
-msgstr "Ничего"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Focused"
-msgstr "Активное"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "App"
-msgstr "Приложение"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Title"
-msgstr "Заголовок"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->description
-#. 3.4->settings-schema.json->hoverPseudoClass->description
-msgid "App button hover pseudo class"
-msgstr "Вид кнопки при наведении"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
-#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons on hover."
-msgstr "Перезаписывает псевдокласс hover для кнопок."
-
-#. 2.8->settings-schema.json->show-alerts->description
-#. 3.4->settings-schema.json->show-alerts->description
-msgid "Show app alerts and notifications"
-msgstr "Показывать уведомления приложений"
-
-#. 2.8->settings-schema.json->show-alerts->tooltip
-#. 3.4->settings-schema.json->show-alerts->tooltip
-msgid "If enabled, notifications and alerts will appear."
-msgstr "Если включено, будут появляться уведомления."
-
-#. 2.8->settings-schema.json->pinOnDrag->description
-#. 2.8->settings-schema.json->pinOnDrag->tooltip
-#. 3.4->settings-schema.json->pinOnDrag->description
-#. 3.4->settings-schema.json->pinOnDrag->tooltip
-msgid "Pin apps when dragged to a new position"
-msgstr "Прикрепить приложение при перетаскивании в новую позицию"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->description
-#. 3.4->settings-schema.json->show-apps-order-hotkey->description
-msgid "Global hotkey to show the order of apps"
-msgstr "Глобальные горячие клавиши, показывающие порядок приложений"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
-#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
-msgid ""
-"When triggered, the window count label will be replaced with its order in "
-"the app list temporarily."
-msgstr ""
-"При срабатывании, счетчик окон будет временно заменен порядковым номером в "
-"списке приложений."
-
-#. 2.8->settings-schema.json->menuItemType->description
-#. 3.4->settings-schema.json->menuItemType->description
-msgid "Menu item type"
-msgstr "Тип пункта меню"
-
-#. 2.8->settings-schema.json->menuItemType->tooltip
-#. 3.4->settings-schema.json->menuItemType->tooltip
-msgid ""
-"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
-msgstr ""
-"Определяет, будут ли иконки в меню: символьными, несимвольными или "
-"вовсе не будут отображаться."
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Symbolic icons"
-msgstr "Символьные иконки"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "No icons"
-msgstr "Нет иконок"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Non-symbolic icons"
-msgstr "Несимвольные иконки"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->description
-#. 3.4->settings-schema.json->hover-peek-opacity->description
-msgid "Window opacity"
-msgstr "Прозрачность окна"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
-#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
-msgid "Opacity of the windows on hover."
-msgstr "Устанавливает прозрачность окна при наведении."
-
-#. 2.8->settings-schema.json->hover-peek-opacity->units
-#. 3.4->settings-schema.json->hover-peek-opacity->units
-msgid "percent"
-msgstr "проценты"
-
-#. 2.8->settings-schema.json->enable-hover-peek->description
-#. 3.4->settings-schema.json->enable-hover-peek->description
-msgid "Show windows when hovered over"
-msgstr "Показывать при наведении"
-
-#. 2.8->settings-schema.json->enable-hover-peek->tooltip
-#. 3.4->settings-schema.json->enable-hover-peek->tooltip
-msgid "Controls whether or not windows display when hovered over."
-msgstr "Показывать окно при наведении курсора мыши на его миниатюру"
-
-#. 2.8->settings-schema.json->activePseudoClass->description
-#. 3.4->settings-schema.json->activePseudoClass->description
-msgid "App button active pseudo class"
-msgstr "Вид активной кнопки"
-
-#. 2.8->settings-schema.json->activePseudoClass->tooltip
-#. 3.4->settings-schema.json->activePseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons when they are active."
-msgstr "Перезаписывает псевдокласс active для кнопок."
-
-#. 2.8->settings-schema.json->animate-thumbnails->description
-#. 3.4->settings-schema.json->animate-thumbnails->description
-msgid "Animate thumbnails"
-msgstr "Анимация миниатюр"
-
-#. 2.8->settings-schema.json->animate-thumbnails->tooltip
-#. 3.4->settings-schema.json->animate-thumbnails->tooltip
-msgid "If enabled, thumbnails will animate when appearing and disappearing."
-msgstr "Если включено, миниатюры анимировано появляются и исчезают."
-
-#. 2.8->settings-schema.json->autostart-menu-item->description
-#. 3.4->settings-schema.json->autostart-menu-item->description
-msgid "Show autostart option"
-msgstr "Отображать параметры автозагрузки"
-
-#. 2.8->settings-schema.json->autostart-menu-item->tooltip
-#. 3.4->settings-schema.json->autostart-menu-item->tooltip
-msgid "Shows the autostart toggle option in an app's context menu."
-msgstr "Показывает включение автозагрузки в контекстном меню приложения."
-
-#. 2.8->settings-schema.json->show-pinned->description
-#. 3.4->settings-schema.json->show-pinned->description
-msgid "Show pinned apps"
-msgstr "Показывать прикрепленные"
-
-#. 2.8->settings-schema.json->show-pinned->tooltip
-#. 3.4->settings-schema.json->show-pinned->tooltip
-msgid ""
-"Controls whether or not the pinned apps appear in the panel if they are not "
-"open."
-msgstr "Показывать иконки прикрепленных приложений."
-
-#. 2.8->settings-schema.json->useSystemTooltips->description
-msgid "Use system tooltips for closed apps"
-msgstr "Системные подсказки для закрытых приложений"
-
-#. 2.8->settings-schema.json->useSystemTooltips->tooltip
-msgid ""
-"Controls whether or not system tooltips are in use when hovering over closed "
-"pinned apps."
-msgstr ""
-"Устанавливает отображение системых всплывающих подсказок при наведении "
-"курсора на закрытые прикрепленные приложения."
+#. 2.8->settings-schema.json->ITM->description
+msgid "ITM Settings"
+msgstr "Настройки ITM"
 
 #. 2.8->settings-schema.json->WindowList->description
 msgid "Window List Settings"
 msgstr "Настройки списка окон"
 
-#. 2.8->settings-schema.json->AppMenu->description
-msgid "Context Menu Settings"
-msgstr "Настройки контекстного меню"
-
-#. 2.8->settings-schema.json->Thumbnails->description
-msgid "Thumbnail Settings"
-msgstr "Настройки миниатюр"
-
-#. 2.8->settings-schema.json->show-recent->description
-#. 3.4->settings-schema.json->show-recent->description
-msgid "Show recent items"
-msgstr "Показывать недавние элементы."
-
-#. 2.8->settings-schema.json->show-recent->tooltip
-#. 3.4->settings-schema.json->show-recent->tooltip
-msgid "Controls whether recent items will appear in the context menu."
-msgstr "Управляет отображением последних элементов в контекстном меню."
-
-#. 2.8->settings-schema.json->vertical-thumbnails->description
-#. 3.4->settings-schema.json->vertical-thumbnails->description
-msgid "Enable vertical thumbnails"
-msgstr "Вертикальные миниатюры"
-
-#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
-#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
-msgid "If enabled, thumbnails will stack vertically."
-msgstr "Если включено, миниатюры расположены вертикально."
-
-#. 2.8->settings-schema.json->thumbnail-timeout->description
-#. 3.4->settings-schema.json->thumbnail-timeout->description
-msgid "Thumbnail timeout"
-msgstr "Таймаут миниатюр"
-
-#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
-#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
-msgid ""
-"Controls how quickly an app's set of window thumbnails will fade out when "
-"the mouse leaves the app button."
-msgstr ""
-"Установить время, через которое появится миниатюра, "
-"в миллисекундах."
-
-#. 2.8->settings-schema.json->ThemeSettings->description
-msgid "Theme Settings"
-msgstr "Настройки темы"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->description
-#. 3.4->settings-schema.json->onclick-thumbnails->description
-msgid "Open thumbnails on click"
-msgstr "Открывать миниатюры по клику"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
-#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
-msgid "Open the thumbnails on click if there is more than one window open."
-msgstr "Открывать миниатюры по клику, если открыто более одного окна."
-
-#. 2.8->settings-schema.json->panelLauncherClass->description
-msgid "Use the panel launcher class for pinned apps"
-msgstr "Использовать класс панели запуска для прикрепленных приложений"
-
-#. 2.8->settings-schema.json->panelLauncherClass->tooltip
-msgid "Enabling this helps with certain themes."
-msgstr "Включение этого помогает с определенными темами."
-
-#. 2.8->settings-schema.json->include-all-windows->description
-#. 3.4->settings-schema.json->include-all-windows->description
-msgid "Include all app windows"
-msgstr "Отображение всех окон приложения"
-
-#. 2.8->settings-schema.json->include-all-windows->tooltip
-#. 3.4->settings-schema.json->include-all-windows->tooltip
-msgid ""
-"Controls whether or not thumbnails for smalller child windows, such as exit "
-"confirmations and file dialogues will be included in the thumbnail list."
-msgstr ""
-"Определяет, отображаются ли миниатюры для маленьких дочерних окон, таких как "
-"подтверждение выхода или диалог файлов."
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->description
-#. 3.4->settings-schema.json->cycleMenusHotkey->description
-msgid "Global hotkey for cycling through thumbnail menus"
-msgstr "Глобальные горячие клавиши переключения миниатюр"
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
-#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
-msgid "This allows you to cycle through the menus without activating a window."
-msgstr "Это позволяет циклически переключать миниатюру без активации окна."
-
-#. 2.8->settings-schema.json->enable-iconSize->description
-#. 3.4->settings-schema.json->enable-iconSize->description
-msgid "Adjust icon size"
-msgstr "Свой размер иконок"
-
-#. 2.8->settings-schema.json->enable-iconSize->tooltip
-#. 3.4->settings-schema.json->enable-iconSize->tooltip
-msgid "Adjust icon size independent of Cinnamon's panel scaling."
-msgstr ""
-"Отрегулируйте размер иконок независимо от масштабирования панели Cinnamon."
-
 #. 2.8->settings-schema.json->number-display->description
+#. 3.8->settings-schema.json->number-display->description
 #. 3.4->settings-schema.json->number-display->description
 msgid "Number display"
 msgstr "Счетчик окон"
 
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Smart"
+msgstr "Умный"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Normal"
+msgstr "Обычный"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "None"
+msgstr "Ничего"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "All"
+msgstr "Всегда"
+
 #. 2.8->settings-schema.json->number-display->tooltip
+#. 3.8->settings-schema.json->number-display->tooltip
 #. 3.4->settings-schema.json->number-display->tooltip
 msgid ""
 "normal: display window number, smart: display window number if more than one "
@@ -575,42 +244,95 @@ msgstr ""
 "более одного окна, Ничего: не отображает счетчик, Всегда: отображает счетчик "
 "всех иконок"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "All"
-msgstr "Всегда"
+#. 2.8->settings-schema.json->title-display->description
+#. 3.8->settings-schema.json->title-display->description
+#. 3.4->settings-schema.json->title-display->description
+msgid "Title display"
+msgstr "Отображение заголовков"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Smart"
-msgstr "Умный"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "App"
+msgstr "Приложение"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Normal"
-msgstr "Обычный"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Title"
+msgstr "Заголовок"
 
-#. 2.8->settings-schema.json->ITM->description
-msgid "ITM Settings"
-msgstr "Настройки ITM"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Focused"
+msgstr "Активное"
 
-#. 2.8->settings-schema.json->HoverPeek->description
-msgid "Hover Peek Settings"
-msgstr "Настройки наведения"
-
-#. 2.8->settings-schema.json->icon-padding->description
-#. 3.4->settings-schema.json->icon-padding->description
-msgid "Icon padding"
-msgstr "Рамка иконки"
-
-#. 2.8->settings-schema.json->icon-padding->tooltip
-#. 3.4->settings-schema.json->icon-padding->tooltip
+#. 2.8->settings-schema.json->title-display->tooltip
+#. 3.8->settings-schema.json->title-display->tooltip
+#. 3.4->settings-schema.json->title-display->tooltip
 msgid ""
-"Controls how much horizontal padding is inside the app buttons. Padding is "
-"only applied to instances of this applet on horizontal panels."
+"focused: show focused window title, title: display the window title, app: "
+"diplay app name, none: don't display anything"
 msgstr ""
-"Устанавливает размер горизонтальной рамки внутри кнопки. Рамка "
-"применяется только к этому апплету на горизонтальных панелях."
+"Активное: показывать заголовок активного окна; Заголовок: показывать "
+"заголовок окна; Приложение: показывать название приложения, Ничего: не "
+"показывать ничего"
+
+#. 2.8->settings-schema.json->group-apps->description
+#. 3.8->settings-schema.json->group-apps->description
+#. 3.4->settings-schema.json->group-apps->description
+msgid "Group apps"
+msgstr "Группировать приложения"
+
+#. 2.8->settings-schema.json->group-apps->tooltip
+#. 3.8->settings-schema.json->group-apps->tooltip
+#. 3.4->settings-schema.json->group-apps->tooltip
+msgid "Group each app's set of windows."
+msgstr "Группировать каждое окно приложения."
+
+#. 2.8->settings-schema.json->show-alerts->description
+#. 3.8->settings-schema.json->show-alerts->description
+#. 3.4->settings-schema.json->show-alerts->description
+msgid "Show app alerts and notifications"
+msgstr "Показывать уведомления приложений"
+
+#. 2.8->settings-schema.json->show-alerts->tooltip
+#. 3.8->settings-schema.json->show-alerts->tooltip
+#. 3.4->settings-schema.json->show-alerts->tooltip
+msgid "If enabled, notifications and alerts will appear."
+msgstr "Если включено, будут появляться уведомления."
+
+#. 2.8->settings-schema.json->show-pinned->description
+#. 3.8->settings-schema.json->show-pinned->description
+#. 3.4->settings-schema.json->show-pinned->description
+msgid "Show pinned apps"
+msgstr "Показывать прикрепленные"
+
+#. 2.8->settings-schema.json->show-pinned->tooltip
+#. 3.8->settings-schema.json->show-pinned->tooltip
+#. 3.4->settings-schema.json->show-pinned->tooltip
+msgid ""
+"Controls whether or not the pinned apps appear in the panel if they are not "
+"open."
+msgstr "Показывать иконки прикрепленных приложений."
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->description
+msgid "Arrange pinned apps"
+msgstr "Перемещать прикрепленные"
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
+msgid "Arrange pinned apps into a different order."
+msgstr "Включает возможность перемещения прикрепленных приложений."
+
+#. 2.8->settings-schema.json->pinOnDrag->description
+#. 2.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.8->settings-schema.json->pinOnDrag->description
+#. 3.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.4->settings-schema.json->pinOnDrag->description
+#. 3.4->settings-schema.json->pinOnDrag->tooltip
+msgid "Pin apps when dragged to a new position"
+msgstr "Прикрепить приложение при перетаскивании в новую позицию"
 
 #. 2.8->settings-schema.json->middle-click-action->description
 msgid "Middle clicking app buttons creates new app instances"
@@ -626,12 +348,251 @@ msgstr ""
 "установке этого значения в false будет закрыто последнее сфокусированное "
 "окно из группы приложений при среднем клике."
 
+#. 2.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.4->settings-schema.json->cycleMenusHotkey->description
+msgid "Global hotkey for cycling through thumbnail menus"
+msgstr "Глобальные горячие клавиши переключения миниатюр"
+
+#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
+msgid "This allows you to cycle through the menus without activating a window."
+msgstr "Это позволяет циклически переключать миниатюру без активации окна."
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.4->settings-schema.json->show-apps-order-hotkey->description
+msgid "Global hotkey to show the order of apps"
+msgstr "Глобальные горячие клавиши, показывающие порядок приложений"
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
+msgid ""
+"When triggered, the window count label will be replaced with its order in "
+"the app list temporarily."
+msgstr ""
+"При срабатывании, счетчик окон будет временно заменен порядковым номером в "
+"списке приложений."
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->units
+#. 2.8->settings-schema.json->thumbnail-timeout->units
+#. 2.8->settings-schema.json->hover-peek-time->units
+#. 3.8->settings-schema.json->show-apps-order-timeout->units
+#. 3.8->settings-schema.json->thumbnail-timeout->units
+#. 3.8->settings-schema.json->hover-peek-time->units
+#. 3.4->settings-schema.json->show-apps-order-timeout->units
+#. 3.4->settings-schema.json->thumbnail-timeout->units
+#. 3.4->settings-schema.json->hover-peek-time->units
+msgid "milliseconds"
+msgstr "миллисекунды"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.4->settings-schema.json->show-apps-order-timeout->description
+msgid "Duration of the apps order display on hotkey press"
+msgstr "Продолжительность отображения порядка приложений"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
+msgid ""
+"Determines the duration the window count labels are replaced with the app's "
+"order number."
+msgstr ""
+"Определяет длительность замены счетчика окон на порядковые номера приложений."
+
+#. 2.8->settings-schema.json->Thumbnails->description
+msgid "Thumbnail Settings"
+msgstr "Настройки миниатюр"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->description
+#. 3.8->settings-schema.json->thumbnail-timeout->description
+#. 3.4->settings-schema.json->thumbnail-timeout->description
+msgid "Thumbnail timeout"
+msgstr "Таймаут миниатюр"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
+msgid ""
+"Controls how quickly an app's set of window thumbnails will fade out when "
+"the mouse leaves the app button."
+msgstr "Установить время, через которое появится миниатюра, в миллисекундах."
+
+# should not be set, just leave it blank and insert one white-space character
+#. 2.8->settings-schema.json->thumbnail-size->units
+#. 3.8->settings-schema.json->thumbnail-size->units
+#. 3.4->settings-schema.json->thumbnail-size->units
+msgid "size"
+msgstr "размер"
+
+#. 2.8->settings-schema.json->thumbnail-size->description
+#. 3.8->settings-schema.json->thumbnail-size->description
+#. 3.4->settings-schema.json->thumbnail-size->description
+msgid "Thumbnail size"
+msgstr "Размер миниатюры"
+
+#. 2.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-size->tooltip
+msgid "Controls the size of the thumbnails."
+msgstr "Управляет размером миниатюры."
+
+#. 2.8->settings-schema.json->show-thumbnails->description
+#. 3.8->settings-schema.json->show-thumbnails->description
+#. 3.4->settings-schema.json->show-thumbnails->description
+msgid "Show thumbnails"
+msgstr "Показывать миниатюры"
+
+#. 2.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.4->settings-schema.json->show-thumbnails->tooltip
+msgid "Show window thumbnails when hovering over an app button."
+msgstr "Показывать миниатюры открытых окон при наведении на кнопку."
+
+#. 2.8->settings-schema.json->animate-thumbnails->description
+#. 3.8->settings-schema.json->animate-thumbnails->description
+#. 3.4->settings-schema.json->animate-thumbnails->description
+msgid "Animate thumbnails"
+msgstr "Анимация миниатюр"
+
+#. 2.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.4->settings-schema.json->animate-thumbnails->tooltip
+msgid "If enabled, thumbnails will animate when appearing and disappearing."
+msgstr "Если включено, миниатюры анимировано появляются и исчезают."
+
+#. 2.8->settings-schema.json->vertical-thumbnails->description
+#. 3.8->settings-schema.json->vertical-thumbnails->description
+#. 3.4->settings-schema.json->vertical-thumbnails->description
+msgid "Enable vertical thumbnails"
+msgstr "Вертикальные миниатюры"
+
+#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
+msgid "If enabled, thumbnails will stack vertically."
+msgstr "Если включено, миниатюры расположены вертикально."
+
+#. 2.8->settings-schema.json->sort-thumbnails->description
+#. 3.8->settings-schema.json->sort-thumbnails->description
+#. 3.4->settings-schema.json->sort-thumbnails->description
+msgid "Sort windows for each app by last focused"
+msgstr "Сортировать по последнему активному"
+
+#. 2.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.4->settings-schema.json->sort-thumbnails->tooltip
+msgid ""
+"Controls whether the order windows appear for an app is by last focused, or "
+"the order they were opened."
+msgstr "Сначала показывать последние активные"
+
+#. 2.8->settings-schema.json->onclick-thumbnails->description
+#. 3.8->settings-schema.json->onclick-thumbnails->description
+#. 3.4->settings-schema.json->onclick-thumbnails->description
+msgid "Open thumbnails on click"
+msgstr "Открывать миниатюры по клику"
+
+#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
+msgid "Open the thumbnails on click if there is more than one window open."
+msgstr "Открывать миниатюры по клику, если открыто более одного окна."
+
+#. 2.8->settings-schema.json->include-all-windows->description
+#. 3.8->settings-schema.json->include-all-windows->description
+#. 3.4->settings-schema.json->include-all-windows->description
+msgid "Include all app windows"
+msgstr "Отображение всех окон приложения"
+
+#. 2.8->settings-schema.json->include-all-windows->tooltip
+#. 3.8->settings-schema.json->include-all-windows->tooltip
+#. 3.4->settings-schema.json->include-all-windows->tooltip
+msgid ""
+"Controls whether or not thumbnails for smalller child windows, such as exit "
+"confirmations and file dialogues will be included in the thumbnail list."
+msgstr ""
+"Определяет, отображаются ли миниатюры для маленьких дочерних окон, таких как "
+"подтверждение выхода или диалог файлов."
+
+#. 2.8->settings-schema.json->AppMenu->description
+msgid "Context Menu Settings"
+msgstr "Настройки контекстного меню"
+
+#. 2.8->settings-schema.json->show-recent->description
+#. 3.8->settings-schema.json->show-recent->description
+#. 3.4->settings-schema.json->show-recent->description
+msgid "Show recent items"
+msgstr "Показывать недавние элементы."
+
+#. 2.8->settings-schema.json->show-recent->tooltip
+#. 3.8->settings-schema.json->show-recent->tooltip
+#. 3.4->settings-schema.json->show-recent->tooltip
+msgid "Controls whether recent items will appear in the context menu."
+msgstr "Управляет отображением последних элементов в контекстном меню."
+
+#. 2.8->settings-schema.json->menuItemType->description
+#. 3.8->settings-schema.json->menuItemType->description
+#. 3.4->settings-schema.json->menuItemType->description
+msgid "Menu item type"
+msgstr "Тип пункта меню"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Symbolic icons"
+msgstr "Символьные иконки"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Non-symbolic icons"
+msgstr "Несимвольные иконки"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "No icons"
+msgstr "Нет иконок"
+
+#. 2.8->settings-schema.json->menuItemType->tooltip
+#. 3.8->settings-schema.json->menuItemType->tooltip
+#. 3.4->settings-schema.json->menuItemType->tooltip
+msgid ""
+"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
+msgstr ""
+"Определяет, будут ли иконки в меню: символьными, несимвольными или вовсе не "
+"будут отображаться."
+
 #. 2.8->settings-schema.json->firefox-menu->description
+#. 3.8->settings-schema.json->firefox-menu->description
 #. 3.4->settings-schema.json->firefox-menu->description
 msgid "Firefox context menu"
 msgstr "Контекстное меню для Firefox"
 
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Most Visited"
+msgstr "Часто посещаемые"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Recent History"
+msgstr "История"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Bookmarks"
+msgstr "Закладки"
+
 #. 2.8->settings-schema.json->firefox-menu->tooltip
+#. 3.8->settings-schema.json->firefox-menu->tooltip
 #. 3.4->settings-schema.json->firefox-menu->tooltip
 msgid ""
 "Most Visited: show the sites you visit most, Recent History: display the the "
@@ -640,20 +601,141 @@ msgstr ""
 "Часто посещаемые: показать часто посещаемые сайты; История: показать "
 "последние посещенные сайты; Закладки: показать избранные закладки"
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Bookmarks"
-msgstr "Закладки"
+#. 2.8->settings-schema.json->autostart-menu-item->description
+#. 3.8->settings-schema.json->autostart-menu-item->description
+#. 3.4->settings-schema.json->autostart-menu-item->description
+msgid "Show autostart option"
+msgstr "Отображать параметры автозагрузки"
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Most Visited"
-msgstr "Часто посещаемые"
+#. 2.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.4->settings-schema.json->autostart-menu-item->tooltip
+msgid "Shows the autostart toggle option in an app's context menu."
+msgstr "Показывает включение автозагрузки в контекстном меню приложения."
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Recent History"
-msgstr "История"
+#. 2.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.4->settings-schema.json->monitor-move-all-windows->description
+msgid "Apply the monitor move option to all windows"
+msgstr "Применить параметры перемещения монитора для всех окон"
+
+#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
+msgid ""
+"When clicking \"Move to monitor\" in the context menu, this option will move "
+"all of an app's windows instead of just the last focused window from the app."
+msgstr ""
+"При нажатии \"Переместить в монитор \" в контекстном меню, этот параметр "
+"переместит все окна приложения вместо последнего активного окна приложения."
+
+#. 2.8->settings-schema.json->HoverPeek->description
+msgid "Hover Peek Settings"
+msgstr "Настройки наведения"
+
+#. 2.8->settings-schema.json->enable-hover-peek->description
+#. 3.8->settings-schema.json->enable-hover-peek->description
+#. 3.4->settings-schema.json->enable-hover-peek->description
+msgid "Show windows when hovered over"
+msgstr "Показывать при наведении"
+
+#. 2.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.4->settings-schema.json->enable-hover-peek->tooltip
+msgid "Controls whether or not windows display when hovered over."
+msgstr "Показывать окно при наведении курсора мыши на его миниатюру"
+
+#. 2.8->settings-schema.json->hover-peek-time->description
+#. 3.8->settings-schema.json->hover-peek-time->description
+#. 3.4->settings-schema.json->hover-peek-time->description
+msgid "Window fade time"
+msgstr "Скорость анимации"
+
+#. 2.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.4->settings-schema.json->hover-peek-time->tooltip
+msgid "Controls how quickly a window will fade on hover."
+msgstr "Скорость исчезновения окна, миллисекунды"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->units
+#. 3.8->settings-schema.json->hover-peek-opacity->units
+#. 3.4->settings-schema.json->hover-peek-opacity->units
+msgid "percent"
+msgstr "проценты"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->description
+#. 3.8->settings-schema.json->hover-peek-opacity->description
+#. 3.4->settings-schema.json->hover-peek-opacity->description
+msgid "Window opacity"
+msgstr "Прозрачность окна"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
+msgid "Opacity of the windows on hover."
+msgstr "Устанавливает прозрачность окна при наведении."
+
+#. 2.8->settings-schema.json->ThemeSettings->description
+msgid "Theme Settings"
+msgstr "Настройки темы"
+
+#. 2.8->settings-schema.json->show-active->description
+#. 3.8->settings-schema.json->show-active->description
+#. 3.4->settings-schema.json->show-active->description
+msgid "Show active app indicators"
+msgstr "Показать индикаторы активных приложений"
+
+#. 2.8->settings-schema.json->show-active->tooltip
+#. 3.8->settings-schema.json->show-active->tooltip
+#. 3.4->settings-schema.json->show-active->tooltip
+msgid "Active app styling will indicate if an app is active."
+msgstr "Активный стиль будет указывать, что приложение активно."
+
+#. 2.8->settings-schema.json->icon-spacing->units
+#. 2.8->settings-schema.json->icon-padding->units
+#. 2.8->settings-schema.json->icon-size->units
+#. 3.8->settings-schema.json->app-button-width->units
+#. 3.8->settings-schema.json->thumbnail-close-button-size->units
+#. 3.8->settings-schema.json->thumbnail-padding->units
+#. 3.8->settings-schema.json->icon-spacing->units
+#. 3.8->settings-schema.json->icon-padding->units
+#. 3.8->settings-schema.json->icon-size->units
+#. 3.4->settings-schema.json->app-button-width->units
+#. 3.4->settings-schema.json->thumbnail-close-button-size->units
+#. 3.4->settings-schema.json->thumbnail-padding->units
+#. 3.4->settings-schema.json->icon-spacing->units
+#. 3.4->settings-schema.json->icon-padding->units
+#. 3.4->settings-schema.json->icon-size->units
+msgid "px"
+msgstr "пиксели"
+
+#. 2.8->settings-schema.json->icon-spacing->description
+#. 3.8->settings-schema.json->icon-spacing->description
+#. 3.4->settings-schema.json->icon-spacing->description
+msgid "Icon spacing"
+msgstr "Расстояние между иконками"
+
+#. 2.8->settings-schema.json->icon-spacing->tooltip
+#. 3.8->settings-schema.json->icon-spacing->tooltip
+#. 3.4->settings-schema.json->icon-spacing->tooltip
+msgid "Controls how much space is between the icons."
+msgstr "Устанавливает расстояние между иконками в пикселях."
+
+#. 2.8->settings-schema.json->icon-padding->description
+#. 3.8->settings-schema.json->icon-padding->description
+#. 3.4->settings-schema.json->icon-padding->description
+msgid "Icon padding"
+msgstr "Рамка иконки"
+
+#. 2.8->settings-schema.json->icon-padding->tooltip
+#. 3.8->settings-schema.json->icon-padding->tooltip
+#. 3.4->settings-schema.json->icon-padding->tooltip
+msgid ""
+"Controls how much horizontal padding is inside the app buttons. Padding is "
+"only applied to instances of this applet on horizontal panels."
+msgstr ""
+"Устанавливает размер горизонтальной рамки внутри кнопки. Рамка применяется "
+"только к этому апплету на горизонтальных панелях."
 
 #. 2.8->settings-schema.json->themePadding->description
 msgid "Use theme padding to center button icons"
@@ -663,341 +745,474 @@ msgstr "Использовать отступы темы для центриро
 msgid "If button icons look off-centered, toggling this may help."
 msgstr "Если иконки кнопок выглядят со смещенным центром, это может помочь."
 
-#. 2.8->settings-schema.json->group-apps->description
-#. 3.4->settings-schema.json->group-apps->description
-msgid "Group apps"
-msgstr "Группировать приложения"
+#. 2.8->settings-schema.json->enable-iconSize->description
+#. 3.8->settings-schema.json->enable-iconSize->description
+#. 3.4->settings-schema.json->enable-iconSize->description
+msgid "Adjust icon size"
+msgstr "Свой размер иконок"
 
-#. 2.8->settings-schema.json->group-apps->tooltip
-#. 3.4->settings-schema.json->group-apps->tooltip
-msgid "Group each app's set of windows."
-msgstr "Группировать каждое окно приложения."
-
-#. 2.8->settings-schema.json->show-active->description
-#. 3.4->settings-schema.json->show-active->description
-msgid "Show active app indicators"
-msgstr "Показать индикаторы активных приложений"
-
-#. 2.8->settings-schema.json->show-active->tooltip
-#. 3.4->settings-schema.json->show-active->tooltip
-msgid "Active app styling will indicate if an app is active."
-msgstr "Активный стиль будет указывать, что приложение активно."
-
-#. 2.8->settings-schema.json->show-apps-order-timeout->description
-#. 3.4->settings-schema.json->show-apps-order-timeout->description
-msgid "Duration of the apps order display on hotkey press"
-msgstr "Продолжительность отображения порядка приложений"
-
-#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
-#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
-msgid ""
-"Determines the duration the window count labels are replaced with the app's "
-"order number."
+#. 2.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.4->settings-schema.json->enable-iconSize->tooltip
+msgid "Adjust icon size independent of Cinnamon's panel scaling."
 msgstr ""
-"Определяет длительность замены счетчика окон на "
-"порядковые номера приложений."
+"Отрегулируйте размер иконок независимо от масштабирования панели Cinnamon."
 
-#. 2.8->settings-schema.json->arrange-pinnedApps->description
-msgid "Arrange pinned apps"
-msgstr "Перемещать прикрепленные"
+#. 2.8->settings-schema.json->icon-size->description
+#. 3.8->settings-schema.json->icon-size->description
+#. 3.4->settings-schema.json->icon-size->description
+msgid "Icon size"
+msgstr "Размер иконки"
 
-#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
-msgid "Arrange pinned apps into a different order."
-msgstr "Включает возможность перемещения прикрепленных приложений."
+#. 2.8->settings-schema.json->icon-size->tooltip
+#. 3.8->settings-schema.json->icon-size->tooltip
+#. 3.4->settings-schema.json->icon-size->tooltip
+msgid "Set icon size"
+msgstr "Установить размер иконки"
 
-#. 2.8->settings-schema.json->monitor-move-all-windows->description
-#. 3.4->settings-schema.json->monitor-move-all-windows->description
-msgid "Apply the monitor move option to all windows"
-msgstr "Применить параметры перемещения монитора для всех окон"
+#. 2.8->settings-schema.json->hoverPseudoClass->description
+#. 3.8->settings-schema.json->hoverPseudoClass->description
+#. 3.4->settings-schema.json->hoverPseudoClass->description
+msgid "App button hover pseudo class"
+msgstr "Вид кнопки при наведении"
 
-#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
-#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
-msgid ""
-"When clicking \"Move to monitor\" in the context menu, this option will move "
-"all of an app's windows instead of just the last focused window from the app."
-msgstr ""
-"При нажатии \"Переместить в монитор \" в контекстном меню, этот параметр "
-"переместит все окна приложения вместо последнего активного окна приложения."
-
-#. 2.8->settings-schema.json->sort-thumbnails->description
-#. 3.4->settings-schema.json->sort-thumbnails->description
-msgid "Sort windows for each app by last focused"
-msgstr "Сортировать по последнему активному"
-
-#. 2.8->settings-schema.json->sort-thumbnails->tooltip
-#. 3.4->settings-schema.json->sort-thumbnails->tooltip
-msgid ""
-"Controls whether the order windows appear for an app is by last focused, or "
-"the order they were opened."
-msgstr "Сначала показывать последние активные"
-
-#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
 #. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
 #. 3.4->settings-schema.json->activePseudoClass->options
-msgid "checked"
+msgid "hover"
 msgstr ""
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
-msgid "Highlight the last focused window within an app group"
-msgstr "Выделить последнее активное окно в группе приложений"
-
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
-msgid ""
-"When enabled, the last window that was interacted with will be indicated."
-msgstr "Выделяет последнее окно, с которым взаимодействовали."
-
-#. 3.4->settings-schema.json->app-button-transition-duration->description
-msgid "App button transition duration"
-msgstr "Скорость анимации перехода стиля"
-
-#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
-msgid ""
-"Overrides the theme's animation time for app buttons. If set to zero, the "
-"theme's transition duration will be used."
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "focus"
 msgstr ""
-"Перезаписывает скорость анимации кнопки, установленной темой. "
-"Если выбран ноль, то скорость управляется темой."
 
-#. 3.4->settings-schema.json->app-button-transition-duration->units
-msgid "ms"
-msgstr "мс"
-
-#. 3.4->settings-schema.json->thumbnail-padding->description
-#, fuzzy
-msgid "Thumbnail padding"
-msgstr "Отступы миниатюр"
-
-#. 3.4->settings-schema.json->thumbnail-padding->tooltip
-#, fuzzy
-msgid "Controls how much space will be around the window preview thumbnails."
-msgstr "Устанавливает размер отступов вокруг миниатюр с предпросмотром окон."
-
-#. 3.4->settings-schema.json->system-favorites->description
-#, fuzzy
-msgid "Use system favorites for pinned apps"
-msgstr "Системное избранное как прикрепленные приложения"
-
-#. 3.4->settings-schema.json->system-favorites->tooltip
-#, fuzzy
-msgid ""
-"Controls whether or not pinned apps consist of the system favorites list."
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "active"
 msgstr ""
-"Прикрепленные приложения добавляются в список избранного в системе."
 
-#. 3.4->settings-schema.json->generalSection->title
-msgid "Behavior"
-msgstr "Поведение"
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "outlined"
+msgstr ""
 
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "selected"
+msgstr ""
+
+#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons on hover."
+msgstr "Перезаписывает псевдокласс hover для кнопок."
+
+#. 2.8->settings-schema.json->focusPseudoClass->description
+#. 3.8->settings-schema.json->focusPseudoClass->description
+#. 3.4->settings-schema.json->focusPseudoClass->description
+msgid "App button focus pseudo class"
+msgstr "Вид кнопки в фокусе"
+
+#. 2.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.4->settings-schema.json->focusPseudoClass->tooltip
+msgid "Overrides the pseudo class for app button on focus."
+msgstr "Перезаписывает псевдокласс focus для кнопки."
+
+#. 2.8->settings-schema.json->activePseudoClass->description
+#. 3.8->settings-schema.json->activePseudoClass->description
+#. 3.4->settings-schema.json->activePseudoClass->description
+msgid "App button active pseudo class"
+msgstr "Вид активной кнопки"
+
+#. 2.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.4->settings-schema.json->activePseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons when they are active."
+msgstr "Перезаписывает псевдокласс active для кнопок."
+
+#. 2.8->settings-schema.json->panelLauncherClass->description
+msgid "Use the panel launcher class for pinned apps"
+msgstr "Использовать класс панели запуска для прикрепленных приложений"
+
+#. 2.8->settings-schema.json->panelLauncherClass->tooltip
+msgid "Enabling this helps with certain themes."
+msgstr "Включение этого помогает с определенными темами."
+
+#. 2.8->settings-schema.json->close-button-style->description
+msgid "Allow themes to control the thumbnail close button"
+msgstr "Разрешить теме установить кнопку закрытия миниатюр"
+
+#. 2.8->settings-schema.json->close-button-style->tooltip
+msgid ""
+"Controls whether or not the theme controls the window thumbnail's close "
+"button."
+msgstr "Устанавливает кнопку закрытия миниатюр из темы."
+
+#. 2.8->settings-schema.json->useSystemTooltips->description
+msgid "Use system tooltips for closed apps"
+msgstr "Системные подсказки для закрытых приложений"
+
+#. 2.8->settings-schema.json->useSystemTooltips->tooltip
+msgid ""
+"Controls whether or not system tooltips are in use when hovering over closed "
+"pinned apps."
+msgstr ""
+"Устанавливает отображение системых всплывающих подсказок при наведении "
+"курсора на закрытые прикрепленные приложения."
+
+#. 3.8->settings-schema.json->generalPage->title
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr "Общие"
+
+#. 3.8->settings-schema.json->panelPage->title
+#. 3.4->settings-schema.json->panelPage->title
+msgid "Panel"
+msgstr "Панель"
+
+#. 3.8->settings-schema.json->thumbnailsPage->title
+#. 3.8->settings-schema.json->thumbnailsSection->title
 #. 3.4->settings-schema.json->thumbnailsPage->title
 #. 3.4->settings-schema.json->thumbnailsSection->title
 #, fuzzy
 msgid "Thumbnails"
 msgstr "Миниатюры"
 
-#. 3.4->settings-schema.json->presetSection->title
-msgid "Recommended Presets"
-msgstr "Рекомендуемые настройки"
-
-#. 3.4->settings-schema.json->appButtonsSection->title
-msgid "App Buttons"
-msgstr "Кнопки приложений"
-
-#. 3.4->settings-schema.json->generalPage->title
-msgid "General"
-msgstr "Общие"
-
-#. 3.4->settings-schema.json->hoverPeekSection->title
-#, fuzzy
-msgid "Hover Peek"
-msgstr "Настройки наведения"
-
-#. 3.4->settings-schema.json->panelPage->title
-msgid "Panel"
-msgstr "Панель"
-
-#. 3.4->settings-schema.json->iconSection->title
-#, fuzzy
-msgid "Icons"
-msgstr "Размер иконки"
-
-#. 3.4->settings-schema.json->hotKeysSection->title
-msgid "Hot Keys"
-msgstr "Горячие клавиши"
-
-#. 3.4->settings-schema.json->stylingSection->title
-msgid "Styling"
-msgstr "Стиль"
-
+#. 3.8->settings-schema.json->contextMenuPage->title
 #. 3.4->settings-schema.json->contextMenuPage->title
 #, fuzzy
 msgid "Context Menu"
 msgstr "Контекстное меню"
 
+#. 3.8->settings-schema.json->themePage->title
 #. 3.4->settings-schema.json->themePage->title
 #, fuzzy
 msgid "Theming"
 msgstr "Тема"
 
-#. 3.4->settings-schema.json->mintYPreset->description
-#. 3.4->settings-schema.json->mintYPreset->tooltip
-msgid "Mint Y and Variants"
-msgstr "Mint Y и другие"
+#. 3.8->settings-schema.json->generalSection->title
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr "Поведение"
 
-#. 3.4->settings-schema.json->show-icons->description
+#. 3.8->settings-schema.json->appButtonsSection->title
+#. 3.4->settings-schema.json->appButtonsSection->title
+msgid "App Buttons"
+msgstr "Кнопки приложений"
+
+#. 3.8->settings-schema.json->hotKeysSection->title
+#. 3.4->settings-schema.json->hotKeysSection->title
+msgid "Hot Keys"
+msgstr "Горячие клавиши"
+
+#. 3.8->settings-schema.json->hoverPeekSection->title
+#. 3.4->settings-schema.json->hoverPeekSection->title
 #, fuzzy
-msgid "Show icons"
-msgstr "Показывать иконки"
+msgid "Hover Peek"
+msgstr "Настройки наведения"
 
-#. 3.4->settings-schema.json->show-icons->tooltip
-msgid "Show the window's icon next to the title."
-msgstr "Показывает иконки перед заголовком."
+#. 3.8->settings-schema.json->stylingSection->title
+#. 3.4->settings-schema.json->stylingSection->title
+msgid "Styling"
+msgstr "Стиль"
 
-#. 3.4->settings-schema.json->enable-app-button-dragging->description
-#. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
-msgid "Enable app button dragging"
-msgstr "Перетаскивание кнопок"
-
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#. 3.8->settings-schema.json->iconSection->title
+#. 3.4->settings-schema.json->iconSection->title
 #, fuzzy
-msgid "Show new window option"
-msgstr "Показывает опцию Новое окно"
+msgid "Icons"
+msgstr "Размер иконки"
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
-msgid ""
-"Shows the \"New Window\" option in an app's context menu if it doesn't "
-"already have one from the app's own action menu items."
-msgstr ""
-"Показывает опцию \"Новое окно\" в контекстном меню приложения, если "
-"в приложении такая возможность в меню отсутсвует."
+#. 3.8->settings-schema.json->presetSection->title
+#. 3.4->settings-schema.json->presetSection->title
+msgid "Recommended Presets"
+msgstr "Рекомендуемые настройки"
 
-#. 3.4->settings-schema.json->app-button-width->description
-msgid "App button width"
-msgstr "Ширина кнопки"
-
-#. 3.4->settings-schema.json->app-button-width->tooltip
-#, fuzzy
-msgid ""
-"Controls the width of the application button. This option only works for "
-"horizontal panels."
-msgstr ""
-"Управляет размером миниатюры. Работает только "
-"на горизонтальных панелях."
-
-#. 3.4->settings-schema.json->mintXPreset->description
-#. 3.4->settings-schema.json->mintXPreset->tooltip
-msgid "Mint X, Linux Mint, and Variants"
-msgstr "Mint X, Linux Mint и другие"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->description
-msgid "Launcher animation effect"
-msgstr "Анимация запуска"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
-#. 3.4->settings-schema.json->left-click-action->description
-#. 3.4->settings-schema.json->left-click-action->tooltip
-msgid "Left click action"
-msgstr "Действие левого клика"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Scale"
-msgstr "Масштабирование"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Fade"
-msgstr "Затухание"
-
-#. 3.4->settings-schema.json->enable-app-button-width->description
-msgid "Use a custom width for app buttons"
-msgstr "Ширину кнопок задаёт пользователь"
-
-#. 3.4->settings-schema.json->enable-app-button-width->tooltip
-msgid "When disabled, the app button width is determined by the panel height."
-msgstr "Когда отключено, ширина кнопок задается высотой панели."
-
-#. 3.4->settings-schema.json->list-monitor-windows->description
-msgid "Only list windows from the monitor displaying this instance"
-msgstr "Отображать список окон только для активного монитора"
-
-#. 3.4->settings-schema.json->list-monitor-windows->tooltip
-msgid ""
-"This option will only come into effect for monitors displaying an ITM "
-"instance."
-msgstr ""
-"Этот параметр будет работать только на мониторах с "
-"установленным ITM."
-
-#. 3.4->settings-schema.json->thumbnail-close-button-size->description
-#, fuzzy
-msgid "Close button size"
-msgstr "Размер кнопки закрытия"
-
-#. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
-#, fuzzy
-msgid "Controls how large the thumbnail close button is."
-msgstr "Устанавлиает размеры кнопки закрытия на миниатюре."
-
-#. 3.4->settings-schema.json->middle-click-action->description
-#. 3.4->settings-schema.json->middle-click-action->tooltip
-msgid "Middle click action"
-msgstr "Действие среднего клика"
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Launch new app instance"
-msgstr "Открыть новое окно"
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Close last focused window in group"
-msgstr "Закрыть последнее активное окно в группе"
-
+#. 3.8->settings-schema.json->scroll-behavior->description
 #. 3.4->settings-schema.json->scroll-behavior->description
 msgid "Mouse wheel scroll behavior"
 msgstr "Поведение колёсика"
 
-#. 3.4->settings-schema.json->scroll-behavior->tooltip
-msgid ""
-"Choose if scrolling the mouse wheel cycles running apps, an app button's "
-"windows on hover, or is disabled."
-msgstr ""
-"Поведение скролла колёсиком мыши при "
-"наведении на кнопки приложений."
-
+#. 3.8->settings-schema.json->scroll-behavior->options
 #. 3.4->settings-schema.json->scroll-behavior->options
 msgid "Cycle apps"
 msgstr "Переключение приложений"
 
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
 #. 3.4->settings-schema.json->scroll-behavior->options
 #. 3.4->settings-schema.json->left-click-action->options
 #, fuzzy
 msgid "Cycle windows"
 msgstr "Переключение окон"
 
+#. 3.8->settings-schema.json->scroll-behavior->tooltip
+#. 3.4->settings-schema.json->scroll-behavior->tooltip
+msgid ""
+"Choose if scrolling the mouse wheel cycles running apps, an app button's "
+"windows on hover, or is disabled."
+msgstr "Поведение скролла колёсиком мыши при наведении на кнопки приложений."
+
+#. 3.8->settings-schema.json->left-click-action->description
+#. 3.8->settings-schema.json->left-click-action->tooltip
+#. 3.8->settings-schema.json->launcher-animation-effect->tooltip
+#. 3.4->settings-schema.json->left-click-action->description
+#. 3.4->settings-schema.json->left-click-action->tooltip
+#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
+msgid "Left click action"
+msgstr "Действие левого клика"
+
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->left-click-action->options
+msgid "Toggle activation of last focused window"
+msgstr "Открыть последнее активное окно"
+
+#. 3.8->settings-schema.json->middle-click-action->description
+#. 3.8->settings-schema.json->middle-click-action->tooltip
+#. 3.4->settings-schema.json->middle-click-action->description
+#. 3.4->settings-schema.json->middle-click-action->tooltip
+msgid "Middle click action"
+msgstr "Действие среднего клика"
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Launch new app instance"
+msgstr "Открыть новое окно"
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Close last focused window in group"
+msgstr "Закрыть последнее активное окно в группе"
+
+#. 3.8->settings-schema.json->system-favorites->description
+#. 3.4->settings-schema.json->system-favorites->description
+#, fuzzy
+msgid "Use system favorites for pinned apps"
+msgstr "Системное избранное как прикрепленные приложения"
+
+#. 3.8->settings-schema.json->system-favorites->tooltip
+#. 3.4->settings-schema.json->system-favorites->tooltip
+#, fuzzy
+msgid ""
+"Controls whether or not pinned apps consist of the system favorites list."
+msgstr "Прикрепленные приложения добавляются в список избранного в системе."
+
+#. 3.8->settings-schema.json->show-all-workspaces->description
+#. 3.8->settings-schema.json->show-all-workspaces->tooltip
 #. 3.4->settings-schema.json->show-all-workspaces->description
 #. 3.4->settings-schema.json->show-all-workspaces->tooltip
 #, fuzzy
 msgid "Show windows from all workspaces"
 msgstr "Показать окна со всех рабочих столов"
 
+#. 3.8->settings-schema.json->enable-app-button-dragging->description
+#. 3.8->settings-schema.json->enable-app-button-dragging->tooltip
+#. 3.4->settings-schema.json->enable-app-button-dragging->description
+#. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
+msgid "Enable app button dragging"
+msgstr "Перетаскивание кнопок"
+
+#. 3.8->settings-schema.json->launcher-animation-effect->description
+#. 3.4->settings-schema.json->launcher-animation-effect->description
+msgid "Launcher animation effect"
+msgstr "Анимация запуска"
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Fade"
+msgstr "Затухание"
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Scale"
+msgstr "Масштабирование"
+
+#. 3.8->settings-schema.json->list-monitor-windows->description
+#. 3.4->settings-schema.json->list-monitor-windows->description
+msgid "Only list windows from the monitor displaying this instance"
+msgstr "Отображать список окон только для активного монитора"
+
+#. 3.8->settings-schema.json->list-monitor-windows->tooltip
+#. 3.4->settings-schema.json->list-monitor-windows->tooltip
+msgid ""
+"This option will only come into effect for monitors displaying an ITM "
+"instance."
+msgstr "Этот параметр будет работать только на мониторах с установленным ITM."
+
+#. 3.8->settings-schema.json->enable-app-button-width->description
+#. 3.4->settings-schema.json->enable-app-button-width->description
+msgid "Use a custom width for app buttons"
+msgstr "Ширину кнопок задаёт пользователь"
+
+#. 3.8->settings-schema.json->enable-app-button-width->tooltip
+#. 3.4->settings-schema.json->enable-app-button-width->tooltip
+msgid "When disabled, the app button width is determined by the panel height."
+msgstr "Когда отключено, ширина кнопок задается высотой панели."
+
+#. 3.8->settings-schema.json->app-button-width->description
+#. 3.4->settings-schema.json->app-button-width->description
+msgid "App button width"
+msgstr "Ширина кнопки"
+
+#. 3.8->settings-schema.json->app-button-width->tooltip
+#. 3.4->settings-schema.json->app-button-width->tooltip
+#, fuzzy
+msgid ""
+"Controls the width of the application button. This option only works for "
+"horizontal panels."
+msgstr ""
+"Управляет размером миниатюры. Работает только на горизонтальных панелях."
+
+#. 3.8->settings-schema.json->thumbnail-close-button-size->description
+#. 3.4->settings-schema.json->thumbnail-close-button-size->description
+#, fuzzy
+msgid "Close button size"
+msgstr "Размер кнопки закрытия"
+
+#. 3.8->settings-schema.json->thumbnail-close-button-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
+#, fuzzy
+msgid "Controls how large the thumbnail close button is."
+msgstr "Устанавлиает размеры кнопки закрытия на миниатюре."
+
+#. 3.8->settings-schema.json->thumbnail-padding->description
+#. 3.4->settings-schema.json->thumbnail-padding->description
+#, fuzzy
+msgid "Thumbnail padding"
+msgstr "Отступы миниатюр"
+
+#. 3.8->settings-schema.json->thumbnail-padding->tooltip
+#. 3.4->settings-schema.json->thumbnail-padding->tooltip
+#, fuzzy
+msgid "Controls how much space will be around the window preview thumbnails."
+msgstr "Устанавливает размер отступов вокруг миниатюр с предпросмотром окон."
+
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->description
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
 msgid "Cycle windows on mouse wheel scroll"
 msgstr "Переключение окон при скролле колёсиком мыши"
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->tooltip
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
 msgid ""
 "Choose whether or not scrolling the mouse wheel cycles windows when hovering "
 "over a thumbnail menu."
-msgstr ""
-"Поведение скролла колёсиком мыши при "
-"наведении на миниатюры окон."
+msgstr "Поведение скролла колёсиком мыши при наведении на миниатюры окон."
 
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "Toggle activation of last focused window"
-msgstr "Открыть последнее активное окно"
-
-#. IcingTaskManager@json->metadata.json->name
-msgid "Icing Task Manager"
-msgstr "Icing Task Manager"
-
-#. IcingTaskManager@json->metadata.json->description
+#. 3.8->settings-schema.json->show-icons->description
+#. 3.4->settings-schema.json->show-icons->description
 #, fuzzy
-msgid "Window list with app grouping and thumbnails"
-msgstr "Список окон с группировкой и миниатюрами"
+msgid "Show icons"
+msgstr "Показывать иконки"
+
+#. 3.8->settings-schema.json->show-icons->tooltip
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
+msgstr "Показывает иконки перед заголовком."
+
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->description
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
+msgid "Highlight the last focused window within an app group"
+msgstr "Выделить последнее активное окно в группе приложений"
+
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+msgid ""
+"When enabled, the last window that was interacted with will be indicated."
+msgstr "Выделяет последнее окно, с которым взаимодействовали."
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->description
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "Показывает опцию Новое окно"
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->tooltip
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+"Показывает опцию \"Новое окно\" в контекстном меню приложения, если в "
+"приложении такая возможность в меню отсутсвует."
+
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->units
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr "мс"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->description
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr "Скорость анимации перехода стиля"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->tooltip
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+"Перезаписывает скорость анимации кнопки, установленной темой. Если выбран "
+"ноль, то скорость управляется темой."
+
+#. 3.8->settings-schema.json->mintYPreset->description
+#. 3.8->settings-schema.json->mintYPreset->tooltip
+#. 3.4->settings-schema.json->mintYPreset->description
+#. 3.4->settings-schema.json->mintYPreset->tooltip
+msgid "Mint Y and Variants"
+msgstr "Mint Y и другие"
+
+#. 3.8->settings-schema.json->mintXPreset->description
+#. 3.8->settings-schema.json->mintXPreset->tooltip
+#. 3.4->settings-schema.json->mintXPreset->description
+#. 3.4->settings-schema.json->mintXPreset->tooltip
+msgid "Mint X, Linux Mint, and Variants"
+msgstr "Mint X, Linux Mint и другие"
+
+#. 3.8->settings-schema.json->migrationButton->description
+msgid "Migrate Pinned Apps to Grouped Window List"
+msgstr ""

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/ru.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-10 00:43-0600\n"
+"POT-Creation-Date: 2018-12-13 18:37-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: ArionWT <arionwhiteac@gmail.com>\n"
 "Language-Team: \n"
@@ -14,53 +14,53 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: 3.8/applet.js:471
-msgid "Icing Task Manager is now Grouped Window List"
-msgstr ""
+#: 3.8/applet.js:476
+#, fuzzy
+msgid "Icing Task Manager is deprecated"
+msgstr "Icing Task Manager"
 
-#: 3.8/applet.js:472
+#: 3.8/applet.js:477
 msgid ""
-"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
-"Window List\". "
+"Please upgrade to Grouped Window List for a more stable, bug-free experience."
 msgstr ""
 
-#: 3.8/applet.js:473
+#: 3.8/applet.js:478
 msgid ""
-"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
-"List."
+"Add GWL to your panel, open the applet's settings and click \"Migrate Pinned "
+"Apps to Grouped Window List\"."
 msgstr ""
 
-#: 3.8/applet.js:485
-msgid "Migration can only be performed on Cinnamon 4.0."
+#: 3.8/applet.js:490
+msgid "Migration can only be performed on Cinnamon 4.0+."
 msgstr ""
 
-#: 3.8/applet.js:496
+#: 3.8/applet.js:501
 msgid ""
 "Please add Grouped Window List to a panel before proceeding with the "
 "migration."
 msgstr ""
 
-#: 3.8/applet.js:504
+#: 3.8/applet.js:509
 msgid "ITM settings directory could not be found!"
 msgstr ""
 
-#: 3.8/applet.js:534
+#: 3.8/applet.js:539
 msgid "System favorites enabled - no migration is needed."
 msgstr ""
 
-#: 3.8/applet.js:577
+#: 3.8/applet.js:582
 msgid "Unable to find a suitable ITM settings file to migrate."
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid "Migration complete. "
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid " settings file(s) could not be migrated."
 msgstr ""
 
-#: 3.8/applet.js:592
+#: 3.8/applet.js:597
 msgid "Migration was successful."
 msgstr ""
 
@@ -1216,3 +1216,7 @@ msgstr "Mint X, Linux Mint и другие"
 #. 3.8->settings-schema.json->migrationButton->description
 msgid "Migrate Pinned Apps to Grouped Window List"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Icing Task Manager is deprecated - please use Grouped Window List"
+#~ msgstr "Icing Task Manager"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/sv.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IcingTaskManager@json\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-23 21:32-0600\n"
+"POT-Creation-Date: 2018-12-10 00:43-0600\n"
 "PO-Revision-Date: 2017-10-16 14:48-0500\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
@@ -18,549 +18,220 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/applet.js:471
+msgid "Icing Task Manager is now Grouped Window List"
+msgstr ""
+
+#: 3.8/applet.js:472
+msgid ""
+"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
+"Window List\". "
+msgstr ""
+
+#: 3.8/applet.js:473
+msgid ""
+"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
+"List."
+msgstr ""
+
+#: 3.8/applet.js:485
+msgid "Migration can only be performed on Cinnamon 4.0."
+msgstr ""
+
+#: 3.8/applet.js:496
+msgid ""
+"Please add Grouped Window List to a panel before proceeding with the "
+"migration."
+msgstr ""
+
+#: 3.8/applet.js:504
+msgid "ITM settings directory could not be found!"
+msgstr ""
+
+#: 3.8/applet.js:534
+msgid "System favorites enabled - no migration is needed."
+msgstr ""
+
+#: 3.8/applet.js:577
+msgid "Unable to find a suitable ITM settings file to migrate."
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid "Migration complete. "
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid " settings file(s) could not be migrated."
+msgstr ""
+
+#: 3.8/applet.js:592
+msgid "Migration was successful."
+msgstr ""
+
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to the other monitor"
 msgstr "Flytta till andra skärmen"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to monitor "
 msgstr "Flytta till skärm"
 
-#: 3.4/specialMenus.js:126
+#: 3.8/specialMenus.js:98 3.4/specialMenus.js:126
 msgid "Only on this workspace"
 msgstr "Endast på denna arbetsyta"
 
-#: 3.4/specialMenus.js:133
+#: 3.8/specialMenus.js:105 3.4/specialMenus.js:133
 msgid "Visible on all workspaces"
 msgstr "Synlig på alla arbetsytor"
 
-#: 3.4/specialMenus.js:140
+#: 3.8/specialMenus.js:112 3.4/specialMenus.js:140
 msgid "Move to another workspace"
 msgstr "Flytta till en annan arbetsyta"
 
-#: 3.4/specialMenus.js:168
+#: 3.8/specialMenus.js:140 3.4/specialMenus.js:168
 msgid "Places"
 msgstr "Platser"
 
-#: 3.4/specialMenus.js:207
+#: 3.8/specialMenus.js:179 3.4/specialMenus.js:207
 msgid "Bookmarks/History requires gir1.2-gda-5.0"
 msgstr ""
 
-#: 3.4/specialMenus.js:227
+#: 3.8/specialMenus.js:199 3.4/specialMenus.js:227
 msgid "Recent"
 msgstr "Tidigare"
 
-#: 3.4/specialMenus.js:246
+#: 3.8/specialMenus.js:218 3.4/specialMenus.js:246
 msgid "Preferences"
 msgstr "Inställningar"
 
-#: 3.4/specialMenus.js:249
+#: 3.8/specialMenus.js:221 3.4/specialMenus.js:249
 msgid "About..."
 msgstr "Om..."
 
-#: 3.4/specialMenus.js:253
+#: 3.8/specialMenus.js:225 3.4/specialMenus.js:253
 msgid "Configure..."
 msgstr "Konfigurera..."
 
-#: 3.4/specialMenus.js:257
+#: 3.8/specialMenus.js:229 3.4/specialMenus.js:257
 msgid "Remove"
 msgstr "Ta bort"
 
-#: 3.4/specialMenus.js:287
+#: 3.8/specialMenus.js:259 3.4/specialMenus.js:287
 #, fuzzy
 msgid "New Window"
 msgstr "Inkludera alla programfönster"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Unpin from Panel"
 msgstr "Ta bort från panelen"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Pin to Panel"
 msgstr "Fäst på panelen"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Remove from Autostart"
 msgstr "Ta bort från autostart"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Add to Autostart"
 msgstr "Lägg till i autostart"
 
-#: 3.4/specialMenus.js:318
+#: 3.8/specialMenus.js:290 3.4/specialMenus.js:318
 msgid "Create Shortcut"
 msgstr "Skapa genväg"
 
-#: 3.4/specialMenus.js:329
+#: 3.8/specialMenus.js:301 3.4/specialMenus.js:329
 msgid "Restore to full opacity"
 msgstr "Återställ full opacitet"
 
-#: 3.4/specialMenus.js:337
+#: 3.8/specialMenus.js:309 3.4/specialMenus.js:337
 msgid "Restore"
 msgstr "Återställ"
 
-#: 3.4/specialMenus.js:342
+#: 3.8/specialMenus.js:314 3.4/specialMenus.js:342
 msgid "Minimize"
 msgstr "Minimera"
 
-#: 3.4/specialMenus.js:350
+#: 3.8/specialMenus.js:322 3.4/specialMenus.js:350
 msgid "Unmaximize"
 msgstr "Avmaximera"
 
-#: 3.4/specialMenus.js:355
+#: 3.8/specialMenus.js:327 3.4/specialMenus.js:355
 msgid "Maximize"
 msgstr "Maximera"
 
-#: 3.4/specialMenus.js:365
+#: 3.8/specialMenus.js:337 3.4/specialMenus.js:365
 msgid "Close others"
 msgstr "Stäng alla andra"
 
-#: 3.4/specialMenus.js:375
+#: 3.8/specialMenus.js:347 3.4/specialMenus.js:375
 msgid "Close all"
 msgstr "Stäng alla"
 
-#: 3.4/specialMenus.js:385
+#: 3.8/specialMenus.js:357 3.4/specialMenus.js:385
 msgid "Close"
 msgstr "Stäng"
 
-#. 2.8->settings-schema.json->thumbnail-size->description
-#. 3.4->settings-schema.json->thumbnail-size->description
-msgid "Thumbnail size"
-msgstr "Miniatyrstorlek"
+#. metadata.json->description
+msgid "Window list with app grouping and thumbnails"
+msgstr "Fönsterlista med programgruppering och miniatyrer"
 
-#. 2.8->settings-schema.json->thumbnail-size->tooltip
-#. 3.4->settings-schema.json->thumbnail-size->tooltip
-msgid "Controls the size of the thumbnails."
-msgstr "Avgör storleken på miniatyrerna."
+#. metadata.json->name
+msgid "Icing Task Manager"
+msgstr "Icing Task Manager"
 
-#. 2.8->settings-schema.json->thumbnail-size->units
-#. 3.4->settings-schema.json->thumbnail-size->units
-msgid "size"
-msgstr "storlek"
-
-#. 2.8->settings-schema.json->focusPseudoClass->description
-#. 3.4->settings-schema.json->focusPseudoClass->description
-msgid "App button focus pseudo class"
-msgstr "Pseudoklass för programknapp vid fokus"
-
-#. 2.8->settings-schema.json->focusPseudoClass->tooltip
-#. 3.4->settings-schema.json->focusPseudoClass->tooltip
-msgid "Overrides the pseudo class for app button on focus."
-msgstr "Åsidosätter pseudoklassen för programknappar vid fokus."
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "active"
-msgstr "aktiv"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "outlined"
-msgstr "kontur"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "hover"
-msgstr "hovring"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "focus"
-msgstr "fokus"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "selected"
-msgstr "markerad"
-
-#. 2.8->settings-schema.json->icon-spacing->description
-#. 3.4->settings-schema.json->icon-spacing->description
-msgid "Icon spacing"
-msgstr "Ikonavstånd"
-
-#. 2.8->settings-schema.json->icon-spacing->tooltip
-#. 3.4->settings-schema.json->icon-spacing->tooltip
-msgid "Controls how much space is between the icons."
-msgstr "Avgör avståndet mellan ikonerna."
-
-#. 2.8->settings-schema.json->icon-spacing->units
-#. 2.8->settings-schema.json->icon-size->units
-#. 2.8->settings-schema.json->icon-padding->units
-#. 3.4->settings-schema.json->icon-spacing->units
-#. 3.4->settings-schema.json->thumbnail-padding->units
-#. 3.4->settings-schema.json->icon-size->units
-#. 3.4->settings-schema.json->app-button-width->units
-#. 3.4->settings-schema.json->thumbnail-close-button-size->units
-#. 3.4->settings-schema.json->icon-padding->units
-msgid "px"
-msgstr "px"
-
-#. 2.8->settings-schema.json->show-thumbnails->description
-#. 3.4->settings-schema.json->show-thumbnails->description
-msgid "Show thumbnails"
-msgstr "Visa miniatyrer"
-
-#. 2.8->settings-schema.json->show-thumbnails->tooltip
-#. 3.4->settings-schema.json->show-thumbnails->tooltip
-msgid "Show window thumbnails when hovering over an app button."
-msgstr "Visa fönsterminiatyr vid hovring över en programknapp."
-
-#. 2.8->settings-schema.json->icon-size->description
-#. 3.4->settings-schema.json->icon-size->description
-msgid "Icon size"
-msgstr "Ikonstorlek"
-
-#. 2.8->settings-schema.json->icon-size->tooltip
-#. 3.4->settings-schema.json->icon-size->tooltip
-msgid "Set icon size"
-msgstr "Ange ikonstorlek"
-
-#. 2.8->settings-schema.json->hover-peek-time->description
-#. 3.4->settings-schema.json->hover-peek-time->description
-msgid "Window fade time"
-msgstr "Fönstertoningstid"
-
-#. 2.8->settings-schema.json->hover-peek-time->tooltip
-#. 3.4->settings-schema.json->hover-peek-time->tooltip
-msgid "Controls how quickly a window will fade on hover."
-msgstr ""
-"Avgör hur fort ett fönster skall tonas in/ut vid hovring över miniatyren."
-
-#. 2.8->settings-schema.json->hover-peek-time->units
-#. 2.8->settings-schema.json->thumbnail-timeout->units
-#. 2.8->settings-schema.json->show-apps-order-timeout->units
-#. 3.4->settings-schema.json->hover-peek-time->units
-#. 3.4->settings-schema.json->thumbnail-timeout->units
-#. 3.4->settings-schema.json->show-apps-order-timeout->units
-msgid "milliseconds"
-msgstr "millisekunder"
-
-#. 2.8->settings-schema.json->close-button-style->description
-msgid "Allow themes to control the thumbnail close button"
-msgstr "Låt teman kontrollera miniatyrens stängknapp"
-
-#. 2.8->settings-schema.json->close-button-style->tooltip
-msgid ""
-"Controls whether or not the theme controls the window thumbnail's close "
-"button."
-msgstr "avgör om temat kontrollerar fönsterminiatyrers stängningsknapp."
-
-#. 2.8->settings-schema.json->title-display->description
-#. 3.4->settings-schema.json->title-display->description
-msgid "Title display"
-msgstr "Titelvisning"
-
-#. 2.8->settings-schema.json->title-display->tooltip
-#. 3.4->settings-schema.json->title-display->tooltip
-msgid ""
-"focused: show focused window title, title: display the window title, app: "
-"diplay app name, none: don't display anything"
-msgstr ""
-"Fokuserad: Visa titel för fokuserat fönster, Titel: Visa fönstertitel, "
-"Program: Visa programnamn, Ingen: Visa inget"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-#. 3.4->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->middle-click-action->options
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "None"
-msgstr "Ingen"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Focused"
-msgstr "Fokuserad"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "App"
-msgstr "Program"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Title"
-msgstr "Titel"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->description
-#. 3.4->settings-schema.json->hoverPseudoClass->description
-msgid "App button hover pseudo class"
-msgstr "Pseudoklass för programknapp vid hovring"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
-#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons on hover."
-msgstr "Åsidosätter pseudoklassen för programknappar vid hovring."
-
-#. 2.8->settings-schema.json->show-alerts->description
-#. 3.4->settings-schema.json->show-alerts->description
-msgid "Show app alerts and notifications"
-msgstr "Visa programmeddelanden och aviseringar"
-
-#. 2.8->settings-schema.json->show-alerts->tooltip
-#. 3.4->settings-schema.json->show-alerts->tooltip
-msgid "If enabled, notifications and alerts will appear."
-msgstr "Vid aktivering visas aviseringar och meddelanden."
-
-#. 2.8->settings-schema.json->pinOnDrag->description
-#. 2.8->settings-schema.json->pinOnDrag->tooltip
-#. 3.4->settings-schema.json->pinOnDrag->description
-#. 3.4->settings-schema.json->pinOnDrag->tooltip
-msgid "Pin apps when dragged to a new position"
-msgstr "Fäst program när de dras till en ny position"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->description
-#. 3.4->settings-schema.json->show-apps-order-hotkey->description
-msgid "Global hotkey to show the order of apps"
-msgstr "Systemövergripande snabbtangent för att visa programordning"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
-#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
-msgid ""
-"When triggered, the window count label will be replaced with its order in "
-"the app list temporarily."
-msgstr ""
-"Vid användning kommer fönsterantalet att tillfälligt ersättas med "
-"programmets ordningsnummer."
-
-#. 2.8->settings-schema.json->menuItemType->description
-#. 3.4->settings-schema.json->menuItemType->description
-msgid "Menu item type"
-msgstr "Menyobjekttyp"
-
-#. 2.8->settings-schema.json->menuItemType->tooltip
-#. 3.4->settings-schema.json->menuItemType->tooltip
-msgid ""
-"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
-msgstr ""
-"Avgör om menyobjektikoner skall vara symboliska, icke-symboliska eller inte "
-"visas."
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Symbolic icons"
-msgstr "Symboliska ikoner"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "No icons"
-msgstr "Inga ikoner"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Non-symbolic icons"
-msgstr "Icke-symboliska ikoner"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->description
-#. 3.4->settings-schema.json->hover-peek-opacity->description
-msgid "Window opacity"
-msgstr "Fönsteropacitet"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
-#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
-msgid "Opacity of the windows on hover."
-msgstr "Fönsteropacitet vid hovring"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->units
-#. 3.4->settings-schema.json->hover-peek-opacity->units
-msgid "percent"
-msgstr "procent"
-
-#. 2.8->settings-schema.json->enable-hover-peek->description
-#. 3.4->settings-schema.json->enable-hover-peek->description
-msgid "Show windows when hovered over"
-msgstr "Visa fönster vid hovring"
-
-#. 2.8->settings-schema.json->enable-hover-peek->tooltip
-#. 3.4->settings-schema.json->enable-hover-peek->tooltip
-msgid "Controls whether or not windows display when hovered over."
-msgstr "Avgör om fönster skall visas vid hovring över miniatyren."
-
-#. 2.8->settings-schema.json->activePseudoClass->description
-#. 3.4->settings-schema.json->activePseudoClass->description
-msgid "App button active pseudo class"
-msgstr "Pseudoklass för programknapp vid aktiv"
-
-#. 2.8->settings-schema.json->activePseudoClass->tooltip
-#. 3.4->settings-schema.json->activePseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons when they are active."
-msgstr "Åsidosätter pseudoklassen för programknappar när de är aktiva."
-
-#. 2.8->settings-schema.json->animate-thumbnails->description
-#. 3.4->settings-schema.json->animate-thumbnails->description
-msgid "Animate thumbnails"
-msgstr "Animera miniatyrer"
-
-#. 2.8->settings-schema.json->animate-thumbnails->tooltip
-#. 3.4->settings-schema.json->animate-thumbnails->tooltip
-msgid "If enabled, thumbnails will animate when appearing and disappearing."
-msgstr "Vid aktivering animeras miniatyrer vid in- och uttoning."
-
-#. 2.8->settings-schema.json->autostart-menu-item->description
-#. 3.4->settings-schema.json->autostart-menu-item->description
-msgid "Show autostart option"
-msgstr "Visa autostartalternativ"
-
-#. 2.8->settings-schema.json->autostart-menu-item->tooltip
-#. 3.4->settings-schema.json->autostart-menu-item->tooltip
-msgid "Shows the autostart toggle option in an app's context menu."
-msgstr "Visar autostartalternativ i ett programs kontextmeny"
-
-#. 2.8->settings-schema.json->show-pinned->description
-#. 3.4->settings-schema.json->show-pinned->description
-msgid "Show pinned apps"
-msgstr "Visa fastnålade program"
-
-#. 2.8->settings-schema.json->show-pinned->tooltip
-#. 3.4->settings-schema.json->show-pinned->tooltip
-msgid ""
-"Controls whether or not the pinned apps appear in the panel if they are not "
-"open."
-msgstr "Avgör om fastnålade program visas i panelen när de inte är igång."
-
-#. 2.8->settings-schema.json->useSystemTooltips->description
-msgid "Use system tooltips for closed apps"
-msgstr "Använd systemets verktygsbeskrivningar för stängda program"
-
-#. 2.8->settings-schema.json->useSystemTooltips->tooltip
-msgid ""
-"Controls whether or not system tooltips are in use when hovering over closed "
-"pinned apps."
-msgstr ""
-"Avgör om systemets verktygsbeskrivningar används vid hovring över stängda "
-"fastnålade program."
+#. 2.8->settings-schema.json->ITM->description
+msgid "ITM Settings"
+msgstr "ITM-inställningar"
 
 #. 2.8->settings-schema.json->WindowList->description
 msgid "Window List Settings"
 msgstr "Inställningar för fönsterlista"
 
-#. 2.8->settings-schema.json->AppMenu->description
-msgid "Context Menu Settings"
-msgstr "Inställningar för kontextmenyn"
-
-#. 2.8->settings-schema.json->Thumbnails->description
-msgid "Thumbnail Settings"
-msgstr "Miniatyrinställningar"
-
-#. 2.8->settings-schema.json->show-recent->description
-#. 3.4->settings-schema.json->show-recent->description
-msgid "Show recent items"
-msgstr "Visa tidigare objekt"
-
-#. 2.8->settings-schema.json->show-recent->tooltip
-#. 3.4->settings-schema.json->show-recent->tooltip
-msgid "Controls whether recent items will appear in the context menu."
-msgstr "Avgör om tidigare objekt skall visas i kontextmenyn."
-
-#. 2.8->settings-schema.json->vertical-thumbnails->description
-#. 3.4->settings-schema.json->vertical-thumbnails->description
-msgid "Enable vertical thumbnails"
-msgstr "Aktivera vertikala miniatyrer"
-
-#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
-#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
-msgid "If enabled, thumbnails will stack vertically."
-msgstr "Vid aktivering staplas miniatyrer vertikalt."
-
-#. 2.8->settings-schema.json->thumbnail-timeout->description
-#. 3.4->settings-schema.json->thumbnail-timeout->description
-msgid "Thumbnail timeout"
-msgstr "Tidsgräns för miniatyrer"
-
-#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
-#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
-msgid ""
-"Controls how quickly an app's set of window thumbnails will fade out when "
-"the mouse leaves the app button."
-msgstr ""
-"Avgör hur snabbt ett programs fönsterminiatyrer, tonas ut när muspekaren "
-"lämnar programknappen."
-
-#. 2.8->settings-schema.json->ThemeSettings->description
-msgid "Theme Settings"
-msgstr "Temainställningar"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->description
-#. 3.4->settings-schema.json->onclick-thumbnails->description
-msgid "Open thumbnails on click"
-msgstr "Öppna miniatyrer vid klick"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
-#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
-msgid "Open the thumbnails on click if there is more than one window open."
-msgstr "Öppna miniatyrerna vid klick, om det finns fler än ett öppet fönster."
-
-#. 2.8->settings-schema.json->panelLauncherClass->description
-msgid "Use the panel launcher class for pinned apps"
-msgstr "Använd panelstartklassen för fastnålade program"
-
-#. 2.8->settings-schema.json->panelLauncherClass->tooltip
-msgid "Enabling this helps with certain themes."
-msgstr "Aktivering hjälper i vissa teman"
-
-#. 2.8->settings-schema.json->include-all-windows->description
-#. 3.4->settings-schema.json->include-all-windows->description
-msgid "Include all app windows"
-msgstr "Inkludera alla programfönster"
-
-#. 2.8->settings-schema.json->include-all-windows->tooltip
-#. 3.4->settings-schema.json->include-all-windows->tooltip
-msgid ""
-"Controls whether or not thumbnails for smalller child windows, such as exit "
-"confirmations and file dialogues will be included in the thumbnail list."
-msgstr ""
-"Avgör om miniatyrer för mindre underfönster, såsom avslutningsbekräftelser "
-"och fildialoger, skall inkluderas i miniatyrlistan."
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->description
-#. 3.4->settings-schema.json->cycleMenusHotkey->description
-msgid "Global hotkey for cycling through thumbnail menus"
-msgstr "Systemövergripande snabbtangent för bläddring genom miniatyrmenyer"
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
-#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
-msgid "This allows you to cycle through the menus without activating a window."
-msgstr "Låter dig bläddra igenom menyerna utan att aktivera ett fönster."
-
-#. 2.8->settings-schema.json->enable-iconSize->description
-#. 3.4->settings-schema.json->enable-iconSize->description
-msgid "Adjust icon size"
-msgstr "Justera ikonstorlek"
-
-#. 2.8->settings-schema.json->enable-iconSize->tooltip
-#. 3.4->settings-schema.json->enable-iconSize->tooltip
-msgid "Adjust icon size independent of Cinnamon's panel scaling."
-msgstr "Justera ikonstorlek oberoende av Cinnamons panelskalning."
-
 #. 2.8->settings-schema.json->number-display->description
+#. 3.8->settings-schema.json->number-display->description
 #. 3.4->settings-schema.json->number-display->description
 msgid "Number display"
 msgstr "Nummervisning"
 
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Smart"
+msgstr "Smart"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Normal"
+msgstr "Normal"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "None"
+msgstr "Ingen"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "All"
+msgstr "Alla"
+
 #. 2.8->settings-schema.json->number-display->tooltip
+#. 3.8->settings-schema.json->number-display->tooltip
 #. 3.4->settings-schema.json->number-display->tooltip
 msgid ""
 "normal: display window number, smart: display window number if more than one "
@@ -571,42 +242,94 @@ msgstr ""
 "fönster, Ingen: Visa inga nummer, Alla: Visa fönsternummer för favoriter "
 "också"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "All"
-msgstr "Alla"
+#. 2.8->settings-schema.json->title-display->description
+#. 3.8->settings-schema.json->title-display->description
+#. 3.4->settings-schema.json->title-display->description
+msgid "Title display"
+msgstr "Titelvisning"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Smart"
-msgstr "Smart"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "App"
+msgstr "Program"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Normal"
-msgstr "Normal"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Title"
+msgstr "Titel"
 
-#. 2.8->settings-schema.json->ITM->description
-msgid "ITM Settings"
-msgstr "ITM-inställningar"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Focused"
+msgstr "Fokuserad"
 
-#. 2.8->settings-schema.json->HoverPeek->description
-msgid "Hover Peek Settings"
-msgstr "Hovringsinställningar"
-
-#. 2.8->settings-schema.json->icon-padding->description
-#. 3.4->settings-schema.json->icon-padding->description
-msgid "Icon padding"
-msgstr "Ikonutfyllnad"
-
-#. 2.8->settings-schema.json->icon-padding->tooltip
-#. 3.4->settings-schema.json->icon-padding->tooltip
+#. 2.8->settings-schema.json->title-display->tooltip
+#. 3.8->settings-schema.json->title-display->tooltip
+#. 3.4->settings-schema.json->title-display->tooltip
 msgid ""
-"Controls how much horizontal padding is inside the app buttons. Padding is "
-"only applied to instances of this applet on horizontal panels."
+"focused: show focused window title, title: display the window title, app: "
+"diplay app name, none: don't display anything"
 msgstr ""
-"Avgör hur mycket horisontell utfyllnad som skall visas i programknappar. "
-"Inramning tillämpas bara på detta panelprogram i horisontella paneler."
+"Fokuserad: Visa titel för fokuserat fönster, Titel: Visa fönstertitel, "
+"Program: Visa programnamn, Ingen: Visa inget"
+
+#. 2.8->settings-schema.json->group-apps->description
+#. 3.8->settings-schema.json->group-apps->description
+#. 3.4->settings-schema.json->group-apps->description
+msgid "Group apps"
+msgstr "Gruppera program"
+
+#. 2.8->settings-schema.json->group-apps->tooltip
+#. 3.8->settings-schema.json->group-apps->tooltip
+#. 3.4->settings-schema.json->group-apps->tooltip
+msgid "Group each app's set of windows."
+msgstr "Gruppera varje programs fönsteruppsättning."
+
+#. 2.8->settings-schema.json->show-alerts->description
+#. 3.8->settings-schema.json->show-alerts->description
+#. 3.4->settings-schema.json->show-alerts->description
+msgid "Show app alerts and notifications"
+msgstr "Visa programmeddelanden och aviseringar"
+
+#. 2.8->settings-schema.json->show-alerts->tooltip
+#. 3.8->settings-schema.json->show-alerts->tooltip
+#. 3.4->settings-schema.json->show-alerts->tooltip
+msgid "If enabled, notifications and alerts will appear."
+msgstr "Vid aktivering visas aviseringar och meddelanden."
+
+#. 2.8->settings-schema.json->show-pinned->description
+#. 3.8->settings-schema.json->show-pinned->description
+#. 3.4->settings-schema.json->show-pinned->description
+msgid "Show pinned apps"
+msgstr "Visa fastnålade program"
+
+#. 2.8->settings-schema.json->show-pinned->tooltip
+#. 3.8->settings-schema.json->show-pinned->tooltip
+#. 3.4->settings-schema.json->show-pinned->tooltip
+msgid ""
+"Controls whether or not the pinned apps appear in the panel if they are not "
+"open."
+msgstr "Avgör om fastnålade program visas i panelen när de inte är igång."
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->description
+msgid "Arrange pinned apps"
+msgstr "Arrangera fastnålade program"
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
+msgid "Arrange pinned apps into a different order."
+msgstr "Arrangera fastnålade program i en annan ordning."
+
+#. 2.8->settings-schema.json->pinOnDrag->description
+#. 2.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.8->settings-schema.json->pinOnDrag->description
+#. 3.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.4->settings-schema.json->pinOnDrag->description
+#. 3.4->settings-schema.json->pinOnDrag->tooltip
+msgid "Pin apps when dragged to a new position"
+msgstr "Fäst program när de dras till en ny position"
 
 #. 2.8->settings-schema.json->middle-click-action->description
 msgid "Middle clicking app buttons creates new app instances"
@@ -621,12 +344,254 @@ msgstr ""
 "Avgör beteendet för mushjulsklick på programknappar. Inaktivering stänger "
 "det sist fokuserade fönstret i programgruppen vid mushjulsklick."
 
+#. 2.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.4->settings-schema.json->cycleMenusHotkey->description
+msgid "Global hotkey for cycling through thumbnail menus"
+msgstr "Systemövergripande snabbtangent för bläddring genom miniatyrmenyer"
+
+#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
+msgid "This allows you to cycle through the menus without activating a window."
+msgstr "Låter dig bläddra igenom menyerna utan att aktivera ett fönster."
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.4->settings-schema.json->show-apps-order-hotkey->description
+msgid "Global hotkey to show the order of apps"
+msgstr "Systemövergripande snabbtangent för att visa programordning"
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
+msgid ""
+"When triggered, the window count label will be replaced with its order in "
+"the app list temporarily."
+msgstr ""
+"Vid användning kommer fönsterantalet att tillfälligt ersättas med "
+"programmets ordningsnummer."
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->units
+#. 2.8->settings-schema.json->thumbnail-timeout->units
+#. 2.8->settings-schema.json->hover-peek-time->units
+#. 3.8->settings-schema.json->show-apps-order-timeout->units
+#. 3.8->settings-schema.json->thumbnail-timeout->units
+#. 3.8->settings-schema.json->hover-peek-time->units
+#. 3.4->settings-schema.json->show-apps-order-timeout->units
+#. 3.4->settings-schema.json->thumbnail-timeout->units
+#. 3.4->settings-schema.json->hover-peek-time->units
+msgid "milliseconds"
+msgstr "millisekunder"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.4->settings-schema.json->show-apps-order-timeout->description
+msgid "Duration of the apps order display on hotkey press"
+msgstr "Varaktighet för visning av programordning vid snabbtangenttryck"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
+msgid ""
+"Determines the duration the window count labels are replaced with the app's "
+"order number."
+msgstr ""
+"Avgör hur länge fönsterantalet skall ersättas med programmets ordningsnummer."
+
+#. 2.8->settings-schema.json->Thumbnails->description
+msgid "Thumbnail Settings"
+msgstr "Miniatyrinställningar"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->description
+#. 3.8->settings-schema.json->thumbnail-timeout->description
+#. 3.4->settings-schema.json->thumbnail-timeout->description
+msgid "Thumbnail timeout"
+msgstr "Tidsgräns för miniatyrer"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
+msgid ""
+"Controls how quickly an app's set of window thumbnails will fade out when "
+"the mouse leaves the app button."
+msgstr ""
+"Avgör hur snabbt ett programs fönsterminiatyrer, tonas ut när muspekaren "
+"lämnar programknappen."
+
+#. 2.8->settings-schema.json->thumbnail-size->units
+#. 3.8->settings-schema.json->thumbnail-size->units
+#. 3.4->settings-schema.json->thumbnail-size->units
+msgid "size"
+msgstr "storlek"
+
+#. 2.8->settings-schema.json->thumbnail-size->description
+#. 3.8->settings-schema.json->thumbnail-size->description
+#. 3.4->settings-schema.json->thumbnail-size->description
+msgid "Thumbnail size"
+msgstr "Miniatyrstorlek"
+
+#. 2.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-size->tooltip
+msgid "Controls the size of the thumbnails."
+msgstr "Avgör storleken på miniatyrerna."
+
+#. 2.8->settings-schema.json->show-thumbnails->description
+#. 3.8->settings-schema.json->show-thumbnails->description
+#. 3.4->settings-schema.json->show-thumbnails->description
+msgid "Show thumbnails"
+msgstr "Visa miniatyrer"
+
+#. 2.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.4->settings-schema.json->show-thumbnails->tooltip
+msgid "Show window thumbnails when hovering over an app button."
+msgstr "Visa fönsterminiatyr vid hovring över en programknapp."
+
+#. 2.8->settings-schema.json->animate-thumbnails->description
+#. 3.8->settings-schema.json->animate-thumbnails->description
+#. 3.4->settings-schema.json->animate-thumbnails->description
+msgid "Animate thumbnails"
+msgstr "Animera miniatyrer"
+
+#. 2.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.4->settings-schema.json->animate-thumbnails->tooltip
+msgid "If enabled, thumbnails will animate when appearing and disappearing."
+msgstr "Vid aktivering animeras miniatyrer vid in- och uttoning."
+
+#. 2.8->settings-schema.json->vertical-thumbnails->description
+#. 3.8->settings-schema.json->vertical-thumbnails->description
+#. 3.4->settings-schema.json->vertical-thumbnails->description
+msgid "Enable vertical thumbnails"
+msgstr "Aktivera vertikala miniatyrer"
+
+#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
+msgid "If enabled, thumbnails will stack vertically."
+msgstr "Vid aktivering staplas miniatyrer vertikalt."
+
+#. 2.8->settings-schema.json->sort-thumbnails->description
+#. 3.8->settings-schema.json->sort-thumbnails->description
+#. 3.4->settings-schema.json->sort-thumbnails->description
+msgid "Sort windows for each app by last focused"
+msgstr "Sortera fönster för varje program, efter senast fokuserat"
+
+#. 2.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.4->settings-schema.json->sort-thumbnails->tooltip
+msgid ""
+"Controls whether the order windows appear for an app is by last focused, or "
+"the order they were opened."
+msgstr ""
+"Avgör om ordningen i vilken programfönster visas, är efter senast fokuserad "
+"eller efter den ordning de öppnades."
+
+#. 2.8->settings-schema.json->onclick-thumbnails->description
+#. 3.8->settings-schema.json->onclick-thumbnails->description
+#. 3.4->settings-schema.json->onclick-thumbnails->description
+msgid "Open thumbnails on click"
+msgstr "Öppna miniatyrer vid klick"
+
+#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
+msgid "Open the thumbnails on click if there is more than one window open."
+msgstr "Öppna miniatyrerna vid klick, om det finns fler än ett öppet fönster."
+
+#. 2.8->settings-schema.json->include-all-windows->description
+#. 3.8->settings-schema.json->include-all-windows->description
+#. 3.4->settings-schema.json->include-all-windows->description
+msgid "Include all app windows"
+msgstr "Inkludera alla programfönster"
+
+#. 2.8->settings-schema.json->include-all-windows->tooltip
+#. 3.8->settings-schema.json->include-all-windows->tooltip
+#. 3.4->settings-schema.json->include-all-windows->tooltip
+msgid ""
+"Controls whether or not thumbnails for smalller child windows, such as exit "
+"confirmations and file dialogues will be included in the thumbnail list."
+msgstr ""
+"Avgör om miniatyrer för mindre underfönster, såsom avslutningsbekräftelser "
+"och fildialoger, skall inkluderas i miniatyrlistan."
+
+#. 2.8->settings-schema.json->AppMenu->description
+msgid "Context Menu Settings"
+msgstr "Inställningar för kontextmenyn"
+
+#. 2.8->settings-schema.json->show-recent->description
+#. 3.8->settings-schema.json->show-recent->description
+#. 3.4->settings-schema.json->show-recent->description
+msgid "Show recent items"
+msgstr "Visa tidigare objekt"
+
+#. 2.8->settings-schema.json->show-recent->tooltip
+#. 3.8->settings-schema.json->show-recent->tooltip
+#. 3.4->settings-schema.json->show-recent->tooltip
+msgid "Controls whether recent items will appear in the context menu."
+msgstr "Avgör om tidigare objekt skall visas i kontextmenyn."
+
+#. 2.8->settings-schema.json->menuItemType->description
+#. 3.8->settings-schema.json->menuItemType->description
+#. 3.4->settings-schema.json->menuItemType->description
+msgid "Menu item type"
+msgstr "Menyobjekttyp"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Symbolic icons"
+msgstr "Symboliska ikoner"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Non-symbolic icons"
+msgstr "Icke-symboliska ikoner"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "No icons"
+msgstr "Inga ikoner"
+
+#. 2.8->settings-schema.json->menuItemType->tooltip
+#. 3.8->settings-schema.json->menuItemType->tooltip
+#. 3.4->settings-schema.json->menuItemType->tooltip
+msgid ""
+"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
+msgstr ""
+"Avgör om menyobjektikoner skall vara symboliska, icke-symboliska eller inte "
+"visas."
+
 #. 2.8->settings-schema.json->firefox-menu->description
+#. 3.8->settings-schema.json->firefox-menu->description
 #. 3.4->settings-schema.json->firefox-menu->description
 msgid "Firefox context menu"
 msgstr "Firefox kontextmeny"
 
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Most Visited"
+msgstr "Mest besökta"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Recent History"
+msgstr "Tidigare historik"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Bookmarks"
+msgstr "Bokmärken"
+
 #. 2.8->settings-schema.json->firefox-menu->tooltip
+#. 3.8->settings-schema.json->firefox-menu->tooltip
 #. 3.4->settings-schema.json->firefox-menu->tooltip
 msgid ""
 "Most Visited: show the sites you visit most, Recent History: display the the "
@@ -635,76 +600,26 @@ msgstr ""
 "Mest besökta: Visa dina mest besökta sidor, Tidigarehistorik: Visa dina "
 "senast besökta sidor, Bokmärken: Visa dina favoritbokmärken."
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Bookmarks"
-msgstr "Bokmärken"
+#. 2.8->settings-schema.json->autostart-menu-item->description
+#. 3.8->settings-schema.json->autostart-menu-item->description
+#. 3.4->settings-schema.json->autostart-menu-item->description
+msgid "Show autostart option"
+msgstr "Visa autostartalternativ"
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Most Visited"
-msgstr "Mest besökta"
-
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Recent History"
-msgstr "Tidigare historik"
-
-#. 2.8->settings-schema.json->themePadding->description
-msgid "Use theme padding to center button icons"
-msgstr "Använd temats utfyllnad för att centrera knappikoner"
-
-#. 2.8->settings-schema.json->themePadding->tooltip
-msgid "If button icons look off-centered, toggling this may help."
-msgstr "Om knappikoner inte är centrerade, kan det här möjligen hjälpa."
-
-#. 2.8->settings-schema.json->group-apps->description
-#. 3.4->settings-schema.json->group-apps->description
-msgid "Group apps"
-msgstr "Gruppera program"
-
-#. 2.8->settings-schema.json->group-apps->tooltip
-#. 3.4->settings-schema.json->group-apps->tooltip
-msgid "Group each app's set of windows."
-msgstr "Gruppera varje programs fönsteruppsättning."
-
-#. 2.8->settings-schema.json->show-active->description
-#. 3.4->settings-schema.json->show-active->description
-msgid "Show active app indicators"
-msgstr "Visa indikator för aktivt program"
-
-#. 2.8->settings-schema.json->show-active->tooltip
-#. 3.4->settings-schema.json->show-active->tooltip
-msgid "Active app styling will indicate if an app is active."
-msgstr "Indikator visar om ett program är aktivt."
-
-#. 2.8->settings-schema.json->show-apps-order-timeout->description
-#. 3.4->settings-schema.json->show-apps-order-timeout->description
-msgid "Duration of the apps order display on hotkey press"
-msgstr "Varaktighet för visning av programordning vid snabbtangenttryck"
-
-#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
-#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
-msgid ""
-"Determines the duration the window count labels are replaced with the app's "
-"order number."
-msgstr ""
-"Avgör hur länge fönsterantalet skall ersättas med programmets ordningsnummer."
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->description
-msgid "Arrange pinned apps"
-msgstr "Arrangera fastnålade program"
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
-msgid "Arrange pinned apps into a different order."
-msgstr "Arrangera fastnålade program i en annan ordning."
+#. 2.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.4->settings-schema.json->autostart-menu-item->tooltip
+msgid "Shows the autostart toggle option in an app's context menu."
+msgstr "Visar autostartalternativ i ett programs kontextmeny"
 
 #. 2.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.8->settings-schema.json->monitor-move-all-windows->description
 #. 3.4->settings-schema.json->monitor-move-all-windows->description
 msgid "Apply the monitor move option to all windows"
 msgstr "Tillämpa alternativet \"Flytta till skärm\" på alla fönster"
 
 #. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.8->settings-schema.json->monitor-move-all-windows->tooltip
 #. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
 msgid ""
 "When clicking \"Move to monitor\" in the context menu, this option will move "
@@ -714,153 +629,462 @@ msgstr ""
 "fönster från ett program, istället för enbart det senast fokuserade fönstret "
 "från det programmet."
 
-#. 2.8->settings-schema.json->sort-thumbnails->description
-#. 3.4->settings-schema.json->sort-thumbnails->description
-msgid "Sort windows for each app by last focused"
-msgstr "Sortera fönster för varje program, efter senast fokuserat"
+#. 2.8->settings-schema.json->HoverPeek->description
+msgid "Hover Peek Settings"
+msgstr "Hovringsinställningar"
 
-#. 2.8->settings-schema.json->sort-thumbnails->tooltip
-#. 3.4->settings-schema.json->sort-thumbnails->tooltip
+#. 2.8->settings-schema.json->enable-hover-peek->description
+#. 3.8->settings-schema.json->enable-hover-peek->description
+#. 3.4->settings-schema.json->enable-hover-peek->description
+msgid "Show windows when hovered over"
+msgstr "Visa fönster vid hovring"
+
+#. 2.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.4->settings-schema.json->enable-hover-peek->tooltip
+msgid "Controls whether or not windows display when hovered over."
+msgstr "Avgör om fönster skall visas vid hovring över miniatyren."
+
+#. 2.8->settings-schema.json->hover-peek-time->description
+#. 3.8->settings-schema.json->hover-peek-time->description
+#. 3.4->settings-schema.json->hover-peek-time->description
+msgid "Window fade time"
+msgstr "Fönstertoningstid"
+
+#. 2.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.4->settings-schema.json->hover-peek-time->tooltip
+msgid "Controls how quickly a window will fade on hover."
+msgstr ""
+"Avgör hur fort ett fönster skall tonas in/ut vid hovring över miniatyren."
+
+#. 2.8->settings-schema.json->hover-peek-opacity->units
+#. 3.8->settings-schema.json->hover-peek-opacity->units
+#. 3.4->settings-schema.json->hover-peek-opacity->units
+msgid "percent"
+msgstr "procent"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->description
+#. 3.8->settings-schema.json->hover-peek-opacity->description
+#. 3.4->settings-schema.json->hover-peek-opacity->description
+msgid "Window opacity"
+msgstr "Fönsteropacitet"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
+msgid "Opacity of the windows on hover."
+msgstr "Fönsteropacitet vid hovring"
+
+#. 2.8->settings-schema.json->ThemeSettings->description
+msgid "Theme Settings"
+msgstr "Temainställningar"
+
+#. 2.8->settings-schema.json->show-active->description
+#. 3.8->settings-schema.json->show-active->description
+#. 3.4->settings-schema.json->show-active->description
+msgid "Show active app indicators"
+msgstr "Visa indikator för aktivt program"
+
+#. 2.8->settings-schema.json->show-active->tooltip
+#. 3.8->settings-schema.json->show-active->tooltip
+#. 3.4->settings-schema.json->show-active->tooltip
+msgid "Active app styling will indicate if an app is active."
+msgstr "Indikator visar om ett program är aktivt."
+
+#. 2.8->settings-schema.json->icon-spacing->units
+#. 2.8->settings-schema.json->icon-padding->units
+#. 2.8->settings-schema.json->icon-size->units
+#. 3.8->settings-schema.json->app-button-width->units
+#. 3.8->settings-schema.json->thumbnail-close-button-size->units
+#. 3.8->settings-schema.json->thumbnail-padding->units
+#. 3.8->settings-schema.json->icon-spacing->units
+#. 3.8->settings-schema.json->icon-padding->units
+#. 3.8->settings-schema.json->icon-size->units
+#. 3.4->settings-schema.json->app-button-width->units
+#. 3.4->settings-schema.json->thumbnail-close-button-size->units
+#. 3.4->settings-schema.json->thumbnail-padding->units
+#. 3.4->settings-schema.json->icon-spacing->units
+#. 3.4->settings-schema.json->icon-padding->units
+#. 3.4->settings-schema.json->icon-size->units
+msgid "px"
+msgstr "px"
+
+#. 2.8->settings-schema.json->icon-spacing->description
+#. 3.8->settings-schema.json->icon-spacing->description
+#. 3.4->settings-schema.json->icon-spacing->description
+msgid "Icon spacing"
+msgstr "Ikonavstånd"
+
+#. 2.8->settings-schema.json->icon-spacing->tooltip
+#. 3.8->settings-schema.json->icon-spacing->tooltip
+#. 3.4->settings-schema.json->icon-spacing->tooltip
+msgid "Controls how much space is between the icons."
+msgstr "Avgör avståndet mellan ikonerna."
+
+#. 2.8->settings-schema.json->icon-padding->description
+#. 3.8->settings-schema.json->icon-padding->description
+#. 3.4->settings-schema.json->icon-padding->description
+msgid "Icon padding"
+msgstr "Ikonutfyllnad"
+
+#. 2.8->settings-schema.json->icon-padding->tooltip
+#. 3.8->settings-schema.json->icon-padding->tooltip
+#. 3.4->settings-schema.json->icon-padding->tooltip
 msgid ""
-"Controls whether the order windows appear for an app is by last focused, or "
-"the order they were opened."
+"Controls how much horizontal padding is inside the app buttons. Padding is "
+"only applied to instances of this applet on horizontal panels."
 msgstr ""
-"Avgör om ordningen i vilken programfönster visas, är efter senast fokuserad "
-"eller efter den ordning de öppnades."
+"Avgör hur mycket horisontell utfyllnad som skall visas i programknappar. "
+"Inramning tillämpas bara på detta panelprogram i horisontella paneler."
 
-#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->themePadding->description
+msgid "Use theme padding to center button icons"
+msgstr "Använd temats utfyllnad för att centrera knappikoner"
+
+#. 2.8->settings-schema.json->themePadding->tooltip
+msgid "If button icons look off-centered, toggling this may help."
+msgstr "Om knappikoner inte är centrerade, kan det här möjligen hjälpa."
+
+#. 2.8->settings-schema.json->enable-iconSize->description
+#. 3.8->settings-schema.json->enable-iconSize->description
+#. 3.4->settings-schema.json->enable-iconSize->description
+msgid "Adjust icon size"
+msgstr "Justera ikonstorlek"
+
+#. 2.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.4->settings-schema.json->enable-iconSize->tooltip
+msgid "Adjust icon size independent of Cinnamon's panel scaling."
+msgstr "Justera ikonstorlek oberoende av Cinnamons panelskalning."
+
+#. 2.8->settings-schema.json->icon-size->description
+#. 3.8->settings-schema.json->icon-size->description
+#. 3.4->settings-schema.json->icon-size->description
+msgid "Icon size"
+msgstr "Ikonstorlek"
+
+#. 2.8->settings-schema.json->icon-size->tooltip
+#. 3.8->settings-schema.json->icon-size->tooltip
+#. 3.4->settings-schema.json->icon-size->tooltip
+msgid "Set icon size"
+msgstr "Ange ikonstorlek"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->description
+#. 3.8->settings-schema.json->hoverPseudoClass->description
+#. 3.4->settings-schema.json->hoverPseudoClass->description
+msgid "App button hover pseudo class"
+msgstr "Pseudoklass för programknapp vid hovring"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
 #. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
 #. 3.4->settings-schema.json->activePseudoClass->options
-msgid "checked"
+msgid "hover"
+msgstr "hovring"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "focus"
+msgstr "fokus"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "active"
+msgstr "aktiv"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "outlined"
+msgstr "kontur"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "selected"
+msgstr "markerad"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons on hover."
+msgstr "Åsidosätter pseudoklassen för programknappar vid hovring."
+
+#. 2.8->settings-schema.json->focusPseudoClass->description
+#. 3.8->settings-schema.json->focusPseudoClass->description
+#. 3.4->settings-schema.json->focusPseudoClass->description
+msgid "App button focus pseudo class"
+msgstr "Pseudoklass för programknapp vid fokus"
+
+#. 2.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.4->settings-schema.json->focusPseudoClass->tooltip
+msgid "Overrides the pseudo class for app button on focus."
+msgstr "Åsidosätter pseudoklassen för programknappar vid fokus."
+
+#. 2.8->settings-schema.json->activePseudoClass->description
+#. 3.8->settings-schema.json->activePseudoClass->description
+#. 3.4->settings-schema.json->activePseudoClass->description
+msgid "App button active pseudo class"
+msgstr "Pseudoklass för programknapp vid aktiv"
+
+#. 2.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.4->settings-schema.json->activePseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons when they are active."
+msgstr "Åsidosätter pseudoklassen för programknappar när de är aktiva."
+
+#. 2.8->settings-schema.json->panelLauncherClass->description
+msgid "Use the panel launcher class for pinned apps"
+msgstr "Använd panelstartklassen för fastnålade program"
+
+#. 2.8->settings-schema.json->panelLauncherClass->tooltip
+msgid "Enabling this helps with certain themes."
+msgstr "Aktivering hjälper i vissa teman"
+
+#. 2.8->settings-schema.json->close-button-style->description
+msgid "Allow themes to control the thumbnail close button"
+msgstr "Låt teman kontrollera miniatyrens stängknapp"
+
+#. 2.8->settings-schema.json->close-button-style->tooltip
+msgid ""
+"Controls whether or not the theme controls the window thumbnail's close "
+"button."
+msgstr "avgör om temat kontrollerar fönsterminiatyrers stängningsknapp."
+
+#. 2.8->settings-schema.json->useSystemTooltips->description
+msgid "Use system tooltips for closed apps"
+msgstr "Använd systemets verktygsbeskrivningar för stängda program"
+
+#. 2.8->settings-schema.json->useSystemTooltips->tooltip
+msgid ""
+"Controls whether or not system tooltips are in use when hovering over closed "
+"pinned apps."
+msgstr ""
+"Avgör om systemets verktygsbeskrivningar används vid hovring över stängda "
+"fastnålade program."
+
+#. 3.8->settings-schema.json->generalPage->title
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
 msgstr ""
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
-msgid "Highlight the last focused window within an app group"
+#. 3.8->settings-schema.json->panelPage->title
+#. 3.4->settings-schema.json->panelPage->title
+msgid "Panel"
+msgstr "Panel"
+
+#. 3.8->settings-schema.json->thumbnailsPage->title
+#. 3.8->settings-schema.json->thumbnailsSection->title
+#. 3.4->settings-schema.json->thumbnailsPage->title
+#. 3.4->settings-schema.json->thumbnailsSection->title
+msgid "Thumbnails"
+msgstr "Miniatyrer"
+
+#. 3.8->settings-schema.json->contextMenuPage->title
+#. 3.4->settings-schema.json->contextMenuPage->title
+msgid "Context Menu"
+msgstr "Kontextmeny"
+
+#. 3.8->settings-schema.json->themePage->title
+#. 3.4->settings-schema.json->themePage->title
+msgid "Theming"
+msgstr "Temasättning"
+
+#. 3.8->settings-schema.json->generalSection->title
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.8->settings-schema.json->appButtonsSection->title
+#. 3.4->settings-schema.json->appButtonsSection->title
+msgid "App Buttons"
+msgstr "Programknappar"
+
+#. 3.8->settings-schema.json->hotKeysSection->title
+#. 3.4->settings-schema.json->hotKeysSection->title
+msgid "Hot Keys"
+msgstr "Snabbtangenter"
+
+#. 3.8->settings-schema.json->hoverPeekSection->title
+#. 3.4->settings-schema.json->hoverPeekSection->title
+msgid "Hover Peek"
+msgstr "Hovringsminiatyr"
+
+#. 3.8->settings-schema.json->stylingSection->title
+#. 3.4->settings-schema.json->stylingSection->title
+msgid "Styling"
+msgstr "Stilsättning"
+
+#. 3.8->settings-schema.json->iconSection->title
+#. 3.4->settings-schema.json->iconSection->title
+msgid "Icons"
+msgstr "Ikoner"
+
+#. 3.8->settings-schema.json->presetSection->title
+#. 3.4->settings-schema.json->presetSection->title
+msgid "Recommended Presets"
+msgstr "Rekommenderade förinställningar"
+
+#. 3.8->settings-schema.json->scroll-behavior->description
+#. 3.4->settings-schema.json->scroll-behavior->description
+msgid "Mouse wheel scroll behavior"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+msgid "Cycle apps"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#, fuzzy
+msgid "Cycle windows"
+msgstr "Inkludera alla programfönster"
+
+#. 3.8->settings-schema.json->scroll-behavior->tooltip
+#. 3.4->settings-schema.json->scroll-behavior->tooltip
+msgid ""
+"Choose if scrolling the mouse wheel cycles running apps, an app button's "
+"windows on hover, or is disabled."
+msgstr ""
+
+#. 3.8->settings-schema.json->left-click-action->description
+#. 3.8->settings-schema.json->left-click-action->tooltip
+#. 3.8->settings-schema.json->launcher-animation-effect->tooltip
+#. 3.4->settings-schema.json->left-click-action->description
+#. 3.4->settings-schema.json->left-click-action->tooltip
+#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
+msgid "Left click action"
+msgstr ""
+
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->left-click-action->options
+msgid "Toggle activation of last focused window"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->description
+#. 3.8->settings-schema.json->middle-click-action->tooltip
+#. 3.4->settings-schema.json->middle-click-action->description
+#. 3.4->settings-schema.json->middle-click-action->tooltip
+msgid "Middle click action"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Launch new app instance"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+#, fuzzy
+msgid "Close last focused window in group"
 msgstr "Färgmarkera det senast fokuserade fönstret i en programgrupp"
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
-msgid ""
-"When enabled, the last window that was interacted with will be indicated."
-msgstr "Vid aktivering, indikeras det senast använda fönstret."
-
-#. 3.4->settings-schema.json->app-button-transition-duration->description
-#, fuzzy
-msgid "App button transition duration"
-msgstr "Programknappsbredd"
-
-#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
-msgid ""
-"Overrides the theme's animation time for app buttons. If set to zero, the "
-"theme's transition duration will be used."
-msgstr ""
-
-#. 3.4->settings-schema.json->app-button-transition-duration->units
-msgid "ms"
-msgstr ""
-
-#. 3.4->settings-schema.json->thumbnail-padding->description
-msgid "Thumbnail padding"
-msgstr "Miniatyrutfyllnad"
-
-#. 3.4->settings-schema.json->thumbnail-padding->tooltip
-msgid "Controls how much space will be around the window preview thumbnails."
-msgstr ""
-"Kontrollerar hur mycket tomt utrymme som skall finnas runt "
-"fönsterminiatyrerna."
-
+#. 3.8->settings-schema.json->system-favorites->description
 #. 3.4->settings-schema.json->system-favorites->description
 msgid "Use system favorites for pinned apps"
 msgstr "Använd systemets favoriter som fastnålade program"
 
+#. 3.8->settings-schema.json->system-favorites->tooltip
 #. 3.4->settings-schema.json->system-favorites->tooltip
 msgid ""
 "Controls whether or not pinned apps consist of the system favorites list."
 msgstr ""
 "Avgör om fastnålade program består av systemets favoritlista, eller inte."
 
-#. 3.4->settings-schema.json->generalSection->title
-msgid "Behavior"
-msgstr ""
-
-#. 3.4->settings-schema.json->thumbnailsPage->title
-#. 3.4->settings-schema.json->thumbnailsSection->title
-msgid "Thumbnails"
-msgstr "Miniatyrer"
-
-#. 3.4->settings-schema.json->presetSection->title
-msgid "Recommended Presets"
-msgstr "Rekommenderade förinställningar"
-
-#. 3.4->settings-schema.json->appButtonsSection->title
-msgid "App Buttons"
-msgstr "Programknappar"
-
-#. 3.4->settings-schema.json->generalPage->title
-msgid "General"
-msgstr ""
-
-#. 3.4->settings-schema.json->hoverPeekSection->title
-msgid "Hover Peek"
-msgstr "Hovringsminiatyr"
-
-#. 3.4->settings-schema.json->panelPage->title
-msgid "Panel"
-msgstr "Panel"
-
-#. 3.4->settings-schema.json->iconSection->title
-msgid "Icons"
-msgstr "Ikoner"
-
-#. 3.4->settings-schema.json->hotKeysSection->title
-msgid "Hot Keys"
-msgstr "Snabbtangenter"
-
-#. 3.4->settings-schema.json->stylingSection->title
-msgid "Styling"
-msgstr "Stilsättning"
-
-#. 3.4->settings-schema.json->contextMenuPage->title
-msgid "Context Menu"
-msgstr "Kontextmeny"
-
-#. 3.4->settings-schema.json->themePage->title
-msgid "Theming"
-msgstr "Temasättning"
-
-#. 3.4->settings-schema.json->mintYPreset->description
-#. 3.4->settings-schema.json->mintYPreset->tooltip
-msgid "Mint Y and Variants"
-msgstr "Mint Y och varianter"
-
-#. 3.4->settings-schema.json->show-icons->description
+#. 3.8->settings-schema.json->show-all-workspaces->description
+#. 3.8->settings-schema.json->show-all-workspaces->tooltip
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
 #, fuzzy
-msgid "Show icons"
-msgstr "Inga ikoner"
+msgid "Show windows from all workspaces"
+msgstr "Synlig på alla arbetsytor"
 
-#. 3.4->settings-schema.json->show-icons->tooltip
-msgid "Show the window's icon next to the title."
-msgstr ""
-
+#. 3.8->settings-schema.json->enable-app-button-dragging->description
+#. 3.8->settings-schema.json->enable-app-button-dragging->tooltip
 #. 3.4->settings-schema.json->enable-app-button-dragging->description
 #. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
 msgid "Enable app button dragging"
 msgstr "Aktivera dra och släpp för programknappar"
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
-#, fuzzy
-msgid "Show new window option"
-msgstr "Visa autostartalternativ"
-
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
-msgid ""
-"Shows the \"New Window\" option in an app's context menu if it doesn't "
-"already have one from the app's own action menu items."
+#. 3.8->settings-schema.json->launcher-animation-effect->description
+#. 3.4->settings-schema.json->launcher-animation-effect->description
+msgid "Launcher animation effect"
 msgstr ""
 
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Fade"
+msgstr ""
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Scale"
+msgstr ""
+
+#. 3.8->settings-schema.json->list-monitor-windows->description
+#. 3.4->settings-schema.json->list-monitor-windows->description
+msgid "Only list windows from the monitor displaying this instance"
+msgstr "Lista endast fönster från den skärm som visar denna instans"
+
+#. 3.8->settings-schema.json->list-monitor-windows->tooltip
+#. 3.4->settings-schema.json->list-monitor-windows->tooltip
+msgid ""
+"This option will only come into effect for monitors displaying an ITM "
+"instance."
+msgstr "Detta alternativ påverkar endast skärmar som visar en ITM-instans."
+
+#. 3.8->settings-schema.json->enable-app-button-width->description
+#. 3.4->settings-schema.json->enable-app-button-width->description
+msgid "Use a custom width for app buttons"
+msgstr "Använd anpassad bredd på programknappar"
+
+#. 3.8->settings-schema.json->enable-app-button-width->tooltip
+#. 3.4->settings-schema.json->enable-app-button-width->tooltip
+msgid "When disabled, the app button width is determined by the panel height."
+msgstr "Vid inaktivering, avgörs knappbredden av panelens höjd."
+
+#. 3.8->settings-schema.json->app-button-width->description
 #. 3.4->settings-schema.json->app-button-width->description
 msgid "App button width"
 msgstr "Programknappsbredd"
 
+#. 3.8->settings-schema.json->app-button-width->tooltip
 #. 3.4->settings-schema.json->app-button-width->tooltip
 msgid ""
 "Controls the width of the application button. This option only works for "
@@ -868,117 +1092,120 @@ msgid ""
 msgstr ""
 "Kontrollerar bredden på programknappen. Berör endast horisontella paneler."
 
-#. 3.4->settings-schema.json->mintXPreset->description
-#. 3.4->settings-schema.json->mintXPreset->tooltip
-#, fuzzy
-msgid "Mint X, Linux Mint, and Variants"
-msgstr "Mint Y och varianter"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->description
-msgid "Launcher animation effect"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
-#. 3.4->settings-schema.json->left-click-action->description
-#. 3.4->settings-schema.json->left-click-action->tooltip
-msgid "Left click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Scale"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Fade"
-msgstr ""
-
-#. 3.4->settings-schema.json->enable-app-button-width->description
-msgid "Use a custom width for app buttons"
-msgstr "Använd anpassad bredd på programknappar"
-
-#. 3.4->settings-schema.json->enable-app-button-width->tooltip
-msgid "When disabled, the app button width is determined by the panel height."
-msgstr "Vid inaktivering, avgörs knappbredden av panelens höjd."
-
-#. 3.4->settings-schema.json->list-monitor-windows->description
-msgid "Only list windows from the monitor displaying this instance"
-msgstr "Lista endast fönster från den skärm som visar denna instans"
-
-#. 3.4->settings-schema.json->list-monitor-windows->tooltip
-msgid ""
-"This option will only come into effect for monitors displaying an ITM "
-"instance."
-msgstr "Detta alternativ påverkar endast skärmar som visar en ITM-instans."
-
+#. 3.8->settings-schema.json->thumbnail-close-button-size->description
 #. 3.4->settings-schema.json->thumbnail-close-button-size->description
 msgid "Close button size"
 msgstr "Storlek på stängningsknappen"
 
+#. 3.8->settings-schema.json->thumbnail-close-button-size->tooltip
 #. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
 msgid "Controls how large the thumbnail close button is."
 msgstr "Kontrollerar storleken på miniatyrens stängningsknapp."
 
-#. 3.4->settings-schema.json->middle-click-action->description
-#. 3.4->settings-schema.json->middle-click-action->tooltip
-msgid "Middle click action"
+#. 3.8->settings-schema.json->thumbnail-padding->description
+#. 3.4->settings-schema.json->thumbnail-padding->description
+msgid "Thumbnail padding"
+msgstr "Miniatyrutfyllnad"
+
+#. 3.8->settings-schema.json->thumbnail-padding->tooltip
+#. 3.4->settings-schema.json->thumbnail-padding->tooltip
+msgid "Controls how much space will be around the window preview thumbnails."
 msgstr ""
+"Kontrollerar hur mycket tomt utrymme som skall finnas runt "
+"fönsterminiatyrerna."
 
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Launch new app instance"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-#, fuzzy
-msgid "Close last focused window in group"
-msgstr "Färgmarkera det senast fokuserade fönstret i en programgrupp"
-
-#. 3.4->settings-schema.json->scroll-behavior->description
-msgid "Mouse wheel scroll behavior"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->tooltip
-msgid ""
-"Choose if scrolling the mouse wheel cycles running apps, an app button's "
-"windows on hover, or is disabled."
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->options
-msgid "Cycle apps"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
-#, fuzzy
-msgid "Cycle windows"
-msgstr "Inkludera alla programfönster"
-
-#. 3.4->settings-schema.json->show-all-workspaces->description
-#. 3.4->settings-schema.json->show-all-workspaces->tooltip
-#, fuzzy
-msgid "Show windows from all workspaces"
-msgstr "Synlig på alla arbetsytor"
-
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->description
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
 msgid "Cycle windows on mouse wheel scroll"
 msgstr ""
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->tooltip
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
 msgid ""
 "Choose whether or not scrolling the mouse wheel cycles windows when hovering "
 "over a thumbnail menu."
 msgstr ""
 
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "Toggle activation of last focused window"
+#. 3.8->settings-schema.json->show-icons->description
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "Inga ikoner"
+
+#. 3.8->settings-schema.json->show-icons->tooltip
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
 msgstr ""
 
-#. IcingTaskManager@json->metadata.json->name
-msgid "Icing Task Manager"
-msgstr "Icing Task Manager"
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->description
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
+msgid "Highlight the last focused window within an app group"
+msgstr "Färgmarkera det senast fokuserade fönstret i en programgrupp"
 
-#. IcingTaskManager@json->metadata.json->description
-msgid "Window list with app grouping and thumbnails"
-msgstr "Fönsterlista med programgruppering och miniatyrer"
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+msgid ""
+"When enabled, the last window that was interacted with will be indicated."
+msgstr "Vid aktivering, indikeras det senast använda fönstret."
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->description
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "Visa autostartalternativ"
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->tooltip
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->units
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->description
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+#, fuzzy
+msgid "App button transition duration"
+msgstr "Programknappsbredd"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->tooltip
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.8->settings-schema.json->mintYPreset->description
+#. 3.8->settings-schema.json->mintYPreset->tooltip
+#. 3.4->settings-schema.json->mintYPreset->description
+#. 3.4->settings-schema.json->mintYPreset->tooltip
+msgid "Mint Y and Variants"
+msgstr "Mint Y och varianter"
+
+#. 3.8->settings-schema.json->mintXPreset->description
+#. 3.8->settings-schema.json->mintXPreset->tooltip
+#. 3.4->settings-schema.json->mintXPreset->description
+#. 3.4->settings-schema.json->mintXPreset->tooltip
+#, fuzzy
+msgid "Mint X, Linux Mint, and Variants"
+msgstr "Mint Y och varianter"
+
+#. 3.8->settings-schema.json->migrationButton->description
+msgid "Migrate Pinned Apps to Grouped Window List"
+msgstr ""
 
 #~ msgid "number"
 #~ msgstr "antal"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/sv.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IcingTaskManager@json\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-10 00:43-0600\n"
+"POT-Creation-Date: 2018-12-13 18:37-0600\n"
 "PO-Revision-Date: 2017-10-16 14:48-0500\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
@@ -18,53 +18,53 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: 3.8/applet.js:471
-msgid "Icing Task Manager is now Grouped Window List"
-msgstr ""
+#: 3.8/applet.js:476
+#, fuzzy
+msgid "Icing Task Manager is deprecated"
+msgstr "Icing Task Manager"
 
-#: 3.8/applet.js:472
+#: 3.8/applet.js:477
 msgid ""
-"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
-"Window List\". "
+"Please upgrade to Grouped Window List for a more stable, bug-free experience."
 msgstr ""
 
-#: 3.8/applet.js:473
+#: 3.8/applet.js:478
 msgid ""
-"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
-"List."
+"Add GWL to your panel, open the applet's settings and click \"Migrate Pinned "
+"Apps to Grouped Window List\"."
 msgstr ""
 
-#: 3.8/applet.js:485
-msgid "Migration can only be performed on Cinnamon 4.0."
+#: 3.8/applet.js:490
+msgid "Migration can only be performed on Cinnamon 4.0+."
 msgstr ""
 
-#: 3.8/applet.js:496
+#: 3.8/applet.js:501
 msgid ""
 "Please add Grouped Window List to a panel before proceeding with the "
 "migration."
 msgstr ""
 
-#: 3.8/applet.js:504
+#: 3.8/applet.js:509
 msgid "ITM settings directory could not be found!"
 msgstr ""
 
-#: 3.8/applet.js:534
+#: 3.8/applet.js:539
 msgid "System favorites enabled - no migration is needed."
 msgstr ""
 
-#: 3.8/applet.js:577
+#: 3.8/applet.js:582
 msgid "Unable to find a suitable ITM settings file to migrate."
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid "Migration complete. "
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid " settings file(s) could not be migrated."
 msgstr ""
 
-#: 3.8/applet.js:592
+#: 3.8/applet.js:597
 msgid "Migration was successful."
 msgstr ""
 
@@ -1206,6 +1206,10 @@ msgstr "Mint Y och varianter"
 #. 3.8->settings-schema.json->migrationButton->description
 msgid "Migrate Pinned Apps to Grouped Window List"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Icing Task Manager is deprecated - please use Grouped Window List"
+#~ msgstr "Icing Task Manager"
 
 #~ msgid "number"
 #~ msgstr "antal"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/tr.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/tr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-10 00:43-0600\n"
+"POT-Creation-Date: 2018-12-13 18:37-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Gökhan Gökkaya <gokhanlnx@gmail.com>\n"
 "Language-Team: Linux Mint Türkiye\n"
@@ -13,53 +13,53 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: 3.8/applet.js:471
-msgid "Icing Task Manager is now Grouped Window List"
-msgstr ""
+#: 3.8/applet.js:476
+#, fuzzy
+msgid "Icing Task Manager is deprecated"
+msgstr "Icing Görev Yöneticisi"
 
-#: 3.8/applet.js:472
+#: 3.8/applet.js:477
 msgid ""
-"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
-"Window List\". "
+"Please upgrade to Grouped Window List for a more stable, bug-free experience."
 msgstr ""
 
-#: 3.8/applet.js:473
+#: 3.8/applet.js:478
 msgid ""
-"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
-"List."
+"Add GWL to your panel, open the applet's settings and click \"Migrate Pinned "
+"Apps to Grouped Window List\"."
 msgstr ""
 
-#: 3.8/applet.js:485
-msgid "Migration can only be performed on Cinnamon 4.0."
+#: 3.8/applet.js:490
+msgid "Migration can only be performed on Cinnamon 4.0+."
 msgstr ""
 
-#: 3.8/applet.js:496
+#: 3.8/applet.js:501
 msgid ""
 "Please add Grouped Window List to a panel before proceeding with the "
 "migration."
 msgstr ""
 
-#: 3.8/applet.js:504
+#: 3.8/applet.js:509
 msgid "ITM settings directory could not be found!"
 msgstr ""
 
-#: 3.8/applet.js:534
+#: 3.8/applet.js:539
 msgid "System favorites enabled - no migration is needed."
 msgstr ""
 
-#: 3.8/applet.js:577
+#: 3.8/applet.js:582
 msgid "Unable to find a suitable ITM settings file to migrate."
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid "Migration complete. "
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid " settings file(s) could not be migrated."
 msgstr ""
 
-#: 3.8/applet.js:592
+#: 3.8/applet.js:597
 msgid "Migration was successful."
 msgstr ""
 
@@ -1230,6 +1230,10 @@ msgstr ""
 #. 3.8->settings-schema.json->migrationButton->description
 msgid "Migrate Pinned Apps to Grouped Window List"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Icing Task Manager is deprecated - please use Grouped Window List"
+#~ msgstr "Icing Görev Yöneticisi"
 
 #~ msgid "number"
 #~ msgstr "sayı"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/tr.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/tr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-23 21:32-0600\n"
+"POT-Creation-Date: 2018-12-10 00:43-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Gökhan Gökkaya <gokhanlnx@gmail.com>\n"
 "Language-Team: Linux Mint Türkiye\n"
@@ -13,566 +13,225 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/applet.js:471
+msgid "Icing Task Manager is now Grouped Window List"
+msgstr ""
+
+#: 3.8/applet.js:472
+msgid ""
+"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
+"Window List\". "
+msgstr ""
+
+#: 3.8/applet.js:473
+msgid ""
+"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
+"List."
+msgstr ""
+
+#: 3.8/applet.js:485
+msgid "Migration can only be performed on Cinnamon 4.0."
+msgstr ""
+
+#: 3.8/applet.js:496
+msgid ""
+"Please add Grouped Window List to a panel before proceeding with the "
+"migration."
+msgstr ""
+
+#: 3.8/applet.js:504
+msgid "ITM settings directory could not be found!"
+msgstr ""
+
+#: 3.8/applet.js:534
+msgid "System favorites enabled - no migration is needed."
+msgstr ""
+
+#: 3.8/applet.js:577
+msgid "Unable to find a suitable ITM settings file to migrate."
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid "Migration complete. "
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid " settings file(s) could not be migrated."
+msgstr ""
+
+#: 3.8/applet.js:592
+msgid "Migration was successful."
+msgstr ""
+
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 #, fuzzy
 msgid "Move to the other monitor"
 msgstr "Monitöre taşı"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 #, fuzzy
 msgid "Move to monitor "
 msgstr "Monitöre taşı"
 
-#: 3.4/specialMenus.js:126
+#: 3.8/specialMenus.js:98 3.4/specialMenus.js:126
 msgid "Only on this workspace"
 msgstr "Sadece bu çalışma alanında görünür"
 
-#: 3.4/specialMenus.js:133
+#: 3.8/specialMenus.js:105 3.4/specialMenus.js:133
 msgid "Visible on all workspaces"
 msgstr "Tüm çalışma alanlarında görünür"
 
-#: 3.4/specialMenus.js:140
+#: 3.8/specialMenus.js:112 3.4/specialMenus.js:140
 #, fuzzy
 msgid "Move to another workspace"
 msgstr "Soldaki çalışma alanına taşı"
 
-#: 3.4/specialMenus.js:168
+#: 3.8/specialMenus.js:140 3.4/specialMenus.js:168
 msgid "Places"
 msgstr ""
 
-#: 3.4/specialMenus.js:207
+#: 3.8/specialMenus.js:179 3.4/specialMenus.js:207
 msgid "Bookmarks/History requires gir1.2-gda-5.0"
 msgstr ""
 
-#: 3.4/specialMenus.js:227
+#: 3.8/specialMenus.js:199 3.4/specialMenus.js:227
 #, fuzzy
 msgid "Recent"
 msgstr "oran"
 
-#: 3.4/specialMenus.js:246
+#: 3.8/specialMenus.js:218 3.4/specialMenus.js:246
 msgid "Preferences"
 msgstr ""
 
-#: 3.4/specialMenus.js:249
+#: 3.8/specialMenus.js:221 3.4/specialMenus.js:249
 msgid "About..."
 msgstr "Hakkında..."
 
-#: 3.4/specialMenus.js:253
+#: 3.8/specialMenus.js:225 3.4/specialMenus.js:253
 msgid "Configure..."
 msgstr "Yapılandır..."
 
-#: 3.4/specialMenus.js:257
+#: 3.8/specialMenus.js:229 3.4/specialMenus.js:257
 msgid "Remove"
 msgstr ""
 
-#: 3.4/specialMenus.js:287
+#: 3.8/specialMenus.js:259 3.4/specialMenus.js:287
 #, fuzzy
 msgid "New Window"
 msgstr "Tüm uygulama pencerelerini dahil et"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Unpin from Panel"
 msgstr "Panelden Kaldır"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Pin to Panel"
 msgstr "Panele Sabitle"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Remove from Autostart"
 msgstr "Otomatik Başlatmadan Sil"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Add to Autostart"
 msgstr "Otomatik Başlatmaya Ekle"
 
-#: 3.4/specialMenus.js:318
+#: 3.8/specialMenus.js:290 3.4/specialMenus.js:318
 msgid "Create Shortcut"
 msgstr "Kısayol Oluştur"
 
-#: 3.4/specialMenus.js:329
+#: 3.8/specialMenus.js:301 3.4/specialMenus.js:329
 msgid "Restore to full opacity"
 msgstr ""
 
-#: 3.4/specialMenus.js:337
+#: 3.8/specialMenus.js:309 3.4/specialMenus.js:337
 msgid "Restore"
 msgstr "Geri yükle"
 
-#: 3.4/specialMenus.js:342
+#: 3.8/specialMenus.js:314 3.4/specialMenus.js:342
 msgid "Minimize"
 msgstr "Küçült"
 
-#: 3.4/specialMenus.js:350
+#: 3.8/specialMenus.js:322 3.4/specialMenus.js:350
 msgid "Unmaximize"
 msgstr "Tam ekrandan çık"
 
-#: 3.4/specialMenus.js:355
+#: 3.8/specialMenus.js:327 3.4/specialMenus.js:355
 msgid "Maximize"
 msgstr "Ekranı Kapla"
 
-#: 3.4/specialMenus.js:365
+#: 3.8/specialMenus.js:337 3.4/specialMenus.js:365
 msgid "Close others"
 msgstr ""
 
-#: 3.4/specialMenus.js:375
+#: 3.8/specialMenus.js:347 3.4/specialMenus.js:375
 #, fuzzy
 msgid "Close all"
 msgstr "Tümünü Kapat"
 
-#: 3.4/specialMenus.js:385
+#: 3.8/specialMenus.js:357 3.4/specialMenus.js:385
 msgid "Close"
 msgstr "Kapat"
 
-#. 2.8->settings-schema.json->thumbnail-size->description
-#. 3.4->settings-schema.json->thumbnail-size->description
-msgid "Thumbnail size"
-msgstr "Ön izleme boyutu"
+#. metadata.json->description
+msgid "Window list with app grouping and thumbnails"
+msgstr "Uygulama gruplama ve pencere ön izleme destekli pencere listesi"
 
-#. 2.8->settings-schema.json->thumbnail-size->tooltip
-#. 3.4->settings-schema.json->thumbnail-size->tooltip
-msgid "Controls the size of the thumbnails."
-msgstr "Ön izlemelerin boyutunu kontrol eder"
+#. metadata.json->name
+msgid "Icing Task Manager"
+msgstr "Icing Görev Yöneticisi"
 
-#. 2.8->settings-schema.json->thumbnail-size->units
-#. 3.4->settings-schema.json->thumbnail-size->units
-msgid "size"
-msgstr "boyut"
-
-#. 2.8->settings-schema.json->focusPseudoClass->description
-#. 3.4->settings-schema.json->focusPseudoClass->description
-msgid "App button focus pseudo class"
-msgstr "Uygulama düğmesi odaklama sahte sınıfı"
-
-#. 2.8->settings-schema.json->focusPseudoClass->tooltip
-#. 3.4->settings-schema.json->focusPseudoClass->tooltip
-msgid "Overrides the pseudo class for app button on focus."
-msgstr "Odaklamada uygulama düğmeleri için sahte sınıfı geçersiz kılar."
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "active"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "outlined"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "hover"
-msgstr ""
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-#, fuzzy
-msgid "focus"
-msgstr "Etkin"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "selected"
-msgstr ""
-
-#. 2.8->settings-schema.json->icon-spacing->description
-#. 3.4->settings-schema.json->icon-spacing->description
-msgid "Icon spacing"
-msgstr "Simge boşluğu"
-
-#. 2.8->settings-schema.json->icon-spacing->tooltip
-#. 3.4->settings-schema.json->icon-spacing->tooltip
-msgid "Controls how much space is between the icons."
-msgstr "Simgeler arasında ne kadar boşluk olacağını kontrol eder"
-
-#. 2.8->settings-schema.json->icon-spacing->units
-#. 2.8->settings-schema.json->icon-size->units
-#. 2.8->settings-schema.json->icon-padding->units
-#. 3.4->settings-schema.json->icon-spacing->units
-#. 3.4->settings-schema.json->thumbnail-padding->units
-#. 3.4->settings-schema.json->icon-size->units
-#. 3.4->settings-schema.json->app-button-width->units
-#. 3.4->settings-schema.json->thumbnail-close-button-size->units
-#. 3.4->settings-schema.json->icon-padding->units
-msgid "px"
-msgstr "px"
-
-#. 2.8->settings-schema.json->show-thumbnails->description
-#. 3.4->settings-schema.json->show-thumbnails->description
-msgid "Show thumbnails"
-msgstr "Ön izlemeleri göster"
-
-#. 2.8->settings-schema.json->show-thumbnails->tooltip
-#. 3.4->settings-schema.json->show-thumbnails->tooltip
-msgid "Show window thumbnails when hovering over an app button."
-msgstr "Bir uygulama düğmesinin üstüne gelince ön izleme göster."
-
-#. 2.8->settings-schema.json->icon-size->description
-#. 3.4->settings-schema.json->icon-size->description
-msgid "Icon size"
-msgstr "Simge boyutu"
-
-#. 2.8->settings-schema.json->icon-size->tooltip
-#. 3.4->settings-schema.json->icon-size->tooltip
-msgid "Set icon size"
-msgstr "Simge boyutunu ayarla"
-
-#. 2.8->settings-schema.json->hover-peek-time->description
-#. 3.4->settings-schema.json->hover-peek-time->description
-msgid "Window fade time"
-msgstr "Pencere solma süresi"
-
-#. 2.8->settings-schema.json->hover-peek-time->tooltip
-#. 3.4->settings-schema.json->hover-peek-time->tooltip
-msgid "Controls how quickly a window will fade on hover."
-msgstr "Üstüne geldiğinde bir pencerenin nasıl hızlı solacağını kontrol eder."
-
-#. 2.8->settings-schema.json->hover-peek-time->units
-#. 2.8->settings-schema.json->thumbnail-timeout->units
-#. 2.8->settings-schema.json->show-apps-order-timeout->units
-#. 3.4->settings-schema.json->hover-peek-time->units
-#. 3.4->settings-schema.json->thumbnail-timeout->units
-#. 3.4->settings-schema.json->show-apps-order-timeout->units
-msgid "milliseconds"
-msgstr "milisaniye"
-
-#. 2.8->settings-schema.json->close-button-style->description
-msgid "Allow themes to control the thumbnail close button"
-msgstr ""
-"Temaların ön izleme penceresi kapat düğmesini kontrol etmesine izin verir."
-
-#. 2.8->settings-schema.json->close-button-style->tooltip
-msgid ""
-"Controls whether or not the theme controls the window thumbnail's close "
-"button."
-msgstr ""
-"Temanın, ön izleme penceresindeki kapat düğmesini kontrol edip etmediğini "
-"belirler."
-
-#. 2.8->settings-schema.json->title-display->description
-#. 3.4->settings-schema.json->title-display->description
-msgid "Title display"
-msgstr "Başlık gösterimi"
-
-#. 2.8->settings-schema.json->title-display->tooltip
-#. 3.4->settings-schema.json->title-display->tooltip
-msgid ""
-"focused: show focused window title, title: display the window title, app: "
-"diplay app name, none: don't display anything"
-msgstr ""
-"etkin: etkin pencere başlığını göster, başlık: pencere başlığını göster, "
-"uygulama: uygulama adını göster, hiçbiri: hiç bir şey gösterme"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-#. 3.4->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->middle-click-action->options
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "None"
-msgstr "Hiçbiri"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Focused"
-msgstr "Etkin"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "App"
-msgstr "Uygulama"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Title"
-msgstr "Başlık"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->description
-#. 3.4->settings-schema.json->hoverPseudoClass->description
-msgid "App button hover pseudo class"
-msgstr "Uygulama düğmesi üstüne gelme sahte sınıfı"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
-#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons on hover."
-msgstr "Üstüne gelmede uygulama düğmeleri için sahte sınıfı geçersiz kılar."
-
-#. 2.8->settings-schema.json->show-alerts->description
-#. 3.4->settings-schema.json->show-alerts->description
-msgid "Show app alerts and notifications"
-msgstr "Uygulama uyarıları ve bildirimlerini göster"
-
-#. 2.8->settings-schema.json->show-alerts->tooltip
-#. 3.4->settings-schema.json->show-alerts->tooltip
-msgid "If enabled, notifications and alerts will appear."
-msgstr "Eğer etkinse, bildirimler ve uyarılar görünür."
-
-#. 2.8->settings-schema.json->pinOnDrag->description
-#. 2.8->settings-schema.json->pinOnDrag->tooltip
-#. 3.4->settings-schema.json->pinOnDrag->description
-#. 3.4->settings-schema.json->pinOnDrag->tooltip
-msgid "Pin apps when dragged to a new position"
-msgstr "Uygulamalar yeni bir konuma sürüklediğinde sabitle"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->description
-#. 3.4->settings-schema.json->show-apps-order-hotkey->description
-msgid "Global hotkey to show the order of apps"
-msgstr "Uygulamaların sırasını gösteren genel kısayol tuşu"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
-#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
-msgid ""
-"When triggered, the window count label will be replaced with its order in "
-"the app list temporarily."
-msgstr ""
-"Tetiklendiğinde, pencere sayısı etiketi uygulama listesindeki sırasıyla "
-"geçici olarak değiştirilir."
-
-#. 2.8->settings-schema.json->menuItemType->description
-#. 3.4->settings-schema.json->menuItemType->description
-msgid "Menu item type"
-msgstr "Menü öğesi türü"
-
-#. 2.8->settings-schema.json->menuItemType->tooltip
-#. 3.4->settings-schema.json->menuItemType->tooltip
-msgid ""
-"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
-msgstr ""
-"Menü öğesi simgelerinin sembolik, sembolik olmayan ya da gösterilip "
-"gösterilmediğini belirler."
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Symbolic icons"
-msgstr "Sembolik simgeler"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "No icons"
-msgstr "Simge yok"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Non-symbolic icons"
-msgstr "Sembolik olmayan simgeler"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->description
-#. 3.4->settings-schema.json->hover-peek-opacity->description
-msgid "Window opacity"
-msgstr "Pencere şeffaflığı"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
-#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
-msgid "Opacity of the windows on hover."
-msgstr "Üstüne gelince etkinleşen pencere şeffaflığı."
-
-#. 2.8->settings-schema.json->hover-peek-opacity->units
-#. 3.4->settings-schema.json->hover-peek-opacity->units
-msgid "percent"
-msgstr "oran"
-
-#. 2.8->settings-schema.json->enable-hover-peek->description
-#. 3.4->settings-schema.json->enable-hover-peek->description
-msgid "Show windows when hovered over"
-msgstr "Üstüne geldiğinde pencereleri göster"
-
-#. 2.8->settings-schema.json->enable-hover-peek->tooltip
-#. 3.4->settings-schema.json->enable-hover-peek->tooltip
-msgid "Controls whether or not windows display when hovered over."
-msgstr ""
-"Fare simge üstüne geldiğinde pencere ön izlemesinin görüntülenip "
-"görüntülenmeyeceğini kontrol eder."
-
-#. 2.8->settings-schema.json->activePseudoClass->description
-#. 3.4->settings-schema.json->activePseudoClass->description
-msgid "App button active pseudo class"
-msgstr "Uygulama düğmesi aktifleştirme sahte sınıfı"
-
-#. 2.8->settings-schema.json->activePseudoClass->tooltip
-#. 3.4->settings-schema.json->activePseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons when they are active."
-msgstr ""
-"Etkin olduklarında uygulama düğmeleri için sahte sınıfı geçersiz kılar."
-
-#. 2.8->settings-schema.json->animate-thumbnails->description
-#. 3.4->settings-schema.json->animate-thumbnails->description
-msgid "Animate thumbnails"
-msgstr "Ön izleme animasyonu"
-
-#. 2.8->settings-schema.json->animate-thumbnails->tooltip
-#. 3.4->settings-schema.json->animate-thumbnails->tooltip
-msgid "If enabled, thumbnails will animate when appearing and disappearing."
-msgstr "Eğer etkinse, ön izlemelerin görünüp gizlenmesi animasyon ile yapılır."
-
-#. 2.8->settings-schema.json->autostart-menu-item->description
-#. 3.4->settings-schema.json->autostart-menu-item->description
-msgid "Show autostart option"
-msgstr "Otomatik başlatma seçeneğini göster"
-
-#. 2.8->settings-schema.json->autostart-menu-item->tooltip
-#. 3.4->settings-schema.json->autostart-menu-item->tooltip
-msgid "Shows the autostart toggle option in an app's context menu."
-msgstr "Bu ayar içerik menüsünde Otomatik Başlatma seçeneğini gösterir."
-
-#. 2.8->settings-schema.json->show-pinned->description
-#. 3.4->settings-schema.json->show-pinned->description
-msgid "Show pinned apps"
-msgstr "Sabitlenen uygulamaları göster"
-
-#. 2.8->settings-schema.json->show-pinned->tooltip
-#. 3.4->settings-schema.json->show-pinned->tooltip
-msgid ""
-"Controls whether or not the pinned apps appear in the panel if they are not "
-"open."
-msgstr ""
-"Sabitlenen uygulamaların açık olmadığı halde panelde görünüp görünmeyeceğini "
-"kontrol eder."
-
-#. 2.8->settings-schema.json->useSystemTooltips->description
-msgid "Use system tooltips for closed apps"
-msgstr "Kapalı uygulamalar için sistem araç ipuçlarını kullan"
-
-#. 2.8->settings-schema.json->useSystemTooltips->tooltip
-msgid ""
-"Controls whether or not system tooltips are in use when hovering over closed "
-"pinned apps."
-msgstr ""
-"Kapalı olan sabit uygulamaların üzerine gelindiğinde sistem araç ipuçlarının "
-"kullanılıp kullanılmayacağını kontrol eder."
+#. 2.8->settings-schema.json->ITM->description
+msgid "ITM Settings"
+msgstr "IGY Ayarları"
 
 #. 2.8->settings-schema.json->WindowList->description
 msgid "Window List Settings"
 msgstr "Pencere Listesi Ayarları"
 
-#. 2.8->settings-schema.json->AppMenu->description
-msgid "Context Menu Settings"
-msgstr "İçerik Menüsü Ayarları"
-
-#. 2.8->settings-schema.json->Thumbnails->description
-msgid "Thumbnail Settings"
-msgstr "Ön İzleme Ayarları"
-
-#. 2.8->settings-schema.json->show-recent->description
-#. 3.4->settings-schema.json->show-recent->description
-msgid "Show recent items"
-msgstr "Son kullanılan öğeleri göster"
-
-#. 2.8->settings-schema.json->show-recent->tooltip
-#. 3.4->settings-schema.json->show-recent->tooltip
-msgid "Controls whether recent items will appear in the context menu."
-msgstr ""
-"Son kullanılan öğelerin içerik menüsünde görünüp görünmeyeceğini kontrol "
-"eder."
-
-#. 2.8->settings-schema.json->vertical-thumbnails->description
-#. 3.4->settings-schema.json->vertical-thumbnails->description
-msgid "Enable vertical thumbnails"
-msgstr "Dikey ön izleme etkin"
-
-#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
-#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
-msgid "If enabled, thumbnails will stack vertically."
-msgstr "Eğer etkinleştirilirse, ön izlemeler dikey olarak yerleştirilir."
-
-#. 2.8->settings-schema.json->thumbnail-timeout->description
-#. 3.4->settings-schema.json->thumbnail-timeout->description
-msgid "Thumbnail timeout"
-msgstr "Ön izleme gösterim süresi"
-
-#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
-#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
-msgid ""
-"Controls how quickly an app's set of window thumbnails will fade out when "
-"the mouse leaves the app button."
-msgstr ""
-"Fare bir uygulama düğmesi üstünden ayrıldığında, uygulama pencere ön "
-"izlemesinin ne kadar hızlı solacağı ayarını kontrol eder."
-
-#. 2.8->settings-schema.json->ThemeSettings->description
-msgid "Theme Settings"
-msgstr "Tema Ayarları"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->description
-#. 3.4->settings-schema.json->onclick-thumbnails->description
-msgid "Open thumbnails on click"
-msgstr "Ön izlemeyi tıklayınca aç"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
-#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
-msgid "Open the thumbnails on click if there is more than one window open."
-msgstr "Eğer birden fazla pencere açıksa, ön izlemeyi tıklayınca göster."
-
-#. 2.8->settings-schema.json->panelLauncherClass->description
-msgid "Use the panel launcher class for pinned apps"
-msgstr "Sabitlenmiş uygulamalar için panel başlatıcısı sınıfını kullan"
-
-#. 2.8->settings-schema.json->panelLauncherClass->tooltip
-msgid "Enabling this helps with certain themes."
-msgstr "Bunu etkinleştirmek bazı temalarda yardımcı olur."
-
-#. 2.8->settings-schema.json->include-all-windows->description
-#. 3.4->settings-schema.json->include-all-windows->description
-msgid "Include all app windows"
-msgstr "Tüm uygulama pencerelerini dahil et"
-
-#. 2.8->settings-schema.json->include-all-windows->tooltip
-#. 3.4->settings-schema.json->include-all-windows->tooltip
-msgid ""
-"Controls whether or not thumbnails for smalller child windows, such as exit "
-"confirmations and file dialogues will be included in the thumbnail list."
-msgstr ""
-"Çıkış onayları ve dosya diyalogları gibi daha küçük alt pencerelerin ön "
-"izleme listesine eklenip eklenmeyeceğini denetler."
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->description
-#. 3.4->settings-schema.json->cycleMenusHotkey->description
-msgid "Global hotkey for cycling through thumbnail menus"
-msgstr "Ön izleme menülerinin döngü geçişi için genel kısayol tuşu"
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
-#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
-msgid "This allows you to cycle through the menus without activating a window."
-msgstr ""
-"Bu, bir pencereyi etkinleştirmeden menüler arasında gezinmenizi sağlar."
-
-#. 2.8->settings-schema.json->enable-iconSize->description
-#. 3.4->settings-schema.json->enable-iconSize->description
-msgid "Adjust icon size"
-msgstr "Simge boyutunu ayarla"
-
-#. 2.8->settings-schema.json->enable-iconSize->tooltip
-#. 3.4->settings-schema.json->enable-iconSize->tooltip
-msgid "Adjust icon size independent of Cinnamon's panel scaling."
-msgstr ""
-"Cinnamon'un panel ölçeklemesinden bağımsız olarak simge boyutunu ayarlar."
-
 #. 2.8->settings-schema.json->number-display->description
+#. 3.8->settings-schema.json->number-display->description
 #. 3.4->settings-schema.json->number-display->description
 msgid "Number display"
 msgstr "Sayıyı göster"
 
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Smart"
+msgstr "Akıllı"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Normal"
+msgstr "Normal"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "None"
+msgstr "Hiçbiri"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "All"
+msgstr "Tümü"
+
 #. 2.8->settings-schema.json->number-display->tooltip
+#. 3.8->settings-schema.json->number-display->tooltip
 #. 3.4->settings-schema.json->number-display->tooltip
 msgid ""
 "normal: display window number, smart: display window number if more than one "
@@ -583,42 +242,96 @@ msgstr ""
 "sayı gösterilir, hiçbiri: sayı gösterilmez, tümü: favorilerde dahil edilerek "
 "pencere sayıları gösterilir"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "All"
-msgstr "Tümü"
+#. 2.8->settings-schema.json->title-display->description
+#. 3.8->settings-schema.json->title-display->description
+#. 3.4->settings-schema.json->title-display->description
+msgid "Title display"
+msgstr "Başlık gösterimi"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Smart"
-msgstr "Akıllı"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "App"
+msgstr "Uygulama"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Normal"
-msgstr "Normal"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Title"
+msgstr "Başlık"
 
-#. 2.8->settings-schema.json->ITM->description
-msgid "ITM Settings"
-msgstr "IGY Ayarları"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Focused"
+msgstr "Etkin"
 
-#. 2.8->settings-schema.json->HoverPeek->description
-msgid "Hover Peek Settings"
-msgstr "Üstüne Gelme Ayarları"
-
-#. 2.8->settings-schema.json->icon-padding->description
-#. 3.4->settings-schema.json->icon-padding->description
-msgid "Icon padding"
-msgstr "Simge Dolgusu"
-
-#. 2.8->settings-schema.json->icon-padding->tooltip
-#. 3.4->settings-schema.json->icon-padding->tooltip
+#. 2.8->settings-schema.json->title-display->tooltip
+#. 3.8->settings-schema.json->title-display->tooltip
+#. 3.4->settings-schema.json->title-display->tooltip
 msgid ""
-"Controls how much horizontal padding is inside the app buttons. Padding is "
-"only applied to instances of this applet on horizontal panels."
+"focused: show focused window title, title: display the window title, app: "
+"diplay app name, none: don't display anything"
 msgstr ""
-"Uygulama düğmeleri içinde ne kadar yatay dolgu olacağını kontrol eder. Dolgu "
-"sadece bu uygulamanın yatay panellerdeki örneklerine uygulanır."
+"etkin: etkin pencere başlığını göster, başlık: pencere başlığını göster, "
+"uygulama: uygulama adını göster, hiçbiri: hiç bir şey gösterme"
+
+#. 2.8->settings-schema.json->group-apps->description
+#. 3.8->settings-schema.json->group-apps->description
+#. 3.4->settings-schema.json->group-apps->description
+msgid "Group apps"
+msgstr "Uygulamaları gruplandır"
+
+#. 2.8->settings-schema.json->group-apps->tooltip
+#. 3.8->settings-schema.json->group-apps->tooltip
+#. 3.4->settings-schema.json->group-apps->tooltip
+msgid "Group each app's set of windows."
+msgstr "Her uygulamanın pencere kümesini gruplandır."
+
+#. 2.8->settings-schema.json->show-alerts->description
+#. 3.8->settings-schema.json->show-alerts->description
+#. 3.4->settings-schema.json->show-alerts->description
+msgid "Show app alerts and notifications"
+msgstr "Uygulama uyarıları ve bildirimlerini göster"
+
+#. 2.8->settings-schema.json->show-alerts->tooltip
+#. 3.8->settings-schema.json->show-alerts->tooltip
+#. 3.4->settings-schema.json->show-alerts->tooltip
+msgid "If enabled, notifications and alerts will appear."
+msgstr "Eğer etkinse, bildirimler ve uyarılar görünür."
+
+#. 2.8->settings-schema.json->show-pinned->description
+#. 3.8->settings-schema.json->show-pinned->description
+#. 3.4->settings-schema.json->show-pinned->description
+msgid "Show pinned apps"
+msgstr "Sabitlenen uygulamaları göster"
+
+#. 2.8->settings-schema.json->show-pinned->tooltip
+#. 3.8->settings-schema.json->show-pinned->tooltip
+#. 3.4->settings-schema.json->show-pinned->tooltip
+msgid ""
+"Controls whether or not the pinned apps appear in the panel if they are not "
+"open."
+msgstr ""
+"Sabitlenen uygulamaların açık olmadığı halde panelde görünüp görünmeyeceğini "
+"kontrol eder."
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->description
+msgid "Arrange pinned apps"
+msgstr "Sabitlenmiş uygulamaları sırala"
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
+msgid "Arrange pinned apps into a different order."
+msgstr "Sabitlenmiş uygulamaların farklı sıraya alınabilmesini sağlar."
+
+#. 2.8->settings-schema.json->pinOnDrag->description
+#. 2.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.8->settings-schema.json->pinOnDrag->description
+#. 3.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.4->settings-schema.json->pinOnDrag->description
+#. 3.4->settings-schema.json->pinOnDrag->tooltip
+msgid "Pin apps when dragged to a new position"
+msgstr "Uygulamalar yeni bir konuma sürüklediğinde sabitle"
 
 #. 2.8->settings-schema.json->middle-click-action->description
 msgid "Middle clicking app buttons creates new app instances"
@@ -634,12 +347,258 @@ msgstr ""
 "yanlış ayarlandığında, orta tıklama ile uygulama grubundaki son etkinleşen "
 "pencere kapanır."
 
+#. 2.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.4->settings-schema.json->cycleMenusHotkey->description
+msgid "Global hotkey for cycling through thumbnail menus"
+msgstr "Ön izleme menülerinin döngü geçişi için genel kısayol tuşu"
+
+#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
+msgid "This allows you to cycle through the menus without activating a window."
+msgstr ""
+"Bu, bir pencereyi etkinleştirmeden menüler arasında gezinmenizi sağlar."
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.4->settings-schema.json->show-apps-order-hotkey->description
+msgid "Global hotkey to show the order of apps"
+msgstr "Uygulamaların sırasını gösteren genel kısayol tuşu"
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
+msgid ""
+"When triggered, the window count label will be replaced with its order in "
+"the app list temporarily."
+msgstr ""
+"Tetiklendiğinde, pencere sayısı etiketi uygulama listesindeki sırasıyla "
+"geçici olarak değiştirilir."
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->units
+#. 2.8->settings-schema.json->thumbnail-timeout->units
+#. 2.8->settings-schema.json->hover-peek-time->units
+#. 3.8->settings-schema.json->show-apps-order-timeout->units
+#. 3.8->settings-schema.json->thumbnail-timeout->units
+#. 3.8->settings-schema.json->hover-peek-time->units
+#. 3.4->settings-schema.json->show-apps-order-timeout->units
+#. 3.4->settings-schema.json->thumbnail-timeout->units
+#. 3.4->settings-schema.json->hover-peek-time->units
+msgid "milliseconds"
+msgstr "milisaniye"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.4->settings-schema.json->show-apps-order-timeout->description
+msgid "Duration of the apps order display on hotkey press"
+msgstr "Kısayol tuşuna basıldığında uygulama sırası gösterim süresi"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
+msgid ""
+"Determines the duration the window count labels are replaced with the app's "
+"order number."
+msgstr ""
+"Pencere sayısı etiketlerinin uygulamanın sıra numarası ile değiştirilmesi "
+"süresini belirler."
+
+#. 2.8->settings-schema.json->Thumbnails->description
+msgid "Thumbnail Settings"
+msgstr "Ön İzleme Ayarları"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->description
+#. 3.8->settings-schema.json->thumbnail-timeout->description
+#. 3.4->settings-schema.json->thumbnail-timeout->description
+msgid "Thumbnail timeout"
+msgstr "Ön izleme gösterim süresi"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
+msgid ""
+"Controls how quickly an app's set of window thumbnails will fade out when "
+"the mouse leaves the app button."
+msgstr ""
+"Fare bir uygulama düğmesi üstünden ayrıldığında, uygulama pencere ön "
+"izlemesinin ne kadar hızlı solacağı ayarını kontrol eder."
+
+#. 2.8->settings-schema.json->thumbnail-size->units
+#. 3.8->settings-schema.json->thumbnail-size->units
+#. 3.4->settings-schema.json->thumbnail-size->units
+msgid "size"
+msgstr "boyut"
+
+#. 2.8->settings-schema.json->thumbnail-size->description
+#. 3.8->settings-schema.json->thumbnail-size->description
+#. 3.4->settings-schema.json->thumbnail-size->description
+msgid "Thumbnail size"
+msgstr "Ön izleme boyutu"
+
+#. 2.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-size->tooltip
+msgid "Controls the size of the thumbnails."
+msgstr "Ön izlemelerin boyutunu kontrol eder"
+
+#. 2.8->settings-schema.json->show-thumbnails->description
+#. 3.8->settings-schema.json->show-thumbnails->description
+#. 3.4->settings-schema.json->show-thumbnails->description
+msgid "Show thumbnails"
+msgstr "Ön izlemeleri göster"
+
+#. 2.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.4->settings-schema.json->show-thumbnails->tooltip
+msgid "Show window thumbnails when hovering over an app button."
+msgstr "Bir uygulama düğmesinin üstüne gelince ön izleme göster."
+
+#. 2.8->settings-schema.json->animate-thumbnails->description
+#. 3.8->settings-schema.json->animate-thumbnails->description
+#. 3.4->settings-schema.json->animate-thumbnails->description
+msgid "Animate thumbnails"
+msgstr "Ön izleme animasyonu"
+
+#. 2.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.4->settings-schema.json->animate-thumbnails->tooltip
+msgid "If enabled, thumbnails will animate when appearing and disappearing."
+msgstr "Eğer etkinse, ön izlemelerin görünüp gizlenmesi animasyon ile yapılır."
+
+#. 2.8->settings-schema.json->vertical-thumbnails->description
+#. 3.8->settings-schema.json->vertical-thumbnails->description
+#. 3.4->settings-schema.json->vertical-thumbnails->description
+msgid "Enable vertical thumbnails"
+msgstr "Dikey ön izleme etkin"
+
+#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
+msgid "If enabled, thumbnails will stack vertically."
+msgstr "Eğer etkinleştirilirse, ön izlemeler dikey olarak yerleştirilir."
+
+#. 2.8->settings-schema.json->sort-thumbnails->description
+#. 3.8->settings-schema.json->sort-thumbnails->description
+#. 3.4->settings-schema.json->sort-thumbnails->description
+msgid "Sort windows for each app by last focused"
+msgstr "Her uygulamanın pencerelerini son etkinleştirilene göre sırala"
+
+#. 2.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.4->settings-schema.json->sort-thumbnails->tooltip
+msgid ""
+"Controls whether the order windows appear for an app is by last focused, or "
+"the order they were opened."
+msgstr ""
+"Her uygulama için, pencere gösterimlerinin son etkinleştirilene göre "
+"sıralanmalarını ya da açılış sıralarına göre dizilmelerini kontrol eder."
+
+#. 2.8->settings-schema.json->onclick-thumbnails->description
+#. 3.8->settings-schema.json->onclick-thumbnails->description
+#. 3.4->settings-schema.json->onclick-thumbnails->description
+msgid "Open thumbnails on click"
+msgstr "Ön izlemeyi tıklayınca aç"
+
+#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
+msgid "Open the thumbnails on click if there is more than one window open."
+msgstr "Eğer birden fazla pencere açıksa, ön izlemeyi tıklayınca göster."
+
+#. 2.8->settings-schema.json->include-all-windows->description
+#. 3.8->settings-schema.json->include-all-windows->description
+#. 3.4->settings-schema.json->include-all-windows->description
+msgid "Include all app windows"
+msgstr "Tüm uygulama pencerelerini dahil et"
+
+#. 2.8->settings-schema.json->include-all-windows->tooltip
+#. 3.8->settings-schema.json->include-all-windows->tooltip
+#. 3.4->settings-schema.json->include-all-windows->tooltip
+msgid ""
+"Controls whether or not thumbnails for smalller child windows, such as exit "
+"confirmations and file dialogues will be included in the thumbnail list."
+msgstr ""
+"Çıkış onayları ve dosya diyalogları gibi daha küçük alt pencerelerin ön "
+"izleme listesine eklenip eklenmeyeceğini denetler."
+
+#. 2.8->settings-schema.json->AppMenu->description
+msgid "Context Menu Settings"
+msgstr "İçerik Menüsü Ayarları"
+
+#. 2.8->settings-schema.json->show-recent->description
+#. 3.8->settings-schema.json->show-recent->description
+#. 3.4->settings-schema.json->show-recent->description
+msgid "Show recent items"
+msgstr "Son kullanılan öğeleri göster"
+
+#. 2.8->settings-schema.json->show-recent->tooltip
+#. 3.8->settings-schema.json->show-recent->tooltip
+#. 3.4->settings-schema.json->show-recent->tooltip
+msgid "Controls whether recent items will appear in the context menu."
+msgstr ""
+"Son kullanılan öğelerin içerik menüsünde görünüp görünmeyeceğini kontrol "
+"eder."
+
+#. 2.8->settings-schema.json->menuItemType->description
+#. 3.8->settings-schema.json->menuItemType->description
+#. 3.4->settings-schema.json->menuItemType->description
+msgid "Menu item type"
+msgstr "Menü öğesi türü"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Symbolic icons"
+msgstr "Sembolik simgeler"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Non-symbolic icons"
+msgstr "Sembolik olmayan simgeler"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "No icons"
+msgstr "Simge yok"
+
+#. 2.8->settings-schema.json->menuItemType->tooltip
+#. 3.8->settings-schema.json->menuItemType->tooltip
+#. 3.4->settings-schema.json->menuItemType->tooltip
+msgid ""
+"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
+msgstr ""
+"Menü öğesi simgelerinin sembolik, sembolik olmayan ya da gösterilip "
+"gösterilmediğini belirler."
+
 #. 2.8->settings-schema.json->firefox-menu->description
+#. 3.8->settings-schema.json->firefox-menu->description
 #. 3.4->settings-schema.json->firefox-menu->description
 msgid "Firefox context menu"
 msgstr "Firefox içerik menüsü"
 
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Most Visited"
+msgstr "En Çok Ziyaret Edilenler"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Recent History"
+msgstr "Son Kullanılanlar Geçmişi"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Bookmarks"
+msgstr "Sık Kullanılanlar"
+
 #. 2.8->settings-schema.json->firefox-menu->tooltip
+#. 3.8->settings-schema.json->firefox-menu->tooltip
 #. 3.4->settings-schema.json->firefox-menu->tooltip
 msgid ""
 "Most Visited: show the sites you visit most, Recent History: display the the "
@@ -649,20 +608,144 @@ msgstr ""
 "Kullanılanlar Geçmişi: son ziyaret ettiğin sayfalar gösterilir, Sık "
 "Kullanılanlar: beğeni olarak sık kullanılanlara ekledikleriniz gösterilir."
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Bookmarks"
-msgstr "Sık Kullanılanlar"
+#. 2.8->settings-schema.json->autostart-menu-item->description
+#. 3.8->settings-schema.json->autostart-menu-item->description
+#. 3.4->settings-schema.json->autostart-menu-item->description
+msgid "Show autostart option"
+msgstr "Otomatik başlatma seçeneğini göster"
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Most Visited"
-msgstr "En Çok Ziyaret Edilenler"
+#. 2.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.4->settings-schema.json->autostart-menu-item->tooltip
+msgid "Shows the autostart toggle option in an app's context menu."
+msgstr "Bu ayar içerik menüsünde Otomatik Başlatma seçeneğini gösterir."
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Recent History"
-msgstr "Son Kullanılanlar Geçmişi"
+#. 2.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.4->settings-schema.json->monitor-move-all-windows->description
+msgid "Apply the monitor move option to all windows"
+msgstr "Monitör taşıma seçeneğini tüm pencerelere uygulayın"
+
+#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
+msgid ""
+"When clicking \"Move to monitor\" in the context menu, this option will move "
+"all of an app's windows instead of just the last focused window from the app."
+msgstr ""
+"Bu seçenek içerik menüsündeki \"Monitöre taşı\" seçeneğine tıklandığında, "
+"uygulamanın son etkinleşen penceresi yerine uygulamanın tüm pencerelerini "
+"taşır."
+
+#. 2.8->settings-schema.json->HoverPeek->description
+msgid "Hover Peek Settings"
+msgstr "Üstüne Gelme Ayarları"
+
+#. 2.8->settings-schema.json->enable-hover-peek->description
+#. 3.8->settings-schema.json->enable-hover-peek->description
+#. 3.4->settings-schema.json->enable-hover-peek->description
+msgid "Show windows when hovered over"
+msgstr "Üstüne geldiğinde pencereleri göster"
+
+#. 2.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.4->settings-schema.json->enable-hover-peek->tooltip
+msgid "Controls whether or not windows display when hovered over."
+msgstr ""
+"Fare simge üstüne geldiğinde pencere ön izlemesinin görüntülenip "
+"görüntülenmeyeceğini kontrol eder."
+
+#. 2.8->settings-schema.json->hover-peek-time->description
+#. 3.8->settings-schema.json->hover-peek-time->description
+#. 3.4->settings-schema.json->hover-peek-time->description
+msgid "Window fade time"
+msgstr "Pencere solma süresi"
+
+#. 2.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.4->settings-schema.json->hover-peek-time->tooltip
+msgid "Controls how quickly a window will fade on hover."
+msgstr "Üstüne geldiğinde bir pencerenin nasıl hızlı solacağını kontrol eder."
+
+#. 2.8->settings-schema.json->hover-peek-opacity->units
+#. 3.8->settings-schema.json->hover-peek-opacity->units
+#. 3.4->settings-schema.json->hover-peek-opacity->units
+msgid "percent"
+msgstr "oran"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->description
+#. 3.8->settings-schema.json->hover-peek-opacity->description
+#. 3.4->settings-schema.json->hover-peek-opacity->description
+msgid "Window opacity"
+msgstr "Pencere şeffaflığı"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
+msgid "Opacity of the windows on hover."
+msgstr "Üstüne gelince etkinleşen pencere şeffaflığı."
+
+#. 2.8->settings-schema.json->ThemeSettings->description
+msgid "Theme Settings"
+msgstr "Tema Ayarları"
+
+#. 2.8->settings-schema.json->show-active->description
+#. 3.8->settings-schema.json->show-active->description
+#. 3.4->settings-schema.json->show-active->description
+msgid "Show active app indicators"
+msgstr "Etkin uygulamaları işaret ile göster"
+
+#. 2.8->settings-schema.json->show-active->tooltip
+#. 3.8->settings-schema.json->show-active->tooltip
+#. 3.4->settings-schema.json->show-active->tooltip
+msgid "Active app styling will indicate if an app is active."
+msgstr "Eğer bir uygulama etkinse, bir işaret ile gösterilecektir."
+
+#. 2.8->settings-schema.json->icon-spacing->units
+#. 2.8->settings-schema.json->icon-padding->units
+#. 2.8->settings-schema.json->icon-size->units
+#. 3.8->settings-schema.json->app-button-width->units
+#. 3.8->settings-schema.json->thumbnail-close-button-size->units
+#. 3.8->settings-schema.json->thumbnail-padding->units
+#. 3.8->settings-schema.json->icon-spacing->units
+#. 3.8->settings-schema.json->icon-padding->units
+#. 3.8->settings-schema.json->icon-size->units
+#. 3.4->settings-schema.json->app-button-width->units
+#. 3.4->settings-schema.json->thumbnail-close-button-size->units
+#. 3.4->settings-schema.json->thumbnail-padding->units
+#. 3.4->settings-schema.json->icon-spacing->units
+#. 3.4->settings-schema.json->icon-padding->units
+#. 3.4->settings-schema.json->icon-size->units
+msgid "px"
+msgstr "px"
+
+#. 2.8->settings-schema.json->icon-spacing->description
+#. 3.8->settings-schema.json->icon-spacing->description
+#. 3.4->settings-schema.json->icon-spacing->description
+msgid "Icon spacing"
+msgstr "Simge boşluğu"
+
+#. 2.8->settings-schema.json->icon-spacing->tooltip
+#. 3.8->settings-schema.json->icon-spacing->tooltip
+#. 3.4->settings-schema.json->icon-spacing->tooltip
+msgid "Controls how much space is between the icons."
+msgstr "Simgeler arasında ne kadar boşluk olacağını kontrol eder"
+
+#. 2.8->settings-schema.json->icon-padding->description
+#. 3.8->settings-schema.json->icon-padding->description
+#. 3.4->settings-schema.json->icon-padding->description
+msgid "Icon padding"
+msgstr "Simge Dolgusu"
+
+#. 2.8->settings-schema.json->icon-padding->tooltip
+#. 3.8->settings-schema.json->icon-padding->tooltip
+#. 3.4->settings-schema.json->icon-padding->tooltip
+msgid ""
+"Controls how much horizontal padding is inside the app buttons. Padding is "
+"only applied to instances of this applet on horizontal panels."
+msgstr ""
+"Uygulama düğmeleri içinde ne kadar yatay dolgu olacağını kontrol eder. Dolgu "
+"sadece bu uygulamanın yatay panellerdeki örneklerine uygulanır."
 
 #. 2.8->settings-schema.json->themePadding->description
 msgid "Use theme padding to center button icons"
@@ -673,121 +756,292 @@ msgid "If button icons look off-centered, toggling this may help."
 msgstr ""
 "Eğer düğme simgeleri ortalanmış görünmüyorsa, buna geçmek yardımcı olabilir."
 
-#. 2.8->settings-schema.json->group-apps->description
-#. 3.4->settings-schema.json->group-apps->description
-msgid "Group apps"
-msgstr "Uygulamaları gruplandır"
+#. 2.8->settings-schema.json->enable-iconSize->description
+#. 3.8->settings-schema.json->enable-iconSize->description
+#. 3.4->settings-schema.json->enable-iconSize->description
+msgid "Adjust icon size"
+msgstr "Simge boyutunu ayarla"
 
-#. 2.8->settings-schema.json->group-apps->tooltip
-#. 3.4->settings-schema.json->group-apps->tooltip
-msgid "Group each app's set of windows."
-msgstr "Her uygulamanın pencere kümesini gruplandır."
-
-#. 2.8->settings-schema.json->show-active->description
-#. 3.4->settings-schema.json->show-active->description
-msgid "Show active app indicators"
-msgstr "Etkin uygulamaları işaret ile göster"
-
-#. 2.8->settings-schema.json->show-active->tooltip
-#. 3.4->settings-schema.json->show-active->tooltip
-msgid "Active app styling will indicate if an app is active."
-msgstr "Eğer bir uygulama etkinse, bir işaret ile gösterilecektir."
-
-#. 2.8->settings-schema.json->show-apps-order-timeout->description
-#. 3.4->settings-schema.json->show-apps-order-timeout->description
-msgid "Duration of the apps order display on hotkey press"
-msgstr "Kısayol tuşuna basıldığında uygulama sırası gösterim süresi"
-
-#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
-#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
-msgid ""
-"Determines the duration the window count labels are replaced with the app's "
-"order number."
+#. 2.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.4->settings-schema.json->enable-iconSize->tooltip
+msgid "Adjust icon size independent of Cinnamon's panel scaling."
 msgstr ""
-"Pencere sayısı etiketlerinin uygulamanın sıra numarası ile değiştirilmesi "
-"süresini belirler."
+"Cinnamon'un panel ölçeklemesinden bağımsız olarak simge boyutunu ayarlar."
 
-#. 2.8->settings-schema.json->arrange-pinnedApps->description
-msgid "Arrange pinned apps"
-msgstr "Sabitlenmiş uygulamaları sırala"
+#. 2.8->settings-schema.json->icon-size->description
+#. 3.8->settings-schema.json->icon-size->description
+#. 3.4->settings-schema.json->icon-size->description
+msgid "Icon size"
+msgstr "Simge boyutu"
 
-#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
-msgid "Arrange pinned apps into a different order."
-msgstr "Sabitlenmiş uygulamaların farklı sıraya alınabilmesini sağlar."
+#. 2.8->settings-schema.json->icon-size->tooltip
+#. 3.8->settings-schema.json->icon-size->tooltip
+#. 3.4->settings-schema.json->icon-size->tooltip
+msgid "Set icon size"
+msgstr "Simge boyutunu ayarla"
 
-#. 2.8->settings-schema.json->monitor-move-all-windows->description
-#. 3.4->settings-schema.json->monitor-move-all-windows->description
-msgid "Apply the monitor move option to all windows"
-msgstr "Monitör taşıma seçeneğini tüm pencerelere uygulayın"
+#. 2.8->settings-schema.json->hoverPseudoClass->description
+#. 3.8->settings-schema.json->hoverPseudoClass->description
+#. 3.4->settings-schema.json->hoverPseudoClass->description
+msgid "App button hover pseudo class"
+msgstr "Uygulama düğmesi üstüne gelme sahte sınıfı"
 
-#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
-#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
-msgid ""
-"When clicking \"Move to monitor\" in the context menu, this option will move "
-"all of an app's windows instead of just the last focused window from the app."
-msgstr ""
-"Bu seçenek içerik menüsündeki \"Monitöre taşı\" seçeneğine tıklandığında, "
-"uygulamanın son etkinleşen penceresi yerine uygulamanın tüm pencerelerini "
-"taşır."
-
-#. 2.8->settings-schema.json->sort-thumbnails->description
-#. 3.4->settings-schema.json->sort-thumbnails->description
-msgid "Sort windows for each app by last focused"
-msgstr "Her uygulamanın pencerelerini son etkinleştirilene göre sırala"
-
-#. 2.8->settings-schema.json->sort-thumbnails->tooltip
-#. 3.4->settings-schema.json->sort-thumbnails->tooltip
-msgid ""
-"Controls whether the order windows appear for an app is by last focused, or "
-"the order they were opened."
-msgstr ""
-"Her uygulama için, pencere gösterimlerinin son etkinleştirilene göre "
-"sıralanmalarını ya da açılış sıralarına göre dizilmelerini kontrol eder."
-
-#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
 #. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
 #. 3.4->settings-schema.json->activePseudoClass->options
-msgid "checked"
+msgid "hover"
 msgstr ""
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
-msgid "Highlight the last focused window within an app group"
-msgstr ""
-
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
-msgid ""
-"When enabled, the last window that was interacted with will be indicated."
-msgstr ""
-
-#. 3.4->settings-schema.json->app-button-transition-duration->description
-msgid "App button transition duration"
-msgstr ""
-
-#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
-msgid ""
-"Overrides the theme's animation time for app buttons. If set to zero, the "
-"theme's transition duration will be used."
-msgstr ""
-
-#. 3.4->settings-schema.json->app-button-transition-duration->units
-msgid "ms"
-msgstr ""
-
-#. 3.4->settings-schema.json->thumbnail-padding->description
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
 #, fuzzy
-msgid "Thumbnail padding"
-msgstr "Ön İzleme Ayarları"
+msgid "focus"
+msgstr "Etkin"
 
-#. 3.4->settings-schema.json->thumbnail-padding->tooltip
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "active"
+msgstr ""
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "outlined"
+msgstr ""
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "selected"
+msgstr ""
+
+#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons on hover."
+msgstr "Üstüne gelmede uygulama düğmeleri için sahte sınıfı geçersiz kılar."
+
+#. 2.8->settings-schema.json->focusPseudoClass->description
+#. 3.8->settings-schema.json->focusPseudoClass->description
+#. 3.4->settings-schema.json->focusPseudoClass->description
+msgid "App button focus pseudo class"
+msgstr "Uygulama düğmesi odaklama sahte sınıfı"
+
+#. 2.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.4->settings-schema.json->focusPseudoClass->tooltip
+msgid "Overrides the pseudo class for app button on focus."
+msgstr "Odaklamada uygulama düğmeleri için sahte sınıfı geçersiz kılar."
+
+#. 2.8->settings-schema.json->activePseudoClass->description
+#. 3.8->settings-schema.json->activePseudoClass->description
+#. 3.4->settings-schema.json->activePseudoClass->description
+msgid "App button active pseudo class"
+msgstr "Uygulama düğmesi aktifleştirme sahte sınıfı"
+
+#. 2.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.4->settings-schema.json->activePseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons when they are active."
+msgstr ""
+"Etkin olduklarında uygulama düğmeleri için sahte sınıfı geçersiz kılar."
+
+#. 2.8->settings-schema.json->panelLauncherClass->description
+msgid "Use the panel launcher class for pinned apps"
+msgstr "Sabitlenmiş uygulamalar için panel başlatıcısı sınıfını kullan"
+
+#. 2.8->settings-schema.json->panelLauncherClass->tooltip
+msgid "Enabling this helps with certain themes."
+msgstr "Bunu etkinleştirmek bazı temalarda yardımcı olur."
+
+#. 2.8->settings-schema.json->close-button-style->description
+msgid "Allow themes to control the thumbnail close button"
+msgstr ""
+"Temaların ön izleme penceresi kapat düğmesini kontrol etmesine izin verir."
+
+#. 2.8->settings-schema.json->close-button-style->tooltip
+msgid ""
+"Controls whether or not the theme controls the window thumbnail's close "
+"button."
+msgstr ""
+"Temanın, ön izleme penceresindeki kapat düğmesini kontrol edip etmediğini "
+"belirler."
+
+#. 2.8->settings-schema.json->useSystemTooltips->description
+msgid "Use system tooltips for closed apps"
+msgstr "Kapalı uygulamalar için sistem araç ipuçlarını kullan"
+
+#. 2.8->settings-schema.json->useSystemTooltips->tooltip
+msgid ""
+"Controls whether or not system tooltips are in use when hovering over closed "
+"pinned apps."
+msgstr ""
+"Kapalı olan sabit uygulamaların üzerine gelindiğinde sistem araç ipuçlarının "
+"kullanılıp kullanılmayacağını kontrol eder."
+
+#. 3.8->settings-schema.json->generalPage->title
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
+msgstr ""
+
+#. 3.8->settings-schema.json->panelPage->title
+#. 3.4->settings-schema.json->panelPage->title
+msgid "Panel"
+msgstr ""
+
+#. 3.8->settings-schema.json->thumbnailsPage->title
+#. 3.8->settings-schema.json->thumbnailsSection->title
+#. 3.4->settings-schema.json->thumbnailsPage->title
+#. 3.4->settings-schema.json->thumbnailsSection->title
 #, fuzzy
-msgid "Controls how much space will be around the window preview thumbnails."
-msgstr "Simgeler arasında ne kadar boşluk olacağını kontrol eder"
+msgid "Thumbnails"
+msgstr "Ön izleme boyutu"
 
+#. 3.8->settings-schema.json->contextMenuPage->title
+#. 3.4->settings-schema.json->contextMenuPage->title
+#, fuzzy
+msgid "Context Menu"
+msgstr "İçerik Menüsü Ayarları"
+
+#. 3.8->settings-schema.json->themePage->title
+#. 3.4->settings-schema.json->themePage->title
+#, fuzzy
+msgid "Theming"
+msgstr "Tema Ayarları"
+
+#. 3.8->settings-schema.json->generalSection->title
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
+msgstr ""
+
+#. 3.8->settings-schema.json->appButtonsSection->title
+#. 3.4->settings-schema.json->appButtonsSection->title
+msgid "App Buttons"
+msgstr ""
+
+#. 3.8->settings-schema.json->hotKeysSection->title
+#. 3.4->settings-schema.json->hotKeysSection->title
+msgid "Hot Keys"
+msgstr ""
+
+#. 3.8->settings-schema.json->hoverPeekSection->title
+#. 3.4->settings-schema.json->hoverPeekSection->title
+#, fuzzy
+msgid "Hover Peek"
+msgstr "Üstüne Gelme"
+
+#. 3.8->settings-schema.json->stylingSection->title
+#. 3.4->settings-schema.json->stylingSection->title
+msgid "Styling"
+msgstr ""
+
+#. 3.8->settings-schema.json->iconSection->title
+#. 3.4->settings-schema.json->iconSection->title
+#, fuzzy
+msgid "Icons"
+msgstr "Simge boyutu"
+
+#. 3.8->settings-schema.json->presetSection->title
+#. 3.4->settings-schema.json->presetSection->title
+msgid "Recommended Presets"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->description
+#. 3.4->settings-schema.json->scroll-behavior->description
+msgid "Mouse wheel scroll behavior"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+msgid "Cycle apps"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#, fuzzy
+msgid "Cycle windows"
+msgstr "Tüm uygulama pencerelerini dahil et"
+
+#. 3.8->settings-schema.json->scroll-behavior->tooltip
+#. 3.4->settings-schema.json->scroll-behavior->tooltip
+msgid ""
+"Choose if scrolling the mouse wheel cycles running apps, an app button's "
+"windows on hover, or is disabled."
+msgstr ""
+
+#. 3.8->settings-schema.json->left-click-action->description
+#. 3.8->settings-schema.json->left-click-action->tooltip
+#. 3.8->settings-schema.json->launcher-animation-effect->tooltip
+#. 3.4->settings-schema.json->left-click-action->description
+#. 3.4->settings-schema.json->left-click-action->tooltip
+#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
+msgid "Left click action"
+msgstr ""
+
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->left-click-action->options
+msgid "Toggle activation of last focused window"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->description
+#. 3.8->settings-schema.json->middle-click-action->tooltip
+#. 3.4->settings-schema.json->middle-click-action->description
+#. 3.4->settings-schema.json->middle-click-action->tooltip
+msgid "Middle click action"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Launch new app instance"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Close last focused window in group"
+msgstr ""
+
+#. 3.8->settings-schema.json->system-favorites->description
 #. 3.4->settings-schema.json->system-favorites->description
 #, fuzzy
 msgid "Use system favorites for pinned apps"
 msgstr "Kapalı uygulamalar için sistem araç ipuçlarını kullan"
 
+#. 3.8->settings-schema.json->system-favorites->tooltip
 #. 3.4->settings-schema.json->system-favorites->tooltip
 #, fuzzy
 msgid ""
@@ -796,94 +1050,64 @@ msgstr ""
 "Sabitlenen uygulamaların açık olmadığı halde panelde görünüp görünmeyeceğini "
 "kontrol eder."
 
-#. 3.4->settings-schema.json->generalSection->title
-msgid "Behavior"
-msgstr ""
-
-#. 3.4->settings-schema.json->thumbnailsPage->title
-#. 3.4->settings-schema.json->thumbnailsSection->title
+#. 3.8->settings-schema.json->show-all-workspaces->description
+#. 3.8->settings-schema.json->show-all-workspaces->tooltip
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
 #, fuzzy
-msgid "Thumbnails"
-msgstr "Ön izleme boyutu"
+msgid "Show windows from all workspaces"
+msgstr "Tüm çalışma alanlarında görünür"
 
-#. 3.4->settings-schema.json->presetSection->title
-msgid "Recommended Presets"
-msgstr ""
-
-#. 3.4->settings-schema.json->appButtonsSection->title
-msgid "App Buttons"
-msgstr ""
-
-#. 3.4->settings-schema.json->generalPage->title
-msgid "General"
-msgstr ""
-
-#. 3.4->settings-schema.json->hoverPeekSection->title
-#, fuzzy
-msgid "Hover Peek"
-msgstr "Üstüne Gelme"
-
-#. 3.4->settings-schema.json->panelPage->title
-msgid "Panel"
-msgstr ""
-
-#. 3.4->settings-schema.json->iconSection->title
-#, fuzzy
-msgid "Icons"
-msgstr "Simge boyutu"
-
-#. 3.4->settings-schema.json->hotKeysSection->title
-msgid "Hot Keys"
-msgstr ""
-
-#. 3.4->settings-schema.json->stylingSection->title
-msgid "Styling"
-msgstr ""
-
-#. 3.4->settings-schema.json->contextMenuPage->title
-#, fuzzy
-msgid "Context Menu"
-msgstr "İçerik Menüsü Ayarları"
-
-#. 3.4->settings-schema.json->themePage->title
-#, fuzzy
-msgid "Theming"
-msgstr "Tema Ayarları"
-
-#. 3.4->settings-schema.json->mintYPreset->description
-#. 3.4->settings-schema.json->mintYPreset->tooltip
-msgid "Mint Y and Variants"
-msgstr ""
-
-#. 3.4->settings-schema.json->show-icons->description
-#, fuzzy
-msgid "Show icons"
-msgstr "Simge yok"
-
-#. 3.4->settings-schema.json->show-icons->tooltip
-msgid "Show the window's icon next to the title."
-msgstr ""
-
+#. 3.8->settings-schema.json->enable-app-button-dragging->description
+#. 3.8->settings-schema.json->enable-app-button-dragging->tooltip
 #. 3.4->settings-schema.json->enable-app-button-dragging->description
 #. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
 msgid "Enable app button dragging"
 msgstr ""
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
-#, fuzzy
-msgid "Show new window option"
-msgstr "Otomatik başlatma seçeneğini göster"
-
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
-msgid ""
-"Shows the \"New Window\" option in an app's context menu if it doesn't "
-"already have one from the app's own action menu items."
+#. 3.8->settings-schema.json->launcher-animation-effect->description
+#. 3.4->settings-schema.json->launcher-animation-effect->description
+msgid "Launcher animation effect"
 msgstr ""
 
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Fade"
+msgstr ""
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Scale"
+msgstr ""
+
+#. 3.8->settings-schema.json->list-monitor-windows->description
+#. 3.4->settings-schema.json->list-monitor-windows->description
+msgid "Only list windows from the monitor displaying this instance"
+msgstr ""
+
+#. 3.8->settings-schema.json->list-monitor-windows->tooltip
+#. 3.4->settings-schema.json->list-monitor-windows->tooltip
+msgid ""
+"This option will only come into effect for monitors displaying an ITM "
+"instance."
+msgstr ""
+
+#. 3.8->settings-schema.json->enable-app-button-width->description
+#. 3.4->settings-schema.json->enable-app-button-width->description
+msgid "Use a custom width for app buttons"
+msgstr ""
+
+#. 3.8->settings-schema.json->enable-app-button-width->tooltip
+#. 3.4->settings-schema.json->enable-app-button-width->tooltip
+msgid "When disabled, the app button width is determined by the panel height."
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-width->description
 #. 3.4->settings-schema.json->app-button-width->description
 msgid "App button width"
 msgstr ""
 
+#. 3.8->settings-schema.json->app-button-width->tooltip
 #. 3.4->settings-schema.json->app-button-width->tooltip
 #, fuzzy
 msgid ""
@@ -891,118 +1115,121 @@ msgid ""
 "horizontal panels."
 msgstr "Ön izlemelerin boyutunu kontrol eder"
 
-#. 3.4->settings-schema.json->mintXPreset->description
-#. 3.4->settings-schema.json->mintXPreset->tooltip
-msgid "Mint X, Linux Mint, and Variants"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->description
-msgid "Launcher animation effect"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
-#. 3.4->settings-schema.json->left-click-action->description
-#. 3.4->settings-schema.json->left-click-action->tooltip
-msgid "Left click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Scale"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Fade"
-msgstr ""
-
-#. 3.4->settings-schema.json->enable-app-button-width->description
-msgid "Use a custom width for app buttons"
-msgstr ""
-
-#. 3.4->settings-schema.json->enable-app-button-width->tooltip
-msgid "When disabled, the app button width is determined by the panel height."
-msgstr ""
-
-#. 3.4->settings-schema.json->list-monitor-windows->description
-msgid "Only list windows from the monitor displaying this instance"
-msgstr ""
-
-#. 3.4->settings-schema.json->list-monitor-windows->tooltip
-msgid ""
-"This option will only come into effect for monitors displaying an ITM "
-"instance."
-msgstr ""
-
+#. 3.8->settings-schema.json->thumbnail-close-button-size->description
 #. 3.4->settings-schema.json->thumbnail-close-button-size->description
 #, fuzzy
 msgid "Close button size"
 msgstr "Simge boyutunu ayarla"
 
+#. 3.8->settings-schema.json->thumbnail-close-button-size->tooltip
 #. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
 #, fuzzy
 msgid "Controls how large the thumbnail close button is."
 msgstr ""
 "Temaların ön izleme penceresi kapat düğmesini kontrol etmesine izin verir."
 
-#. 3.4->settings-schema.json->middle-click-action->description
-#. 3.4->settings-schema.json->middle-click-action->tooltip
-msgid "Middle click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Launch new app instance"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Close last focused window in group"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->description
-msgid "Mouse wheel scroll behavior"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->tooltip
-msgid ""
-"Choose if scrolling the mouse wheel cycles running apps, an app button's "
-"windows on hover, or is disabled."
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->options
-msgid "Cycle apps"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->thumbnail-padding->description
+#. 3.4->settings-schema.json->thumbnail-padding->description
 #, fuzzy
-msgid "Cycle windows"
-msgstr "Tüm uygulama pencerelerini dahil et"
+msgid "Thumbnail padding"
+msgstr "Ön İzleme Ayarları"
 
-#. 3.4->settings-schema.json->show-all-workspaces->description
-#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#. 3.8->settings-schema.json->thumbnail-padding->tooltip
+#. 3.4->settings-schema.json->thumbnail-padding->tooltip
 #, fuzzy
-msgid "Show windows from all workspaces"
-msgstr "Tüm çalışma alanlarında görünür"
+msgid "Controls how much space will be around the window preview thumbnails."
+msgstr "Simgeler arasında ne kadar boşluk olacağını kontrol eder"
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->description
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
 msgid "Cycle windows on mouse wheel scroll"
 msgstr ""
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->tooltip
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
 msgid ""
 "Choose whether or not scrolling the mouse wheel cycles windows when hovering "
 "over a thumbnail menu."
 msgstr ""
 
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "Toggle activation of last focused window"
+#. 3.8->settings-schema.json->show-icons->description
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "Simge yok"
+
+#. 3.8->settings-schema.json->show-icons->tooltip
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
 msgstr ""
 
-#. IcingTaskManager@json->metadata.json->name
-msgid "Icing Task Manager"
-msgstr "Icing Görev Yöneticisi"
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->description
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
+msgid "Highlight the last focused window within an app group"
+msgstr ""
 
-#. IcingTaskManager@json->metadata.json->description
-msgid "Window list with app grouping and thumbnails"
-msgstr "Uygulama gruplama ve pencere ön izleme destekli pencere listesi"
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+msgid ""
+"When enabled, the last window that was interacted with will be indicated."
+msgstr ""
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->description
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "Otomatik başlatma seçeneğini göster"
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->tooltip
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->units
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->description
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+msgid "App button transition duration"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->tooltip
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.8->settings-schema.json->mintYPreset->description
+#. 3.8->settings-schema.json->mintYPreset->tooltip
+#. 3.4->settings-schema.json->mintYPreset->description
+#. 3.4->settings-schema.json->mintYPreset->tooltip
+msgid "Mint Y and Variants"
+msgstr ""
+
+#. 3.8->settings-schema.json->mintXPreset->description
+#. 3.8->settings-schema.json->mintXPreset->tooltip
+#. 3.4->settings-schema.json->mintXPreset->description
+#. 3.4->settings-schema.json->mintXPreset->tooltip
+msgid "Mint X, Linux Mint, and Variants"
+msgstr ""
+
+#. 3.8->settings-schema.json->migrationButton->description
+msgid "Migrate Pinned Apps to Grouped Window List"
+msgstr ""
 
 #~ msgid "number"
 #~ msgstr "sayı"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/zh_CN.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/zh_CN.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-23 21:32-0600\n"
+"POT-Creation-Date: 2018-12-10 00:43-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: zqq90 <zqq_90@163.com>\n"
 "Language-Team: \n"
@@ -14,538 +14,220 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/applet.js:471
+msgid "Icing Task Manager is now Grouped Window List"
+msgstr ""
+
+#: 3.8/applet.js:472
+msgid ""
+"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
+"Window List\". "
+msgstr ""
+
+#: 3.8/applet.js:473
+msgid ""
+"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
+"List."
+msgstr ""
+
+#: 3.8/applet.js:485
+msgid "Migration can only be performed on Cinnamon 4.0."
+msgstr ""
+
+#: 3.8/applet.js:496
+msgid ""
+"Please add Grouped Window List to a panel before proceeding with the "
+"migration."
+msgstr ""
+
+#: 3.8/applet.js:504
+msgid "ITM settings directory could not be found!"
+msgstr ""
+
+#: 3.8/applet.js:534
+msgid "System favorites enabled - no migration is needed."
+msgstr ""
+
+#: 3.8/applet.js:577
+msgid "Unable to find a suitable ITM settings file to migrate."
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid "Migration complete. "
+msgstr ""
+
+#: 3.8/applet.js:586
+msgid " settings file(s) could not be migrated."
+msgstr ""
+
+#: 3.8/applet.js:592
+msgid "Migration was successful."
+msgstr ""
+
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to the other monitor"
 msgstr "移到其他显示器"
 
-#: 3.4/specialMenus.js:118
+#: 3.8/specialMenus.js:90 3.4/specialMenus.js:118
 msgid "Move to monitor "
 msgstr "移到显示器"
 
-#: 3.4/specialMenus.js:126
+#: 3.8/specialMenus.js:98 3.4/specialMenus.js:126
 msgid "Only on this workspace"
 msgstr "仅在此工作区"
 
-#: 3.4/specialMenus.js:133
+#: 3.8/specialMenus.js:105 3.4/specialMenus.js:133
 msgid "Visible on all workspaces"
 msgstr "在所有工作区可见"
 
-#: 3.4/specialMenus.js:140
+#: 3.8/specialMenus.js:112 3.4/specialMenus.js:140
 msgid "Move to another workspace"
 msgstr "移动到另一个工作区"
 
-#: 3.4/specialMenus.js:168
+#: 3.8/specialMenus.js:140 3.4/specialMenus.js:168
 msgid "Places"
 msgstr "位置"
 
-#: 3.4/specialMenus.js:207
+#: 3.8/specialMenus.js:179 3.4/specialMenus.js:207
 msgid "Bookmarks/History requires gir1.2-gda-5.0"
 msgstr ""
 
-#: 3.4/specialMenus.js:227
+#: 3.8/specialMenus.js:199 3.4/specialMenus.js:227
 msgid "Recent"
 msgstr "最近"
 
-#: 3.4/specialMenus.js:246
+#: 3.8/specialMenus.js:218 3.4/specialMenus.js:246
 msgid "Preferences"
 msgstr "首选项"
 
-#: 3.4/specialMenus.js:249
+#: 3.8/specialMenus.js:221 3.4/specialMenus.js:249
 msgid "About..."
 msgstr "关于..."
 
-#: 3.4/specialMenus.js:253
+#: 3.8/specialMenus.js:225 3.4/specialMenus.js:253
 msgid "Configure..."
 msgstr "配置..."
 
-#: 3.4/specialMenus.js:257
+#: 3.8/specialMenus.js:229 3.4/specialMenus.js:257
 msgid "Remove"
 msgstr "移除"
 
-#: 3.4/specialMenus.js:287
+#: 3.8/specialMenus.js:259 3.4/specialMenus.js:287
 #, fuzzy
 msgid "New Window"
 msgstr "包含所有应用窗口"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Unpin from Panel"
 msgstr "取消固定"
 
-#: 3.4/specialMenus.js:305
+#: 3.8/specialMenus.js:277 3.4/specialMenus.js:305
 msgid "Pin to Panel"
 msgstr "固定到面板"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Remove from Autostart"
 msgstr "移出自动启动"
 
-#: 3.4/specialMenus.js:311
+#: 3.8/specialMenus.js:283 3.4/specialMenus.js:311
 msgid "Add to Autostart"
 msgstr "添加到自动启动"
 
-#: 3.4/specialMenus.js:318
+#: 3.8/specialMenus.js:290 3.4/specialMenus.js:318
 msgid "Create Shortcut"
 msgstr "创建快捷方式"
 
-#: 3.4/specialMenus.js:329
+#: 3.8/specialMenus.js:301 3.4/specialMenus.js:329
 msgid "Restore to full opacity"
 msgstr "恢复到完全不透明"
 
-#: 3.4/specialMenus.js:337
+#: 3.8/specialMenus.js:309 3.4/specialMenus.js:337
 msgid "Restore"
 msgstr "恢复"
 
-#: 3.4/specialMenus.js:342
+#: 3.8/specialMenus.js:314 3.4/specialMenus.js:342
 msgid "Minimize"
 msgstr "最小化"
 
-#: 3.4/specialMenus.js:350
+#: 3.8/specialMenus.js:322 3.4/specialMenus.js:350
 msgid "Unmaximize"
 msgstr "取消最大化"
 
-#: 3.4/specialMenus.js:355
+#: 3.8/specialMenus.js:327 3.4/specialMenus.js:355
 msgid "Maximize"
 msgstr "最大化"
 
-#: 3.4/specialMenus.js:365
+#: 3.8/specialMenus.js:337 3.4/specialMenus.js:365
 msgid "Close others"
 msgstr "关闭其他"
 
-#: 3.4/specialMenus.js:375
+#: 3.8/specialMenus.js:347 3.4/specialMenus.js:375
 msgid "Close all"
 msgstr "关闭全部"
 
-#: 3.4/specialMenus.js:385
+#: 3.8/specialMenus.js:357 3.4/specialMenus.js:385
 msgid "Close"
 msgstr "关闭"
 
-#. 2.8->settings-schema.json->thumbnail-size->description
-#. 3.4->settings-schema.json->thumbnail-size->description
-msgid "Thumbnail size"
-msgstr "缩略图尺寸"
+#. metadata.json->description
+msgid "Window list with app grouping and thumbnails"
+msgstr "带应用程序分组和缩略图的窗口列表"
 
-#. 2.8->settings-schema.json->thumbnail-size->tooltip
-#. 3.4->settings-schema.json->thumbnail-size->tooltip
-msgid "Controls the size of the thumbnails."
-msgstr "调节缩略图的尺寸"
+#. metadata.json->name
+msgid "Icing Task Manager"
+msgstr "Icing Task Manager"
 
-#. 2.8->settings-schema.json->thumbnail-size->units
-#. 3.4->settings-schema.json->thumbnail-size->units
-msgid "size"
-msgstr "尺寸"
-
-#. 2.8->settings-schema.json->focusPseudoClass->description
-#. 3.4->settings-schema.json->focusPseudoClass->description
-msgid "App button focus pseudo class"
-msgstr "App按钮焦点伪类"
-
-#. 2.8->settings-schema.json->focusPseudoClass->tooltip
-#. 3.4->settings-schema.json->focusPseudoClass->tooltip
-msgid "Overrides the pseudo class for app button on focus."
-msgstr "覆盖焦点上的app按钮的伪类。"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "active"
-msgstr "活动"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "outlined"
-msgstr "概述"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "hover"
-msgstr "悬停"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "focus"
-msgstr "焦点"
-
-#. 2.8->settings-schema.json->focusPseudoClass->options
-#. 2.8->settings-schema.json->hoverPseudoClass->options
-#. 2.8->settings-schema.json->activePseudoClass->options
-#. 3.4->settings-schema.json->focusPseudoClass->options
-#. 3.4->settings-schema.json->hoverPseudoClass->options
-#. 3.4->settings-schema.json->activePseudoClass->options
-msgid "selected"
-msgstr "已选中"
-
-#. 2.8->settings-schema.json->icon-spacing->description
-#. 3.4->settings-schema.json->icon-spacing->description
-msgid "Icon spacing"
-msgstr "图标间距"
-
-#. 2.8->settings-schema.json->icon-spacing->tooltip
-#. 3.4->settings-schema.json->icon-spacing->tooltip
-msgid "Controls how much space is between the icons."
-msgstr "调节图标间的距离"
-
-#. 2.8->settings-schema.json->icon-spacing->units
-#. 2.8->settings-schema.json->icon-size->units
-#. 2.8->settings-schema.json->icon-padding->units
-#. 3.4->settings-schema.json->icon-spacing->units
-#. 3.4->settings-schema.json->thumbnail-padding->units
-#. 3.4->settings-schema.json->icon-size->units
-#. 3.4->settings-schema.json->app-button-width->units
-#. 3.4->settings-schema.json->thumbnail-close-button-size->units
-#. 3.4->settings-schema.json->icon-padding->units
-msgid "px"
-msgstr "像素"
-
-#. 2.8->settings-schema.json->show-thumbnails->description
-#. 3.4->settings-schema.json->show-thumbnails->description
-msgid "Show thumbnails"
-msgstr "显示缩略图"
-
-#. 2.8->settings-schema.json->show-thumbnails->tooltip
-#. 3.4->settings-schema.json->show-thumbnails->tooltip
-msgid "Show window thumbnails when hovering over an app button."
-msgstr "当鼠标悬停时显示缩略图"
-
-#. 2.8->settings-schema.json->icon-size->description
-#. 3.4->settings-schema.json->icon-size->description
-msgid "Icon size"
-msgstr "图标尺寸"
-
-#. 2.8->settings-schema.json->icon-size->tooltip
-#. 3.4->settings-schema.json->icon-size->tooltip
-msgid "Set icon size"
-msgstr "调节图标的尺寸"
-
-#. 2.8->settings-schema.json->hover-peek-time->description
-#. 3.4->settings-schema.json->hover-peek-time->description
-msgid "Window fade time"
-msgstr "窗口渐变时长"
-
-#. 2.8->settings-schema.json->hover-peek-time->tooltip
-#. 3.4->settings-schema.json->hover-peek-time->tooltip
-msgid "Controls how quickly a window will fade on hover."
-msgstr "窗口悬浮预览的渐变时长"
-
-#. 2.8->settings-schema.json->hover-peek-time->units
-#. 2.8->settings-schema.json->thumbnail-timeout->units
-#. 2.8->settings-schema.json->show-apps-order-timeout->units
-#. 3.4->settings-schema.json->hover-peek-time->units
-#. 3.4->settings-schema.json->thumbnail-timeout->units
-#. 3.4->settings-schema.json->show-apps-order-timeout->units
-msgid "milliseconds"
-msgstr "毫秒"
-
-#. 2.8->settings-schema.json->close-button-style->description
-msgid "Allow themes to control the thumbnail close button"
-msgstr "使用主题中的缩略图关闭按钮样式"
-
-#. 2.8->settings-schema.json->close-button-style->tooltip
-msgid ""
-"Controls whether or not the theme controls the window thumbnail's close "
-"button."
-msgstr "是否使用主题中的缩略图关闭按钮样式"
-
-#. 2.8->settings-schema.json->title-display->description
-#. 3.4->settings-schema.json->title-display->description
-msgid "Title display"
-msgstr "标题显示"
-
-#. 2.8->settings-schema.json->title-display->tooltip
-#. 3.4->settings-schema.json->title-display->tooltip
-msgid ""
-"focused: show focused window title, title: display the window title, app: "
-"diplay app name, none: don't display anything"
-msgstr ""
-"激活的：显示激活的窗口标题；标题：显示窗口的标题；应用：显示应用名称；无：不"
-"显示"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-#. 3.4->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->middle-click-action->options
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "None"
-msgstr "无"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Focused"
-msgstr "激活的"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "App"
-msgstr "应用"
-
-#. 2.8->settings-schema.json->title-display->options
-#. 3.4->settings-schema.json->title-display->options
-msgid "Title"
-msgstr "标题"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->description
-#. 3.4->settings-schema.json->hoverPseudoClass->description
-msgid "App button hover pseudo class"
-msgstr "App按钮悬停伪类"
-
-#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
-#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons on hover."
-msgstr "覆盖悬停时应用按钮的伪类。"
-
-#. 2.8->settings-schema.json->show-alerts->description
-#. 3.4->settings-schema.json->show-alerts->description
-msgid "Show app alerts and notifications"
-msgstr "显示应用警告和通知"
-
-#. 2.8->settings-schema.json->show-alerts->tooltip
-#. 3.4->settings-schema.json->show-alerts->tooltip
-msgid "If enabled, notifications and alerts will appear."
-msgstr "是否显示应用的警告和通知"
-
-#. 2.8->settings-schema.json->pinOnDrag->description
-#. 2.8->settings-schema.json->pinOnDrag->tooltip
-#. 3.4->settings-schema.json->pinOnDrag->description
-#. 3.4->settings-schema.json->pinOnDrag->tooltip
-msgid "Pin apps when dragged to a new position"
-msgstr "引脚应用时拖动到新位置"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->description
-#. 3.4->settings-schema.json->show-apps-order-hotkey->description
-msgid "Global hotkey to show the order of apps"
-msgstr "全局热键以显示应用程序的顺序"
-
-#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
-#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
-msgid ""
-"When triggered, the window count label will be replaced with its order in "
-"the app list temporarily."
-msgstr "触发时，窗口计数标签将暂时替换为其在应用程序列表中的顺序。"
-
-#. 2.8->settings-schema.json->menuItemType->description
-#. 3.4->settings-schema.json->menuItemType->description
-msgid "Menu item type"
-msgstr "菜单项类型"
-
-#. 2.8->settings-schema.json->menuItemType->tooltip
-#. 3.4->settings-schema.json->menuItemType->tooltip
-msgid ""
-"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
-msgstr "确定菜单项图标是符号，非符号还是未显示。"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Symbolic icons"
-msgstr "符号图标"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "No icons"
-msgstr "没有图标"
-
-#. 2.8->settings-schema.json->menuItemType->options
-#. 3.4->settings-schema.json->menuItemType->options
-msgid "Non-symbolic icons"
-msgstr "非符号图标"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->description
-#. 3.4->settings-schema.json->hover-peek-opacity->description
-msgid "Window opacity"
-msgstr "窗口不透明度"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
-#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
-msgid "Opacity of the windows on hover."
-msgstr "悬停时窗口的不透明度"
-
-#. 2.8->settings-schema.json->hover-peek-opacity->units
-#. 3.4->settings-schema.json->hover-peek-opacity->units
-msgid "percent"
-msgstr "%"
-
-#. 2.8->settings-schema.json->enable-hover-peek->description
-#. 3.4->settings-schema.json->enable-hover-peek->description
-msgid "Show windows when hovered over"
-msgstr "悬停预览窗口"
-
-#. 2.8->settings-schema.json->enable-hover-peek->tooltip
-#. 3.4->settings-schema.json->enable-hover-peek->tooltip
-msgid "Controls whether or not windows display when hovered over."
-msgstr "是否在悬停时显示预览窗口"
-
-#. 2.8->settings-schema.json->activePseudoClass->description
-#. 3.4->settings-schema.json->activePseudoClass->description
-msgid "App button active pseudo class"
-msgstr "App按钮激活伪类"
-
-#. 2.8->settings-schema.json->activePseudoClass->tooltip
-#. 3.4->settings-schema.json->activePseudoClass->tooltip
-msgid "Overrides the pseudo class for app buttons when they are active."
-msgstr "当应用按钮处于活动状态时覆盖应用按钮的伪类。"
-
-#. 2.8->settings-schema.json->animate-thumbnails->description
-#. 3.4->settings-schema.json->animate-thumbnails->description
-msgid "Animate thumbnails"
-msgstr "缩略图动画"
-
-#. 2.8->settings-schema.json->animate-thumbnails->tooltip
-#. 3.4->settings-schema.json->animate-thumbnails->tooltip
-msgid "If enabled, thumbnails will animate when appearing and disappearing."
-msgstr "是否显示在缩略图显示和隐藏时启用动画"
-
-#. 2.8->settings-schema.json->autostart-menu-item->description
-#. 3.4->settings-schema.json->autostart-menu-item->description
-msgid "Show autostart option"
-msgstr "显示自动启动开关"
-
-#. 2.8->settings-schema.json->autostart-menu-item->tooltip
-#. 3.4->settings-schema.json->autostart-menu-item->tooltip
-msgid "Shows the autostart toggle option in an app's context menu."
-msgstr "是否在应用菜单里显示自动启动开关"
-
-#. 2.8->settings-schema.json->show-pinned->description
-#. 3.4->settings-schema.json->show-pinned->description
-msgid "Show pinned apps"
-msgstr "显示固定开关"
-
-#. 2.8->settings-schema.json->show-pinned->tooltip
-#. 3.4->settings-schema.json->show-pinned->tooltip
-msgid ""
-"Controls whether or not the pinned apps appear in the panel if they are not "
-"open."
-msgstr "是否在应用菜单里显示固定开关"
-
-#. 2.8->settings-schema.json->useSystemTooltips->description
-msgid "Use system tooltips for closed apps"
-msgstr "对已关闭的应用使用系统工具提示"
-
-#. 2.8->settings-schema.json->useSystemTooltips->tooltip
-msgid ""
-"Controls whether or not system tooltips are in use when hovering over closed "
-"pinned apps."
-msgstr "控制悬停在已锁定的固定应用程序上时系统工具提示是否正在使用。"
+#. 2.8->settings-schema.json->ITM->description
+msgid "ITM Settings"
+msgstr "ITM设置"
 
 #. 2.8->settings-schema.json->WindowList->description
 msgid "Window List Settings"
 msgstr "窗口列表设置"
 
-#. 2.8->settings-schema.json->AppMenu->description
-msgid "Context Menu Settings"
-msgstr "菜单设置"
-
-#. 2.8->settings-schema.json->Thumbnails->description
-msgid "Thumbnail Settings"
-msgstr "缩略图设置"
-
-#. 2.8->settings-schema.json->show-recent->description
-#. 3.4->settings-schema.json->show-recent->description
-msgid "Show recent items"
-msgstr "显示最近访问列表"
-
-#. 2.8->settings-schema.json->show-recent->tooltip
-#. 3.4->settings-schema.json->show-recent->tooltip
-msgid "Controls whether recent items will appear in the context menu."
-msgstr "是否在菜单中显示最近访问列表"
-
-#. 2.8->settings-schema.json->vertical-thumbnails->description
-#. 3.4->settings-schema.json->vertical-thumbnails->description
-msgid "Enable vertical thumbnails"
-msgstr "垂直排列缩略图"
-
-#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
-#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
-msgid "If enabled, thumbnails will stack vertically."
-msgstr "是否垂直排列缩略图"
-
-#. 2.8->settings-schema.json->thumbnail-timeout->description
-#. 3.4->settings-schema.json->thumbnail-timeout->description
-msgid "Thumbnail timeout"
-msgstr "缩略图消失延时"
-
-#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
-#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
-msgid ""
-"Controls how quickly an app's set of window thumbnails will fade out when "
-"the mouse leaves the app button."
-msgstr "鼠标离开时缩略图的消失延迟"
-
-#. 2.8->settings-schema.json->ThemeSettings->description
-msgid "Theme Settings"
-msgstr "主题设置"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->description
-#. 3.4->settings-schema.json->onclick-thumbnails->description
-msgid "Open thumbnails on click"
-msgstr "点击时显示缩略图"
-
-#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
-#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
-msgid "Open the thumbnails on click if there is more than one window open."
-msgstr "点击显示打开的窗口的缩略图"
-
-#. 2.8->settings-schema.json->panelLauncherClass->description
-msgid "Use the panel launcher class for pinned apps"
-msgstr "对固定应用使用面板启动器类"
-
-#. 2.8->settings-schema.json->panelLauncherClass->tooltip
-msgid "Enabling this helps with certain themes."
-msgstr "启用此功能有助于确定某些主题。"
-
-#. 2.8->settings-schema.json->include-all-windows->description
-#. 3.4->settings-schema.json->include-all-windows->description
-msgid "Include all app windows"
-msgstr "包含所有应用窗口"
-
-#. 2.8->settings-schema.json->include-all-windows->tooltip
-#. 3.4->settings-schema.json->include-all-windows->tooltip
-msgid ""
-"Controls whether or not thumbnails for smalller child windows, such as exit "
-"confirmations and file dialogues will be included in the thumbnail list."
-msgstr "是否在缩略图中包含子窗口，例如退出确认 , 选择文件等窗口"
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->description
-#. 3.4->settings-schema.json->cycleMenusHotkey->description
-msgid "Global hotkey for cycling through thumbnail menus"
-msgstr "循环通过缩略图菜单的全局热键"
-
-#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
-#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
-msgid "This allows you to cycle through the menus without activating a window."
-msgstr "这允许您在不激活窗口的情况下循环浏览菜单。"
-
-#. 2.8->settings-schema.json->enable-iconSize->description
-#. 3.4->settings-schema.json->enable-iconSize->description
-msgid "Adjust icon size"
-msgstr "调节图标尺寸"
-
-#. 2.8->settings-schema.json->enable-iconSize->tooltip
-#. 3.4->settings-schema.json->enable-iconSize->tooltip
-msgid "Adjust icon size independent of Cinnamon's panel scaling."
-msgstr "自定义图标尺寸，不使用自带的缩放"
-
 #. 2.8->settings-schema.json->number-display->description
+#. 3.8->settings-schema.json->number-display->description
 #. 3.4->settings-schema.json->number-display->description
 msgid "Number display"
 msgstr "个数显示"
 
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Smart"
+msgstr "自动"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "Normal"
+msgstr "普通"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "None"
+msgstr "无"
+
+#. 2.8->settings-schema.json->number-display->options
+#. 3.8->settings-schema.json->number-display->options
+#. 3.4->settings-schema.json->number-display->options
+msgid "All"
+msgstr "所有"
+
 #. 2.8->settings-schema.json->number-display->tooltip
+#. 3.8->settings-schema.json->number-display->tooltip
 #. 3.4->settings-schema.json->number-display->tooltip
 msgid ""
 "normal: display window number, smart: display window number if more than one "
@@ -554,40 +236,94 @@ msgid ""
 msgstr ""
 "普通：窗口数量；自动：一个以上才显示； 无：不显示；所有：包括所有（包括收藏）"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "All"
-msgstr "所有"
+#. 2.8->settings-schema.json->title-display->description
+#. 3.8->settings-schema.json->title-display->description
+#. 3.4->settings-schema.json->title-display->description
+msgid "Title display"
+msgstr "标题显示"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Smart"
-msgstr "自动"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "App"
+msgstr "应用"
 
-#. 2.8->settings-schema.json->number-display->options
-#. 3.4->settings-schema.json->number-display->options
-msgid "Normal"
-msgstr "普通"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Title"
+msgstr "标题"
 
-#. 2.8->settings-schema.json->ITM->description
-msgid "ITM Settings"
-msgstr "ITM设置"
+#. 2.8->settings-schema.json->title-display->options
+#. 3.8->settings-schema.json->title-display->options
+#. 3.4->settings-schema.json->title-display->options
+msgid "Focused"
+msgstr "激活的"
 
-#. 2.8->settings-schema.json->HoverPeek->description
-msgid "Hover Peek Settings"
-msgstr "悬停预览设置"
-
-#. 2.8->settings-schema.json->icon-padding->description
-#. 3.4->settings-schema.json->icon-padding->description
-msgid "Icon padding"
-msgstr "图标填充"
-
-#. 2.8->settings-schema.json->icon-padding->tooltip
-#. 3.4->settings-schema.json->icon-padding->tooltip
+#. 2.8->settings-schema.json->title-display->tooltip
+#. 3.8->settings-schema.json->title-display->tooltip
+#. 3.4->settings-schema.json->title-display->tooltip
 msgid ""
-"Controls how much horizontal padding is inside the app buttons. Padding is "
-"only applied to instances of this applet on horizontal panels."
-msgstr "调节图标的宽度（填充多少像素）。仅适用此小程序的横向面板。"
+"focused: show focused window title, title: display the window title, app: "
+"diplay app name, none: don't display anything"
+msgstr ""
+"激活的：显示激活的窗口标题；标题：显示窗口的标题；应用：显示应用名称；无：不"
+"显示"
+
+#. 2.8->settings-schema.json->group-apps->description
+#. 3.8->settings-schema.json->group-apps->description
+#. 3.4->settings-schema.json->group-apps->description
+msgid "Group apps"
+msgstr "按程序分组折叠"
+
+#. 2.8->settings-schema.json->group-apps->tooltip
+#. 3.8->settings-schema.json->group-apps->tooltip
+#. 3.4->settings-schema.json->group-apps->tooltip
+msgid "Group each app's set of windows."
+msgstr "按程序将窗口分组折叠"
+
+#. 2.8->settings-schema.json->show-alerts->description
+#. 3.8->settings-schema.json->show-alerts->description
+#. 3.4->settings-schema.json->show-alerts->description
+msgid "Show app alerts and notifications"
+msgstr "显示应用警告和通知"
+
+#. 2.8->settings-schema.json->show-alerts->tooltip
+#. 3.8->settings-schema.json->show-alerts->tooltip
+#. 3.4->settings-schema.json->show-alerts->tooltip
+msgid "If enabled, notifications and alerts will appear."
+msgstr "是否显示应用的警告和通知"
+
+#. 2.8->settings-schema.json->show-pinned->description
+#. 3.8->settings-schema.json->show-pinned->description
+#. 3.4->settings-schema.json->show-pinned->description
+msgid "Show pinned apps"
+msgstr "显示固定开关"
+
+#. 2.8->settings-schema.json->show-pinned->tooltip
+#. 3.8->settings-schema.json->show-pinned->tooltip
+#. 3.4->settings-schema.json->show-pinned->tooltip
+msgid ""
+"Controls whether or not the pinned apps appear in the panel if they are not "
+"open."
+msgstr "是否在应用菜单里显示固定开关"
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->description
+msgid "Arrange pinned apps"
+msgstr "排列已固定的应用"
+
+#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
+msgid "Arrange pinned apps into a different order."
+msgstr "以不同顺序排列已固定的应用"
+
+#. 2.8->settings-schema.json->pinOnDrag->description
+#. 2.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.8->settings-schema.json->pinOnDrag->description
+#. 3.8->settings-schema.json->pinOnDrag->tooltip
+#. 3.4->settings-schema.json->pinOnDrag->description
+#. 3.4->settings-schema.json->pinOnDrag->tooltip
+msgid "Pin apps when dragged to a new position"
+msgstr "引脚应用时拖动到新位置"
 
 #. 2.8->settings-schema.json->middle-click-action->description
 msgid "Middle clicking app buttons creates new app instances"
@@ -602,12 +338,243 @@ msgstr ""
 "确定应用按钮上鼠标中键点击的行为。 将此设置为false将关闭中间点击应用程序组的"
 "最后一个焦点窗口。"
 
+#. 2.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.8->settings-schema.json->cycleMenusHotkey->description
+#. 3.4->settings-schema.json->cycleMenusHotkey->description
+msgid "Global hotkey for cycling through thumbnail menus"
+msgstr "循环通过缩略图菜单的全局热键"
+
+#. 2.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.8->settings-schema.json->cycleMenusHotkey->tooltip
+#. 3.4->settings-schema.json->cycleMenusHotkey->tooltip
+msgid "This allows you to cycle through the menus without activating a window."
+msgstr "这允许您在不激活窗口的情况下循环浏览菜单。"
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.8->settings-schema.json->show-apps-order-hotkey->description
+#. 3.4->settings-schema.json->show-apps-order-hotkey->description
+msgid "Global hotkey to show the order of apps"
+msgstr "全局热键以显示应用程序的顺序"
+
+#. 2.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.8->settings-schema.json->show-apps-order-hotkey->tooltip
+#. 3.4->settings-schema.json->show-apps-order-hotkey->tooltip
+msgid ""
+"When triggered, the window count label will be replaced with its order in "
+"the app list temporarily."
+msgstr "触发时，窗口计数标签将暂时替换为其在应用程序列表中的顺序。"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->units
+#. 2.8->settings-schema.json->thumbnail-timeout->units
+#. 2.8->settings-schema.json->hover-peek-time->units
+#. 3.8->settings-schema.json->show-apps-order-timeout->units
+#. 3.8->settings-schema.json->thumbnail-timeout->units
+#. 3.8->settings-schema.json->hover-peek-time->units
+#. 3.4->settings-schema.json->show-apps-order-timeout->units
+#. 3.4->settings-schema.json->thumbnail-timeout->units
+#. 3.4->settings-schema.json->hover-peek-time->units
+msgid "milliseconds"
+msgstr "毫秒"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.8->settings-schema.json->show-apps-order-timeout->description
+#. 3.4->settings-schema.json->show-apps-order-timeout->description
+msgid "Duration of the apps order display on hotkey press"
+msgstr "热键按下应用程序顺序的时间显示"
+
+#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.8->settings-schema.json->show-apps-order-timeout->tooltip
+#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
+msgid ""
+"Determines the duration the window count labels are replaced with the app's "
+"order number."
+msgstr "确定窗口计数标签被应用程序的订单号替换的持续时间。"
+
+#. 2.8->settings-schema.json->Thumbnails->description
+msgid "Thumbnail Settings"
+msgstr "缩略图设置"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->description
+#. 3.8->settings-schema.json->thumbnail-timeout->description
+#. 3.4->settings-schema.json->thumbnail-timeout->description
+msgid "Thumbnail timeout"
+msgstr "缩略图消失延时"
+
+#. 2.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.8->settings-schema.json->thumbnail-timeout->tooltip
+#. 3.4->settings-schema.json->thumbnail-timeout->tooltip
+msgid ""
+"Controls how quickly an app's set of window thumbnails will fade out when "
+"the mouse leaves the app button."
+msgstr "鼠标离开时缩略图的消失延迟"
+
+#. 2.8->settings-schema.json->thumbnail-size->units
+#. 3.8->settings-schema.json->thumbnail-size->units
+#. 3.4->settings-schema.json->thumbnail-size->units
+msgid "size"
+msgstr "尺寸"
+
+#. 2.8->settings-schema.json->thumbnail-size->description
+#. 3.8->settings-schema.json->thumbnail-size->description
+#. 3.4->settings-schema.json->thumbnail-size->description
+msgid "Thumbnail size"
+msgstr "缩略图尺寸"
+
+#. 2.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.8->settings-schema.json->thumbnail-size->tooltip
+#. 3.4->settings-schema.json->thumbnail-size->tooltip
+msgid "Controls the size of the thumbnails."
+msgstr "调节缩略图的尺寸"
+
+#. 2.8->settings-schema.json->show-thumbnails->description
+#. 3.8->settings-schema.json->show-thumbnails->description
+#. 3.4->settings-schema.json->show-thumbnails->description
+msgid "Show thumbnails"
+msgstr "显示缩略图"
+
+#. 2.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.8->settings-schema.json->show-thumbnails->tooltip
+#. 3.4->settings-schema.json->show-thumbnails->tooltip
+msgid "Show window thumbnails when hovering over an app button."
+msgstr "当鼠标悬停时显示缩略图"
+
+#. 2.8->settings-schema.json->animate-thumbnails->description
+#. 3.8->settings-schema.json->animate-thumbnails->description
+#. 3.4->settings-schema.json->animate-thumbnails->description
+msgid "Animate thumbnails"
+msgstr "缩略图动画"
+
+#. 2.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.8->settings-schema.json->animate-thumbnails->tooltip
+#. 3.4->settings-schema.json->animate-thumbnails->tooltip
+msgid "If enabled, thumbnails will animate when appearing and disappearing."
+msgstr "是否显示在缩略图显示和隐藏时启用动画"
+
+#. 2.8->settings-schema.json->vertical-thumbnails->description
+#. 3.8->settings-schema.json->vertical-thumbnails->description
+#. 3.4->settings-schema.json->vertical-thumbnails->description
+msgid "Enable vertical thumbnails"
+msgstr "垂直排列缩略图"
+
+#. 2.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.8->settings-schema.json->vertical-thumbnails->tooltip
+#. 3.4->settings-schema.json->vertical-thumbnails->tooltip
+msgid "If enabled, thumbnails will stack vertically."
+msgstr "是否垂直排列缩略图"
+
+#. 2.8->settings-schema.json->sort-thumbnails->description
+#. 3.8->settings-schema.json->sort-thumbnails->description
+#. 3.4->settings-schema.json->sort-thumbnails->description
+msgid "Sort windows for each app by last focused"
+msgstr "根据最后激活时间排列窗口"
+
+#. 2.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.8->settings-schema.json->sort-thumbnails->tooltip
+#. 3.4->settings-schema.json->sort-thumbnails->tooltip
+msgid ""
+"Controls whether the order windows appear for an app is by last focused, or "
+"the order they were opened."
+msgstr "是否根据最后的激活时间排列窗口， 否则按照打开时间排列"
+
+#. 2.8->settings-schema.json->onclick-thumbnails->description
+#. 3.8->settings-schema.json->onclick-thumbnails->description
+#. 3.4->settings-schema.json->onclick-thumbnails->description
+msgid "Open thumbnails on click"
+msgstr "点击时显示缩略图"
+
+#. 2.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.8->settings-schema.json->onclick-thumbnails->tooltip
+#. 3.4->settings-schema.json->onclick-thumbnails->tooltip
+msgid "Open the thumbnails on click if there is more than one window open."
+msgstr "点击显示打开的窗口的缩略图"
+
+#. 2.8->settings-schema.json->include-all-windows->description
+#. 3.8->settings-schema.json->include-all-windows->description
+#. 3.4->settings-schema.json->include-all-windows->description
+msgid "Include all app windows"
+msgstr "包含所有应用窗口"
+
+#. 2.8->settings-schema.json->include-all-windows->tooltip
+#. 3.8->settings-schema.json->include-all-windows->tooltip
+#. 3.4->settings-schema.json->include-all-windows->tooltip
+msgid ""
+"Controls whether or not thumbnails for smalller child windows, such as exit "
+"confirmations and file dialogues will be included in the thumbnail list."
+msgstr "是否在缩略图中包含子窗口，例如退出确认 , 选择文件等窗口"
+
+#. 2.8->settings-schema.json->AppMenu->description
+msgid "Context Menu Settings"
+msgstr "菜单设置"
+
+#. 2.8->settings-schema.json->show-recent->description
+#. 3.8->settings-schema.json->show-recent->description
+#. 3.4->settings-schema.json->show-recent->description
+msgid "Show recent items"
+msgstr "显示最近访问列表"
+
+#. 2.8->settings-schema.json->show-recent->tooltip
+#. 3.8->settings-schema.json->show-recent->tooltip
+#. 3.4->settings-schema.json->show-recent->tooltip
+msgid "Controls whether recent items will appear in the context menu."
+msgstr "是否在菜单中显示最近访问列表"
+
+#. 2.8->settings-schema.json->menuItemType->description
+#. 3.8->settings-schema.json->menuItemType->description
+#. 3.4->settings-schema.json->menuItemType->description
+msgid "Menu item type"
+msgstr "菜单项类型"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Symbolic icons"
+msgstr "符号图标"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "Non-symbolic icons"
+msgstr "非符号图标"
+
+#. 2.8->settings-schema.json->menuItemType->options
+#. 3.8->settings-schema.json->menuItemType->options
+#. 3.4->settings-schema.json->menuItemType->options
+msgid "No icons"
+msgstr "没有图标"
+
+#. 2.8->settings-schema.json->menuItemType->tooltip
+#. 3.8->settings-schema.json->menuItemType->tooltip
+#. 3.4->settings-schema.json->menuItemType->tooltip
+msgid ""
+"Determines whether menu item icons are symbolic, non-symbolic, or not shown."
+msgstr "确定菜单项图标是符号，非符号还是未显示。"
+
 #. 2.8->settings-schema.json->firefox-menu->description
+#. 3.8->settings-schema.json->firefox-menu->description
 #. 3.4->settings-schema.json->firefox-menu->description
 msgid "Firefox context menu"
 msgstr "Firefox菜单"
 
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Most Visited"
+msgstr "访问最多"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Recent History"
+msgstr "最近历史"
+
+#. 2.8->settings-schema.json->firefox-menu->options
+#. 3.8->settings-schema.json->firefox-menu->options
+#. 3.4->settings-schema.json->firefox-menu->options
+msgid "Bookmarks"
+msgstr "书签"
+
 #. 2.8->settings-schema.json->firefox-menu->tooltip
+#. 3.8->settings-schema.json->firefox-menu->tooltip
 #. 3.4->settings-schema.json->firefox-menu->tooltip
 msgid ""
 "Most Visited: show the sites you visit most, Recent History: display the the "
@@ -616,20 +583,139 @@ msgstr ""
 "访问最多：显示访问最多的网站；最近历史：显示最近访问的页面；书签：显示收藏的"
 "书签"
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Bookmarks"
-msgstr "书签"
+#. 2.8->settings-schema.json->autostart-menu-item->description
+#. 3.8->settings-schema.json->autostart-menu-item->description
+#. 3.4->settings-schema.json->autostart-menu-item->description
+msgid "Show autostart option"
+msgstr "显示自动启动开关"
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Most Visited"
-msgstr "访问最多"
+#. 2.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.8->settings-schema.json->autostart-menu-item->tooltip
+#. 3.4->settings-schema.json->autostart-menu-item->tooltip
+msgid "Shows the autostart toggle option in an app's context menu."
+msgstr "是否在应用菜单里显示自动启动开关"
 
-#. 2.8->settings-schema.json->firefox-menu->options
-#. 3.4->settings-schema.json->firefox-menu->options
-msgid "Recent History"
-msgstr "最近历史"
+#. 2.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.8->settings-schema.json->monitor-move-all-windows->description
+#. 3.4->settings-schema.json->monitor-move-all-windows->description
+msgid "Apply the monitor move option to all windows"
+msgstr "将monitor move选项应用于所有窗口"
+
+#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.8->settings-schema.json->monitor-move-all-windows->tooltip
+#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
+msgid ""
+"When clicking \"Move to monitor\" in the context menu, this option will move "
+"all of an app's windows instead of just the last focused window from the app."
+msgstr ""
+"在上下文菜单中单击”移至监视器“时，此选项将移动所有的应用程序的窗口，而不是只"
+"是最后的焦点窗口从应用程序"
+
+#. 2.8->settings-schema.json->HoverPeek->description
+msgid "Hover Peek Settings"
+msgstr "悬停预览设置"
+
+#. 2.8->settings-schema.json->enable-hover-peek->description
+#. 3.8->settings-schema.json->enable-hover-peek->description
+#. 3.4->settings-schema.json->enable-hover-peek->description
+msgid "Show windows when hovered over"
+msgstr "悬停预览窗口"
+
+#. 2.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.8->settings-schema.json->enable-hover-peek->tooltip
+#. 3.4->settings-schema.json->enable-hover-peek->tooltip
+msgid "Controls whether or not windows display when hovered over."
+msgstr "是否在悬停时显示预览窗口"
+
+#. 2.8->settings-schema.json->hover-peek-time->description
+#. 3.8->settings-schema.json->hover-peek-time->description
+#. 3.4->settings-schema.json->hover-peek-time->description
+msgid "Window fade time"
+msgstr "窗口渐变时长"
+
+#. 2.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.8->settings-schema.json->hover-peek-time->tooltip
+#. 3.4->settings-schema.json->hover-peek-time->tooltip
+msgid "Controls how quickly a window will fade on hover."
+msgstr "窗口悬浮预览的渐变时长"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->units
+#. 3.8->settings-schema.json->hover-peek-opacity->units
+#. 3.4->settings-schema.json->hover-peek-opacity->units
+msgid "percent"
+msgstr "%"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->description
+#. 3.8->settings-schema.json->hover-peek-opacity->description
+#. 3.4->settings-schema.json->hover-peek-opacity->description
+msgid "Window opacity"
+msgstr "窗口不透明度"
+
+#. 2.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.8->settings-schema.json->hover-peek-opacity->tooltip
+#. 3.4->settings-schema.json->hover-peek-opacity->tooltip
+msgid "Opacity of the windows on hover."
+msgstr "悬停时窗口的不透明度"
+
+#. 2.8->settings-schema.json->ThemeSettings->description
+msgid "Theme Settings"
+msgstr "主题设置"
+
+#. 2.8->settings-schema.json->show-active->description
+#. 3.8->settings-schema.json->show-active->description
+#. 3.4->settings-schema.json->show-active->description
+msgid "Show active app indicators"
+msgstr "高亮显示打开的应用"
+
+#. 2.8->settings-schema.json->show-active->tooltip
+#. 3.8->settings-schema.json->show-active->tooltip
+#. 3.4->settings-schema.json->show-active->tooltip
+msgid "Active app styling will indicate if an app is active."
+msgstr "高亮显示打开的应用"
+
+#. 2.8->settings-schema.json->icon-spacing->units
+#. 2.8->settings-schema.json->icon-padding->units
+#. 2.8->settings-schema.json->icon-size->units
+#. 3.8->settings-schema.json->app-button-width->units
+#. 3.8->settings-schema.json->thumbnail-close-button-size->units
+#. 3.8->settings-schema.json->thumbnail-padding->units
+#. 3.8->settings-schema.json->icon-spacing->units
+#. 3.8->settings-schema.json->icon-padding->units
+#. 3.8->settings-schema.json->icon-size->units
+#. 3.4->settings-schema.json->app-button-width->units
+#. 3.4->settings-schema.json->thumbnail-close-button-size->units
+#. 3.4->settings-schema.json->thumbnail-padding->units
+#. 3.4->settings-schema.json->icon-spacing->units
+#. 3.4->settings-schema.json->icon-padding->units
+#. 3.4->settings-schema.json->icon-size->units
+msgid "px"
+msgstr "像素"
+
+#. 2.8->settings-schema.json->icon-spacing->description
+#. 3.8->settings-schema.json->icon-spacing->description
+#. 3.4->settings-schema.json->icon-spacing->description
+msgid "Icon spacing"
+msgstr "图标间距"
+
+#. 2.8->settings-schema.json->icon-spacing->tooltip
+#. 3.8->settings-schema.json->icon-spacing->tooltip
+#. 3.4->settings-schema.json->icon-spacing->tooltip
+msgid "Controls how much space is between the icons."
+msgstr "调节图标间的距离"
+
+#. 2.8->settings-schema.json->icon-padding->description
+#. 3.8->settings-schema.json->icon-padding->description
+#. 3.4->settings-schema.json->icon-padding->description
+msgid "Icon padding"
+msgstr "图标填充"
+
+#. 2.8->settings-schema.json->icon-padding->tooltip
+#. 3.8->settings-schema.json->icon-padding->tooltip
+#. 3.4->settings-schema.json->icon-padding->tooltip
+msgid ""
+"Controls how much horizontal padding is inside the app buttons. Padding is "
+"only applied to instances of this applet on horizontal panels."
+msgstr "调节图标的宽度（填充多少像素）。仅适用此小程序的横向面板。"
 
 #. 2.8->settings-schema.json->themePadding->description
 msgid "Use theme padding to center button icons"
@@ -639,204 +725,341 @@ msgstr "使用主题填充中心按钮图标"
 msgid "If button icons look off-centered, toggling this may help."
 msgstr "如果按钮图标看起来偏心，切换这可能有所帮助。"
 
-#. 2.8->settings-schema.json->group-apps->description
-#. 3.4->settings-schema.json->group-apps->description
-msgid "Group apps"
-msgstr "按程序分组折叠"
+#. 2.8->settings-schema.json->enable-iconSize->description
+#. 3.8->settings-schema.json->enable-iconSize->description
+#. 3.4->settings-schema.json->enable-iconSize->description
+msgid "Adjust icon size"
+msgstr "调节图标尺寸"
 
-#. 2.8->settings-schema.json->group-apps->tooltip
-#. 3.4->settings-schema.json->group-apps->tooltip
-msgid "Group each app's set of windows."
-msgstr "按程序将窗口分组折叠"
+#. 2.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.8->settings-schema.json->enable-iconSize->tooltip
+#. 3.4->settings-schema.json->enable-iconSize->tooltip
+msgid "Adjust icon size independent of Cinnamon's panel scaling."
+msgstr "自定义图标尺寸，不使用自带的缩放"
 
-#. 2.8->settings-schema.json->show-active->description
-#. 3.4->settings-schema.json->show-active->description
-msgid "Show active app indicators"
-msgstr "高亮显示打开的应用"
+#. 2.8->settings-schema.json->icon-size->description
+#. 3.8->settings-schema.json->icon-size->description
+#. 3.4->settings-schema.json->icon-size->description
+msgid "Icon size"
+msgstr "图标尺寸"
 
-#. 2.8->settings-schema.json->show-active->tooltip
-#. 3.4->settings-schema.json->show-active->tooltip
-msgid "Active app styling will indicate if an app is active."
-msgstr "高亮显示打开的应用"
+#. 2.8->settings-schema.json->icon-size->tooltip
+#. 3.8->settings-schema.json->icon-size->tooltip
+#. 3.4->settings-schema.json->icon-size->tooltip
+msgid "Set icon size"
+msgstr "调节图标的尺寸"
 
-#. 2.8->settings-schema.json->show-apps-order-timeout->description
-#. 3.4->settings-schema.json->show-apps-order-timeout->description
-msgid "Duration of the apps order display on hotkey press"
-msgstr "热键按下应用程序顺序的时间显示"
+#. 2.8->settings-schema.json->hoverPseudoClass->description
+#. 3.8->settings-schema.json->hoverPseudoClass->description
+#. 3.4->settings-schema.json->hoverPseudoClass->description
+msgid "App button hover pseudo class"
+msgstr "App按钮悬停伪类"
 
-#. 2.8->settings-schema.json->show-apps-order-timeout->tooltip
-#. 3.4->settings-schema.json->show-apps-order-timeout->tooltip
-msgid ""
-"Determines the duration the window count labels are replaced with the app's "
-"order number."
-msgstr "确定窗口计数标签被应用程序的订单号替换的持续时间。"
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->description
-msgid "Arrange pinned apps"
-msgstr "排列已固定的应用"
-
-#. 2.8->settings-schema.json->arrange-pinnedApps->tooltip
-msgid "Arrange pinned apps into a different order."
-msgstr "以不同顺序排列已固定的应用"
-
-#. 2.8->settings-schema.json->monitor-move-all-windows->description
-#. 3.4->settings-schema.json->monitor-move-all-windows->description
-msgid "Apply the monitor move option to all windows"
-msgstr "将monitor move选项应用于所有窗口"
-
-#. 2.8->settings-schema.json->monitor-move-all-windows->tooltip
-#. 3.4->settings-schema.json->monitor-move-all-windows->tooltip
-msgid ""
-"When clicking \"Move to monitor\" in the context menu, this option will move "
-"all of an app's windows instead of just the last focused window from the app."
-msgstr ""
-"在上下文菜单中单击”移至监视器“时，此选项将移动所有的应用程序的窗口，而不是只"
-"是最后的焦点窗口从应用程序"
-
-#. 2.8->settings-schema.json->sort-thumbnails->description
-#. 3.4->settings-schema.json->sort-thumbnails->description
-msgid "Sort windows for each app by last focused"
-msgstr "根据最后激活时间排列窗口"
-
-#. 2.8->settings-schema.json->sort-thumbnails->tooltip
-#. 3.4->settings-schema.json->sort-thumbnails->tooltip
-msgid ""
-"Controls whether the order windows appear for an app is by last focused, or "
-"the order they were opened."
-msgstr "是否根据最后的激活时间排列窗口， 否则按照打开时间排列"
-
-#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
 #. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
 #. 3.4->settings-schema.json->activePseudoClass->options
-msgid "checked"
-msgstr ""
+msgid "hover"
+msgstr "悬停"
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
-msgid "Highlight the last focused window within an app group"
-msgstr ""
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "focus"
+msgstr "焦点"
 
-#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "active"
+msgstr "活动"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "outlined"
+msgstr "概述"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->options
+#. 2.8->settings-schema.json->focusPseudoClass->options
+#. 2.8->settings-schema.json->activePseudoClass->options
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "selected"
+msgstr "已选中"
+
+#. 2.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.8->settings-schema.json->hoverPseudoClass->tooltip
+#. 3.4->settings-schema.json->hoverPseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons on hover."
+msgstr "覆盖悬停时应用按钮的伪类。"
+
+#. 2.8->settings-schema.json->focusPseudoClass->description
+#. 3.8->settings-schema.json->focusPseudoClass->description
+#. 3.4->settings-schema.json->focusPseudoClass->description
+msgid "App button focus pseudo class"
+msgstr "App按钮焦点伪类"
+
+#. 2.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.8->settings-schema.json->focusPseudoClass->tooltip
+#. 3.4->settings-schema.json->focusPseudoClass->tooltip
+msgid "Overrides the pseudo class for app button on focus."
+msgstr "覆盖焦点上的app按钮的伪类。"
+
+#. 2.8->settings-schema.json->activePseudoClass->description
+#. 3.8->settings-schema.json->activePseudoClass->description
+#. 3.4->settings-schema.json->activePseudoClass->description
+msgid "App button active pseudo class"
+msgstr "App按钮激活伪类"
+
+#. 2.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.8->settings-schema.json->activePseudoClass->tooltip
+#. 3.4->settings-schema.json->activePseudoClass->tooltip
+msgid "Overrides the pseudo class for app buttons when they are active."
+msgstr "当应用按钮处于活动状态时覆盖应用按钮的伪类。"
+
+#. 2.8->settings-schema.json->panelLauncherClass->description
+msgid "Use the panel launcher class for pinned apps"
+msgstr "对固定应用使用面板启动器类"
+
+#. 2.8->settings-schema.json->panelLauncherClass->tooltip
+msgid "Enabling this helps with certain themes."
+msgstr "启用此功能有助于确定某些主题。"
+
+#. 2.8->settings-schema.json->close-button-style->description
+msgid "Allow themes to control the thumbnail close button"
+msgstr "使用主题中的缩略图关闭按钮样式"
+
+#. 2.8->settings-schema.json->close-button-style->tooltip
 msgid ""
-"When enabled, the last window that was interacted with will be indicated."
-msgstr ""
+"Controls whether or not the theme controls the window thumbnail's close "
+"button."
+msgstr "是否使用主题中的缩略图关闭按钮样式"
 
-#. 3.4->settings-schema.json->app-button-transition-duration->description
-#, fuzzy
-msgid "App button transition duration"
-msgstr "应用程序按钮宽度"
+#. 2.8->settings-schema.json->useSystemTooltips->description
+msgid "Use system tooltips for closed apps"
+msgstr "对已关闭的应用使用系统工具提示"
 
-#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+#. 2.8->settings-schema.json->useSystemTooltips->tooltip
 msgid ""
-"Overrides the theme's animation time for app buttons. If set to zero, the "
-"theme's transition duration will be used."
+"Controls whether or not system tooltips are in use when hovering over closed "
+"pinned apps."
+msgstr "控制悬停在已锁定的固定应用程序上时系统工具提示是否正在使用。"
+
+#. 3.8->settings-schema.json->generalPage->title
+#. 3.4->settings-schema.json->generalPage->title
+msgid "General"
 msgstr ""
 
-#. 3.4->settings-schema.json->app-button-transition-duration->units
-msgid "ms"
-msgstr ""
+#. 3.8->settings-schema.json->panelPage->title
+#. 3.4->settings-schema.json->panelPage->title
+msgid "Panel"
+msgstr "面板"
 
-#. 3.4->settings-schema.json->thumbnail-padding->description
-#, fuzzy
-msgid "Thumbnail padding"
-msgstr "缩略图设置"
-
-#. 3.4->settings-schema.json->thumbnail-padding->tooltip
-#, fuzzy
-msgid "Controls how much space will be around the window preview thumbnails."
-msgstr "调节图标间的距离"
-
-#. 3.4->settings-schema.json->system-favorites->description
-msgid "Use system favorites for pinned apps"
-msgstr "为固定的应用程序使用系统收藏夹"
-
-#. 3.4->settings-schema.json->system-favorites->tooltip
-msgid ""
-"Controls whether or not pinned apps consist of the system favorites list."
-msgstr "控制是否固定包含在系统收藏列表的应用程序。"
-
-#. 3.4->settings-schema.json->generalSection->title
-msgid "Behavior"
-msgstr ""
-
+#. 3.8->settings-schema.json->thumbnailsPage->title
+#. 3.8->settings-schema.json->thumbnailsSection->title
 #. 3.4->settings-schema.json->thumbnailsPage->title
 #. 3.4->settings-schema.json->thumbnailsSection->title
 msgid "Thumbnails"
 msgstr "缩略图"
 
-#. 3.4->settings-schema.json->presetSection->title
-msgid "Recommended Presets"
-msgstr "推荐预设值"
-
-#. 3.4->settings-schema.json->appButtonsSection->title
-msgid "App Buttons"
-msgstr "应用程序按钮"
-
-#. 3.4->settings-schema.json->generalPage->title
-msgid "General"
-msgstr ""
-
-#. 3.4->settings-schema.json->hoverPeekSection->title
-msgid "Hover Peek"
-msgstr "悬停预览"
-
-#. 3.4->settings-schema.json->panelPage->title
-msgid "Panel"
-msgstr "面板"
-
-#. 3.4->settings-schema.json->iconSection->title
-msgid "Icons"
-msgstr "图标"
-
-#. 3.4->settings-schema.json->hotKeysSection->title
-msgid "Hot Keys"
-msgstr "热键"
-
-#. 3.4->settings-schema.json->stylingSection->title
-msgid "Styling"
-msgstr "样式"
-
+#. 3.8->settings-schema.json->contextMenuPage->title
 #. 3.4->settings-schema.json->contextMenuPage->title
 msgid "Context Menu"
 msgstr "右键菜单"
 
+#. 3.8->settings-schema.json->themePage->title
 #. 3.4->settings-schema.json->themePage->title
 msgid "Theming"
 msgstr "主题"
 
-#. 3.4->settings-schema.json->mintYPreset->description
-#. 3.4->settings-schema.json->mintYPreset->tooltip
-msgid "Mint Y and Variants"
-msgstr "Mint Y 及其变种"
-
-#. 3.4->settings-schema.json->show-icons->description
-#, fuzzy
-msgid "Show icons"
-msgstr "没有图标"
-
-#. 3.4->settings-schema.json->show-icons->tooltip
-msgid "Show the window's icon next to the title."
+#. 3.8->settings-schema.json->generalSection->title
+#. 3.4->settings-schema.json->generalSection->title
+msgid "Behavior"
 msgstr ""
 
+#. 3.8->settings-schema.json->appButtonsSection->title
+#. 3.4->settings-schema.json->appButtonsSection->title
+msgid "App Buttons"
+msgstr "应用程序按钮"
+
+#. 3.8->settings-schema.json->hotKeysSection->title
+#. 3.4->settings-schema.json->hotKeysSection->title
+msgid "Hot Keys"
+msgstr "热键"
+
+#. 3.8->settings-schema.json->hoverPeekSection->title
+#. 3.4->settings-schema.json->hoverPeekSection->title
+msgid "Hover Peek"
+msgstr "悬停预览"
+
+#. 3.8->settings-schema.json->stylingSection->title
+#. 3.4->settings-schema.json->stylingSection->title
+msgid "Styling"
+msgstr "样式"
+
+#. 3.8->settings-schema.json->iconSection->title
+#. 3.4->settings-schema.json->iconSection->title
+msgid "Icons"
+msgstr "图标"
+
+#. 3.8->settings-schema.json->presetSection->title
+#. 3.4->settings-schema.json->presetSection->title
+msgid "Recommended Presets"
+msgstr "推荐预设值"
+
+#. 3.8->settings-schema.json->scroll-behavior->description
+#. 3.4->settings-schema.json->scroll-behavior->description
+msgid "Mouse wheel scroll behavior"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+msgid "Cycle apps"
+msgstr ""
+
+#. 3.8->settings-schema.json->scroll-behavior->options
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->scroll-behavior->options
+#. 3.4->settings-schema.json->left-click-action->options
+#, fuzzy
+msgid "Cycle windows"
+msgstr "包含所有应用窗口"
+
+#. 3.8->settings-schema.json->scroll-behavior->tooltip
+#. 3.4->settings-schema.json->scroll-behavior->tooltip
+msgid ""
+"Choose if scrolling the mouse wheel cycles running apps, an app button's "
+"windows on hover, or is disabled."
+msgstr ""
+
+#. 3.8->settings-schema.json->left-click-action->description
+#. 3.8->settings-schema.json->left-click-action->tooltip
+#. 3.8->settings-schema.json->launcher-animation-effect->tooltip
+#. 3.4->settings-schema.json->left-click-action->description
+#. 3.4->settings-schema.json->left-click-action->tooltip
+#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
+msgid "Left click action"
+msgstr ""
+
+#. 3.8->settings-schema.json->left-click-action->options
+#. 3.4->settings-schema.json->left-click-action->options
+msgid "Toggle activation of last focused window"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->description
+#. 3.8->settings-schema.json->middle-click-action->tooltip
+#. 3.4->settings-schema.json->middle-click-action->description
+#. 3.4->settings-schema.json->middle-click-action->tooltip
+msgid "Middle click action"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Launch new app instance"
+msgstr ""
+
+#. 3.8->settings-schema.json->middle-click-action->options
+#. 3.4->settings-schema.json->middle-click-action->options
+msgid "Close last focused window in group"
+msgstr ""
+
+#. 3.8->settings-schema.json->system-favorites->description
+#. 3.4->settings-schema.json->system-favorites->description
+msgid "Use system favorites for pinned apps"
+msgstr "为固定的应用程序使用系统收藏夹"
+
+#. 3.8->settings-schema.json->system-favorites->tooltip
+#. 3.4->settings-schema.json->system-favorites->tooltip
+msgid ""
+"Controls whether or not pinned apps consist of the system favorites list."
+msgstr "控制是否固定包含在系统收藏列表的应用程序。"
+
+#. 3.8->settings-schema.json->show-all-workspaces->description
+#. 3.8->settings-schema.json->show-all-workspaces->tooltip
+#. 3.4->settings-schema.json->show-all-workspaces->description
+#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#, fuzzy
+msgid "Show windows from all workspaces"
+msgstr "在所有工作区可见"
+
+#. 3.8->settings-schema.json->enable-app-button-dragging->description
+#. 3.8->settings-schema.json->enable-app-button-dragging->tooltip
 #. 3.4->settings-schema.json->enable-app-button-dragging->description
 #. 3.4->settings-schema.json->enable-app-button-dragging->tooltip
 msgid "Enable app button dragging"
 msgstr "启用应用程序按钮拖动"
 
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
-#, fuzzy
-msgid "Show new window option"
-msgstr "显示自动启动开关"
-
-#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
-msgid ""
-"Shows the \"New Window\" option in an app's context menu if it doesn't "
-"already have one from the app's own action menu items."
+#. 3.8->settings-schema.json->launcher-animation-effect->description
+#. 3.4->settings-schema.json->launcher-animation-effect->description
+msgid "Launcher animation effect"
 msgstr ""
 
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Fade"
+msgstr ""
+
+#. 3.8->settings-schema.json->launcher-animation-effect->options
+#. 3.4->settings-schema.json->launcher-animation-effect->options
+msgid "Scale"
+msgstr ""
+
+#. 3.8->settings-schema.json->list-monitor-windows->description
+#. 3.4->settings-schema.json->list-monitor-windows->description
+msgid "Only list windows from the monitor displaying this instance"
+msgstr "仅显示该实例的显示器的列表窗口"
+
+#. 3.8->settings-schema.json->list-monitor-windows->tooltip
+#. 3.4->settings-schema.json->list-monitor-windows->tooltip
+msgid ""
+"This option will only come into effect for monitors displaying an ITM "
+"instance."
+msgstr "该选项仅对显示ITM实例的显示器生效。"
+
+#. 3.8->settings-schema.json->enable-app-button-width->description
+#. 3.4->settings-schema.json->enable-app-button-width->description
+msgid "Use a custom width for app buttons"
+msgstr ""
+
+#. 3.8->settings-schema.json->enable-app-button-width->tooltip
+#. 3.4->settings-schema.json->enable-app-button-width->tooltip
+msgid "When disabled, the app button width is determined by the panel height."
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-width->description
 #. 3.4->settings-schema.json->app-button-width->description
 msgid "App button width"
 msgstr "应用程序按钮宽度"
 
+#. 3.8->settings-schema.json->app-button-width->tooltip
 #. 3.4->settings-schema.json->app-button-width->tooltip
 #, fuzzy
 msgid ""
@@ -844,118 +1067,122 @@ msgid ""
 "horizontal panels."
 msgstr "控制应用程序按钮的宽度。"
 
-#. 3.4->settings-schema.json->mintXPreset->description
-#. 3.4->settings-schema.json->mintXPreset->tooltip
-#, fuzzy
-msgid "Mint X, Linux Mint, and Variants"
-msgstr "Mint Y 及其变种"
-
-#. 3.4->settings-schema.json->launcher-animation-effect->description
-msgid "Launcher animation effect"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->tooltip
-#. 3.4->settings-schema.json->left-click-action->description
-#. 3.4->settings-schema.json->left-click-action->tooltip
-msgid "Left click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Scale"
-msgstr ""
-
-#. 3.4->settings-schema.json->launcher-animation-effect->options
-msgid "Fade"
-msgstr ""
-
-#. 3.4->settings-schema.json->enable-app-button-width->description
-msgid "Use a custom width for app buttons"
-msgstr ""
-
-#. 3.4->settings-schema.json->enable-app-button-width->tooltip
-msgid "When disabled, the app button width is determined by the panel height."
-msgstr ""
-
-#. 3.4->settings-schema.json->list-monitor-windows->description
-msgid "Only list windows from the monitor displaying this instance"
-msgstr "仅显示该实例的显示器的列表窗口"
-
-#. 3.4->settings-schema.json->list-monitor-windows->tooltip
-msgid ""
-"This option will only come into effect for monitors displaying an ITM "
-"instance."
-msgstr "该选项仅对显示ITM实例的显示器生效。"
-
+#. 3.8->settings-schema.json->thumbnail-close-button-size->description
 #. 3.4->settings-schema.json->thumbnail-close-button-size->description
 #, fuzzy
 msgid "Close button size"
 msgstr "调节图标的尺寸"
 
+#. 3.8->settings-schema.json->thumbnail-close-button-size->tooltip
 #. 3.4->settings-schema.json->thumbnail-close-button-size->tooltip
 #, fuzzy
 msgid "Controls how large the thumbnail close button is."
 msgstr "使用主题中的缩略图关闭按钮样式"
 
-#. 3.4->settings-schema.json->middle-click-action->description
-#. 3.4->settings-schema.json->middle-click-action->tooltip
-msgid "Middle click action"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Launch new app instance"
-msgstr ""
-
-#. 3.4->settings-schema.json->middle-click-action->options
-msgid "Close last focused window in group"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->description
-msgid "Mouse wheel scroll behavior"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->tooltip
-msgid ""
-"Choose if scrolling the mouse wheel cycles running apps, an app button's "
-"windows on hover, or is disabled."
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->options
-msgid "Cycle apps"
-msgstr ""
-
-#. 3.4->settings-schema.json->scroll-behavior->options
-#. 3.4->settings-schema.json->left-click-action->options
+#. 3.8->settings-schema.json->thumbnail-padding->description
+#. 3.4->settings-schema.json->thumbnail-padding->description
 #, fuzzy
-msgid "Cycle windows"
-msgstr "包含所有应用窗口"
+msgid "Thumbnail padding"
+msgstr "缩略图设置"
 
-#. 3.4->settings-schema.json->show-all-workspaces->description
-#. 3.4->settings-schema.json->show-all-workspaces->tooltip
+#. 3.8->settings-schema.json->thumbnail-padding->tooltip
+#. 3.4->settings-schema.json->thumbnail-padding->tooltip
 #, fuzzy
-msgid "Show windows from all workspaces"
-msgstr "在所有工作区可见"
+msgid "Controls how much space will be around the window preview thumbnails."
+msgstr "调节图标间的距离"
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->description
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->description
 msgid "Cycle windows on mouse wheel scroll"
 msgstr ""
 
+#. 3.8->settings-schema.json->thumbnail-scroll-behavior->tooltip
 #. 3.4->settings-schema.json->thumbnail-scroll-behavior->tooltip
 msgid ""
 "Choose whether or not scrolling the mouse wheel cycles windows when hovering "
 "over a thumbnail menu."
 msgstr ""
 
-#. 3.4->settings-schema.json->left-click-action->options
-msgid "Toggle activation of last focused window"
+#. 3.8->settings-schema.json->show-icons->description
+#. 3.4->settings-schema.json->show-icons->description
+#, fuzzy
+msgid "Show icons"
+msgstr "没有图标"
+
+#. 3.8->settings-schema.json->show-icons->tooltip
+#. 3.4->settings-schema.json->show-icons->tooltip
+msgid "Show the window's icon next to the title."
 msgstr ""
 
-#. IcingTaskManager@json->metadata.json->name
-msgid "Icing Task Manager"
-msgstr "Icing Task Manager"
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->description
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->description
+msgid "Highlight the last focused window within an app group"
+msgstr ""
 
-#. IcingTaskManager@json->metadata.json->description
-msgid "Window list with app grouping and thumbnails"
-msgstr "带应用程序分组和缩略图的窗口列表"
+#. 3.8->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+#. 3.4->settings-schema.json->highlight-last-focused-thumbnail->tooltip
+msgid ""
+"When enabled, the last window that was interacted with will be indicated."
+msgstr ""
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->description
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->description
+#, fuzzy
+msgid "Show new window option"
+msgstr "显示自动启动开关"
+
+#. 3.8->settings-schema.json->launch-new-instance-menu-item->tooltip
+#. 3.4->settings-schema.json->launch-new-instance-menu-item->tooltip
+msgid ""
+"Shows the \"New Window\" option in an app's context menu if it doesn't "
+"already have one from the app's own action menu items."
+msgstr ""
+
+#. 3.8->settings-schema.json->hoverPseudoClass->options
+#. 3.8->settings-schema.json->focusPseudoClass->options
+#. 3.8->settings-schema.json->activePseudoClass->options
+#. 3.4->settings-schema.json->hoverPseudoClass->options
+#. 3.4->settings-schema.json->focusPseudoClass->options
+#. 3.4->settings-schema.json->activePseudoClass->options
+msgid "checked"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->units
+#. 3.4->settings-schema.json->app-button-transition-duration->units
+msgid "ms"
+msgstr ""
+
+#. 3.8->settings-schema.json->app-button-transition-duration->description
+#. 3.4->settings-schema.json->app-button-transition-duration->description
+#, fuzzy
+msgid "App button transition duration"
+msgstr "应用程序按钮宽度"
+
+#. 3.8->settings-schema.json->app-button-transition-duration->tooltip
+#. 3.4->settings-schema.json->app-button-transition-duration->tooltip
+msgid ""
+"Overrides the theme's animation time for app buttons. If set to zero, the "
+"theme's transition duration will be used."
+msgstr ""
+
+#. 3.8->settings-schema.json->mintYPreset->description
+#. 3.8->settings-schema.json->mintYPreset->tooltip
+#. 3.4->settings-schema.json->mintYPreset->description
+#. 3.4->settings-schema.json->mintYPreset->tooltip
+msgid "Mint Y and Variants"
+msgstr "Mint Y 及其变种"
+
+#. 3.8->settings-schema.json->mintXPreset->description
+#. 3.8->settings-schema.json->mintXPreset->tooltip
+#. 3.4->settings-schema.json->mintXPreset->description
+#. 3.4->settings-schema.json->mintXPreset->tooltip
+#, fuzzy
+msgid "Mint X, Linux Mint, and Variants"
+msgstr "Mint Y 及其变种"
+
+#. 3.8->settings-schema.json->migrationButton->description
+msgid "Migrate Pinned Apps to Grouped Window List"
+msgstr ""
 
 #~ msgid "number"
 #~ msgstr "个数"

--- a/IcingTaskManager@json/files/IcingTaskManager@json/po/zh_CN.po
+++ b/IcingTaskManager@json/files/IcingTaskManager@json/po/zh_CN.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-10 00:43-0600\n"
+"POT-Creation-Date: 2018-12-13 18:37-0600\n"
 "PO-Revision-Date: \n"
 "Last-Translator: zqq90 <zqq_90@163.com>\n"
 "Language-Team: \n"
@@ -14,53 +14,53 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: 3.8/applet.js:471
-msgid "Icing Task Manager is now Grouped Window List"
-msgstr ""
+#: 3.8/applet.js:476
+#, fuzzy
+msgid "Icing Task Manager is deprecated"
+msgstr "Icing Task Manager"
 
-#: 3.8/applet.js:472
+#: 3.8/applet.js:477
 msgid ""
-"Please open the applet's settings and click \"Migrate Pinned Apps to Grouped "
-"Window List\". "
+"Please upgrade to Grouped Window List for a more stable, bug-free experience."
 msgstr ""
 
-#: 3.8/applet.js:473
+#: 3.8/applet.js:478
 msgid ""
-"Then from Applet Settings, replace Icing Task Manager with Grouped Window "
-"List."
+"Add GWL to your panel, open the applet's settings and click \"Migrate Pinned "
+"Apps to Grouped Window List\"."
 msgstr ""
 
-#: 3.8/applet.js:485
-msgid "Migration can only be performed on Cinnamon 4.0."
+#: 3.8/applet.js:490
+msgid "Migration can only be performed on Cinnamon 4.0+."
 msgstr ""
 
-#: 3.8/applet.js:496
+#: 3.8/applet.js:501
 msgid ""
 "Please add Grouped Window List to a panel before proceeding with the "
 "migration."
 msgstr ""
 
-#: 3.8/applet.js:504
+#: 3.8/applet.js:509
 msgid "ITM settings directory could not be found!"
 msgstr ""
 
-#: 3.8/applet.js:534
+#: 3.8/applet.js:539
 msgid "System favorites enabled - no migration is needed."
 msgstr ""
 
-#: 3.8/applet.js:577
+#: 3.8/applet.js:582
 msgid "Unable to find a suitable ITM settings file to migrate."
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid "Migration complete. "
 msgstr ""
 
-#: 3.8/applet.js:586
+#: 3.8/applet.js:591
 msgid " settings file(s) could not be migrated."
 msgstr ""
 
-#: 3.8/applet.js:592
+#: 3.8/applet.js:597
 msgid "Migration was successful."
 msgstr ""
 
@@ -1183,6 +1183,10 @@ msgstr "Mint Y 及其变种"
 #. 3.8->settings-schema.json->migrationButton->description
 msgid "Migrate Pinned Apps to Grouped Window List"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Icing Task Manager is deprecated - please use Grouped Window List"
+#~ msgstr "Icing Task Manager"
 
 #~ msgid "number"
 #~ msgstr "个数"


### PR DESCRIPTION
  * Added a deprecation notice notification for Cinnamon 4.0 users.
  * Added migration functionality for moving local pinned apps from ITM to Grouped Window List in Cinnamon 4.0. This can be accessed by clicking "Migrate Pinned Apps to Grouped Window List" from ITM's settings.