### PR TITLE
batterymonitor@pdcurtis v 1.3.8 Change location of temporary files to…

### DIFF
--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/3.2/CHANGELOG.md
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/3.2/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+### 1.3.8
+  * Change location of temporary files to home folder to avoid permissions problem when switching users
+  * Fixes #2502
+
+### 1.3.7.1
+  * Change to cinnamon-version in metadata.json to add use under Cinnamon 4.2
+
 ### 1.3.7
   * Change to allow Multiversion 3.2
   * Change to allow selection of audible alert file in Applet Settings for 3.2 and higher.

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/3.2/applet.js
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/3.2/applet.js
@@ -194,8 +194,8 @@ MyApplet.prototype = {
 
             // Make sure the temp files are created
 
-            GLib.spawn_command_line_async('touch /tmp/.batteryPercentage');
-            GLib.spawn_command_line_async('touch /tmp/.batteryState');
+            GLib.spawn_command_line_async('touch .batteryPercentage');
+            GLib.spawn_command_line_async('touch .batteryState');
 
             // Finally setup to start the update loop for the applet display running
 
@@ -348,7 +348,7 @@ MyApplet.prototype = {
     updateUI: function() {
 
         try {
-            this.batteryPercentage = GLib.file_get_contents("/tmp/.batteryPercentage").toString();
+            this.batteryPercentage = GLib.file_get_contents(".batteryPercentage").toString();
             this.batteryPercentage = this.batteryPercentage.trim().substr(5);
             this.batteryPercentage = Math.floor(this.batteryPercentage);
              // now check we have a genuine number otherwise use last value
@@ -357,7 +357,7 @@ MyApplet.prototype = {
             }
 //          Comment out following line when tests are complete
 //          this.batteryPercentage = this.batteryPercentage / 5 ;
-            this.batteryState = GLib.file_get_contents("/tmp/.batteryState").toString();
+            this.batteryState = GLib.file_get_contents(".batteryState").toString();
             if ( this.batteryState.trim().length > 6 ) {
                  this.batteryState = this.batteryState.trim().substr(5);
                  this.batteryStateOld = this.batteryState;
@@ -616,5 +616,10 @@ Bug Fix for use with early versions of Cinnamon
 ### 1.3.7
   * Change to allow Multiversion 3.2
   * Change to selection of audible alert file in Applet Settings for 3.2 and higher.
+### 1.3.7.1
+  * Change to cinnamon-version in metadata.json to add use under Cinnamon 4.2
+### 1.3.8
+  * Change location of temporary files to home folder to avoid permissions problem when switching users
+  * Fixes #2502
 */
 

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/3.2/batteryscript.sh
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/3.2/batteryscript.sh
@@ -2,6 +2,6 @@
 #
 #Script calls upower and writes values of battery percentage and state to temporary files which can be read by the BAMS applet
 #
-upower -i $(upower -e | grep BAT) | grep -E percentage | xargs | cut -d' ' -f2|sed s/%// > /tmp/.batteryPercentage
-upower -i $(upower -e | grep BAT) | grep -E state | xargs | cut -d' ' -f2|sed s/%// > /tmp/.batteryState
+upower -i $(upower -e | grep BAT) | grep -E percentage | xargs | cut -d' ' -f2|sed s/%// > .batteryPercentage
+upower -i $(upower -e | grep BAT) | grep -E state | xargs | cut -d' ' -f2|sed s/%// > .batteryState
 exit 0

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/CHANGELOG.md
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+### 1.3.8
+  * Change location of temporary files to home folder to avoid permissions problem when switching users
+  * Fixes #2502
+
+### 1.3.7.1
+  * Change to cinnamon-version in metadata.json to add use under Cinnamon 4.2
+
 ### 1.3.7
   * Change to allow Multiversion 3.2
   * Change to allow selection of audible alert file in Applet Settings for 3.2 and higher.

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/applet.js
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/applet.js
@@ -155,8 +155,8 @@ MyApplet.prototype = {
 
             // Make sure the temp files are created
 
-            GLib.spawn_command_line_async('touch /tmp/.batteryPercentage');
-            GLib.spawn_command_line_async('touch /tmp/.batteryState');
+            GLib.spawn_command_line_async('touch .batteryPercentage');
+            GLib.spawn_command_line_async('touch .batteryState');
 
             // Finally setup to start the update loop for the applet display running
 
@@ -302,7 +302,7 @@ MyApplet.prototype = {
     updateUI: function() {
 
         try {
-            this.batteryPercentage = GLib.file_get_contents("/tmp/.batteryPercentage").toString();
+            this.batteryPercentage = GLib.file_get_contents(".batteryPercentage").toString();
             this.batteryPercentage = this.batteryPercentage.trim().substr(5);
             this.batteryPercentage = Math.floor(this.batteryPercentage);
              // now check we have a genuine number otherwise use last value
@@ -311,7 +311,7 @@ MyApplet.prototype = {
             }
 //          Comment out following line when tests are complete
 //          this.batteryPercentage = this.batteryPercentage / 5 ;
-            this.batteryState = GLib.file_get_contents("/tmp/.batteryState").toString();
+            this.batteryState = GLib.file_get_contents("/.batteryState").toString();
             if ( this.batteryState.trim().length > 6 ) {
                  this.batteryState = this.batteryState.trim().substr(5);
                  this.batteryStateOld = this.batteryState;
@@ -569,5 +569,10 @@ Bug Fix for use with early versions of Cinnamon
 ### 1.3.7
   * Change to allow Multiversion 3.2
   * Change to selection of audible alert file in Applet Settings for 3.2 and higher instead of mechanism introduced in 1.3.4.
+### 1.3.7.1
+  * Change to cinnamon-version in metadata.json to add use under Cinnamon 4.2
+### 1.3.8
+  * Change location of temporary files to home folder to avoid permissions problem when switching users
+  * Fixes #2502
 */
 

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/batteryscript.sh
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/batteryscript.sh
@@ -2,6 +2,6 @@
 #
 #Script calls upower and writes values of battery percentage and state to temporary files which can be read by the BAMS applet
 #
-upower -i $(upower -e | grep BAT) | grep -E percentage | xargs | cut -d' ' -f2|sed s/%// > /tmp/.batteryPercentage
-upower -i $(upower -e | grep BAT) | grep -E state | xargs | cut -d' ' -f2|sed s/%// > /tmp/.batteryState
+upower -i $(upower -e | grep BAT) | grep -E percentage | xargs | cut -d' ' -f2|sed s/%// > .batteryPercentage
+upower -i $(upower -e | grep BAT) | grep -E state | xargs | cut -d' ' -f2|sed s/%// > .batteryState
 exit 0

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/metadata.json
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/metadata.json
@@ -2,7 +2,7 @@
     "max-instances": "1",
     "description": "Displays Charge as Percentage and allows Alerts and Actions",
     "name": "Battery  Applet with Monitoring and Shutdown (BAMS)",
-    "version": "1.3.7.1",
+    "version": "1.3.8",
     "uuid": "batterymonitor@pdcurtis",
     "multiversion": true,
     "cinnamon-version": ["2.2","2.4","2.6","2.8","3.0","3.2","3.4","3.6","3.8","4.0","4.2"]


### PR DESCRIPTION
  * Change location of temporary files to home folder to avoid permissions problem when switching users
  
Fixes #2502