### PR TITLE
[SpicesUpdate@claudiux] Fixes #2545 (Cinnamon 2.8 to 3.6)

### DIFF
--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/2.8/applet.js
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/2.8/applet.js
@@ -1047,7 +1047,7 @@ SpicesUpdate.prototype = {
       }
       this.dependenciesMet = false;
     }
-  }; // End of check_dependencies
+  }, // End of check_dependencies
 
   _load_cache:function (type) {
     let jsonFileName = CACHE_MAP[type];


### PR DESCRIPTION
Fixes #2545. Just a typo that made this applet unusable with Cinnamon 2.8 to 3.6!

Hi @brownsr,

Can you merge this branch with your master one, please?

Best regards.
Claudiux