### PR TITLE
[SpicesUpdate@claudiux] v2.2.0

### DIFF
--- a/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,3 +1,13 @@
+### v2.2.0~20190803
+  * Adding a "Help..." button in the menu. This help (in English by default) can be translated into your language. To do it:
+   * Place you into the `help` directory: `cd ~/.local/share/cinnamon/applets/SpicesUpdate@claudiux/help`
+   * Copy the `en` directory into a new directory named as your language code. Example: `cp -a en de`
+   * Place you into this new directory. Translate the contents of the README.md file. (Do not rename this file.)
+   * Install the `grip` package, then export the README.md file into html format: `grip --title "Spices Update - Help" --export README.md README.html`. (Translate _Help_.)
+   * You can propose your translation, mentionning me (@claudiux) on Github.
+  * French translation of the README.md file is available.
+  * When only one Spice (by category: Applets, Desklets, ...) needs an update, its icon appears into the notification messages.
+
 ### v2.1.0~20190721
   * Allows user to update even downloaded xlets from the Download button on the site.
   * Compatible with Cinnamon 3.8, 4.0 and 4.2.

--- a/SpicesUpdate@claudiux/README.md
+++ b/SpicesUpdate@claudiux/README.md
@@ -20,7 +20,7 @@ Fully supported by the author, under continuing development and in continuous us
 
 The Spices Update requires the ```notify-send``` tool and the ```symbola``` TrueType font.
 
