### PR TITLE
[SpicesUpdate@claudiux] v2.3.0 - Bypass all caches downloading json files

### DIFF
--- a/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v2.3.0~20190806
+  * Bypass all caches to download json files containing data about Spices.
+
 ### v2.2.0~20190803
   * Adding a "Help..." button in the menu. This help (in English by default) can be translated into your language. To do it:
    * Place you into the `help` directory: `cd ~/.local/share/cinnamon/applets/SpicesUpdate@claudiux/help`

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v2.3.0~20190806
+  * Bypass all caches to download json files containing data about Spices.
+
 ### v2.2.0~20190803
   * Adding a "Help..." button in the menu. This help (in English by default) can be translated into your language. To do it:
    * Place you into the `help` directory: `cd ~/.local/share/cinnamon/applets/SpicesUpdate@claudiux/help`

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/applet.js
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/applet.js
@@ -1039,7 +1039,7 @@ class SpicesUpdate extends Applet.TextIconApplet {
 
     if (is_to_download === true) {
       // replace local json cache file by the remote one
-      let message = Soup.Message.new('GET', URL_MAP[type]);
+      let message = Soup.Message.new('GET', URL_MAP[type] + GLib.uuid_string_random());
       _httpSession.queue_message(message, Lang.bind(this, this._on_response_download_cache, type));
       this.testblink[type]=null;
     }

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/metadata.json
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/metadata.json
@@ -3,7 +3,7 @@
     "name": "Spices Update",
     "max-instances": "1",
     "hide-configuration": false,
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "Warns you when installed Spices (applets, desklets, extensions, themes) require an update or new Spices are available.",
     "cinnamon-version": [
         "3.8",


### PR DESCRIPTION
Hi @brownsr,

This version of SpicesUpdate@claudiux bypasses all caches to obtain the latest version of json files containing Spices data. This gives more responsiveness and more reliability to this applet.

Can you merge this branch with your master one, please?

Best regards.
Claudiux