### PR TITLE
sysmonitor@orcus: Fixed memory leak and optimized rendering

### DIFF
--- a/sysmonitor@orcus/CHANGELOG.md
+++ b/sysmonitor@orcus/CHANGELOG.md
@@ -1,0 +1,35 @@
+### 1.6.4
+* Fixed memory leak
+* Applet now uses one drawing area for all graphs, it should reduce drawing overhead
+
+### 1.6.3
+* Fixed rendering, it should be pixel perfect now
+* Added option to show decimal value as CPU usage in the tooltip
+
+### 1.6.2
+* Fixed applet not loading in Cinnamon older than 3.2
+
+### 1.6.1
+* Fixed an issue with applet not loading on some distributions due to a missing function `GTop.glibtop.get_netlist`
+
+### 1.6
+* Added support for vertical panels
+* Applet checks for missing dependency on startup (glibtop) and asks the user to install it instead of just failing to load
+
+### 1.5
+* Using Cinnamon Applet Settings API instead of custom application
+
+### 1.4
+* Changed CPU provider to support system suspend without breaking
+
+### 1.3
+* Rewrote rendering code, applet now supports smooth graphs
+
+### 1.2
+* Enabled customization through custom application
+
+### 1.1
+* Added more data providers
+
+### 1.0
+* First applet version

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.0/graph.js
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.0/graph.js
@@ -1,12 +1,11 @@
 const Lang = imports.lang;
 
