### PR TITLE
Replaced dbus commands by systemctl

### DIFF
--- a/shutdown-timer@webum.by/files/shutdown-timer@webum.by/applet.js
+++ b/shutdown-timer@webum.by/files/shutdown-timer@webum.by/applet.js
@@ -334,19 +334,19 @@ MyApplet.prototype = {
 		  		break;
 
 			case 'suspend':
-		  		Util.spawnCommandLine("dbus-send --system --print-reply --dest=org.freedesktop.UPower /org/freedesktop/UPower org.freedesktop.UPower.Suspend");
+		  		Util.spawnCommandLine("systemctl suspend");
 		  		break;
 
 			case 'hibernate':
-				Util.spawnCommandLine("dbus-send --system --print-reply --dest=org.freedesktop.UPower /org/freedesktop/UPower org.freedesktop.UPower.Suspend");
+				Util.spawnCommandLine("systemctl hibernate");
 		  		break;
 
 			case 'restart':
-				Util.spawnCommandLine("dbus-send --system --print-reply --dest=org.freedesktop.ConsoleKit /org/freedesktop/ConsoleKit/Manager org.freedesktop.ConsoleKit.Manager.Restart");
+				Util.spawnCommandLine("systemctl reboot");
 		  		break;
 
 			case 'shutdown':
-		  		Util.spawnCommandLine("dbus-send --system --print-reply --dest=org.freedesktop.ConsoleKit /org/freedesktop/ConsoleKit/Manager org.freedesktop.ConsoleKit.Manager.Stop");
+		  		Util.spawnCommandLine("systemctl poweroff");
 		  		break;
 
 			case 'restart-cinnamon':


### PR DESCRIPTION
dBus commands don't work on Debian Testing.
Replacing suspend/hibernate/reboot/shutdown with corresponding systemctl commands, this applet works on Debian. Lock-Screen still doesn't work (I don't know which dbus command is necessary).

@maintainers: I cannot verify if this works on Mint. According to https://forums.linuxmint.com/viewtopic.php?t=235654 , it should be necessary to change this applet for Mint as well.

Signed-off-by: Benjamin Aigner <aignerb@technikum-wien.at>