### PR TITLE
cpu-monitor-text@gnemonix: Fixed width of cpu monitor label

### DIFF
--- a/cpu-monitor-text@gnemonix/files/cpu-monitor-text@gnemonix/applet.js
+++ b/cpu-monitor-text@gnemonix/files/cpu-monitor-text@gnemonix/applet.js
@@ -40,7 +40,7 @@ MyApplet.prototype = {
 	
 			this.gtop = new GTop.glibtop_cpu();
 	
-			this._applet_label.set_style('text-align: left');
+			this._applet_label.set_style('min-width: 2.5em; text-align: left');
 	
 			this.current = 0;
 			this.last = 0;
@@ -94,9 +94,7 @@ MyApplet.prototype = {
 		}
 
 		let percent = Math.round(this.max_percentage - this.usage);
-		this.set_applet_label("  " + this.cpu_label + " " + this._pad(percent) + "%");
-		
-		this.actor.style = "width: " + (this.max_percentage.toString().length + 1.5) + "em";
+		this.set_applet_label(this.cpu_label + " " + this._pad(percent) + "%");
 	},
 
 	_updateLoop: function () {


### PR DESCRIPTION
Changelist:

- Fixed a bug where the width of the label of cpu monitor had a space at the beginning which pushed it outside the visual box of the applet.

@gnemonix

As it was, the label for the CPU monitor applet had an extra two white spaces that were making it override other applets, I simply removed those whitespaces and set the min-width to be more consistent with for example _[mem-monitor-text@datanom.net](https://github.com/linuxmint/cinnamon-spices-applets/tree/master/mem-monitor-text%40datanom.net)_