### PR TITLE
Make empty arrows appear if network state is undefined. (for  ifstat@tagadan)

### DIFF
--- a/ifstat@tagadan/files/ifstat@tagadan/applet.js
+++ b/ifstat@tagadan/files/ifstat@tagadan/applet.js
@@ -55,7 +55,7 @@ MyApplet.prototype = {
 			if (outa != "0.00" && outb =="0.00"){
 				printout="\u25bc\u25b3";}
 			if (outa == "undefined" && outb =="undefined"){
-				printout="";}
+				printout="\u25bd\u25b3";}
 
             		this.set_applet_tooltip(_(asd + "\nKB/s in: " + outa + "\nKB/s out: " + outb));
 			this.set_applet_label(printout);


### PR DESCRIPTION
The applet changes sizes when network state is undefined, which is jarring. Changed it to show the empty arrows instead of nothing.