### PR TITLE
fix for unformated value

### DIFF
--- a/cryptocoin@guantanamoe/files/cryptocoin@guantanamoe/applet.js
+++ b/cryptocoin@guantanamoe/files/cryptocoin@guantanamoe/applet.js
@@ -185,7 +185,7 @@ MyApplet.prototype = {
                                                       currency_config.precision);
                 break;
             case 'name':
-                value = `${value} ${this.currency}`;
+                value = Accounting.formatMoney(value, '', 2) + ` ${this.currency}`;
                 break;
         }
         return value;


### PR DESCRIPTION
The value is not formatted if `Show currency` is set to `name`.

Values like `1234.5` are show as `1234.5 USD` instead of `1,234.50 USD`.