### PR TITLE
 [calendar@simonwiles.net] Adds feature to let the applet check and apply system clock setting 'use-24h' and 'show-seconds'

### DIFF
--- a/calendar@simonwiles.net/files/calendar@simonwiles.net/applet.js
+++ b/calendar@simonwiles.net/files/calendar@simonwiles.net/applet.js
@@ -29,6 +29,7 @@ if (typeof require !== 'undefined') {
     Calendar = AppletDir.calendar;
 }
 const GLib = imports.gi.GLib;
+const Gio = imports.gi.Gio;
 
 let DEFAULT_FORMAT = _("%l:%M %p");
 
@@ -137,6 +138,15 @@ MyApplet.prototype = {
             this._dateFormat = DEFAULT_FORMAT;
             this._dateFormatFull = _("%A %B %e, %Y");
 
+            // connect to system clock settings
+            this.desktop_settings = new Gio.Settings({ schema_id: "org.cinnamon.desktop.interface" });
+            this.desktop_settings.connect("changed::clock-use-24h", Lang.bind(this, function(key) {
+                this.on_settings_changed();
+            }));
+            this.desktop_settings.connect("changed::clock-show-seconds", Lang.bind(this, function(key) {
+                this.on_settings_changed();
+            }));
+
             this.settings.bindProperty(Settings.BindingDirection.IN, "use-custom-format", "use_custom_format", this.on_settings_changed, null);
             this.settings.bindProperty(Settings.BindingDirection.IN, "custom-format", "custom_format", this.on_settings_changed, null);
             this.settings.bindProperty(Settings.BindingDirection.IN, "keybinding", "keybinding", this._onKeySettingsUpdated, null);
@@ -178,12 +188,32 @@ MyApplet.prototype = {
     },
 
     on_settings_changed: function() {
+        this._updateClockAndDate();
+        this._updateFormatString();
+    },
+
+    // reads system clock setting to apply "24h" and "seconds" setting to this applet
+    _updateFormatString() {
         if (this.use_custom_format) {
             this._dateFormat = this.custom_format;
         } else {
-            this._dateFormat = DEFAULT_FORMAT;
+            let use_24h = this.desktop_settings.get_boolean("clock-use-24h");
+            let show_seconds = this.desktop_settings.get_boolean("clock-show-seconds");            
+
+            if (use_24h) {
+                if (show_seconds) {
+                    this._dateFormat = "%H:%M:%S";
+                } else {
+                    this._dateFormat = "%H:%M%";
+                }
+            } else {
+                if (show_seconds) {
+                    this._dateFormat = "%l:%M:%S %p";
+                } else {
+                    this._dateFormat = DEFAULT_FORMAT;
+                }
+            }
         }
-        this._updateClockAndDate();
     },
 
     on_custom_format_button_pressed: function() {

--- a/calendar@simonwiles.net/files/calendar@simonwiles.net/applet.js
+++ b/calendar@simonwiles.net/files/calendar@simonwiles.net/applet.js
@@ -188,8 +188,8 @@ MyApplet.prototype = {
     },
 
     on_settings_changed: function() {
-        this._updateClockAndDate();
         this._updateFormatString();
+        this._updateClockAndDate();
     },
 
     // reads system clock setting to apply "24h" and "seconds" setting to this applet


### PR DESCRIPTION
This change introduces honoring of the system clock settings 'use-24h' and 'show-seconds'. The changes are ported back from the current version of the system's calendar applet, see:
https://github.com/linuxmint/cinnamon/tree/ec6fb27452da571142bd39fccd8dbb5c64c066c6/files/usr/share/cinnamon/applets/calendar%40cinnamon.org

I usually don't code in JavaScript, so please someone have a quick look at the code for anti-patterns and such.

@simonwiles Thanks for the applet! Would you have a look at proposed changes and approve them if you agree?