-To install it:
+To install them:
 
   * Fedora: `sudo dnf install libnotify gdouros-symbola-fonts`
   * Arch:

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,3 +1,13 @@
+### v2.2.0~20190803
+  * Adding a "Help..." button in the menu. This help (in English by default) can be translated into your language. To do it:
+   * Place you into the `help` directory: `cd ~/.local/share/cinnamon/applets/SpicesUpdate@claudiux/help`
+   * Copy the `en` directory into a new directory named as your language code. Example: `cp -a en de`
+   * Place you into this new directory. Translate the contents of the README.md file. (Do not rename this file.)
+   * Install the `grip` package, then export the README.md file into html format: `grip --title "Spices Update - Help" --export README.md README.html`. (Translate _Help_.)
+   * You can propose your translation, mentionning me (@claudiux) on Github.
+  * French translation of the README.md file is available.
+  * When only one Spice (by category: Applets, Desklets, ...) needs an update, its icon appears into the notification messages.
+
 ### v2.1.0~20190721
   * Allows user to update even downloaded xlets from the Download button on the site.
   * Compatible with Cinnamon 3.8, 4.0 and 4.2.

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/en/README.html
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/en/README.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Spices Update - Help</title>
+  <link rel="icon" href="data:image/x-icon;base64,AAABAAEAEBAAAAEACABoBQAAFgAAACgAAAAQAAAAIAAAAAEACAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAKCgr/FRUX/xYWGP8YGBr/GRkb/xsbHP8dHR7/Hh4f/x4eIP8fHyD/ICAh/yMjJP8kJCX/JiYo/ygoKv8pKSr/LCwu/y0tLv80NDT/QUFC/0ZGR/9MTE7/UFBR/1JSUv9bW1v/XFxc/2BgYP9hYWP/aGhp/2xsbP9ycnL/d3d3/3l5e/98fHz/f3+A/2dn/P9z3a//cNX8/4CAgP+Xl5f/nZ2e/56en/+fn5//n5+h/6amp/+rq6v/rKys/7CvsP+zs7T/uLi5/7u7u/+8vLz/wMDA/8fHx//Kysr/zc3N/9HR0f/d3d3/3t7e/+Xl5f/q6ur/6+vr/+3t7f/z8/P/9fX1//b29v/39/f/+Pj4//n5+f/6+vr/+/v7//z8/P/9/f3//v7+//////8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/NCYmJiYmJiYmJiYmJiYmNCZKSkpKSkpKSkpKSkpKSiYmSkpKRisdRkMbMklKSkomJkpKSSEiNUhEEQwpSUpKJiZKSi8LHhhAPAwBDDZKSiYmSkoWACA7SEc6HAEaSkomJkpKBxI/SkpKSj4ICkpKJiZKSgUTR0pKSkpGDwZKSiYmSkoTED1KSkpKOQQVSkomJkpKKgowMy4sNycIMUpKJiZKSkEZDgkDAgsNH0VKSiYmSkpKQigUBgkXLUhKSkomJkpKSkpKSkpKSkpKSkpKJiYmJiYmJiYmJiYmJiYmJiYmIyUkNDQ0NDQ0NDQ0NDQmOCYmJiYmJiYmJiYmJiYmOAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" />
+  <link rel="stylesheet" href="//octicons.github.com/components/octicons/octicons/octicons.css" />
+  <style>
+    /* Page tweaks */
+    .preview-page {
+      margin-top: 64px;
+    }
+    /* User-content tweaks */
+    .timeline-comment-wrapper > .timeline-comment:after,
+    .timeline-comment-wrapper > .timeline-comment:before {
+      content: none;
+    }
+    /* User-content overrides */
+    .discussion-timeline.wide {
+      width: 920px;
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div id="preview-page" class="preview-page" data-autorefresh-url="">
+
+    
+
+      <div role="main" class="main-content">
+        <div class="container new-discussion-timeline experiment-repo-nav">
+          <div class="repository-content">
+            <div id="readme" class="readme boxed-group clearfix announce instapaper_body md">
+              
+                <h3>
+                  <span class="octicon octicon-book"></span>
+                  Spices Update - Help
+                </h3>
+              
+              <article class="markdown-body entry-content" itemprop="text" id="grip-content">
+                <h1>
+<a id="user-content-spices-update" class="anchor" href="#spices-update" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Spices Update</h1>
+<h2>
+<a id="user-content-summary" class="anchor" href="#summary" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Summary</h2>
+<p>Cinnamon Spices are Applets, Desklets, Extensions and Themes.</p>
+<p>You usually check updates for the Spices using Cinnamon Settings. But, like me, you do it too seldom.</p>
+<p>The <strong>Spices Update</strong> applet plays these roles:</p>
+<ul>
+<li>It warns you when the Spices you have installed need updates.</li>
+<li>Optional: It can also warn you when new Spices are available.</li>
+<li>It gives you direct access to Cinnamon Settings for Applets, Desklets, Extensions and Themes.</li>
+</ul>
+<h2>
+<a id="user-content-status" class="anchor" href="#status" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Status</h2>
+<p>Fully supported by the author, under continuing development and in continuous use on several machines, running with <strong>Linux Mint</strong>, <strong>Fedora</strong> or <strong>Archlinux</strong>.</p>
+<h2>
+<a id="user-content-requirements" class="anchor" href="#requirements" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Requirements</h2>
+<p>The Spices Update requires the <code>notify-send</code> tool and the <code>symbola</code> TrueType font.</p>
+<p>To install them:</p>
+<ul>
+<li>Fedora: <code>sudo dnf install libnotify gdouros-symbola-fonts</code>
+</li>
+<li>Arch:
+<ul>
+<li><code>sudo pacman -Syu libnotify</code></li>
+<li>
+<code>yay -S ttf-symbola</code> <em>or</em> <code>pamac build ttf-symbola</code>
+</li>
+</ul>
+</li>
+<li>Linux Mint: <code>sudo apt install libnotify-bin fonts-symbola</code>
+</li>
+</ul>
+<p><strong>This applet helps you to install these dependencies, if needed.</strong></p>
+<h2>
+<a id="user-content-settings" class="anchor" href="#settings" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Settings</h2>
+<p>There are five tabs in settings.</p>
+<p>The first, <em>General</em>, allows you to:</p>
+<ul>
+<li>Select the <em>Time interval between two checks</em> (in hours). Please note that the first check will take place one minute after starting this applet.</li>
+<li>Select the ways to warn you : changing the appearance (by color changing) of the icon of this applet and/or displaying messages in the notification zone. You can also choose the type of notification: Minimal or With a button to open the Download tab in System Settings. If desired, the notification may contain the description of each update or new Spice.</li>
+<li>Select the <em>Type of display</em> of the icon: with or without text?</li>
+<li>Hide the icon applet while nothing is to report. <em>Please note that Spices Update settings are only accessible when the applet icon is visible or by opening the Cinnamon Settings-&gt; Applets.</em>
+</li>
+</ul>
+<p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/System_Settings_Applets.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/System_Settings_Applets.png" alt="system_settings_applet" style="max-width:100%;"></a></p>
+<p>For the content of the other tabs (<em>Applets</em>, <em>Desklets</em>, etc), please look at the screenshot above and note that <strong>the list of installed Spices is automatically filled</strong> at startup, but a button allows you to reload it.</p>
+<p>Set to <em>FALSE</em> all the Spices you <em>do not want</em> to check updates. There are two reasons to do this:</p>
+<ul>
+<li>A spice is OK for you, and you do not want to be notified of any changes to it.</li>
+<li>You are a developer working on a spice and you do not want to be informed about changes during development.</li>
+</ul>
+<h2>
+<a id="user-content-menu" class="anchor" href="#menu" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Menu</h2>
+<p>In the menu of this applet:</p>
+<ul>
+<li>a Refresh button allows you to force checking the availability of updates for your Spices;</li>
+<li>a dot appears in front of each type of Spice when at least one update is available;</li>
+<li>a click on a type of Spice (Applets, Desklets, etc) opens the Download tab of the corresponding page in Cinnamon Settings, with Spices sorted by date;</li>
+<li>when new Spices are available, an option <em>Forget new Spices</em> appears; clicking it will clear these notifications of new spices, until others arrive;</li>
+<li>a Configure... button opens the Settings.</li>
+</ul>
+<h2>
+<a id="user-content-icon" class="anchor" href="#icon" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Icon</h2>
+<p>The color of the icon changes when at least one of your Spices needs an update.</p>
+<p>Its tooltip (the message displayed when the icon is hovered) contains the list of spices to update, if any.</p>
+<p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/hovering_icon.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/hovering_icon.png" alt="hovering_icon" style="max-width:100%;"></a></p>
+<h2>
+<a id="user-content-notifications" class="anchor" href="#notifications" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Notifications</h2>
+<p>There are two types of notifications: <em>Minimal</em> or <em>With buttons</em>. Each of them may or may not contain details: the reason for an update or the description of a new spice.</p>
+<h3>
+<a id="user-content-minimal-notifications" class="anchor" href="#minimal-notifications" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Minimal notifications</h3>
+<p>Here with the reason for update:</p>
+<p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_simple_with_details.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_simple_with_details.png" alt="notif_simple_with_details" style="max-width:100%;"></a></p>
+<h3>
+<a id="user-content-notifications-with-buttons" class="anchor" href="#notifications-with-buttons" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Notifications with buttons</h3>
+<p>Two buttons: firstly a button to open the System Settings page to download updates; secondly a button to refresh the notification to obtain details, if any.</p>
+<p>Here without details:</p>
+<p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_without_details.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_without_details.png" alt="notif_without_details" style="max-width:100%;"></a></p>
+<p>After refreshing, the reason for the update appears:</p>
+<p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_with_details2.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_with_details2.png" alt="notif_with_details" style="max-width:100%;"></a></p>
+<h2>
+<a id="user-content-translations" class="anchor" href="#translations" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Translations</h2>
+<p>Any translation is welcome. Thank you for contributing to translate the applet's messages into new languages, or to improve or supplement existing translations.</p>
+<h2>
+<a id="user-content-installation" class="anchor" href="#installation" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Installation</h2>
+<h3>
+<a id="user-content-automatic-installation" class="anchor" href="#automatic-installation" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Automatic Installation</h3>
+<p>Use the <em>Applets</em> menu in Cinnamon Settings, or <em>Add Applets to Panel</em> in the context menu (right-click) of your desktop panel. Then go on the Download tab to install this Spices Update applet.</p>
+<h3>
+<a id="user-content-manual-installation" class="anchor" href="#manual-installation" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Manual Installation:</h3>
+<ul>
+<li>Install the additional programs required.</li>
+<li>Download the Spices Update from the Spices Web Site.</li>
+<li>Unzip and extract the folder <code>SpicesUpdate@claudiux</code> into <code>~/.local/share/cinnamon/applets/</code>
+</li>
+<li>Enable this applet in System Settings -&gt; Applets.</li>
+<li>You can also access the Settings Screen from System Settings -&gt; Applets, or from the context menu of this applet (right-clicking on its icon).</li>
+</ul>
+<h2>
+<a id="user-content-a-star-to-thank-the-author" class="anchor" href="#a-star-to-thank-the-author" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>A Star to thank the author</h2>
+<p>If you like this Spices Update applet, please do not offer money or coffee, but log in and click on the Star at the top of this page.</p>
+<p>Many Thanks.</p>
+
+              </article>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    
+
+  </div>
+  <div>&nbsp;</div>
+  </div><script>
+    function showCanonicalImages() {
+      var images = document.getElementsByTagName('img');
+      if (!images) {
+        return;
+      }
+      for (var index = 0; index < images.length; index++) {
+        var image = images[index];
+        if (image.getAttribute('data-canonical-src') && image.src !== image.getAttribute('data-canonical-src')) {
+          image.src = image.getAttribute('data-canonical-src');
+        }
+      }
+    }
+
+    function scrollToHash() {
+      if (location.hash && !document.querySelector(':target')) {
+        var element = document.getElementById('user-content-' + location.hash.slice(1));
+        if (element) {
+           element.scrollIntoView();
+        }
+      }
+    }
+
+    function autorefreshContent(eventSourceUrl) {
+      var initialTitle = document.title;
+      var contentElement = document.getElementById('grip-content');
+      var source = new EventSource(eventSourceUrl);
+      var isRendering = false;
+
+      source.onmessage = function(ev) {
+        var msg = JSON.parse(ev.data);
+        if (msg.updating) {
+          isRendering = true;
+          document.title = '(Rendering) ' + document.title;
+        } else {
+          isRendering = false;
+          document.title = initialTitle;
+          contentElement.innerHTML = msg.content;
+          showCanonicalImages();
+        }
+      }
+
+      source.onerror = function(e) {
+        if (e.readyState === EventSource.CLOSED && isRendering) {
+          isRendering = false;
+          document.title = initialTitle;
+        }
+      }
+    }
+
+    window.onhashchange = function() {
+      scrollToHash();
+    }
+
+    window.onload = function() {
+      scrollToHash();
+    }
+
+    showCanonicalImages();
+
+    var autorefreshUrl = document.getElementById('preview-page').getAttribute('data-autorefresh-url');
+    if (autorefreshUrl) {
+      autorefreshContent(autorefreshUrl);
+    }
+  </script>
+</body>
+</html>

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/en/README.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/en/README.md
@@ -20,7 +20,7 @@ Fully supported by the author, under continuing development and in continuous us
 
 The Spices Update requires the ```notify-send``` tool and the ```symbola``` TrueType font.
 
-To install it:
+To install them:
 
   * Fedora: `sudo dnf install libnotify gdouros-symbola-fonts`
   * Arch:

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/fr/README.html
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/fr/README.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Spices Update - Aide en Français</title>
+  <link rel="icon" href="data:image/x-icon;base64,AAABAAEAEBAAAAEACABoBQAAFgAAACgAAAAQAAAAIAAAAAEACAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAKCgr/FRUX/xYWGP8YGBr/GRkb/xsbHP8dHR7/Hh4f/x4eIP8fHyD/ICAh/yMjJP8kJCX/JiYo/ygoKv8pKSr/LCwu/y0tLv80NDT/QUFC/0ZGR/9MTE7/UFBR/1JSUv9bW1v/XFxc/2BgYP9hYWP/aGhp/2xsbP9ycnL/d3d3/3l5e/98fHz/f3+A/2dn/P9z3a//cNX8/4CAgP+Xl5f/nZ2e/56en/+fn5//n5+h/6amp/+rq6v/rKys/7CvsP+zs7T/uLi5/7u7u/+8vLz/wMDA/8fHx//Kysr/zc3N/9HR0f/d3d3/3t7e/+Xl5f/q6ur/6+vr/+3t7f/z8/P/9fX1//b29v/39/f/+Pj4//n5+f/6+vr/+/v7//z8/P/9/f3//v7+//////8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/NCYmJiYmJiYmJiYmJiYmNCZKSkpKSkpKSkpKSkpKSiYmSkpKRisdRkMbMklKSkomJkpKSSEiNUhEEQwpSUpKJiZKSi8LHhhAPAwBDDZKSiYmSkoWACA7SEc6HAEaSkomJkpKBxI/SkpKSj4ICkpKJiZKSgUTR0pKSkpGDwZKSiYmSkoTED1KSkpKOQQVSkomJkpKKgowMy4sNycIMUpKJiZKSkEZDgkDAgsNH0VKSiYmSkpKQigUBgkXLUhKSkomJkpKSkpKSkpKSkpKSkpKJiYmJiYmJiYmJiYmJiYmJiYmIyUkNDQ0NDQ0NDQ0NDQmOCYmJiYmJiYmJiYmJiYmOAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" />
+  <link rel="stylesheet" href="//octicons.github.com/components/octicons/octicons/octicons.css" />
+  <style>
+    /* Page tweaks */
+    .preview-page {
+      margin-top: 64px;
+    }
+    /* User-content tweaks */
+    .timeline-comment-wrapper > .timeline-comment:after,
+    .timeline-comment-wrapper > .timeline-comment:before {
+      content: none;
+    }
+    /* User-content overrides */
+    .discussion-timeline.wide {
+      width: 920px;
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div id="preview-page" class="preview-page" data-autorefresh-url="">
+
+    
+
+      <div role="main" class="main-content">
+        <div class="container new-discussion-timeline experiment-repo-nav">
+          <div class="repository-content">
+            <div id="readme" class="readme boxed-group clearfix announce instapaper_body md">
+              
+                <h3>
+                  <span class="octicon octicon-book"></span>
+                  Spices Update - Aide en Français
+                </h3>
+              
+              <article class="markdown-body entry-content" itemprop="text" id="grip-content">
+                <h1>
+<a id="user-content-spices-update" class="anchor" href="#spices-update" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Spices Update</h1>
+<h2>
+<a id="user-content-résumé" class="anchor" href="#r%C3%A9sum%C3%A9" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Résumé</h2>
+<p>Les Spices de Cinnamon sont les Applets, Desklets, Extensions et Thèmes.</p>
+<p>Habituellement, vous vérifiez si les Spices que vous avez installées disposent de mises à jour à l'aide des Paramètres système de Cinnamon.</p>
+<p>Mais, comme moi, vous le faites trop rarement.</p>
+<p>L'applet <strong>Spices Update</strong> :</p>
+<ul>
+<li>vous avertit dès lors que des Spices que vous avez installées disposent d'une mise à jour ;</li>
+<li>peut vous avertir, si vous le désirez, lorsque de nouvelles Spices sont disponibles ;</li>
+<li>vous donne un accès direct aux Paramètres système des Applets, Desklets, Extensions et Thèmes.</li>
+</ul>
+<h2>
+<a id="user-content-état" class="anchor" href="#%C3%A9tat" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>État</h2>
+<p>Cette applet est active, c'est-à-dire développée et utilisée par l'auteur sur plusieurs machines fonctionnant sous <strong>Linux Mint</strong>, <strong>Fedora</strong> ou <strong>Archlinux</strong>.</p>
+<p>L'auteur est ouvert à toute suggestion d'amélioration.</p>
+<h2>
+<a id="user-content-dépendances" class="anchor" href="#d%C3%A9pendances" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Dépendances</h2>
+<p>Spices Update nécessite l'installation de l'outil <code>notify-send</code> et de la police de caractères <code>symbola</code> (de type TrueType).</p>
+<p>Pour les installer :</p>
+<ul>
+<li>Fedora: <code>sudo dnf install libnotify gdouros-symbola-fonts</code>
+</li>
+<li>Arch:
+<ul>
+<li><code>sudo pacman -Syu libnotify</code></li>
+<li>
+<code>yay -S ttf-symbola</code> <em>or</em> <code>pamac build ttf-symbola</code>
+</li>
+</ul>
+</li>
+<li>Linux Mint: <code>sudo apt install libnotify-bin fonts-symbola</code>
+</li>
+</ul>
+<p><strong>Cette applet vous aide à installer ces dépendances, si besoin.</strong> En effet, lors de son lancement, l'applet Spice Update vérifie que ces dépendances sont installées. Si ce n'est pas le cas, elle vous propose de les installer.</p>
+<h2>
+<a id="user-content-configuration" class="anchor" href="#configuration" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Configuration</h2>
+<p>La fenêtre de configuration dispose de cinq onglets.</p>
+<p>Le premier, <em>Général</em>, vous permet de :</p>
+<ul>
+<li>Choisir l'<em>Intervalle de temps entre deux vérifications</em> (en heures). Veuillez noter que la première vérification aura lieu une minute après le démarrage de cette applet.</li>
+<li>Choisir la façon dont vous serez prévenu : par changement de la couleur de l'icône de cette applet et/ou par affichage de messages dans la zone de notification. Vous pouvez également choisir le type de notification: <em>Minimal</em> ou <em>Avec un bouton</em> permettant d'ouvrir l'onglet Télécharger dans les Paramètres système. Si vous le souhaitez également, la notification peut contenir la description de chaque mise à jour ou nouveauté.</li>
+<li>Choisir le <em>Type d'affichage</em> de l'icône: avec ou sans texte?</li>
+<li>Cacher l'icône de cette applet tant que rien de nouveau n'est à signaler. <em>Veuillez noter que les Préférences de Spices Update ne sont accessibles, tant que l'icône n'est pas affichée, qu'en passant par Paramètres système -&gt; Applets.</em>
+</li>
+</ul>
+<p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/System_Settings_Applets-fr.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/System_Settings_Applets-fr.png" alt="system_settings_applet" style="max-width:100%;"></a></p>
+<p>Quant au contenu des autres onglets (<em>Applets</em>, <em>Desklets</em>, etc), veuillez consulter la capture d'écran ci-dessous et noter que <strong>la liste des Spices installées est automatiquement remplie</strong> au démarrage, mais qu'un bouton <em>Rafraîchir</em> vous permet de la recharger.</p>
+<p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/Settings_Spices_Update_Applets-fr.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/Settings_Spices_Update_Applets-fr.png" alt="settings_spices_update_applets" style="max-width:100%;"></a></p>
+<p>Réglez sur <em>FALSE</em> (ou décochez à partir de Cinnamon 4.2) toutes les Spices dont vous ne voulez pas vérifier les mises à jour. Il y a au moins deux raisons à cela:</p>
+<ul>
+<li>Une Spice vous convient pleinement et vous ne voulez pas être averti d'un quelconque changement la concernant.</li>
+<li>Vous êtes un développeur travaillant sur une Spice et vous ne souhaitez pas être informé de quelque modification que ce soit durant son développement.</li>
+</ul>
+<h2>
+<a id="user-content-menu" class="anchor" href="#menu" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Menu</h2>
+<p>Dans le menu de Spices Update (accessible par un clic sur son icône) :</p>
+<ul>
+<li>un bouton Actualiser vous permet de forcer la vérification de la disponibilité des mises à jour pour vos Spices;</li>
+<li>un point apparaît devant chaque type de Spices lorsqu'au moins une mise à jour est disponible;</li>
+<li>un clic sur un type de Spices (applets, desklets, etc.) ouvre l'onglet de téléchargement de la page correspondante dans les paramètres de Cinnamon, avec les Spices triées par date décroissante (les plus récentes en premier);</li>
+<li>lorsque de nouvelles Spices sont disponibles, une option <em>Oublier les nouveautés</em> apparaît; en cliquant dessus, ces notifications de nouvelles Spices seront effacées jusqu'à l'arrivée d'autres;</li>
+<li>Un bouton <em>Configurer...</em> ouvre la fenêtre de configuration de Spices Update.</li>
+</ul>
+<h2>
+<a id="user-content-icône" class="anchor" href="#ic%C3%B4ne" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Icône</h2>
+<p>La couleur de l'icône change lorsqu'au moins une de vos Spices nécessite une mise à jour, ou lorsqu'une nouveauté est signalée.</p>
+<p>Son infobulle (le message affiché lorsque l'icône est survolé) contient la liste des Spices à mettre à jour et/ou des nouveautés.</p>
+<p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/hovering_icon-fr.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/hovering_icon-fr.png" alt="hovering_icon" style="max-width:100%;"></a></p>
+<h2>
+<a id="user-content-notifications" class="anchor" href="#notifications" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Notifications</h2>
+<p>Il existe deux types de notifications: <em>Minimale</em> or <em>Avec boutons</em>. Chacune d’elles peut contenir ou non des détails: le motif d’une mise à jour ou la description d’une nouvelle épice.</p>
+<h3>
+<a id="user-content-notifications-minimales" class="anchor" href="#notifications-minimales" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Notifications minimales</h3>
+<p>Ici avec la raison de la mise à jour :</p>
+<p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_simple_with_details-fr.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_simple_with_details-fr.png" alt="notif_simple_with_details" style="max-width:100%;"></a></p>
+<h3>
+<a id="user-content-notifications-avec-boutons" class="anchor" href="#notifications-avec-boutons" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Notifications avec boutons</h3>
+<p>Deux boutons sont présents : l'un pour ouvrir la page Paramètres système afin de télécharger les mises à jour ; l'autre pour actualiser la notification afin d’obtenir des détails, le cas échéant.</p>
+<p>Ici sans les détails :</p>
+<p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_without_details-fr.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_without_details-fr.png" alt="notif_without_details" style="max-width:100%;"></a></p>
+<p>Après actualisation, le motif de la mise à jour apparaît :</p>
+<p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_with_details2-fr.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_with_details2-fr.png" alt="notif_with_details" style="max-width:100%;"></a></p>
+<h2>
+<a id="user-content-traductions" class="anchor" href="#traductions" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Traductions</h2>
+<p>Toute traduction est la bienvenue. Merci de contribuer en traduisant les messages de l'applet dans de nouvelles langues ou en améliorant/complétant les traductions existantes.</p>
+<h2>
+<a id="user-content-installation" class="anchor" href="#installation" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Installation</h2>
+<h3>
+<a id="user-content-installation-automatique-" class="anchor" href="#installation-automatique-" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Installation automatique :</h3>
+<p>Utilisez le menu <em>Applets</em> dans les Paramètres système de Cinnamon ou <em>Ajouter des Applets au tableau de bord</em> dans le menu contextuel (clic droit) du panneau de votre bureau. Ensuite, cliquez sur l'onglet Télécharger pour installer cette applet Spices Update.</p>
+<h3>
+<a id="user-content-installation-manuelle-" class="anchor" href="#installation-manuelle-" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Installation manuelle :</h3>
+<ul>
+<li>Installer les programmes supplémentaires requis.</li>
+<li>Télécharger Spices Update à partir du <a href="https://cinnamon-spices.linuxmint.com/applets/view/309" rel="nofollow">site web des Spices</a>.</li>
+<li>Décompresser et extraire le dossier <code>SpicesUpdate@claudiux</code> dans <code> ~/.local/share/cinnamon/applets/</code>
+</li>
+<li>Activer cette applet dans Paramètres système -&gt; Applets.</li>
+<li>Vous pouvez également accéder à la fenêtre de configuration à partir de Paramètres système -&gt; Applets ou du menu de cet applet (en cliquant sur son icône).</li>
+</ul>
+<h2>
+<a id="user-content-une-étoile-pour-remercier-lauteur" class="anchor" href="#une-%C3%A9toile-pour-remercier-lauteur" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Une Étoile pour remercier l'auteur</h2>
+<p>Si vous appréciez les services rendus par Spices Update, n'offrez ni argent ni café à l'auteur, mais connectez-vous et cliquez sur l'étoile en haut de <a href="https://cinnamon-spices.linuxmint.com/applets/view/309#" rel="nofollow">cette page</a>.</p>
+<p>Merci beaucoup.</p>
+
+              </article>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    
+
+  </div>
+  <div>&nbsp;</div>
+  </div><script>
+    function showCanonicalImages() {
+      var images = document.getElementsByTagName('img');
+      if (!images) {
+        return;
+      }
+      for (var index = 0; index < images.length; index++) {
+        var image = images[index];
+        if (image.getAttribute('data-canonical-src') && image.src !== image.getAttribute('data-canonical-src')) {
+          image.src = image.getAttribute('data-canonical-src');
+        }
+      }
+    }
+
+    function scrollToHash() {
+      if (location.hash && !document.querySelector(':target')) {
+        var element = document.getElementById('user-content-' + location.hash.slice(1));
+        if (element) {
+           element.scrollIntoView();
+        }
+      }
+    }
+
+    function autorefreshContent(eventSourceUrl) {
+      var initialTitle = document.title;
+      var contentElement = document.getElementById('grip-content');
+      var source = new EventSource(eventSourceUrl);
+      var isRendering = false;
+
+      source.onmessage = function(ev) {
+        var msg = JSON.parse(ev.data);
+        if (msg.updating) {
+          isRendering = true;
+          document.title = '(Rendering) ' + document.title;
+        } else {
+          isRendering = false;
+          document.title = initialTitle;
+          contentElement.innerHTML = msg.content;
+          showCanonicalImages();
+        }
+      }
+
+      source.onerror = function(e) {
+        if (e.readyState === EventSource.CLOSED && isRendering) {
+          isRendering = false;
+          document.title = initialTitle;
+        }
+      }
+    }
+
+    window.onhashchange = function() {
+      scrollToHash();
+    }
+
+    window.onload = function() {
+      scrollToHash();
+    }
+
+    showCanonicalImages();
+
+    var autorefreshUrl = document.getElementById('preview-page').getAttribute('data-autorefresh-url');
+    if (autorefreshUrl) {
+      autorefreshContent(autorefreshUrl);
+    }
+  </script>
+</body>
+</html>

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/fr/README.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/fr/README.md
@@ -1,0 +1,118 @@
+# Spices Update
+
+## Résumé
+
+Les Spices de Cinnamon sont les Applets, Desklets, Extensions et Thèmes.
+
+Habituellement, vous vérifiez si les Spices que vous avez installées disposent de mises à jour à l'aide des Paramètres système de Cinnamon.
+
+Mais, comme moi, vous le faites trop rarement.
+
+L'applet **Spices Update** :
+
+  * vous avertit dès lors que des Spices que vous avez installées disposent d'une mise à jour ;
+  * peut vous avertir, si vous le désirez, lorsque de nouvelles Spices sont disponibles ;
+  * vous donne un accès direct aux Paramètres système des Applets, Desklets, Extensions et Thèmes.
+
+## État
+
+Cette applet est active, c'est-à-dire développée et utilisée par l'auteur sur plusieurs machines fonctionnant sous **Linux Mint**, **Fedora** ou **Archlinux**.
+
+L'auteur est ouvert à toute suggestion d'amélioration.
+
+## Dépendances
+
+Spices Update nécessite l'installation de l'outil ```notify-send``` et de la police de caractères ```symbola``` (de type TrueType).
+
+Pour les installer :
+
+  * Fedora: `sudo dnf install libnotify gdouros-symbola-fonts`
+  * Arch:
+    * ```sudo pacman -Syu libnotify```
+    * `yay -S ttf-symbola` _or_ `pamac build ttf-symbola`
+  * Linux Mint: ```sudo apt install libnotify-bin fonts-symbola```
+
+**Cette applet vous aide à installer ces dépendances, si besoin.** En effet, lors de son lancement, l'applet Spice Update vérifie que ces dépendances sont installées. Si ce n'est pas le cas, elle vous propose de les installer.
+
+## Configuration
+
+La fenêtre de configuration dispose de cinq onglets.
+
+Le premier, _Général_, vous permet de :
+
+  * Choisir l'_Intervalle de temps entre deux vérifications_ (en heures). Veuillez noter que la première vérification aura lieu une minute après le démarrage de cette applet.
+  * Choisir la façon dont vous serez prévenu : par changement de la couleur de l'icône de cette applet et/ou par affichage de messages dans la zone de notification. Vous pouvez également choisir le type de notification: _Minimal_ ou _Avec un bouton_ permettant d'ouvrir l'onglet Télécharger dans les Paramètres système. Si vous le souhaitez également, la notification peut contenir la description de chaque mise à jour ou nouveauté.
+  * Choisir le _Type d'affichage_ de l'icône: avec ou sans texte?
+  * Cacher l'icône de cette applet tant que rien de nouveau n'est à signaler. _Veuillez noter que les Préférences de Spices Update ne sont accessibles, tant que l'icône n'est pas affichée, qu'en passant par Paramètres système -> Applets._
+
+![system_settings_applet](https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/System_Settings_Applets-fr.png)
+
+Quant au contenu des autres onglets (_Applets_, _Desklets_, etc), veuillez consulter la capture d'écran ci-dessous et noter que **la liste des Spices installées est automatiquement remplie** au démarrage, mais qu'un bouton _Rafraîchir_ vous permet de la recharger.
+
+![settings_spices_update_applets](https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/Settings_Spices_Update_Applets-fr.png)
+
+Réglez sur _FALSE_ (ou décochez à partir de Cinnamon 4.2) toutes les Spices dont vous ne voulez pas vérifier les mises à jour. Il y a au moins deux raisons à cela:
+
+  * Une Spice vous convient pleinement et vous ne voulez pas être averti d'un quelconque changement la concernant.
+  * Vous êtes un développeur travaillant sur une Spice et vous ne souhaitez pas être informé de quelque modification que ce soit durant son développement.
+
+## Menu
+
+Dans le menu de Spices Update (accessible par un clic sur son icône) :
+
+   * un bouton Actualiser vous permet de forcer la vérification de la disponibilité des mises à jour pour vos Spices;
+   * un point apparaît devant chaque type de Spices lorsqu'au moins une mise à jour est disponible;
+   * un clic sur un type de Spices (applets, desklets, etc.) ouvre l'onglet de téléchargement de la page correspondante dans les paramètres de Cinnamon, avec les Spices triées par date décroissante (les plus récentes en premier);
+   * lorsque de nouvelles Spices sont disponibles, une option _Oublier les nouveautés_ apparaît; en cliquant dessus, ces notifications de nouvelles Spices seront effacées jusqu'à l'arrivée d'autres;
+   * Un bouton _Configurer..._ ouvre la fenêtre de configuration de Spices Update.
+
+## Icône
+
+La couleur de l'icône change lorsqu'au moins une de vos Spices nécessite une mise à jour, ou lorsqu'une nouveauté est signalée.
+
+Son infobulle (le message affiché lorsque l'icône est survolé) contient la liste des Spices à mettre à jour et/ou des nouveautés.
+
+![hovering_icon](https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/hovering_icon-fr.png)
+
+## Notifications
+Il existe deux types de notifications: _Minimale_ or _Avec boutons_. Chacune d’elles peut contenir ou non des détails: le motif d’une mise à jour ou la description d’une nouvelle épice.
+
+### Notifications minimales
+Ici avec la raison de la mise à jour :
+
+![notif_simple_with_details](https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_simple_with_details-fr.png)
+
+### Notifications avec boutons
+Deux boutons sont présents : l'un pour ouvrir la page Paramètres système afin de télécharger les mises à jour ; l'autre pour actualiser la notification afin d’obtenir des détails, le cas échéant.
+
+Ici sans les détails :
+
+![notif_without_details](https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_without_details-fr.png)
+
+Après actualisation, le motif de la mise à jour apparaît :
+
+![notif_with_details](https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_with_details2-fr.png)
+
+## Traductions
+
+Toute traduction est la bienvenue. Merci de contribuer en traduisant les messages de l'applet dans de nouvelles langues ou en améliorant/complétant les traductions existantes.
+
+## Installation
+
+### Installation automatique :
+
+Utilisez le menu _Applets_ dans les Paramètres système de Cinnamon ou _Ajouter des Applets au tableau de bord_ dans le menu contextuel (clic droit) du panneau de votre bureau. Ensuite, cliquez sur l'onglet Télécharger pour installer cette applet Spices Update.
+
+### Installation manuelle :
+
+  * Installer les programmes supplémentaires requis.
+  * Télécharger Spices Update à partir du [site web des Spices](https://cinnamon-spices.linuxmint.com/applets/view/309).
+  * Décompresser et extraire le dossier ```SpicesUpdate@claudiux``` dans ``` ~/.local/share/cinnamon/applets/```
+  * Activer cette applet dans Paramètres système -> Applets.
+  * Vous pouvez également accéder à la fenêtre de configuration à partir de Paramètres système -> Applets ou du menu de cet applet (en cliquant sur son icône).
+
+## Une Étoile pour remercier l'auteur
+
+Si vous appréciez les services rendus par Spices Update, n'offrez ni argent ni café à l'auteur, mais connectez-vous et cliquez sur l'étoile en haut de [cette page](https://cinnamon-spices.linuxmint.com/applets/view/309#).
+
+Merci beaucoup.


### PR DESCRIPTION
Hi @brownsr,

This version of SpicesUpdate@claudiux adds a Help button in its menu; this help (in html) can be translated and is loaded into the preferred browser.

A French translation of this help is available.

Other improvement: When only one Spice (by category: Applets, Desklets, ...) needs an update, its icon appears into the notification messages.

Can you merge this branch with your master one, please?

Best regards.
Claudiux