### PR TITLE
[placesCenter@scollins] Now right-click on a recent document opens the forder containing it

### DIFF
--- a/placesCenter@scollins/README.md
+++ b/placesCenter@scollins/README.md
@@ -10,7 +10,7 @@ Places Center is a feature-rich, cross-platform Cinnamon applet that provides ea
 * Supports additional user defined places
 * Easy to read layout with multiple columns
 * Ability to set the panel icon and text (symbolic icons supported)
-* Option to show recent documents
+* Option to show recent documents (click on a recent document to open it; right-click to open the folder that contains it)
 * Quick keyboard access (default super+p)
 * Search tool that allows you to quickly search for files and folders (supports regular expressions)
 * Add middle click to open

--- a/placesCenter@scollins/files/placesCenter@scollins/applet.js
+++ b/placesCenter@scollins/files/placesCenter@scollins/applet.js
@@ -457,8 +457,14 @@ class MyApplet extends Applet.TextIconApplet {
             let mimeType = recentInfo.get_mime_type().replace("\/","-");
             let recentItem = new IconMenuItem(recentInfo.get_display_name(), mimeType);
             this.recentSection.addMenuItem(recentItem);
-            recentItem.connect("activate", Lang.bind(this, function() {
-                Gio.app_info_launch_default_for_uri(recentInfo.get_uri(), global.create_app_launch_context());
+            recentItem.connect("activate", Lang.bind(this, function(actor, event) {
+                let button = event.get_button();
+                let uri = recentInfo.get_uri();
+                if (button == 3) {
+                    Gio.app_info_launch_default_for_uri(uri.substr(0, uri.lastIndexOf("/")+1), global.create_app_launch_context());
+                } else {
+                    Gio.app_info_launch_default_for_uri(uri, global.create_app_launch_context());
+                }
             }))
         }
     }


### PR DESCRIPTION
@collinss 
Hi Stephen,

I propose this small change that improves the Recent Documents part of your applet.

A click on a recent doc opens it, as usual. A right-click opens the folder that contains this doc.

I hope this will suit you.

Regards.
Claudiux