### PR TITLE
Compatibility with cinnamon 4.2

### DIFF
--- a/Cinnamenu@json/files/Cinnamenu@json/metadata.json
+++ b/Cinnamenu@json/files/Cinnamenu@json/metadata.json
@@ -3,9 +3,9 @@
   "name": "Cinnamenu",
   "description": "A flexible menu providing formatting options, web bookmarks, open window lookup, and search provider support with fuzzy searching.",
   "max-instances": 2,
-  "version": "4.1.2",
+  "version": "4.1.3",
   "multiversion": true,
   "website": "https://github.com/linuxmint/cinnamon-spices-applets/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+Cinnamenu%40json",
   "comments": "Made possible thanks to the efforts of contributors to the Cinnamon menu, Gnomenu, and the contributors to projects they derived from.",
-  "cinnamon-version": ["3.2", "3.4", "3.6", "3.8", "4.0"]
+  "cinnamon-version": ["3.2", "3.4", "3.6", "3.8", "4.0", "4.2"]
 }

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
@@ -1,8 +1,8 @@
 {
     "uuid": "multicore-sys-monitor@ccadeptic23",
     "name": "Multi-Core System Monitor",
-    "version": "1.8.7",
+    "version": "1.8.8",
     "description": "Displays in realtime the cpu usage for each core/cpu and overall memory usage.",
     "multiversion": true,
-    "cinnamon-version": ["2.8", "3.0", "3.2", "3.4", "3.6", "3.8", "4.0"]
+    "cinnamon-version": ["2.8", "3.0", "3.2", "3.4", "3.6", "3.8", "4.0", "4.2"]
 }

--- a/temperature@fevimu/files/temperature@fevimu/metadata.json
+++ b/temperature@fevimu/files/temperature@fevimu/metadata.json
@@ -2,5 +2,5 @@
   "uuid": "temperature@fevimu",
   "name": "CPU Temperature Indicator",
   "description": "Shows CPU Temperature",
-  "cinnamon-version": ["3.6", "3.8", "4.0"]
+  "cinnamon-version": ["3.6", "3.8", "4.0", "4.2"]
 }


### PR DESCRIPTION
Version and Cinnamon Version bump for:
* multicore-sys-monitor
* Cinnamenu
* CPU Temperature indicator

All work the same under 4.2, only added 4.2 to the supported versions array in the metadata.