### PR TITLE
cryptocoin@guantanamoe - fix install instructions for Spices hosted version

### DIFF
--- a/cryptocoin@guantanamoe/README.md
+++ b/cryptocoin@guantanamoe/README.md
@@ -4,12 +4,13 @@ Cinnamon applet that shows the current values of configured cryptos.
 
 ## Getting Started
 
-To install for the local user:
+Install via Cinnamon's Applets settings module Download tab.
 
-```
-cd ~/.local/share/cinnamon/applets
-git clone https://github.com/imDeprecated/cryptocoin-applet.git cryptocoin@guantanamoe
-```
+or
+
+Download the applet's zip file using the Download button on the applet's Cinnamon Spices web-pages and unzip to `~/.local/share/cinnamon/applets/`
+
+Once installed add the applet to your panel via the Applets settings module.
 
 ## Versioning
 


### PR DESCRIPTION
@philtyl

This PR just replaces the Getting Started section of the readme with instructions of how to install the current applet version hosted on Cinnamon Spices rather than from the author's original repo. 

Prompted by this forum thread documenting an attempt to install the applet https://forums.linuxmint.com/viewtopic.php?f=90&t=288713

