### PR TITLE
SpicesUpdate@claudiux: v2.0.1 - Delete old notifications when a new one arrives.

### DIFF
--- a/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v2.0.1~20190201
+  * Delete old notifications when a new one arrives.
+
 ### v2.0.0~20190131
   * Now the notifications can contain a button to open Download page for applets/desklets/extensions/themes in Date sort order. (Feature request #2231.)
   * Now the notifications can contain the description of an update or new Spice. (Feature request #2243.)

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v2.0.1~20190201
+  * Delete old notifications when a new one arrives.
+
 ### v2.0.0~20190131
   * Now the notifications can contain a button to open Download page for applets/desklets/extensions/themes in Date sort order. (Feature request #2231.)
   * Now the notifications can contain the description of an update or new Spice. (Feature request #2243.)

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/applet.js
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/applet.js
@@ -454,6 +454,7 @@ class SpicesUpdate extends Applet.TextIconApplet {
     this.actor.add_child(this.badge);
 
     this.details_by_uuid = {};
+    this.notifications = new Array();
     this.testblink = [];
     this.forceRefresh = false;
     this.applet_running = true;
@@ -472,6 +473,7 @@ class SpicesUpdate extends Applet.TextIconApplet {
       let icon = new St.Icon({ gicon: gicon, 'icon-size': 32});
       let notification = new MessageTray.Notification(source, _("Spices Update"), message, {icon: icon});
       notification.setTransient(false);
+      notification.setResident(true);
       Gtk.IconTheme.get_default().append_search_path(ICONS_DIR);
       notification.setUseActionIcons(true);
       let image = St.TextureCache.get_default().load_uri_async(GLib.filename_to_uri("%s/cs-%s.svg".format(ICONS_DIR, type.toString()), null),
@@ -482,10 +484,21 @@ class SpicesUpdate extends Applet.TextIconApplet {
       let buttonLabel2 = _("Refresh");
       notification.addButton("spices-update", _(buttonLabel));
       notification.addButton("refresh", _(buttonLabel2));
+      this.notifications.push(notification);
       notification.connect('action-invoked', Lang.bind(this, function(self, action) {
             if (action == "spices-update") {
               Util.spawnCommandLine("%s/open_download_tab.py %s".format(SCRIPTS_DIR, type.toString()));
             } else {
+              if (this.force_notifications === true) {
+                while (this.notifications.length != 0) {
+                  let n = this.notifications.pop();
+                  n.destroy(3)
+                }
+              } else {
+                this.old_message[type] = "";
+                this.old_watch_message[type] = "";
+                notification.destroy(3)
+              }
               this._on_refresh_pressed();
             }
           }));


### PR DESCRIPTION
Hi @jaszhix,

To do not flood the notifications area, the old ones concerning Spices Update are removed when the Refresh button is pressed, and new notifications arrive.

Can you merge this branch with your master one, please?

Best regards.
Claudiux