### PR TITLE
edited width of cpu-monitor-text@gnemonix

### DIFF
--- a/cpu-monitor-text@gnemonix/files/cpu-monitor-text@gnemonix/applet.js
+++ b/cpu-monitor-text@gnemonix/files/cpu-monitor-text@gnemonix/applet.js
@@ -96,7 +96,7 @@ MyApplet.prototype = {
 		let percent = Math.round(this.max_percentage - this.usage);
 		this.set_applet_label("  " + this.cpu_label + " " + this._pad(percent) + "%");
 		
-		this.actor.style = "width: " + (this.max_percentage.toString().length + 3.5) + "em";
+		this.actor.style = "width: " + (this.max_percentage.toString().length + 1.5) + "em";
 	},
 
 	_updateLoop: function () {


### PR DESCRIPTION
In solution to #2462 Changes the width to the right of the applet to be more reasonable leaving less dead space. It still adapts to the max percentage length, there is just less buffer. It was 3.5em and is now 1.5em.
Old:
![image](https://user-images.githubusercontent.com/16065962/60275507-953b3c80-98e9-11e9-9fe6-e5460e442eff.png)

New:
![image](https://user-images.githubusercontent.com/16065962/60281254-244d5200-98f4-11e9-8cc4-4074dd9d06cc.png)

I am sort of new to this using github pullrequests so let me know if I did anything wrong. 