### PR TITLE
Display the alarm time in menu and panel

### DIFF
--- a/cinnamon-timer@jake1164/README.md
+++ b/cinnamon-timer@jake1164/README.md
@@ -15,6 +15,10 @@ All settings can be changed by right clicking on the icon and selecting configur
 ## TODO:
 
 ## Changelog
+* 1.2.0
+  - The time of the alarm is displayed (configurable).
+  - Changed the order of the default Preset Times to be strictly descending.
+
 * 1.1.3
   - Added support for Cinnamon 4.0
 

--- a/cinnamon-timer@jake1164/files/cinnamon-timer@jake1164/3.4/applet.js
+++ b/cinnamon-timer@jake1164/files/cinnamon-timer@jake1164/3.4/applet.js
@@ -105,8 +105,32 @@ MyApplet.prototype = {
             null);
 
         this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL,
-            "time_display_enable",
-            "time_display_enable",
+            "duration-display-enable",
+            "duration_display_enable",
+            this._on_settings_changed,
+            null);
+
+        this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL,
+            "alarmtime-display-enable",
+            "alarmtime_display_enable",
+            this._on_settings_changed,
+            null);
+
+        this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL,
+            "alarmtime-format-small",
+            "alarmtime_format_small",
+            this._on_settings_changed,
+            null);
+
+        this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL,
+            "alarmtime-format-large",
+            "alarmtime_format_large",
+            this._on_settings_changed,
+            null);
+
+        this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL,
+            "alarmtime-format-switchover",
+            "alarmtime_format_switchover",
             this._on_settings_changed,
             null);
 
