### PR TITLE
SpicesUpdate@claudiux v1.1.1: Solves FR #2213

### DIFF
--- a/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v1.1.1~20190115
+  * New feature (requested by @sphh in Forget new spices #2213): When new Spices are available, an option _Forget new Spices_ appears in the menu of this applet. Clicking it will clear these notifications of new spices, until others arrive.
+  * Available languages: English, French, Spanish, Croatian, German, Italian.
+
 ### v1.1.0~20190113
   * New feature (requested by @sphh in #2202): This applet can also warn the user when new Spices are available. (New option in general settings.)
   * Minor bug fixes.

--- a/SpicesUpdate@claudiux/README.md
+++ b/SpicesUpdate@claudiux/README.md
@@ -53,6 +53,7 @@ In the menu of this applet:
   * a Refresh button allows you to force checking the availability of updates for your Spices;
   * a dot appears in front of each type of Spice when at least one update is available;
   * a click on a type of Spice (Applets, Desklets, etc) opens the corresponding page in Cinnamon Settings;
+  * when new Spices are available, an option _Forget new Spices_ appears; clicking it will clear these notifications of new spices, until others arrive;
   * a Configure... button opens the Settings.
 
 ## Icon

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v1.1.1~20190115
+  * New feature (requested by @sphh in Forget new spices #2213): When new Spices are available, an option _Forget new Spices_ appears in the menu of this applet. Clicking it will clear these notifications of new spices, until others arrive.
+  * Available languages: English, French, Spanish, Croatian, German, Italian.
+
 ### v1.1.0~20190113
   * New feature (requested by @sphh in #2202): This applet can also warn the user when new Spices are available. (New option in general settings.)
   * Minor bug fixes.

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/README.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/README.md
@@ -53,6 +53,7 @@ In the menu of this applet:
   * a Refresh button allows you to force checking the availability of updates for your Spices;
   * a dot appears in front of each type of Spice when at least one update is available;
   * a click on a type of Spice (Applets, Desklets, etc) opens the corresponding page in Cinnamon Settings;
+  * when new Spices are available, an option _Forget new Spices_ appears; clicking it will clear these notifications of new spices, until others arrive;
   * a Configure... button opens the Settings.
 
 ## Icon

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/metadata.json
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/metadata.json
@@ -3,6 +3,6 @@
     "name": "Spices Update",
     "max-instances": "1",
     "hide-configuration": false,
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Warns you when your Spices (applets, desklets, extensions, themes) require an update."
 }

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/po/fr.po
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/po/fr.po
@@ -5,10 +5,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: SpicesUpdate@claudiux v1.1.0\n"
+"Project-Id-Version: SpicesUpdate@claudiux v1.1.1\n"
 "Report-Msgid-Bugs-To: Claudiux <claude.clerc@gmail.com>\n"
 "POT-Creation-Date: 2019-01-02 13:30+0100\n"
-"PO-Revision-Date: 2019-01-13 03:59+0100\n"
+"PO-Revision-Date: 2019-01-15 19:14+0100\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -338,6 +338,10 @@ msgstr "Veuillez exécuter, dans le terminal qui s'est ouvert, les commandes :"
 msgid "Some dependencies are not installed!"
 msgstr "Certaines dépendances ne sont pas installées !"
 
-#: applet.js:1168
+#: applet.js:1225
+msgid "Forget new Spices"
+msgstr "Oublier les nouveautés"
+
+#: applet.js:1232
 msgid "Configure"
 msgstr "Configurer"

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/po/it.po
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: SpicesUpdate@claudiux v1.1.1\n"
 "Report-Msgid-Bugs-To: Claudiux <claude.clerc@gmail.com>\n"
 "POT-Creation-Date: 2019-01-02 13:30+0100\n"
-"PO-Revision-Date: 2019-01-15 19:22+0100\n"
+"PO-Revision-Date: 2019-01-15 19:24+0100\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,7 +16,7 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 "Last-Translator: Claude CLERC <claude.clerc@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: es\n"
+"Language: it\n"
 
 #: metadata.json:3
 msgid "Spices Update"
@@ -24,219 +24,219 @@ msgstr "Spices Update"
 
 #: metadata.json:7
 msgid "Warns you when your Spices (applets, desklets, extensions, themes) require an update."
-msgstr "Una nueva opción permite al usuario elegir si se muestran mensajes idénticos o no."
+msgstr "Ti avverte quando le tue Spices (applet, desktop, estensioni, temi) richiedono un aggiornamento."
 
 #: settings-schema.json:7
 msgid "Applets"
-msgstr "Applets"
+msgstr "Applet"
 
 #: settings-schema.json:12
 msgid "Desklets"
-msgstr "Desklets"
+msgstr "Desklet"
 
 #: settings-schema.json:17
 msgid "Extensions"
-msgstr "Extensiones"
+msgstr "Estensioni"
 
 #: settings-schema.json:22
 msgid "Themes"
-msgstr "Temas"
+msgstr "Temi"
 
 #: settings-schema.json:27
 msgid "General"
-msgstr "General"
+msgstr "Generali"
 
 #: settings-schema.json:32
 msgid "Checking"
-msgstr "Verificación"
+msgstr "Controllo"
 
 #: settings-schema.json:37
 msgid "Monitoring"
-msgstr "Monitoreo"
+msgstr "Monitoraggio"
 
 #: settings-schema.json:72
 msgid "Frequency"
-msgstr "Frecuencia"
+msgstr "Frequenza"
 
 #: settings-schema.json:77
 msgid "Notifications"
-msgstr "Notificaciones"
+msgstr "Notifiche"
 
 #: settings-schema.json:82
 msgid "Display type"
-msgstr "Tipo de visualización"
+msgstr "Tipo di vizzualizzazione"
 
 #: settings-schema.json:90
 msgid "Let regularly check if your applets are up to date"
-msgstr "Comprobar regularmente si sus applets están actualizadas."
+msgstr "Controllare regolarmente se le tue applet sono aggiornate"
 
 #: settings-schema.json:91
 msgid "If applets updates do not concern you, uncheck this box."
-msgstr "Si las actualizaciones de applets no conciernen usted, desmarque esta casilla."
+msgstr "Se gli aggiornamenti delle applet non ti riguardano, deseleziona questa casella."
 
 #: settings-schema.json:95
 msgid "Refresh"
-msgstr "Actualizar"
+msgstr "Aggiorna"
 
 #: settings-schema.json:100
 msgid "Update these applets:"
-msgstr "Actualizar estas applets:"
+msgstr "Aggiorna queste applet:"
 
 #: settings-schema.json:101
 msgid "If you do not want an applet to be checked, set it to FALSE."
-msgstr "Si no desea que se compruebe una applet, configúrela en FALSE."
+msgstr "Se non si desidera controllare un'applet, impostarla su FALSE."
 
 #: settings-schema.json:105
 msgid "Your Applets"
-msgstr "Sus applets"
+msgstr "Le tue applet"
 
 #: settings-schema.json:110
 msgid "Check for updates?"
-msgstr "¿Buscar actualizaciones?"
+msgstr "Controlla gli aggiornamenti?"
 
 #: settings-schema.json:118
 msgid "Open Cinnamon Settings to manage all the Applets"
-msgstr "Abrir Ajustes de Cinnamon para gestionar todas las applets."
+msgstr "Apri Impostazioni di sistema per gestire tutte le Applet"
 
 #: settings-schema.json:126
 msgid "Let regularly check if your desklets are up to date"
-msgstr "Comprobar regularmente si sus desklets están actualizadas."
+msgstr "Controlla regolarmente se i tuoi desklet sono aggiornati"
 
 #: settings-schema.json:127
 msgid "If desklets updates do not concern you, uncheck this box."
-msgstr "Si las actualizaciones de desklets no conciernen usted, desmarque esta casilla."
+msgstr "Se gli aggiornamenti dei desklet non ti riguardano, deseleziona questa casella."
 
 #: settings-schema.json:136
 msgid "Update these desklets:"
-msgstr "Actualizar estas desklets:"
+msgstr "Aggiorna questi desklet:"
 
 #: settings-schema.json:137
 msgid "If you do not want a desklet to be checked, set it to FALSE."
-msgstr "Si no desea que se compruebe una desklet, configúrela en FALSE."
+msgstr "Se non si desidera controllare un desklet, impostarlo su FALSE."
 
 #: settings-schema.json:141
 msgid "Your Desklets"
-msgstr "Sus Desklets"
+msgstr "I tuoi desklet"
 
 #: settings-schema.json:154
 msgid "Open Cinnamon Settings to manage all the Desklets"
-msgstr "Abrir Ajustes de Cinnamon para gestionar todas las desklets."
+msgstr "Apri Impostazioni di sistema per gestire tutti i Desklet"
 
 #: settings-schema.json:162
 msgid "Let regularly check if your extensions are up to date"
-msgstr "Comprobar regularmente si sus extenciones están actualizadas."
+msgstr "Controlla regolarmente se le tue estensioni sono aggiornate"
 
 #: settings-schema.json:163
 msgid "If extensions updates do not concern you, uncheck this box."
-msgstr "Si las actualizaciones de extensiones no conciernen usted, desmarque esta casilla."
+msgstr "Se gli aggiornamenti delle estensioni non riguardano te, deseleziona questa casella."
 
 #: settings-schema.json:172
 msgid "Update these extensions:"
-msgstr "Actualizar estas extensiones:"
+msgstr "Aggiorna queste estensioni:"
 
 #: settings-schema.json:173
 msgid "If you do not want an extension to be checked, set it to FALSE."
-msgstr "Si no desea que se compruebe una extensión, configúrela en FALSE."
+msgstr "Se non si desidera controllare un'estensione, impostarla su FALSE."
 
 #: settings-schema.json:177
 msgid "Your Extensions"
-msgstr "Sus Extensiones"
+msgstr "Le tue estensioni"
 
 #: settings-schema.json:190
 msgid "Open Cinnamon Settings to manage all the Extensions"
-msgstr "Abrir Ajustes de Cinnamon para gestionar todas las extensiones."
+msgstr "Apri Impostazioni di sistema per gestire tutte le estensioni"
 
 #: settings-schema.json:198
 msgid "Let regularly check if your themes are up to date"
-msgstr "Comprobar regularmente si sus temas están actualizados."
+msgstr "Controlla regolarmente se le tue temi sono aggiornate"
 
 #: settings-schema.json:199
 msgid "If themes updates do not concern you, uncheck this box."
-msgstr "Si las actualizaciones de temas no conciernen usted, desmarque esta casilla."
+msgstr "Se gli aggiornamenti dei temi non ti riguardano, deseleziona questa casella."
 
 #: settings-schema.json:208
 msgid "Update these themes:"
-msgstr "Actualizar estos temas:"
+msgstr "Aggiorna questi temi:"
 
 #: settings-schema.json:209
 msgid "If you do not want a theme to be checked, set it to FALSE."
-msgstr "Si no desea que se compruebe un tema, configúrelo en FALSE."
+msgstr "Se non si desidera controllare un tema, impostarlo su FALSE."
 
 #: settings-schema.json:213
 msgid "Your Themes"
-msgstr "Sus Temas"
+msgstr "I tuoi temi"
 
 #: settings-schema.json:226
 msgid "Open Cinnamon Settings to manage all the Themes"
-msgstr "Abrir Ajustes de Cinnamon para gestionar todos los temas."
+msgstr "Apri Impostazioni di sistema per gestire tutti i temi"
 
 #: settings-schema.json:236
 msgid "hours"
-msgstr "horas"
+msgstr "ore"
 
 #: settings-schema.json:237
 msgid "Time interval between two checks"
-msgstr "Intervalo de tiempo entre dos verificaciones"
+msgstr "Intervallo di tempo tra due controlli"
 
 #: settings-schema.json:238
 msgid "Please note that the first check will take place one minute after starting this applet."
-msgstr "Tenga en cuenta que la primera comprobación se realizará un minuto después de iniciar este applet."
+msgstr "Si noti che il primo controllo avverrà un minuto dopo l'avvio di questa applet."
 
 #: settings-schema.json:244
 msgid "Notify me by changing the icon when Spices need an update"
-msgstr "Notifícame cambiando el ícono cuando las Spices necesiten una actualización."
+msgstr "Avvisami cambiando l'icona quando le Spices hanno bisogno di un aggiornamento"
 
 #: settings-schema.json:245
 msgid "By checking this box, you allow this applet to modify its icon to warn you when at least one of the Spices requires an update."
-msgstr "Al marcar esta casilla, permite que este applet modifique su icono para advertirle cuando al menos una de las Spices requiera una actualización."
+msgstr "Selezionando questa casella, si consente a questa applet di modificare la sua icona per avvisare l'utente quando almeno una delle Spices richiede un aggiornamento."
 
 #: settings-schema.json:252
 msgid "The icon color when Spices need an update"
-msgstr "El color del icono cuando las Spices necesitan una actualización."
+msgstr "Colore dell'icona quando le Spices hanno bisogno di un aggiornamento"
 
 #: settings-schema.json:253
 msgid "Click the button to select another color."
-msgstr "Haga clic en el botón para seleccionar otro color."
+msgstr "Fare clic sul pulsante per selezionare un altro colore."
 
 #: settings-schema.json:259
 msgid "Show notification messages about Spices updates"
-msgstr "Mostrar mensajes de notificación sobre actualizaciones de especias"
+msgstr "Mostra messaggi di notifica sugli aggiornamenti delle Spices"
 
 #: settings-schema.json:260
 msgid "By checking this box, you allow this applet to display messages about Spices updates in notifications viewer."
-msgstr "Al marcar esta casilla, permite que este applet muestre mensajes sobre las actualizaciones de Spices en el visor de notificaciones."
+msgstr "Selezionando questa casella, si consente a questa applet di inviare messaggi sugli aggiornamenti di spezie nel visualizzatore di notifiche."
 
 #: settings-schema.json:266
 msgid "Warn me in the same way when new Spices are available"
-msgstr "Avisarme de la misma manera cuando haya nuevas Spices disponibles."
+msgstr "Avvisami allo stesso modo quando sono disponibili nuove Spices"
 
 #: settings-schema.json:267
 msgid "By checking this box, you allow this applet to display messages about new available Spices in notifications viewer."
-msgstr "Al marcar esta casilla, permite que este applet muestre mensajes sobre las nuevas Spices disponibles en el visor de notificaciones."
+msgstr "Selezionando questa casella, si consente a questa applet di inviare messaggi sulle nuove Spices disponibili nel visualizzatore di notifiche."
 
 #: settings-schema.json:274
 msgid "Show notification messages even if they are unchanged"
-msgstr "Mostrar mensajes de notificación incluso si no se han modificado."
+msgstr "Mostra i messaggi di notifica anche se non sono stati modificati"
 
 #: settings-schema.json:275
 msgid "By checking this box, all notification messages will be displayed, even if they are identical to the previous ones."
-msgstr "Al marcar esta casilla, se mostrarán todos los mensajes de notificación, incluso si son idénticos a los anteriores."
+msgstr "Selezionando questa casella, verranno visualizzati tutti i messaggi di notifica, anche se sono identici ai precedenti."
 
 #: settings-schema.json:281
 msgid "Classic - Icon and Text"
-msgstr "Clásico - Icono y texto"
+msgstr "Classico - Icona e testo"
 
 #: settings-schema.json:282
 msgid "Compact - Icon Only"
-msgstr "Compacto - Solo icono"
+msgstr "Compatto - Solo icone"
 
 #: settings-schema.json:284
 msgid "Type of Display"
-msgstr "Tipo de visualización"
+msgstr "Tipo di vizzualizzazione"
 
 #: settings-schema.json:285
 msgid "This feature offers the Classic (default) display with icon and text, and compact display (Icon Only)."
-msgstr "Esta característica ofrece la visualización clásica (predeterminada) con icono y texto, y visualización compacta (solo icono)."
+msgstr "Questa funzione offre la visualizzazione classica (predefinita) con icona e testo e display compatto (solo icona)."
 
 #: applet.js:89
 msgid "Applet"
@@ -248,7 +248,7 @@ msgstr "Desklet"
 
 #: applet.js:91
 msgid "Extension"
-msgstr "Extensión"
+msgstr "Estensione"
 
 #: applet.js:92
 msgid "Theme"
@@ -256,92 +256,92 @@ msgstr "Tema"
 
 #: applet.js:97
 msgid "One desklet needs update:"
-msgstr "Una desklet necesita actualización:"
+msgstr "Un desklet deve essere aggiornato:"
 
 #: applet.js:98
 msgid "One applet needs update:"
-msgstr "Una applet necesita actualización:"
+msgstr "Un'applet deve essere aggiornata:"
 
 #: applet.js:99
 msgid "One extension needs update:"
-msgstr "Una extensión necesita actualización:"
+msgstr "Un'estensione deve essere aggiornata:"
 
 #: applet.js:100
 msgid "One theme needs update:"
-msgstr "Un tema necesita actualización:"
+msgstr "Un tema deve essere aggiornato:"
 
 #: applet.js:101
 msgid "Some desklets need update:"
-msgstr "Algunas desklets necesitan actualización:"
+msgstr "Alcuni desklet devono essere aggiornati:"
 
 #: applet.js:102
 msgid "Some applets need update:"
-msgstr "Algunas applets necesitan actualización:"
+msgstr "Alcune applet necessitano di aggiornamento:"
 
 #: applet.js:103
 msgid "Some extensions need update:"
-msgstr "Algunas extensiones necesitan actualización:"
+msgstr "Alcune estensioni devono essere aggiornate:"
 
 #: applet.js:104
 msgid "Some themes need update:"
-msgstr "Algunos temas necesitan actualización:"
+msgstr "Alcuni temi devono essere aggiornati:"
 
 #: applet.js:105
 msgid "New desklet available:"
-msgstr "Nueva desklet disponible:"
+msgstr "Nuovo applet disponibile:"
 
 #: applet.js:106
 msgid "New applet available:"
-msgstr "Nueva applet disponible:"
+msgstr "Nuova applet disponibile:"
 
 #: applet.js:107
 msgid "New extension available:"
-msgstr "Nueva extensión disponible:"
+msgstr "Nuova estensione disponibile:"
 
 #: applet.js:108
 msgid "New theme available:"
-msgstr "Nuevo tema disponible:"
+msgstr "Nuovo tema disponibile:"
 
 #: applet.js:109
 msgid "New desklets available:"
-msgstr "Nuevas desklets disponibles:"
+msgstr "Nuovi desklet disponibili:"
 
 #: applet.js:110
 msgid "New applets available:"
-msgstr "Nuevas applets disponibles:"
+msgstr "Nuove applet disponibili:"
 
 #: applet.js:111
 msgid "New extensions available:"
-msgstr "Nuevas extensiones disponibles:"
+msgstr "Nuove estensioni disponibili:"
 
 #: applet.js:112
 msgid "New themes available:"
-msgstr "Nuevos temas disponibles:"
+msgstr "Nuovi temi disponibili:"
 
 #: applet.js:780
 msgid "is fully functional."
-msgstr "es completamente funcional."
+msgstr "è completamente funzionante."
 
 #: applet.js:781
 msgid "All dependencies are installed"
-msgstr "Todas las dependencias están instaladas"
+msgstr "Tutte le dipendenze sono installate"
 
 #: applet.js:803
 msgid "You appear to be missing some of the programs required for this applet to have all its features."
-msgstr "Parece que le faltan algunos de los programas necesarios para que este applet tenga todas sus características."
+msgstr "Sembra che manchino alcuni dei programmi richiesti per questa applet per avere tutte le sue funzionalità."
 
 #: applet.js:804
 msgid "Please execute, in the just opened terminal, the commands:"
-msgstr "Ejecute, en la terminal recién abierta, los comandos:"
+msgstr "Si prega di eseguire, nel terminale appena aperto, i comandi:"
 
 #: applet.js:805
 msgid "Some dependencies are not installed!"
-msgstr "¡Algunas dependencias no están instaladas!"
+msgstr "Alcune dipendenze non sono installate!"
 
 #: applet.js:1225
 msgid "Forget new Spices"
-msgstr "Olvidar las nuevas Spices"
+msgstr "Dimentica le nuove Spices"
 
 #: applet.js:1232
 msgid "Configure"
-msgstr "Configurar"
+msgstr "Configurazione"


### PR DESCRIPTION
Hi @jaszhix,

This PR is an answer to the feature request #2213.

When new Spices are available, an option _Forget new Spices_ appears in the menu of this applet. Clicking it will clear these notifications of new spices, until others arrive.

French and Spanish translations: fr.po and es.po are updated.

Italian translation (new!): it.po.

SpicesUpdate@claudiux.pot updated.

Best regards.
Claudiux