### PR TITLE
SpicesUpdate@claudiux: v1.1.3 Added dependency: Presence of symbola ttf. Fixes #2219.

### DIFF
--- a/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,8 +1,11 @@
+### v1.1.3~20190118
+  * Dependencies: Added presence of `symbola` ttf font.
+
 ### v1.1.2~20190117
-  * New feature (requested by @sphh in Forget new spices #2210): Make support for new Spices Applet, Desklet, Extension and Theme specific.
+  * New feature (requested by @sphh in #2210): Make support for new Spices Applet, Desklet, Extension and Theme specific.
 
 ### v1.1.1~20190115
-  * New feature (requested by @sphh in Forget new spices #2213): When new Spices are available, an option _Forget new Spices_ appears in the menu of this applet. Clicking it will clear these notifications of new spices, until others arrive.
+  * New feature (requested by @sphh in #2213): When new Spices are available, an option _Forget new Spices_ appears in the menu of this applet. Clicking it will clear these notifications of new spices, until others arrive.
   * Available languages: English, French, Spanish, Croatian, German, Italian.
 
 ### v1.1.0~20190113

--- a/SpicesUpdate@claudiux/README.md
+++ b/SpicesUpdate@claudiux/README.md
@@ -18,15 +18,15 @@ Fully supported by the author, under continuing development and in continuous us
 
 ## Requirements
 
-The Spices Update requires the tool ```notify-send```.
+The Spices Update requires the ```notify-send``` tool and the ```symbola``` TrueType font.
 
 To install it:
 
-  * Fedora: ```sudo dnf install libnotify```
-  * Arch: ```sudo pacman -Syu libnotify```
-  * Linux Mint: ```sudo apt install libnotify-bin```
+  * Fedora: ```sudo dnf install libnotify gdouros-symbola-fonts```
+  * Arch: ```sudo pacman -Syu libnotify ttf-symbola```
+  * Linux Mint: ```sudo apt install libnotify-bin fonts-symbola```
 
-**This applet helps you to install this dependency, if any.**
+**This applet helps you to install this dependencies, if any.**
 
 ## Settings
 

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,8 +1,11 @@
+### v1.1.3~20190118
+  * Dependencies: Added presence of `symbola` ttf font.
+
 ### v1.1.2~20190117
-  * New feature (requested by @sphh in Forget new spices #2210): Make support for new Spices Applet, Desklet, Extension and Theme specific.
+  * New feature (requested by @sphh in #2210): Make support for new Spices Applet, Desklet, Extension and Theme specific.
 
 ### v1.1.1~20190115
-  * New feature (requested by @sphh in Forget new spices #2213): When new Spices are available, an option _Forget new Spices_ appears in the menu of this applet. Clicking it will clear these notifications of new spices, until others arrive.
+  * New feature (requested by @sphh in #2213): When new Spices are available, an option _Forget new Spices_ appears in the menu of this applet. Clicking it will clear these notifications of new spices, until others arrive.
   * Available languages: English, French, Spanish, Croatian, German, Italian.
 
 ### v1.1.0~20190113

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/README.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/README.md
@@ -18,15 +18,15 @@ Fully supported by the author, under continuing development and in continuous us
 
 ## Requirements
 
-The Spices Update requires the tool ```notify-send```.
+The Spices Update requires the ```notify-send``` tool and the ```symbola``` TrueType font.
 
 To install it:
 
-  * Fedora: ```sudo dnf install libnotify```
-  * Arch: ```sudo pacman -Syu libnotify```
-  * Linux Mint: ```sudo apt install libnotify-bin```
+  * Fedora: ```sudo dnf install libnotify gdouros-symbola-fonts```
+  * Arch: ```sudo pacman -Syu libnotify ttf-symbola```
+  * Linux Mint: ```sudo apt install libnotify-bin fonts-symbola```
 
-**This applet helps you to install this dependency, if any.**
+**This applet helps you to install this dependencies, if any.**
 
 ## Settings
 

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/applet.js
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/applet.js
@@ -788,7 +788,12 @@ class SpicesUpdate extends Applet.TextIconApplet {
   }; // End of _get_singular_type
 
   are_dependencies_installed() {
-    return (GLib.find_program_in_path("notify-send"))
+    let _fonts_installed = (
+      Gio.file_new_for_path("/usr/share/fonts/truetype/ancient-scripts/Symbola_hint.ttf").query_exists(null) ||
+      Gio.file_new_for_path("/usr/share/fonts/TTF/Symbola.ttf").query_exists(null) ||
+      Gio.file_new_for_path("/usr/share/fonts/gdouros-symbola/Symbola.ttf").query_exists(null)
+    )
+    return (_fonts_installed && GLib.find_program_in_path("notify-send"))
   }; // End of are_dependencies_installed
 
   get_terminal() {
@@ -839,7 +844,7 @@ class SpicesUpdate extends Applet.TextIconApplet {
       let _isArchlinux = _ArchlinuxWitnessFile.query_exists(null);
       let _apt_update =  _isFedora ? "sudo dnf update" : _isArchlinux ? "" : "sudo apt update";
       let _and = _isArchlinux ? "" : " \\\\&\\\\& ";
-      var _apt_install = _isFedora ? "sudo dnf install libnotify" : _isArchlinux ? "sudo pacman -Syu libnotify" : "sudo apt install libnotify-bin";
+      var _apt_install = _isFedora ? "sudo dnf install libnotify gdouros-symbola-fonts" : _isArchlinux ? "sudo pacman -Syu libnotify ttf-symbola" : "sudo apt install libnotify-bin fonts-symbola";
       let criticalMessagePart1 = _("You appear to be missing some of the programs required for this applet to have all its features.");
       let criticalMessage = _is_apturl_present ? criticalMessagePart1 : criticalMessagePart1+"\n\n"+_("Please execute, in the just opened terminal, the commands:")+"\n "+ _apt_update +" \n "+ _apt_install +"\n\n";
       this.notification = criticalNotify(_("Some dependencies are not installed!"), criticalMessage, icon);
@@ -849,7 +854,7 @@ class SpicesUpdate extends Applet.TextIconApplet {
         if (terminal != "")
           GLib.spawn_command_line_async(terminal + " -e 'sh -c \"echo Spices Update message: Some packages needed!; echo To complete the installation, please enter and execute the command: ; echo "+ _apt_update + _and + _apt_install + "; sleep 1; exec bash\"'");
       } else {
-        Util.spawnCommandLine("apturl apt://libnotify-bin");
+        Util.spawnCommandLine("apturl apt://libnotify-bin,fonts-symbola");
       }
       this.dependenciesMet = false;
     }

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/applet.js
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/applet.js
@@ -35,7 +35,7 @@ const CONFIG_DIR = HOME_DIR + "/.cinnamon/configs";
 const SU_CONFIG_DIR = CONFIG_DIR + "/" + UUID;
 const CACHE_DIR = HOME_DIR + "/.cinnamon/spices.cache";
 
-const TYPES = ['applets', 'themes', 'desklets', 'extensions'];
+const TYPES = ['applets', 'desklets', 'extensions', 'themes'];
 
 const URL_MAP = {
   'applets': URL_SPICES_HOME + "/json/applets.json",

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/metadata.json
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/metadata.json
@@ -3,6 +3,6 @@
     "name": "Spices Update",
     "max-instances": "1",
     "hide-configuration": false,
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "Warns you when your Spices (applets, desklets, extensions, themes) require an update."
 }


### PR DESCRIPTION
Hi @jaszhix,

The `symbola` TrueType font is required to display certain characters in the menu of this applet. This has been added in the dependencies, because on Arch this font is not installed by default.

This PR also fixes #2219.

Can you merge this branch into your master one, please?

Best regards.
Claudiux