-function Graph(area, provider, colors) {
-    this._init(area, provider, colors);
+function Graph(provider) {
+    this._init(provider);
 }
 
 Graph.prototype = {
-    _init: function(area, provider) {
-        this.area = area;
+    _init: function(provider) {
         this.provider = provider;
         this.colors = [[1,1,1,1]];
         this.bg_color = [0,0,0,1];
@@ -17,9 +16,9 @@ Graph.prototype = {
         this.autoScale = false;
         this.scale = 1;
         this.width = 1;
+        this.height = 1;
         this.draw_border = true;
-        this.paint_queued = false;
-        this.area.connect('repaint', Lang.bind(this, function() {this.paint();}));
+        this.resize_data = false;
     },
     
     _setColor: function(cr, i) {
@@ -42,31 +41,31 @@ Graph.prototype = {
             this.data = this.data.slice(this.data.length - datasize);
     },
 
-    updateSize: function() {
-        this.width = null;
-        this.repaint();
-    },
-
-    setWidth: function(width, vertical) {
-        if (vertical) {
-            this.area.set_width(-1);
-            this.area.set_height(width);
-        }
-        else {
-            this.area.set_width(width);
-            this.area.set_height(-1);
-        }
-        this.updateSize();
+    setResolution: function(width, height) {
+        this.width = width;
+        this.height = height;
+        this.resize_data = true;
     },
 
     setDrawBorder: function(draw_border) {
         this.draw_border = draw_border;
-        this.updateSize();
+        this.resize_data = true;
+    },
+
+    setSmooth: function(smooth) {
+        this.smooth = smooth;
     },
     
     setColors: function(c) {
         this.colors = c;
-        this.repaint();
+    },
+
+    setBGColor: function(c) {
+        this.bg_color = c;
+    },
+
+    setBorderColor: function(c) {
+        this.border_color = c;
     },
 
     refresh: function() {
@@ -85,7 +84,6 @@ Graph.prototype = {
             }
             this.scale = 1.0 / maxVal;
         }
-        this.repaint();
     },
     
     dataSum: function(i, depth) {
@@ -95,24 +93,15 @@ Graph.prototype = {
         return sum;
     },
     
-    repaint: function() {
-        if (!this.paint_queued) {
-            this.paint_queued = true;
-            this.area.queue_repaint();
-        }
-    },
-    
-    paint: function() {
-        this.paint_queued = false;
-        let cr = this.area.get_context();
-        let [width, height] = this.area.get_size();
-        if (!this.width) {
-            this.width = width;
+    paint: function(cr, no_left_border) {
+        if (this.resize_data) {
             this._resizeData();
+            this.resize_data = false;
         }
         let border_width = this.draw_border ? 1 : 0;
-        let graph_width = width - 2 * border_width;
-        let graph_height = height - 2 * border_width;
+        let graph_width = this.width - 2 * border_width;
+        let graph_height = this.height - 2 * border_width;
+        cr.setLineWidth(1);
         //background
         cr.setSourceRGBA(this.bg_color[0], this.bg_color[1], this.bg_color[2], this.bg_color[3]);
         cr.rectangle(border_width, border_width, graph_width, graph_height);
@@ -121,11 +110,16 @@ Graph.prototype = {
         if (this.smooth)
         {
             for (let j = this.dim - 1; j >= 0; --j) {
-                cr.moveTo(border_width, graph_height + border_width);
                 this._setColor(cr, j);
+                cr.moveTo(border_width, graph_height + border_width);
                 for (let i = 0; i < this.data.length; ++i) {
                     let v = Math.round(graph_height * Math.min(1, this.scale * this.dataSum(i, j)));
-                    cr.lineTo(i + border_width, graph_height + border_width - v);
+                    v = graph_height + border_width - v;
+                    if (i == 0)
+                        cr.lineTo(i + border_width, v);
+                    cr.lineTo(i + border_width + 0.5, v);
+                    if (i == this.data.length - 1)
+                        cr.lineTo(i + border_width + 1, v);
                 }
                 cr.lineTo(graph_width + border_width, graph_height + border_width);
                 cr.lineTo(border_width, graph_height + border_width);
@@ -137,7 +131,7 @@ Graph.prototype = {
             for (let i = 0; i < this.data.length; ++i) {
                 for (let j = this.dim - 1; j >= 0; --j) {
                     this._setColor(cr, j);
-                    cr.moveTo(i + border_width, graph_height + border_width);
+                    cr.moveTo(i + border_width + 0.5, graph_height + border_width);
                     let v = Math.round(graph_height * Math.min(1, this.scale * this.dataSum(i, j)));
                     cr.relLineTo(0, -v);
                     cr.stroke();
@@ -147,10 +141,14 @@ Graph.prototype = {
         //border
         if (this.draw_border) {
             cr.setSourceRGBA(this.border_color[0], this.border_color[1], this.border_color[2], this.border_color[3]);
-            cr.rectangle(0, 0, width, height);
+            cr.moveTo(0.5, 0.5);
+            cr.lineTo(this.width - 0.5, 0.5);
+            cr.lineTo(this.width - 0.5, this.height - 0.5);
+            cr.lineTo(0.5, this.height - 0.5);
+            if (!no_left_border)
+                cr.closePath();
             cr.stroke();
         }
-        cr.$dispose();
     },
     
     setAutoScale: function(minScale)

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.0/graph.js
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.0/graph.js
@@ -150,6 +150,7 @@ Graph.prototype = {
             cr.rectangle(0, 0, width, height);
             cr.stroke();
         }
+        cr.$dispose();
     },
     
     setAutoScale: function(minScale)

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.0/providers.js
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.0/providers.js
@@ -15,6 +15,7 @@ CpuData.prototype = {
         this.sys_last = 0;
         this.iowait_last = 0;
         this.total_last = 0;
+        this.text_decimals = 0;
     },
     
     getDim: function() {
@@ -40,12 +41,16 @@ CpuData.prototype = {
         this.iowait_last = this.gtop.iowait;
         this.total_last = this.gtop.total;
         let used = 1-idle-nice-sys-iowait;
-        this.text = Math.round(100 * used) + " %";
+        this.text = (100 * used).toFixed(this.text_decimals) + " %";
         return [used, nice, sys, iowait];
     },
     
     getText: function() {
         return [_("CPU:"), this.text];
+    },
+
+    setTextDecimals: function(decimals) {
+        this.text_decimals = Math.max(0, decimals);
     }
 };
 
@@ -91,7 +96,7 @@ SwapData.prototype = {
     
     getData: function() {
         GTop.glibtop_get_swap(this.gtop);
-        let used = this.gtop.used / this.gtop.total;
+        let used = this.gtop.total > 0 ? (this.gtop.used / this.gtop.total) : 0;
         this.text = Math.round(this.gtop.used / (1024 * 1024))
             + " / " + Math.round(this.gtop.total / (1024 * 1024)) + _(" MB");
         return [used];

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.0/settings-schema.json
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.0/settings-schema.json
@@ -42,7 +42,7 @@
         "type": "spinbutton",
         "default": 1000,
         "min": 100,
-        "max": 10000,
+        "max": 60000,
         "step": 50,
         "description": "Refresh rate",
         "units": "ms"

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.0/settings-schema.json
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.0/settings-schema.json
@@ -28,6 +28,16 @@
         "units": "pixels",
         "tooltip": "If the applet is in a vertical panel, this sets the graph height. The graph width is then the panel width minus padding"
     },
+    "graph_spacing": {
+        "type": "spinbutton",
+        "default": 3,
+        "min": -1,
+        "max": 100,
+        "step": 1,
+        "description": "Graph spacing",
+        "units": "pixels",
+        "tooltip": "The number of pixels between each graph. Can be set to -1 to allow single line borders between graphs if borders are enabled"
+    },
     "refresh_rate": {
         "type": "spinbutton",
         "default": 1000,
@@ -98,6 +108,15 @@
         "description": "Graph width",
         "units": "pixels",
         "dependency": "cpu_override_graph_width"
+    },
+    "cpu_tooltip_decimals": {
+        "type": "spinbutton",
+        "default": 0,
+        "min": 0,
+        "max": 10,
+        "step": 1,
+        "description": "Show this many decimals in the tooltip",
+        "units": "decimals"
     },
     "cpu_color_0": {
         "type": "colorchooser",

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.2/applet.js
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.2/applet.js
@@ -103,6 +103,7 @@ MyApplet.prototype = {
                 ["bg_color", this.on_cfg_changed_bg_border_color],
                 ["border_color", this.on_cfg_changed_bg_border_color],
                 ["graph_width", this.on_cfg_changed_graph_width],
+                ["graph_spacing", this.on_cfg_changed_graph_spacing],
                 ["cpu_enabled", this.on_cfg_changed_graph_enabled, 0],
                 ["cpu_override_graph_width", this.on_cfg_changed_graph_width, 0],
                 ["cpu_graph_width", this.on_cfg_changed_graph_width, 0],
@@ -113,21 +114,21 @@ MyApplet.prototype = {
                 ["cpu_color_3", this.on_cfg_changed_color, 0],
                 ["mem_enabled", this.on_cfg_changed_graph_enabled, 1],
                 ["mem_override_graph_width", this.on_cfg_changed_graph_width, 1],
-                ["mem_graph_width", this.on_cfg_changed_graph_width, 1],
+                ["mem_graph_width", this.on_cfg_changed_graph_width],
                 ["mem_color_0", this.on_cfg_changed_color, 1],
                 ["mem_color_1", this.on_cfg_changed_color, 1],
                 ["swap_enabled", this.on_cfg_changed_graph_enabled, 2],
                 ["swap_override_graph_width", this.on_cfg_changed_graph_width, 2],
-                ["swap_graph_width", this.on_cfg_changed_graph_width, 2],
+                ["swap_graph_width", this.on_cfg_changed_graph_width],
                 ["swap_color_0", this.on_cfg_changed_color, 2],
                 ["net_enabled", this.on_cfg_changed_graph_enabled, 3],
                 ["net_override_graph_width", this.on_cfg_changed_graph_width, 3],
-                ["net_graph_width", this.on_cfg_changed_graph_width, 3],
+                ["net_graph_width", this.on_cfg_changed_graph_width],
                 ["net_color_0", this.on_cfg_changed_color, 3],
                 ["net_color_1", this.on_cfg_changed_color, 3],
                 ["load_enabled", this.on_cfg_changed_graph_enabled, 4],
                 ["load_override_graph_width", this.on_cfg_changed_graph_width, 4],
-                ["load_graph_width", this.on_cfg_changed_graph_width, 4],
+                ["load_graph_width", this.on_cfg_changed_graph_width],
                 ["load_color_0", this.on_cfg_changed_color, 4]
             ];
             let use_bind = typeof this.settings.bind === "function";
@@ -149,16 +150,16 @@ MyApplet.prototype = {
             this.border_color = colorToArray(this.cfg_border_color);
             this.areas = new Array(this.graph_ids.length)
             this.graphs = new Array(this.graph_ids.length)
-            this.graph_indices = new Array(this.graph_ids.length)
-            for (let i = 0; i < this.graph_ids.length; i++) {
-                this.areas[i] = null;
+            for (let i = 0; i < this.graph_ids.length; i++)
                 this.graphs[i] = null;
-                this.graph_indices[i] = null;
-            }
-            this.graph_order = [0,1,2,3,4];
+            this.resolution_needs_update = true;
+
+            this.area = new St.DrawingArea();
+            this.actor.add_child(this.area);
+            this.area.connect("repaint", Lang.bind(this, function() { this.paint(); }));
             
-            this.on_cfg_changed_padding();
             this.on_cfg_changed_graph_enabled();
+            this.on_cfg_changed_padding();
             this.update();
         }
         catch (e) {
@@ -167,21 +168,15 @@ MyApplet.prototype = {
     },
     
     addGraph: function(provider, graph_idx) {
-        let graph_id = this.graph_ids[graph_idx];
-
-        let area = new St.DrawingArea();
-        this.actor.insert_child_at_index(area, this.graph_indices[graph_idx]);
-        let graph = new Graph(area, provider);
-        this.areas[graph_idx] = area;
+        let graph = new Graph(provider);
         this.graphs[graph_idx] = graph;
 
         provider.refresh_rate = this.cfg_refresh_rate;
-        graph.smooth = this.cfg_smooth;
-        graph.setWidth(this.getGraphWidth(graph_idx), this.vertical);
-        graph.setColors(this.getGraphColors(graph_idx));
+        graph.setSmooth(this.cfg_smooth);
         graph.setDrawBorder(this.cfg_draw_border);
-        graph.bg_color = this.bg_color;
-        graph.border_color = this.border_color;
+        graph.setColors(this.getGraphColors(graph_idx));
+        graph.setBGColor(this.bg_color);
+        graph.setBorderColor(this.border_color);
         let tooltip_decimals = this.getGraphTooltipDecimals(graph_idx);
         if (typeof tooltip_decimals !== "undefined")
             provider.setTextDecimals(tooltip_decimals);
@@ -208,18 +203,44 @@ MyApplet.prototype = {
             this.tooltip.set_text(tooltip);
         else
             this.set_applet_tooltip(tooltip);
+
+        this.repaint();
+
         this.update_timeout_id = Mainloop.timeout_add(Math.max(100, this.cfg_refresh_rate), Lang.bind(this, this.update));
     },
-    
-    recalcGraphIndices: function() {
-        let idx = 0;
-        for (let i = 0; i < this.graph_ids.length; i++) {
-            let graph_id = this.graph_ids[i];
-            let enabled = this["cfg_" + graph_id + "_enabled"];
-            if (!enabled)
-                continue;
-            this.graph_indices[i] = idx++;
+
+    paint: function() {
+        if (this.resolution_needs_update) {
+            // Drawing area size can be reliably retrieved only in repaint callback
+            let [area_width, area_height] = this.area.get_size();
+            for (let i = 0; i < this.graphs.length; i++) {
+                if (this.graphs[i])
+                    this.updateGraphResolution(i, area_width, area_height);
+            }
+            this.resolution_needs_update = false;
         }
+
+        let cr = this.area.get_context();
+        let graph_offset = 0;
+
+        for (let i = 0; i < this.graphs.length; i++) {
+            if (this.graphs[i]) {
+                if (this.vertical)
+                    cr.translate(0, graph_offset);
+                else
+                    cr.translate(graph_offset, 0);
+
+                this.graphs[i].paint(cr, this.cfg_graph_spacing == -1 && i > 0);
+
+                graph_offset = this.getGraphWidth(i) + this.cfg_graph_spacing;
+            }
+        }
+
+        cr.$dispose();
+    },
+
+    repaint: function() {
+        this.area.queue_repaint();
     },
 
     getGraphWidth: function(graph_idx) {
@@ -246,6 +267,33 @@ MyApplet.prototype = {
         if (this.hasOwnProperty(prop))
             return this[prop];
     },
+
+    resizeArea: function() {
+        let total_graph_width = 0;
+        let enabled_graphs = 0;
+        for (let i = 0; i < this.graphs.length; i++) {
+            if (this.graphs[i]) {
+                total_graph_width += this.getGraphWidth(i);
+                enabled_graphs++;
+            }
+        }
+        if (enabled_graphs > 1)
+            total_graph_width += this.cfg_graph_spacing * (enabled_graphs - 1);
+
+        if (this.vertical)
+            this.area.set_size(-1, total_graph_width);
+        else
+            this.area.set_size(total_graph_width, -1);
+
+        this.resolution_needs_update = true;
+    },
+
+    updateGraphResolution: function(graph_idx, area_width, area_height) {
+        if (this.vertical)
+            this.graphs[graph_idx].setResolution(area_width, this.getGraphWidth(graph_idx));
+        else
+            this.graphs[graph_idx].setResolution(this.getGraphWidth(graph_idx), area_height);
+    },
     
     //Cinnamon callbacks
     on_applet_clicked: function(event) {
@@ -263,16 +311,15 @@ MyApplet.prototype = {
     },
 
     on_orientation_changed: function(orientation) {
-        global.log("Orientation changed");
         this.vertical = orientation == St.Side.LEFT || orientation == St.Side.RIGHT;
         this.on_cfg_changed_graph_width();
     },
 
     //Configuration change callbacks
     on_cfg_changed_graph_enabled: function(enabled, graph_idx) {
-        this.recalcGraphIndices();
         let enable = (i) => {
             let graph_id = this.graph_ids[i];
+            global.log("Enabling " + graph_id);
             if (this["cfg_" + graph_id + "_enabled"]) {
                 if (this.graphs[i])
                     return;
@@ -289,28 +336,25 @@ MyApplet.prototype = {
                     this.addGraph(new Providers.LoadAvgData(), i).setAutoScale(2 * ncpu);
                 }
             }
-            else {
-                if (!this.graphs[i])
-                    return;
-                this.actor.remove_child(this.areas[i]);
+            else if (this.graphs[i]) {
                 this.graphs[i] = null;
-                this.areas[i] = null;
             }
         };
-        if (graph_idx)
+        if (typeof graph_idx !== "undefined")
             enable(graph_idx);
         else
             for (let i = 0; i < this.graphs.length; i++)
                 enable(i);
+
+        this.resizeArea();
     },
 
     on_cfg_changed_smooth: function() {
         for (let g of this.graphs) {
-            if (g) {
+            if (g)
                 g.smooth = this.cfg_smooth;
-                g.repaint();
-            }
         }
+        this.repaint();
     },
 
     on_cfg_changed_refresh_rate: function() {
@@ -326,11 +370,10 @@ MyApplet.prototype = {
 
     on_cfg_changed_draw_border: function() {
         for (let g of this.graphs) {
-            if (g) {
+            if (g)
                 g.setDrawBorder(this.cfg_draw_border);
-                g.repaint();
-            }
         }
+        this.repaint();
     },
 
     on_cfg_changed_padding: function() {
@@ -340,9 +383,9 @@ MyApplet.prototype = {
         }
         else
             this.actor.set_style("");
-        for (let g of this.graphs)
-            if (g)
-                g.updateSize();
+
+        this.resolution_needs_update = true;
+        this.repaint();
     },
 
     on_cfg_changed_bg_border_color: function() {
@@ -352,24 +395,23 @@ MyApplet.prototype = {
             if (g) {
                 g.bg_color = this.bg_color;
                 g.border_color = this.border_color;
-                g.repaint();
             }
         }
+        this.repaint();
     },
 
-    on_cfg_changed_graph_width: function(width, graph_idx) {
-        if (graph_idx) {
-            if (this.graphs[graph_idx])
-                this.graphs[graph_idx].setWidth(this.getGraphWidth(graph_idx), this.vertical);
-        }
-        else
-            for (let i = 0; i < this.graphs.length; i++)
-                if (this.graphs[i])
-                    this.graphs[i].setWidth(this.getGraphWidth(i), this.vertical);
+    on_cfg_changed_graph_width: function(width) {
+        this.resizeArea();
+        this.repaint();
+    },
+
+    on_cfg_changed_graph_spacing: function(spacing) {
+        this.resizeArea();
+        this.repaint();
     },
 
     on_cfg_changed_tooltip_decimals: function(decimals, graph_idx) {
-        if (graph_idx) {
+        if (typeof graph_idx !== "undefined") {
             let provider = this.graphs[graph_idx].provider;
             if ("setTextDecimals" in provider)
                 provider.setTextDecimals(this.getGraphTooltipDecimals(graph_idx));
@@ -384,7 +426,7 @@ MyApplet.prototype = {
     },
 
     on_cfg_changed_color: function(width, graph_idx) {
-        if (graph_idx) {
+        if (typeof graph_idx !== "undefined") {
             if (this.graphs[graph_idx])
                 this.graphs[graph_idx].setColors(this.getGraphColors(graph_idx));
         }
@@ -392,6 +434,7 @@ MyApplet.prototype = {
             for (let i = 0; i < this.graphs.length; i++)
                 if (this.graphs[i])
                     this.graphs[i].setColors(this.getGraphColors(i));
+        this.repaint();
     }
 };
 

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.2/applet.js
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.2/applet.js
@@ -319,7 +319,6 @@ MyApplet.prototype = {
     on_cfg_changed_graph_enabled: function(enabled, graph_idx) {
         let enable = (i) => {
             let graph_id = this.graph_ids[i];
-            global.log("Enabling " + graph_id);
             if (this["cfg_" + graph_id + "_enabled"]) {
                 if (this.graphs[i])
                     return;
@@ -400,12 +399,12 @@ MyApplet.prototype = {
         this.repaint();
     },
 
-    on_cfg_changed_graph_width: function(width) {
+    on_cfg_changed_graph_width: function() {
         this.resizeArea();
         this.repaint();
     },
 
-    on_cfg_changed_graph_spacing: function(spacing) {
+    on_cfg_changed_graph_spacing: function() {
         this.resizeArea();
         this.repaint();
     },

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.2/graph.js
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.2/graph.js
@@ -156,6 +156,7 @@ Graph.prototype = {
             cr.rectangle(0.5, 0.5, width - 1, height - 1);
             cr.stroke();
         }
+        cr.$dispose();
     },
     
     setAutoScale: function(minScale)

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.2/graph.js
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.2/graph.js
@@ -17,8 +17,6 @@ Graph.prototype = {
         this.scale = 1;
         this.width = 1;
         this.height = 1;
-        this.x = 0;
-        this.y = 0;
         this.draw_border = true;
         this.resize_data = false;
     },

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.2/providers.js
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.2/providers.js
@@ -103,7 +103,7 @@ SwapData.prototype = {
     
     getData: function() {
         GTop.glibtop_get_swap(this.gtop);
-        let used = this.gtop.used / this.gtop.total;
+        let used = this.gtop.total > 0 ? (this.gtop.used / this.gtop.total) : 0;
         this.text = Math.round(this.gtop.used / (1024 * 1024))
             + " / " + Math.round(this.gtop.total / (1024 * 1024)) + _(" MB");
         return [used];

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.2/settings-schema.json
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.2/settings-schema.json
@@ -10,7 +10,7 @@
         "common_g": {
             "type": "section",
             "title": "General",
-            "keys": ["onclick_program", "smooth", "draw_border", "graph_width", "refresh_rate", "use_padding", "padding_lr", "padding_tb"]
+            "keys": ["onclick_program", "smooth", "draw_border", "graph_width", "graph_spacing", "refresh_rate", "use_padding", "padding_lr", "padding_tb"]
         },
         "common_c": {
             "type": "section",
@@ -118,10 +118,20 @@
         "units": "pixels",
         "tooltip": "If the applet is in a vertical panel, this sets the graph height. The graph width is then the panel width minus padding"
     },
+    "graph_spacing": {
+        "type": "spinbutton",
+        "default": 3,
+        "min": -1,
+        "max": 100,
+        "step": 1,
+        "description": "Graph spacing",
+        "units": "pixels",
+        "tooltip": "The number of pixels between each graph. Can be set to -1 to allow single line borders between graphs if borders are enabled"
+    },
     "refresh_rate": {
         "type": "spinbutton",
         "default": 1000,
-        "min": 100,
+        "min": 10,
         "max": 10000,
         "step": 50,
         "description": "Refresh rate",

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.2/settings-schema.json
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.2/settings-schema.json
@@ -131,8 +131,8 @@
     "refresh_rate": {
         "type": "spinbutton",
         "default": 1000,
-        "min": 10,
-        "max": 10000,
+        "min": 100,
+        "max": 60000,
         "step": 50,
         "description": "Refresh rate",
         "units": "ms"

--- a/sysmonitor@orcus/files/sysmonitor@orcus/metadata.json
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/metadata.json
@@ -2,7 +2,7 @@
     "description": "Displays CPU, memory, swap and network usage and load in graphs", 
     "uuid": "sysmonitor@orcus", 
     "name": "System Monitor", 
-    "version": "1.6.3",
+    "version": "1.6.4",
     "icon": "utilities-system-monitor",
     "max-instances": -1,
     "multiversion": true


### PR DESCRIPTION
I've fixed the memory leak caused by garbage collector not destroying cairo surfaces automatically (fixes #2253). I've also simplified the rendering by using only one drawing area for all graphs now and backported the changes to the applet version 3.0.