@@ -171,7 +195,8 @@ MyApplet.prototype = {
                 // vertical
                 this.isHorizontal = false;
                 // No room in a vertical display to show the time label.
-                this.time_display_enable = false;
+                this.duration_display_enable = false;
+                this.alarmtime_display_enable = false;
             } else {
                 // horizontal
                 this.isHorizontal = true;
@@ -193,7 +218,7 @@ MyApplet.prototype = {
 
         this.buildTimePresetMenu();
 
-        this.timerMenuItem = new PopupMenu.PopupMenuItem(_("Minutes") + ": 0", { reactive: false });
+        this.timerMenuItem = new PopupMenu.PopupMenuItem("0 " + _("Hours") + "," + " 00 " + _("Minutes") + " " +_("and") + " 00 " + _("Seconds"), { reactive: false});
         this.menu.addMenuItem(this.timerMenuItem);
 
         this._timerSlider = new PopupMenu.PopupSliderMenuItem(0);
@@ -324,15 +349,37 @@ MyApplet.prototype = {
         let min = Math.floor((this.timerDuration % 3600) / 60);
         let sec = this.timerDuration % 60;
 
-        this.timerMenuItem.label.text = hr + " " + _("Hours") + "," + " " + min.pad(2) + " " + _("Minutes") + " " + _("and") + " " + sec.pad(2) + " " + _("Seconds");
-        let timeStr = hr + ":" + min.pad(2) + ":" + sec.pad(2);
-        this.set_applet_tooltip(_("Timer") + ":" + " " + timeStr);
+        let durationShortStr = hr + ":" + min.pad(2) + ":" + sec.pad(2);
+        let durationLongStr = hr + " " + _("Hours") + "," + " " + min.pad(2) + " " + _("Minutes") + " " + _("and") + " " + sec.pad(2) + " " + _("Seconds");
 
-        if (this.time_display_enable) {
+        let timeFormat = "%X";
+        if (this.timerDuration < this.alarmtime_format_switchover*60)
+            timeFormat = this.alarmtime_format_small;
+        else
+            timeFormat = this.alarmtime_format_large;
+
+        let alarmtimeExpectedStr = "";
+        if (this.timerDuration != 0)
+            alarmtimeExpectedStr = "[" + GLib.DateTime.new_now_local().add_seconds(this.timerDuration).format(timeFormat) + "]";
+
+        let alarmtimeStr = "";
+        if (!this.timerStopped)
+            alarmtimeStr = "[" + GLib.DateTime.new_from_unix_local(this.alarm_end/1000).format(timeFormat) + "]";
+
+        let applet_label = "";
+        if (this.duration_display_enable)
+            applet_label += durationShortStr;
+        if (this.alarmtime_display_enable)
+            applet_label += " " + alarmtimeStr;
+        
+        this.timerMenuItem.label.text = durationLongStr + " " + alarmtimeExpectedStr;
+        this.set_applet_tooltip(_("Timer") + ":" + " " + durationShortStr + " " + alarmtimeStr);
+
+        if (this.duration_display_enable || this.alarmtime_display_enable) {
             if (this.timerStopped && this.timerDuration == 0)
                 this.set_applet_label("");
             else
-                this.set_applet_label(timeStr);
+                this.set_applet_label(applet_label.trim());
         } else {
             this.set_applet_label("");
         }

--- a/cinnamon-timer@jake1164/files/cinnamon-timer@jake1164/3.4/settings-schema.json
+++ b/cinnamon-timer@jake1164/files/cinnamon-timer@jake1164/3.4/settings-schema.json
@@ -30,7 +30,11 @@
                 "message-prompt-enable", 
                 "display-message", 
                 "display-menu-enable", 
-                "time_display_enable"
+                "duration-display-enable",
+                "alarmtime-display-enable",
+                "alarmtime-format-small",
+                "alarmtime-format-large",
+                "alarmtime-format-switchover"
             ]
         },
         "section2": {
@@ -86,11 +90,42 @@
         "description" : "Show the timer menu when time is elapsed",
         "tooltip" : "Show the timer menu when time is elapsed"
     },
-    "time_display_enable" : {
+    "duration-display-enable" : {
         "type" : "checkbox",
         "default" : true,
         "description" : "Display remaining time in panel",
         "tooltip" : "Display remaining time in panel"
+    },
+    "alarmtime-display-enable" : {
+        "type" : "checkbox",
+        "default" : true,
+        "description" : "Display alarm time in panel",
+        "tooltip" : "Display alarm time in panel"
+    },
+    "alarmtime-format-small" : {
+        "type" : "entry",
+        "default" : "%_I:%M:%S%P",
+        "indent" : true,
+        "description" : "Format used to display alarm time in the near future",
+        "tooltip" : "If the alarm time is less than the minutes specified below away,\nthe alarm time can be displayed with more details\n(see https://developer.gnome.org/glib/stable/glib-GDateTime.html#g-date-time-format)"
+    },
+    "alarmtime-format-large" : {
+        "type" : "entry",
+        "default" : "%_I:%M%P",
+        "indent" : true,
+        "description" : "Format used to display alarm time in the not so near future",
+        "tooltip" : "If the alarm time is more than the minutes specified below away,\nthe alarm time can be displayed with less details\n(see https://developer.gnome.org/glib/stable/glib-GDateTime.html#g-date-time-format)"
+    },
+    "alarmtime-format-switchover" : {
+        "type" : "spinbutton",
+        "default" : 10,
+        "min" : 0,
+        "max" : 1440,
+        "step" : 1,
+        "units" : "minutes",
+        "indent" : true,
+        "description" : "Time when switching from small to large time format",
+        "tooltip" : "Switch over time between the two formats specified above"
     },
     "alarm_end" : {
         "type" : "generic",
@@ -138,8 +173,8 @@
         "default": [
             {"seconds": 0, "minutes": 0, "hours": 5},           
             {"seconds": 0, "minutes": 0, "hours": 4},
-            {"seconds": 0, "minutes": 0, "hours": 2},            
-            {"seconds": 0, "minutes": 0, "hours": 3},             
+            {"seconds": 0, "minutes": 0, "hours": 3},            
+            {"seconds": 0, "minutes": 0, "hours": 2},             
             {"seconds": 0, "hours":1, "minutes": 30},
             {"seconds": 0, "minutes": 0, "hours": 1},
             {"seconds": 0, "minutes": 45, "hours": 0},

--- a/cinnamon-timer@jake1164/files/cinnamon-timer@jake1164/metadata.json
+++ b/cinnamon-timer@jake1164/files/cinnamon-timer@jake1164/metadata.json
@@ -1,6 +1,6 @@
 {
     "uuid": "cinnamon-timer@jake1164",
-    "version": "1.1.3",
+    "version": "1.2.0",
     "name": "Timer with notifications",
     "description": "A timer app with visual and auditory notifications.",
     "website": "https://cinnamon-spices.linuxmint.com/applets/view/302",

--- a/cinnamon-timer@jake1164/files/cinnamon-timer@jake1164/po/cinnamon-timer@jake1164.pot
+++ b/cinnamon-timer@jake1164/files/cinnamon-timer@jake1164/po/cinnamon-timer@jake1164.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-08 12:22-0500\n"
+"POT-Creation-Date: 2019-02-08 11:28+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,159 +17,179 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:189 applet.js:328
+#: applet.js:215 applet.js:376
 msgid "Timer"
 msgstr ""
 
-#. cinnamon-timer@jake1164->settings-schema.json->preset_time->columns->title
-#: applet.js:195 applet.js:235 applet.js:326
-msgid "Minutes"
-msgstr ""
-
-#: applet.js:212
-msgid "Reset"
-msgstr ""
-
-#. cinnamon-timer@jake1164->settings-schema.json->preset_time->columns->title
-#: applet.js:234 applet.js:326
+#. settings-schema.json->preset_time->columns->title
+#: applet.js:221 applet.js:260 applet.js:353
 msgid "Hours"
 msgstr ""
 
-#. cinnamon-timer@jake1164->settings-schema.json->preset_time->columns->title
-#: applet.js:236 applet.js:326
-msgid "Seconds"
+#. settings-schema.json->preset_time->columns->title
+#: applet.js:221 applet.js:261 applet.js:353
+msgid "Minutes"
 msgstr ""
 
-#: applet.js:326
+#: applet.js:221 applet.js:353
 msgid "and"
 msgstr ""
 
-#: applet.js:473
+#. settings-schema.json->preset_time->columns->title
+#: applet.js:221 applet.js:262 applet.js:353
+msgid "Seconds"
+msgstr ""
+
+#: applet.js:238
+msgid "Reset"
+msgstr ""
+
+#: applet.js:523
 msgid "Okay"
 msgstr ""
 
-#: applet.js:491
+#: applet.js:541
 msgid "Cinnamon Timer"
 msgstr ""
 
-#. cinnamon-timer@jake1164->settings-schema.json->confirm-prompt-
-#. enable->description
-msgid "Check this to place a prompt on the window when time has elapsed."
-msgstr ""
-
-#. cinnamon-timer@jake1164->settings-schema.json->confirm-prompt-
-#. enable->tooltip
-msgid "Check this to place a prompt on the window when time has elapsed"
-msgstr ""
-
-#. cinnamon-timer@jake1164->settings-
-#. schema.json->time_display_enable->description
-#. cinnamon-timer@jake1164->settings-schema.json->time_display_enable->tooltip
-msgid "Display remaining time in panel"
-msgstr ""
-
-#. cinnamon-timer@jake1164->settings-schema.json->alarm_end->description
-#. cinnamon-timer@jake1164->settings-schema.json->alarm_end->tooltip
-#. cinnamon-timer@jake1164->settings-schema.json->alarm_start->description
-#. cinnamon-timer@jake1164->settings-schema.json->alarm_start->tooltip
-msgid "Do not change, the time the alarm is set to expire"
-msgstr ""
-
-#. cinnamon-timer@jake1164->settings-schema.json->message-prompt-
-#. enable->description
-#. cinnamon-timer@jake1164->settings-schema.json->message-prompt-
-#. enable->tooltip
-msgid "Display a notification when time has elapsed"
-msgstr ""
-
-#. cinnamon-timer@jake1164->settings-schema.json->sound-file->description
-msgid "Full path and filename of alert sound file"
-msgstr ""
-
-#. cinnamon-timer@jake1164->settings-schema.json->sound-file->tooltip
-msgid "Must have Sox installed. Most sound file types supported"
-msgstr ""
-
-#. cinnamon-timer@jake1164->settings-schema.json->section2->title
-msgid "Sound Settings"
-msgstr ""
-
-#. cinnamon-timer@jake1164->settings-schema.json->section3->title
-#. cinnamon-timer@jake1164->settings-schema.json->page3->title
-#. cinnamon-timer@jake1164->settings-schema.json->preset_time->description
-msgid "Preset Times"
-msgstr ""
-
-#. cinnamon-timer@jake1164->settings-schema.json->page4->title
-#. cinnamon-timer@jake1164->settings-schema.json->section4->title
-#. cinnamon-timer@jake1164->settings-
-#. schema.json->slider_intervals->description
-msgid "Slider Intervals"
-msgstr ""
-
-#. cinnamon-timer@jake1164->settings-schema.json->page2->title
-msgid "Sounds"
-msgstr ""
-
-#. cinnamon-timer@jake1164->settings-schema.json->section1->title
-msgid "General Settings"
-msgstr ""
-
-#. cinnamon-timer@jake1164->settings-schema.json->page1->title
+#. settings-schema.json->page1->title
 msgid "General"
 msgstr ""
 
-#. cinnamon-timer@jake1164->settings-schema.json->preset_time->columns->title
-msgid "Label"
+#. settings-schema.json->page2->title
+msgid "Sounds"
 msgstr ""
 
-#. cinnamon-timer@jake1164->settings-schema.json->preset_time->columns->title
-msgid "Custom Message (overrides global message)"
+#. settings-schema.json->page3->title
+#. settings-schema.json->section3->title
+#. settings-schema.json->preset_time->description
+msgid "Preset Times"
 msgstr ""
 
-#. cinnamon-timer@jake1164->settings-schema.json->display-menu-
-#. enable->description
-#. cinnamon-timer@jake1164->settings-schema.json->display-menu-enable->tooltip
-msgid "Show the timer menu when time is elapsed"
+#. settings-schema.json->page4->title
+#. settings-schema.json->section4->title
+#. settings-schema.json->slider_intervals->description
+msgid "Slider Intervals"
 msgstr ""
 
-#. cinnamon-timer@jake1164->settings-schema.json->sound-prompt-
-#. enable->description
-#. cinnamon-timer@jake1164->settings-schema.json->sound-prompt-enable->tooltip
-msgid "Play a sound when time is elapsed"
+#. settings-schema.json->section1->title
+msgid "General Settings"
 msgstr ""
 
-#. cinnamon-timer@jake1164->settings-
-#. schema.json->slider_intervals->columns->title
-msgid "Minimum"
+#. settings-schema.json->section2->title
+msgid "Sound Settings"
 msgstr ""
 
-#. cinnamon-timer@jake1164->settings-
-#. schema.json->slider_intervals->columns->title
-msgid "Maximum"
+#. settings-schema.json->confirm-prompt-enable->description
+msgid "Check this to place a prompt on the window when time has elapsed."
 msgstr ""
 
-#. cinnamon-timer@jake1164->settings-
-#. schema.json->slider_intervals->columns->title
-msgid "Step"
+#. settings-schema.json->confirm-prompt-enable->tooltip
+msgid "Check this to place a prompt on the window when time has elapsed"
 msgstr ""
 
-#. cinnamon-timer@jake1164->settings-schema.json->message->description
-#. cinnamon-timer@jake1164->settings-schema.json->message->tooltip
-msgid "Do not change, message being displayed when the current timer expires"
+#. settings-schema.json->message-prompt-enable->description
+#. settings-schema.json->message-prompt-enable->tooltip
+msgid "Display a notification when time has elapsed"
 msgstr ""
 
-#. cinnamon-timer@jake1164->settings-schema.json->display-message->description
-#. cinnamon-timer@jake1164->settings-schema.json->display-message->tooltip
+#. settings-schema.json->display-message->description
+#. settings-schema.json->display-message->tooltip
 msgid ""
 "Global message displayed in notification windows unless defined in preset "
 "time."
 msgstr ""
 
-#. cinnamon-timer@jake1164->metadata.json->description
-msgid "A timer app with visual and auditory notifications."
+#. settings-schema.json->sound-prompt-enable->description
+#. settings-schema.json->sound-prompt-enable->tooltip
+msgid "Play a sound when time is elapsed"
 msgstr ""
 
-#. cinnamon-timer@jake1164->metadata.json->name
-msgid "Timer with notifications"
+#. settings-schema.json->sound-file->description
+msgid "Full path and filename of alert sound file"
+msgstr ""
+
+#. settings-schema.json->sound-file->tooltip
+msgid "Must have Sox installed. Most sound file types supported"
+msgstr ""
+
+#. settings-schema.json->display-menu-enable->description
+#. settings-schema.json->display-menu-enable->tooltip
+msgid "Show the timer menu when time is elapsed"
+msgstr ""
+
+#. settings-schema.json->duration-display-enable->description
+#. settings-schema.json->duration-display-enable->tooltip
+msgid "Display remaining time in panel"
+msgstr ""
+
+#. settings-schema.json->alarmtime-display-enable->description
+#. settings-schema.json->alarmtime-display-enable->tooltip
+msgid "Display alarm time in panel"
+msgstr ""
+
+#. settings-schema.json->alarmtime-format-small->description
+msgid "Format used to display alarm time in the near future"
+msgstr ""
+
+#. settings-schema.json->alarmtime-format-small->tooltip
+msgid ""
+"If the alarm time is less than the minutes specified below away,\n"
+"the alarm time can be displayed with more details\n"
+"(see https://developer.gnome.org/glib/stable/glib-GDateTime.html#g-date-time-format)"
+msgstr ""
+
+#. settings-schema.json->alarmtime-format-large->description
+msgid "Format used to display alarm time in the not so near future"
+msgstr ""
+
+#. settings-schema.json->alarmtime-format-large->tooltip
+msgid ""
+"If the alarm time is more than the minutes specified below away,\n"
+"the alarm time can be displayed with less details\n"
+"(see https://developer.gnome.org/glib/stable/glib-GDateTime.html#g-date-time-format)"
+msgstr ""
+
+#. settings-schema.json->alarmtime-format-switchover->units
+msgid "minutes"
+msgstr ""
+
+#. settings-schema.json->alarmtime-format-switchover->description
+msgid "Time when switching from small to large time format"
+msgstr ""
+
+#. settings-schema.json->alarmtime-format-switchover->tooltip
+msgid "Switch over time between the two formats specified above"
+msgstr ""
+
+#. settings-schema.json->alarm_end->description
+#. settings-schema.json->alarm_end->tooltip
+#. settings-schema.json->alarm_start->description
+#. settings-schema.json->alarm_start->tooltip
+msgid "Do not change, the time the alarm is set to expire"
+msgstr ""
+
+#. settings-schema.json->message->description
+#. settings-schema.json->message->tooltip
+msgid "Do not change, message being displayed when the current timer expires"
+msgstr ""
+
+#. settings-schema.json->slider_intervals->columns->title
+msgid "Minimum"
+msgstr ""
+
+#. settings-schema.json->slider_intervals->columns->title
+msgid "Maximum"
+msgstr ""
+
+#. settings-schema.json->slider_intervals->columns->title
+msgid "Step"
+msgstr ""
+
+#. settings-schema.json->preset_time->columns->title
+msgid "Label"
+msgstr ""
+
+#. settings-schema.json->preset_time->columns->title
+msgid "Custom Message (overrides global message)"
 msgstr ""


### PR DESCRIPTION
I always wanted to know the time, when the time will finish. I added this with this pull request. It is even possible to format the alarm time. Because some of the alarm times will be in the far future, I believe it's not necessary to show too much detail, hence two time formats can be specified.

I also changed the order of the default Preset Times to be strictly in descending order (the defaults of 2 and 3 hours were in the wrong order).

I still have one question: Is it possible to add a link in the label of a setting? It would be great to point the user to the website with the available format specifiers. At the moment this is included in the tooltip, but that is far from ideal.