### PR TITLE
Cinnamenu@json: Replace Gtk.RecentManager with docinfo

### DIFF
--- a/Cinnamenu@json/CHANGELOG.md
+++ b/Cinnamenu@json/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 
+### 4.1.2
+
+  * Switched recent file management over to Cinnamon's DocInfo manager.
+
 ### 4.1.1
 
   * Fixed the "Add to desktop" context menu option.

--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/applet.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/applet.js
@@ -7,6 +7,7 @@ const Cinnamon = imports.gi.Cinnamon;
 const St = imports.gi.St;
 const Meta = imports.gi.Meta;
 const Main = imports.ui.main;
+const {getDocManager} = imports.misc.docInfo;
 const Mainloop = imports.mainloop;
 const {SessionManager} = imports.misc.gnomeSession;
 const {ScreenSaverProxy} = imports.misc.screenSaver;
@@ -262,6 +263,7 @@ class CinnamenuApplet extends TextIconApplet {
 
     this.session = new SessionManager();
     this.screenSaverProxy = new ScreenSaverProxy();
+    this.recentManager = getDocManager();
     this.gtkRecentManager = Gtk.RecentManager.get_default();
 
     this.init = true;
@@ -1483,7 +1485,7 @@ class CinnamenuApplet extends TextIconApplet {
     if (!this.state.recentEnabled) {
       return [];
     }
-    let {_infosByTimestamp} = Main.recentManager;
+    let {_infosByTimestamp} = this.recentManager;
     let res = []
 
     for (let i = 0, len = _infosByTimestamp.length; i < len; i++) {

--- a/Cinnamenu@json/files/Cinnamenu@json/metadata.json
+++ b/Cinnamenu@json/files/Cinnamenu@json/metadata.json
@@ -3,7 +3,7 @@
   "name": "Cinnamenu",
   "description": "A flexible menu providing formatting options, web bookmarks, open window lookup, and search provider support with fuzzy searching.",
   "max-instances": 2,
-  "version": "4.1.1",
+  "version": "4.1.2",
   "multiversion": true,
   "website": "https://github.com/linuxmint/cinnamon-spices-applets/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+Cinnamenu%40json",
   "comments": "Made possible thanks to the efforts of contributors to the Cinnamon menu, Gnomenu, and the contributors to projects they derived from.",


### PR DESCRIPTION
Depends on https://github.com/linuxmint/Cinnamon/pull/8278

Cinnamon's docinfo module provides caching and sorting out of the box, among other performance improvements. From the PR comment:

>  - Results are limited to 20 (with RecentManager you can get a huge number of results)
>  - Results are sorted by timestamp (they're not sorted by RecentManager)
>  - Sorting and clamping of the results is done in C and only the 20 most recent results are stored in memory
>  - The "changed" signal sent by DocSystem is delayed via idle_timeout, so your applet doesn't rebuild immediately when Gtk.RecentManager sends its signal (which could potentially reduce the speed at which apps are launched)
>  - DocInfo provides decoded URIs and the ability to quickly create the icon so your applet doesn't need to do that itself.