### PR TITLE
Weather@mockturtl Update 2.1.2

### DIFF
--- a/weather@mockturtl/README.md
+++ b/weather@mockturtl/README.md
@@ -4,12 +4,13 @@ Adaptation of Gnome Shell's [weather extension](https://github.com/simon04/gnome
 
 cinnamon-weather uses [Semantic Versioning](http://semver.org/).  For the current version number, see `metadata.json`.  
 
-### The applet is only compatible with Cinnamon 3.8+ at the moment! For compatibility with Cinnamon 1.8+, use this version [here](https://github.com/Gr3q/cinnamon-spices-applets/blob/weather@mockturtl-2.0.1/weather@mockturtl/README.md)
-
 ----
 
 
+
 ## Setup
+
+
 
 ### OpenWeatherMap API Key
 
@@ -43,9 +44,7 @@ DarkSky only supports Latitude, Longitude format! (e.g. 37.77,122.41)
 
 ## Requirements
 
-* [Cinnamon](https://github.com/linuxmint/Cinnamon) 3.8+
-
-For compatibility with Cinnamon 1.8+, use this version [here](https://github.com/Gr3q/cinnamon-spices-applets/blob/weather@mockturtl-2.0.1/weather@mockturtl/README.md)
+* [Cinnamon](https://github.com/linuxmint/Cinnamon) 1.8+
 
 ## Configuration
 

--- a/weather@mockturtl/files/weather@mockturtl/3.6/metadata.json
+++ b/weather@mockturtl/files/weather@mockturtl/3.6/metadata.json
@@ -3,5 +3,5 @@
 "name": "Weather",
 "description": "View your local weather forecast",
 "max-instances": 3,
-"version": "2.0.1"
+"version": "2.0.2"
 }

--- a/weather@mockturtl/files/weather@mockturtl/3.6/metadata.json
+++ b/weather@mockturtl/files/weather@mockturtl/3.6/metadata.json
@@ -1,7 +1,0 @@
-{
-"uuid": "weather@mockturtl",
-"name": "Weather",
-"description": "View your local weather forecast",
-"max-instances": 3,
-"version": "2.0.2"
-}

--- a/weather@mockturtl/files/weather@mockturtl/3.6/settings-schema.json
+++ b/weather@mockturtl/files/weather@mockturtl/3.6/settings-schema.json
@@ -21,12 +21,6 @@
       "OpenWeatherMap": "OpenWeatherMap"
     }
   },
-  "apiKey":
-  { "type": "entry"
-  , "default": ""
-  , "description": "API Key"
-  , "tooltip": "Copy this from your account on OpenWeatherMap and paste it here."
-  },
   "location":
   { "type": "entry"
   , "default": "London,UK"
@@ -37,7 +31,7 @@
   {
     "type": "button",
     "indent": true,
-    "description": "Setup API Key and Location",
+    "description": "Setup Location",
     "callback": "locationLookup",
     "tooltip": "Opens webpage guide"
   },
@@ -103,7 +97,7 @@
   { "type": "spinbutton"
   , "default": 2
   , "min": 2
-  , "max": 5
+  , "max": 7
   , "units": "days"
   , "step": 1
   , "description": "Forecast length"
@@ -136,7 +130,7 @@
 , "refreshInterval":
   { "type": "spinbutton"
   , "default": 15
-  , "min": 1
+  , "min": 5
   , "max": 360
   , "units": "minutes"
   , "step": 5

--- a/weather@mockturtl/files/weather@mockturtl/3.8/applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/applet.js
@@ -203,7 +203,7 @@ function _(str) {
 }
 
 
-const AppletDir = imports.ui.appletManager.applets['weather@mockturtl'];
+const AppletDir = imports.ui.appletManager.applets['weather@mockturtl/3.8'];
 const darkSky = AppletDir.darkSky;
 const openWeatherMap = AppletDir.openWeatherMap;
 // Location lookup service

--- a/weather@mockturtl/files/weather@mockturtl/3.8/applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/applet.js
@@ -202,10 +202,12 @@ function _(str) {
   return Gettext.dgettext(UUID, str)
 }
 
-const darkSky = require("darkSky");
-const openWeatherMap = require("openWeatherMap");
+
+const AppletDir = imports.ui.appletManager.applets['weather@mockturtl'];
+const darkSky = AppletDir.darkSky;
+const openWeatherMap = AppletDir.openWeatherMap;
 // Location lookup service
-const ipApi = require("ipApi");
+const ipApi = AppletDir.ipApi;
 
 //----------------------------------------------------------------
 //
@@ -345,7 +347,7 @@ function MyApplet(metadata, orientation, panelHeight, instanceId) {
         keyBlock: _("Key Temp. Blocked"),
         cantGetLoc: _("Could not get location"),
         unknown: _("Unknown Error"),
-        noResponse: _("No response from Data Service")
+        noResponse: _("No/Bad response from Data Service")
       }
     }
 
@@ -354,10 +356,37 @@ function MyApplet(metadata, orientation, panelHeight, instanceId) {
 
 // Class Declaration
 MyApplet.prototype = {
-  __proto__: Applet.TextIconApplet.prototype
+  __proto__: Applet.TextIconApplet.prototype,
 
-, refreshAndRebuild: function () {
-    this.refreshWeather(false).then(this.rebuild());
+  refreshAndRebuild: function() {
+    this.refreshWeather().then(this.rebuild());
+  },
+
+  LoadJsonAsync: async function(query) {
+    let json = await new Promise((resolve, reject) => {
+      let message = Soup.Message.new('GET', query);
+      this._httpSession.queue_message(message, (session, message) => {
+          if (message) {
+            this.log.Debug("API full response: " + message.response_body.data.toString());
+            try {
+              let payload = JSON.parse(message.response_body.data);
+              resolve(payload);
+            }
+            catch(e) {    // Payload is not JSON
+              this.log.Error("Error: API response is not JSON. The response: " + message.response_body.data);
+              if (this._dataService == DATA_SERVICE.DARK_SKY) {
+                this.log.Error("DarkSky: This usually indicates that API key is invalid.");
+              }
+              reject(null);
+            }            
+          }
+          else {  // No response
+              this.log.Error("Error: No Response from API");
+              reject(null);
+          }   
+        });
+    });
+    return json;
   },
 
     // Override Methods: TextIconApplet
@@ -411,7 +440,7 @@ MyApplet.prototype = {
         for (let i = 0; i < this._forecastDays; i++) {
           this._forecast[i].Icon.icon_type = this._icon_type
         }
-        this.refreshWeather(false)
+        this.refreshWeather()
       }))
 
       // configuration via context menu is automatically provided in Cinnamon 2.0+
@@ -475,7 +504,7 @@ MyApplet.prototype = {
     // Main independent Loop
     try {
       if (this.lastUpdated == null || new Date(this.lastUpdated.getTime() + this._refreshInterval*60000) < new Date()) {
-        this.refreshWeather(false);
+        this.refreshWeather();
       }
     }
     catch (e) {
@@ -552,17 +581,18 @@ MyApplet.prototype = {
     this._currentWeatherSunrise.text = msg;
   },
 
-  refreshWeather: async function(recurse) {  
+  refreshWeather: async function() {  
     this.wipeCurrentData();
     this.wipeForecastData();
     
     // Making sure location is in place
     try {
+      
       if (!this._manualLocation) {    // Autmatic location
         // Have to check every time to make sure location is the same
         let haveLocation = await this.locProvider.GetLocation();
         if (!haveLocation) {
-          this.log.Error("Couldn't obtain location, retry in 30 seconds...");
+          this.log.Error("Couldn't obtain location, retry in 15 seconds...");
           this.showError(this.errMsg.label.noLoc, this.errMsg.desc.cantGetLoc);
           this.lastUpdated = null;
           return;
@@ -571,13 +601,13 @@ MyApplet.prototype = {
       else {        // Manual Location
         // Adding resilience against bad user input
         let loc = this._location.replace(" ", "");
-        if (this._location == undefined || this._location == "") {
+        if (loc == undefined || loc == "") {
           this.showError(this.errMsg.label.noLoc, "");
           this.log.Error("No location given when setting is on Manual Location");
           return;
         }
       }
-
+          
       let refreshResult;
       switch(this._dataService) {
         case DATA_SERVICE.DARK_SKY:
@@ -588,6 +618,9 @@ MyApplet.prototype = {
           refreshResult = await this.provider.GetWeather();
           break;
         case DATA_SERVICE.OPEN_WEATHER_MAP:
+          //
+          //  No TZ information
+          //
           this.provider = new openWeatherMap.OpenWeatherMap(this);
           refreshResult = await this.provider.GetWeather();
           break;
@@ -601,9 +634,9 @@ MyApplet.prototype = {
         return;
       }
 
-      this.displayWeather();
-      this.displayForecast();
-      this.log.Print("Weather Information refreshed");
+      if (await this.displayWeather() && await this.displayForecast()) {
+        this.log.Print("Weather Information refreshed");
+      }    
     }
     catch(e) { 
       this.log.Error("Error while refreshing Weather info: " + e);
@@ -687,7 +720,7 @@ MyApplet.prototype = {
 
       // Displaying humidity
       if (this.weather.main.humidity !=  null) {
-        this._currentWeatherHumidity.text = this.weather.main.humidity + "%";
+        this._currentWeatherHumidity.text = Math.round(this.weather.main.humidity) + "%";
       }
       
       // Wind
@@ -719,7 +752,17 @@ MyApplet.prototype = {
       }
 
       // Location
-      this._currentWeatherLocation.text = location;
+      this._currentWeatherLocation.label = location;
+      switch (this._dataService) {
+        case DATA_SERVICE.OPEN_WEATHER_MAP:
+          this._currentWeatherLocation.url = "https://openweathermap.org/city/" + this.weather.location.id;
+          break;
+        case DATA_SERVICE.DARK_SKY:
+          this._currentWeatherLocation.url = "https://darksky.net/forecast/" + this.weather.coord.lat + "," + this.weather.coord.lon;
+          break;
+        default:
+          this._currentWeatherLocation.url = null;
+      }
 
       // Sunset/Sunrise
       // gettext can't see these inline
@@ -774,7 +817,7 @@ MyApplet.prototype = {
         }
         let dayName = forecastData.dateTime;
         if (this.weather.timeZone != null) {
-           dayname = this.weather.sunrise.toLocaleString("en-GB", {timeZone: this.weather.timeZone, weekday: "long"});
+           dayname = this.dayName.toLocaleString("en-GB", {timeZone: this.weather.timeZone, weekday: "long"});
         }
         else {
           dayName.setMilliseconds(dayName.getMilliseconds() + (this.weather.location.tzOffset * 1000));
@@ -864,12 +907,23 @@ MyApplet.prototype = {
       style_class: STYLE_SUMMARY
     })
 
-    this._currentWeatherLocation = new St.Label({
+    this._currentWeatherLocation = new St.Button({
       reactive: true,
-      text: ''
-    })
+      label: _('Refresh'),
+    });
 
     this._currentWeatherLocation.style_class = STYLE_LOCATION_LINK
+    this._currentWeatherLocation.connect(SIGNAL_CLICKED, Lang.bind(this, function() {
+      if (this._currentWeatherLocation.url == null) {
+        // Freezes cinnamon if this function called from here
+        this.refreshWeather();
+      } else {
+        Gio.app_info_launch_default_for_uri(
+          this._currentWeatherLocation.url,
+          global.create_app_launch_context()
+        )
+      }
+    }));
 
     let bb = new St.BoxLayout({
       vertical: true,

--- a/weather@mockturtl/files/weather@mockturtl/3.8/darkSky.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/darkSky.js
@@ -1,6 +1,3 @@
-var exports = module.exports = {}
-const Soup = imports.gi.Soup;
-
 
 //////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////
@@ -9,7 +6,7 @@ const Soup = imports.gi.Soup;
 ///////////                                       ////////////
 //////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////
-exports.DarkSky = function(app) {
+function DarkSky(app) {
     //--------------------------------------------------------
     //  Properties
     //--------------------------------------------------------
@@ -40,29 +37,18 @@ exports.DarkSky = function(app) {
         if (query != "" && query != null) {
             app.log.Debug("DarkSky API query: " + query);
             try {
-                message = Soup.Message.new('GET', query);
-                app._httpSession.send_message(message);
-            }
-            catch(e) {
-                    app.log.Error("Unable to Call API: " + e);
+                json = await app.LoadJsonAsync(query);
+                if (json == null) {
+                    app.showError(app.errMsg.label.service, app.errMsg.desc.noResponse);
                     return false;
-                }
-            try {
-                // We get parsing error on persmission denied event
-                json =  JSON.parse(message.response_body.data);
+                } 
             }
             catch(e) {
-                app.log.Error("DarkSky: Unable to parse Response payload: " + e);
-                app.showError(app.errMsg.label.service, app.errMsg.desc.keyBad);
-                return false;
-            }
-            
-            if (!json) {
-                app.log.Error("No Response from API");
-                app.showError(app.errMsg.label.service, app.errMsg.desc.noResponse);
-                return false;
-            } 
-            
+                    app.log.Error("DarkSky: API call failed: " + e);
+                    app.showError(app.errMsg.label.service, app.errMsg.desc.noResponse);
+                    return false;
+            }            
+         
             if (!json.code) {                   // No code, Request Success
                 return this.ParseWeather(json);
             }

--- a/weather@mockturtl/files/weather@mockturtl/3.8/darkSky.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/darkSky.js
@@ -189,7 +189,7 @@ function DarkSky(app) {
         let processed = summary.split(" ");
         let result = "";
         for (let i = 0; i < 2; i++) {
-            if (!/[\(\)]/.test(processed[i])) {
+            if (!/[\(\)]/.test(processed[i]) && (processed[i] != "and")) {
                 result = result + processed[i] + " ";
             }
         }

--- a/weather@mockturtl/files/weather@mockturtl/3.8/ipApi.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/ipApi.js
@@ -1,5 +1,3 @@
-var exports = module.exports = {}
-const Soup = imports.gi.Soup;
 
 //////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////
@@ -9,23 +7,21 @@ const Soup = imports.gi.Soup;
 //////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////
 
-exports.IpApi = function(app) {
+function IpApi(app) {
     this.query = "https://ipapi.co/json";
 
     this.GetLocation = async function() {
         let json;
         try {
-            let message = Soup.Message.new('GET', this.query);
-                app._httpSession.send_message(message);
-                json = JSON.parse(message.response_body.data);
+            json = await app.LoadJsonAsync(this.query);
+            if (json == null) {                         // Bad response
+                app.showError(app.errMsg.label.service, app.errMsg.desc.noResponse);
+                return false;
+            }
         }
         catch(e) {
             app.log.Error("IpApi service error: " + e);
             app.showError(app.errMsg.label.generic, app.errMsg.desc.cantGetLoc);
-            return false;
-        }
-
-        if (!json) {
             return false;
         }
 
@@ -35,6 +31,7 @@ exports.IpApi = function(app) {
         }
 
         return this.ParseInformation(json);
+        
     };
 
     this.ParseInformation = function(json) {

--- a/weather@mockturtl/files/weather@mockturtl/3.8/openWeatherMap.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/openWeatherMap.js
@@ -1,5 +1,3 @@
-var exports = module.exports = {}
-const Soup = imports.gi.Soup;
 
 //////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////
@@ -9,7 +7,7 @@ const Soup = imports.gi.Soup;
 //////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////
 
-exports.OpenWeatherMap = function(app) {
+function OpenWeatherMap(app) {
     //--------------------------------------------------------
     //  Properties
     //--------------------------------------------------------
@@ -44,19 +42,16 @@ exports.OpenWeatherMap = function(app) {
         if (query != null) {
             app.log.Debug("Query: " + query);
             try {
-                let message = Soup.Message.new('GET', query);
-                app._httpSession.send_message(message);
-                json =  JSON.parse(message.response_body.data);
+                json = await app.LoadJsonAsync(query);
+                if (json == null) {
+                    app.showError(app.errMsg.label.service, app.errMsg.desc.noResponse)
+                    return false;                 
+                }
             }
             catch(e) {
                 app.log.Error("Unable to call API:", e);
                 return false;
             }
-
-            if (!json) {
-                app.log.Error("No Response from API");
-                return false;
-            } 
 
             if (json.cod == 200) {   // Request Success
                 return ParseFunction(json, this);
@@ -80,6 +75,7 @@ exports.OpenWeatherMap = function(app) {
             }
             app.weather.location.city = json.name;
             app.weather.location.country = json.sys.country;
+            app.weather.location.id = json.id;
             app.weather.dateTime = new Date((json.dt) * 1000);
             app.weather.sunrise = new Date((json.sys.sunrise) * 1000);
             app.weather.sunset = new Date((json.sys.sunset) * 1000);

--- a/weather@mockturtl/files/weather@mockturtl/3.8/stylesheet.css
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/stylesheet.css
@@ -5,8 +5,8 @@
 .weather-current-location-link:selected,
 .weather-current-location-link:hover {
     background-gradient-direction: vertical;
-    background-gradient-start: rgba(255, 255, 255, 0.4);
-    background-gradient-end: rgba(255, 255, 255, 0.2);
+    background-gradient-start: rgba(255, 255, 255, 0.1);
+    background-gradient-end: rgba(255, 255, 255, 0.1);
 }
 
 .weather-current-summarybox {

--- a/weather@mockturtl/files/weather@mockturtl/metadata.json
+++ b/weather@mockturtl/files/weather@mockturtl/metadata.json
@@ -3,7 +3,7 @@
   "name": "Weather",
   "description": "View your local weather forecast",
   "max-instances": 3,
-  "version": "2.1.1",
+  "version": "2.1.2",
   "multiversion": true,
   "cinnamon-version": ["3.2", "3.4", "3.6", "3.8", "4.0"]
 }


### PR DESCRIPTION
Don't know how to do the versioning anymore.

### Changelog:
**3.6**
* OpenWeatherMap using FOSS key and proper daily forecasts.

**3.8**
* Removed "require"-s, swapped them to imports
* Fixed bug when Cinnamon froze when the taskbar was manipulated when the applet was enabled on it.
* DarkSky was Getting the Forecast day names from sunrise time, fixed
* Humidity is rounded now.
* Location element is a button again, opens Data services webpages with more weather, or it can trigger a refresh if there was an error (there is no need anymore, but still).


@jaszhix Please check the readme on the Compatibility section, is that right?
I don't quite get it how the versioning works.
Basically from Cinnamon v3.2-3.6 the 3.6 folder is used, and Cinnamon v3.8< the 3.8 folder is used?

Right now 3.6 could support all the way back to 1.8.