### PR TITLE
[placesCenter@scollins] Shows help in tooltip about Right click on a Recent File

### DIFF
--- a/placesCenter@scollins/files/placesCenter@scollins/applet.js
+++ b/placesCenter@scollins/files/placesCenter@scollins/applet.js
@@ -121,6 +121,13 @@ class PlaceMenuItem extends FolderTypeMenuItem {
     }
 }
 
+class RecentFileMenuItem extends IconMenuItem {
+    constructor(text, icon){
+        super(text, icon);
+        let tooltip = new Tooltips.Tooltip(this.actor, text + '\n' + _("(Right click to open folder)"));
+    }
+}
+
 class MyApplet extends Applet.TextIconApplet {
     constructor(metadata, orientation, panel_height, instanceId) {
         try {
@@ -206,7 +213,6 @@ class MyApplet extends Applet.TextIconApplet {
         this.settings.bindProperty(Settings.BindingDirection.IN, "showRecentDocuments", "showRecentDocuments", this.buildMenu);
         this.settings.bindProperty(Settings.BindingDirection.IN, "recentSizeLimit", "recentSizeLimit", this.buildRecentDocumentsSection);
         this.settings.bindProperty(Settings.BindingDirection.IN, "keyOpen", "keyOpen", this.setKeybinding);
-        this.settings.bindProperty(Settings.BindingDirection.IN, "showRecentsManual", "showRecentsManual", this.buildMenu);
 
         this.setKeybinding();
     }
@@ -310,8 +316,7 @@ class MyApplet extends Applet.TextIconApplet {
                 section._connectSubMenuSignals(recentPane, recentPane);
 
                 let recents_manual = "";
-                if (this.showRecentsManual === true) recents_manual = '\n' + _("Click to open the file.") + '\n' + _("Right-click to open its folder.");
-                let recentTitle = new PopupMenu.PopupMenuItem(_("RECENT DOCUMENTS") + recents_manual, { style_class: "xCenter-title", reactive: false });
+                let recentTitle = new PopupMenu.PopupMenuItem(_("RECENT DOCUMENTS"), { style_class: "xCenter-title", reactive: false });
                 recentPane.addMenuItem(recentTitle);
 
                 let recentScrollBox = new St.ScrollView({ style_class: "xCenter-scrollBox", x_fill: true, y_fill: false, y_align: St.Align.START });
@@ -459,7 +464,7 @@ class MyApplet extends Applet.TextIconApplet {
         for ( let i = 0; i < showCount; i++ ) {
             let recentInfo = recentDocuments[i];
             let mimeType = recentInfo.get_mime_type().replace("\/","-");
-            let recentItem = new IconMenuItem(recentInfo.get_display_name(), mimeType);
+            let recentItem = new RecentFileMenuItem(recentInfo.get_display_name(), mimeType);
             this.recentSection.addMenuItem(recentItem);
             recentItem.connect("activate", Lang.bind(this, function(actor, event) {
                 let button = event.get_button();

--- a/placesCenter@scollins/files/placesCenter@scollins/applet.js
+++ b/placesCenter@scollins/files/placesCenter@scollins/applet.js
@@ -213,7 +213,6 @@ class MyApplet extends Applet.TextIconApplet {
         this.settings.bindProperty(Settings.BindingDirection.IN, "showRecentDocuments", "showRecentDocuments", this.buildMenu);
         this.settings.bindProperty(Settings.BindingDirection.IN, "recentSizeLimit", "recentSizeLimit", this.buildRecentDocumentsSection);
         this.settings.bindProperty(Settings.BindingDirection.IN, "keyOpen", "keyOpen", this.setKeybinding);
-
         this.setKeybinding();
     }
 
@@ -315,7 +314,6 @@ class MyApplet extends Applet.TextIconApplet {
                 recentPaneBox.add_actor(recentPane.actor);
                 section._connectSubMenuSignals(recentPane, recentPane);
 
-                let recents_manual = "";
                 let recentTitle = new PopupMenu.PopupMenuItem(_("RECENT DOCUMENTS"), { style_class: "xCenter-title", reactive: false });
                 recentPane.addMenuItem(recentTitle);
 

--- a/placesCenter@scollins/files/placesCenter@scollins/applet.js
+++ b/placesCenter@scollins/files/placesCenter@scollins/applet.js
@@ -122,8 +122,18 @@ class PlaceMenuItem extends FolderTypeMenuItem {
 }
 
 class RecentFileMenuItem extends IconMenuItem {
-    constructor(text, icon){
+    constructor(text, icon, uri, folderApp){
         super(text, icon);
+        this.connect("activate", Lang.bind(this, function(actor, event) {
+            let button = event.get_button();
+            if (button == 3) {
+                // Opens the folder containing the file with this file selected:
+                let command = "%s %s".format(folderApp, uri);
+                Util.spawnCommandLine(command);
+            } else {
+                Gio.app_info_launch_default_for_uri(uri, global.create_app_launch_context());
+            }
+        }))
         let tooltip = new Tooltips.Tooltip(this.actor, text + '\n' + _("(Right click to open folder)"));
     }
 }
@@ -456,23 +466,16 @@ class MyApplet extends Applet.TextIconApplet {
 
         let recentDocuments = this.recentManager.get_items();
 
+        let appOpeningFolders = Gio.app_info_get_default_for_type('inode/directory', false).get_executable(); // usually returns: nemo
+
         let showCount;
         if ( this.recentSizeLimit == 0 ) showCount = recentDocuments.length;
         else showCount = ( this.recentSizeLimit < recentDocuments.length ) ? this.recentSizeLimit : recentDocuments.length;
         for ( let i = 0; i < showCount; i++ ) {
             let recentInfo = recentDocuments[i];
             let mimeType = recentInfo.get_mime_type().replace("\/","-");
-            let recentItem = new RecentFileMenuItem(recentInfo.get_display_name(), mimeType);
+            let recentItem = new RecentFileMenuItem( recentInfo.get_display_name(), mimeType, recentInfo.get_uri(), appOpeningFolders );
             this.recentSection.addMenuItem(recentItem);
-            recentItem.connect("activate", Lang.bind(this, function(actor, event) {
-                let button = event.get_button();
-                let uri = recentInfo.get_uri();
-                if (button == 3) {
-                    Gio.app_info_launch_default_for_uri(uri.substr(0, uri.lastIndexOf("/")+1), global.create_app_launch_context());
-                } else {
-                    Gio.app_info_launch_default_for_uri(uri, global.create_app_launch_context());
-                }
-            }))
         }
     }
 

--- a/placesCenter@scollins/files/placesCenter@scollins/applet.js
+++ b/placesCenter@scollins/files/placesCenter@scollins/applet.js
@@ -206,6 +206,8 @@ class MyApplet extends Applet.TextIconApplet {
         this.settings.bindProperty(Settings.BindingDirection.IN, "showRecentDocuments", "showRecentDocuments", this.buildMenu);
         this.settings.bindProperty(Settings.BindingDirection.IN, "recentSizeLimit", "recentSizeLimit", this.buildRecentDocumentsSection);
         this.settings.bindProperty(Settings.BindingDirection.IN, "keyOpen", "keyOpen", this.setKeybinding);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "showRecentsManual", "showRecentsManual", this.buildMenu);
+
         this.setKeybinding();
     }
 
@@ -307,7 +309,9 @@ class MyApplet extends Applet.TextIconApplet {
                 recentPaneBox.add_actor(recentPane.actor);
                 section._connectSubMenuSignals(recentPane, recentPane);
 
-                let recentTitle = new PopupMenu.PopupMenuItem(_("RECENT DOCUMENTS"), { style_class: "xCenter-title", reactive: false });
+                let recents_manual = "";
+                if (this.showRecentsManual === true) recents_manual = '\n' + _("Click to open the file.") + '\n' + _("Right-click to open its folder.");
+                let recentTitle = new PopupMenu.PopupMenuItem(_("RECENT DOCUMENTS") + recents_manual, { style_class: "xCenter-title", reactive: false });
                 recentPane.addMenuItem(recentTitle);
 
                 let recentScrollBox = new St.ScrollView({ style_class: "xCenter-scrollBox", x_fill: true, y_fill: false, y_align: St.Align.START });

--- a/placesCenter@scollins/files/placesCenter@scollins/po/fr.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/fr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-03 10:00+0200\n"
-"PO-Revision-Date: 2019-09-03 10:03+0200\n"
+"POT-Creation-Date: 2019-09-04 01:32+0200\n"
+"PO-Revision-Date: 2019-09-04 01:33+0200\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -18,51 +18,47 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: applet.js:142
+#: applet.js:127
+msgid "(Right click to open folder)"
+msgstr "(Clic droit pour ouvrir son dossier)"
+
+#: applet.js:149
 msgid "Places"
 msgstr "Emplacements"
 
-#: applet.js:255
+#: applet.js:261
 msgid "Search Home Folder"
 msgstr "Rechercher dans mon dossier personnel"
 
-#: applet.js:278
+#: applet.js:284
 msgid "SYSTEM"
 msgstr "SYSTÈME"
 
-#: applet.js:287
+#: applet.js:293
 msgid "Search File System"
 msgstr "Rechercher dans le système de fichiers"
 
-#: applet.js:313
-msgid "Click to open the file."
-msgstr "Clic gauche pour ouvrir le fichier."
-
-#: applet.js:313
-msgid "Right-click to open its folder."
-msgstr "Clic droit pour ouvrir son dossier."
-
-#: applet.js:314
+#: applet.js:319
 msgid "RECENT DOCUMENTS"
 msgstr "DOCUMENTS RÉCENTS"
 
-#: applet.js:328
+#: applet.js:333
 msgid "Clear"
 msgstr "Effacer"
 
-#: applet.js:371
+#: applet.js:376
 msgid "Computer"
 msgstr "Ordinateur"
 
-#: applet.js:377
+#: applet.js:382
 msgid "File System"
 msgstr "Système de fichiers"
 
-#: applet.js:393
+#: applet.js:398
 msgid "Network"
 msgstr "Réseau"
 
-#: applet.js:502
+#: applet.js:507
 msgid "Trash"
 msgstr "Corbeille"
 
@@ -304,6 +300,8 @@ msgstr "Montrer les Documents Récents"
 msgid "Number to show"
 msgstr "Nombre de documents récents à afficher"
 
-#. settings-schema.json->showRecentsManual->description
-msgid "Show help about recent documents"
-msgstr "Afficher l'aide concernant les documents récents"
+#~ msgid "Click to open the file."
+#~ msgstr "Clic gauche pour ouvrir le fichier."
+
+#~ msgid "Show help about recent documents"
+#~ msgstr "Afficher l'aide concernant les documents récents"

--- a/placesCenter@scollins/files/placesCenter@scollins/po/fr.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/fr.po
@@ -7,54 +7,62 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-19 21:13-0700\n"
-"PO-Revision-Date: 2018-10-27 01:05+0200\n"
+"POT-Creation-Date: 2019-09-03 10:00+0200\n"
+"PO-Revision-Date: 2019-09-03 10:03+0200\n"
+"Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.0.6\n"
-"Last-Translator: Claude CLERC <claude.clerc@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Language: fr\n"
 
-#: applet.js:178
+#: applet.js:142
 msgid "Places"
 msgstr "Emplacements"
 
-#: applet.js:291
+#: applet.js:255
 msgid "Search Home Folder"
 msgstr "Rechercher dans mon dossier personnel"
 
-#: applet.js:305
+#: applet.js:278
 msgid "SYSTEM"
 msgstr "SYSTÈME"
 
-#: applet.js:314
+#: applet.js:287
 msgid "Search File System"
 msgstr "Rechercher dans le système de fichiers"
 
-#: applet.js:330
+#: applet.js:313
+msgid "Click to open the file."
+msgstr "Clic gauche pour ouvrir le fichier."
+
+#: applet.js:313
+msgid "Right-click to open its folder."
+msgstr "Clic droit pour ouvrir son dossier."
+
+#: applet.js:314
 msgid "RECENT DOCUMENTS"
 msgstr "DOCUMENTS RÉCENTS"
 
-#: applet.js:344
+#: applet.js:328
 msgid "Clear"
 msgstr "Effacer"
 
-#: applet.js:388
+#: applet.js:371
 msgid "Computer"
 msgstr "Ordinateur"
 
-#: applet.js:394
+#: applet.js:377
 msgid "File System"
 msgstr "Système de fichiers"
 
-#: applet.js:410
+#: applet.js:393
 msgid "Network"
 msgstr "Réseau"
 
-#: applet.js:513
+#: applet.js:502
 msgid "Trash"
 msgstr "Corbeille"
 
@@ -130,6 +138,36 @@ msgstr "Ignoré"
 msgid " - direcotry already searched"
 msgstr " - dossier déjà exploré"
 
+#. metadata.json->name
+msgid "Places Center"
+msgstr "Accès direct (Places Center)"
+
+#. metadata.json->description
+msgid "Provides an easy-to-read layout to access your places"
+msgstr ""
+"Procure une interface pratique pour accéder rapidement à vos dossiers et "
+"documents indispensables"
+
+#. metadata.json->comments
+msgid ""
+"Places Center is a feature-rich, cross-platform Cinnamon applet that "
+"provides easy access to all of your most-used places. Feel free to "
+"contribute by submitting pull requests, bug reports and feature requests to "
+"my github repo."
+msgstr ""
+"Places Center est une applet Cinnamon multi-plateforme et riche en "
+"fonctionnalités qui permet d'accéder facilement à tous vos emplacements "
+"préférés. N'hésitez pas à contribuer en effectuant des rapports de bugs ou "
+"en demandant ou proposant de nouvelles fonctionnalités sur mon compte github."
+
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - Auteur"
+
+#. metadata.json->contributors
+msgid "kehugter - Added configurability to middle click"
+msgstr "kehugter - Ajout de la configurabilité du clic central"
+
 #. settings-schema.json->generalPage->title
 msgid "General"
 msgstr "Général"
@@ -169,7 +207,9 @@ msgstr "Icône sur le tableau de bord"
 
 #. settings-schema.json->panelIcon->tooltip
 msgid "Accepts icon name or direct path (supports symbolic icons)"
-msgstr "Accepte le nom d'une icône ou le chemin complet vers celle-ci (l'icône peut être symbolique)"
+msgstr ""
+"Accepte le nom d'une icône ou le chemin complet vers celle-ci (l'icône peut "
+"être symbolique)"
 
 #. settings-schema.json->panelText->description
 msgid "Panel text"
@@ -206,9 +246,16 @@ msgstr "Emplacements personnels"
 
 #. settings-schema.json->userCustomPlaces->tooltip
 #. settings-schema.json->systemCustomPlaces->tooltip
-msgid "List of uris/file paths to be included. Entries may be separated by either a comma(,) or by a new-line. You can set the name to be displayed by adding :customName after the location. You can likewise set an icon name by adding :iconName after the custom name."
+msgid ""
+"List of uris/file paths to be included. Entries may be separated by either a "
+"comma(,) or by a new-line. You can set the name to be displayed by adding :"
+"customName after the location. You can likewise set an icon name by adding :"
+"iconName after the custom name."
 msgstr ""
-"Liste des emplacements des fichiers ou dossiers à inclure. Les entrées peuvent être séparées par une virgule (,) ou par un retour à la ligne. La structure d'une entrée est composée de trois parties séparées par un deux-points (:), les deux dernières parties étant optionnelles :\n"
+"Liste des emplacements des fichiers ou dossiers à inclure. Les entrées "
+"peuvent être séparées par une virgule (,) ou par un retour à la ligne. La "
+"structure d'une entrée est composée de trois parties séparées par un deux-"
+"points (:), les deux dernières parties étant optionnelles :\n"
 "Par exemple :\n"
 "/usr/share/icons/gnome/scalable:Icônes système:folder-symbolic\n"
 "pour accéder aux icônes du système."
@@ -257,22 +304,6 @@ msgstr "Montrer les Documents Récents"
 msgid "Number to show"
 msgstr "Nombre de documents récents à afficher"
 
-#. metadata.json->name
-msgid "Places Center"
-msgstr "Accès direct (Places Center)"
-
-#. metadata.json->description
-msgid "Provides an easy-to-read layout to access your places"
-msgstr "Procure une interface pratique pour accéder rapidement à vos dossiers et documents indispensables"
-
-#. metadata.json->comments
-msgid "Places Center is a feature-rich, cross-platform Cinnamon applet that provides easy access to all of your most-used places. Feel free to contribute by submitting pull requests, bug reports and feature requests to my github repo."
-msgstr "Places Center est une applet Cinnamon multi-plateforme et riche en fonctionnalités qui permet d'accéder facilement à tous vos emplacements préférés. N'hésitez pas à contribuer en effectuant des rapports de bugs ou en demandant ou proposant de nouvelles fonctionnalités sur mon compte github."
-
-#. metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - Auteur"
-
-#. metadata.json->contributors
-msgid "kehugter - Added configurability to middle click"
-msgstr "kehugter - Ajout de la configurabilité du clic central"
+#. settings-schema.json->showRecentsManual->description
+msgid "Show help about recent documents"
+msgstr "Afficher l'aide concernant les documents récents"

--- a/placesCenter@scollins/files/placesCenter@scollins/po/placesCenter@scollins.pot
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/placesCenter@scollins.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-03 10:00+0200\n"
+"POT-Creation-Date: 2019-09-04 01:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,51 +17,47 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:142
+#: applet.js:127
+msgid "(Right click to open folder)"
+msgstr ""
+
+#: applet.js:149
 msgid "Places"
 msgstr ""
 
-#: applet.js:255
+#: applet.js:261
 msgid "Search Home Folder"
 msgstr ""
 
-#: applet.js:278
+#: applet.js:284
 msgid "SYSTEM"
 msgstr ""
 
-#: applet.js:287
+#: applet.js:293
 msgid "Search File System"
 msgstr ""
 
-#: applet.js:313
-msgid "Click to open the file."
-msgstr ""
-
-#: applet.js:313
-msgid "Right-click to open its folder."
-msgstr ""
-
-#: applet.js:314
+#: applet.js:319
 msgid "RECENT DOCUMENTS"
 msgstr ""
 
-#: applet.js:328
+#: applet.js:333
 msgid "Clear"
 msgstr ""
 
-#: applet.js:371
+#: applet.js:376
 msgid "Computer"
 msgstr ""
 
-#: applet.js:377
+#: applet.js:382
 msgid "File System"
 msgstr ""
 
-#: applet.js:393
+#: applet.js:398
 msgid "Network"
 msgstr ""
 
-#: applet.js:502
+#: applet.js:507
 msgid "Trash"
 msgstr ""
 
@@ -286,8 +282,4 @@ msgstr ""
 
 #. settings-schema.json->recentSizeLimit->description
 msgid "Number to show"
-msgstr ""
-
-#. settings-schema.json->showRecentsManual->description
-msgid "Show help about recent documents"
 msgstr ""

--- a/placesCenter@scollins/files/placesCenter@scollins/po/placesCenter@scollins.pot
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/placesCenter@scollins.pot
@@ -8,52 +8,60 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-19 21:13-0700\n"
+"POT-Creation-Date: 2019-09-03 10:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: \n"
 
-#: applet.js:178
+#: applet.js:142
 msgid "Places"
 msgstr ""
 
-#: applet.js:291
+#: applet.js:255
 msgid "Search Home Folder"
 msgstr ""
 
-#: applet.js:305
+#: applet.js:278
 msgid "SYSTEM"
 msgstr ""
 
-#: applet.js:314
+#: applet.js:287
 msgid "Search File System"
 msgstr ""
 
-#: applet.js:330
+#: applet.js:313
+msgid "Click to open the file."
+msgstr ""
+
+#: applet.js:313
+msgid "Right-click to open its folder."
+msgstr ""
+
+#: applet.js:314
 msgid "RECENT DOCUMENTS"
 msgstr ""
 
-#: applet.js:344
+#: applet.js:328
 msgid "Clear"
 msgstr ""
 
-#: applet.js:388
+#: applet.js:371
 msgid "Computer"
 msgstr ""
 
-#: applet.js:394
+#: applet.js:377
 msgid "File System"
 msgstr ""
 
-#: applet.js:410
+#: applet.js:393
 msgid "Network"
 msgstr ""
 
-#: applet.js:513
+#: applet.js:502
 msgid "Trash"
 msgstr ""
 
@@ -127,6 +135,30 @@ msgstr ""
 
 #: search.py:259
 msgid " - direcotry already searched"
+msgstr ""
+
+#. metadata.json->name
+msgid "Places Center"
+msgstr ""
+
+#. metadata.json->description
+msgid "Provides an easy-to-read layout to access your places"
+msgstr ""
+
+#. metadata.json->comments
+msgid ""
+"Places Center is a feature-rich, cross-platform Cinnamon applet that "
+"provides easy access to all of your most-used places. Feel free to "
+"contribute by submitting pull requests, bug reports and feature requests to "
+"my github repo."
+msgstr ""
+
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr ""
+
+#. metadata.json->contributors
+msgid "kehugter - Added configurability to middle click"
 msgstr ""
 
 #. settings-schema.json->generalPage->title
@@ -256,26 +288,6 @@ msgstr ""
 msgid "Number to show"
 msgstr ""
 
-#. metadata.json->name
-msgid "Places Center"
-msgstr ""
-
-#. metadata.json->description
-msgid "Provides an easy-to-read layout to access your places"
-msgstr ""
-
-#. metadata.json->comments
-msgid ""
-"Places Center is a feature-rich, cross-platform Cinnamon applet that "
-"provides easy access to all of your most-used places. Feel free to "
-"contribute by submitting pull requests, bug reports and feature requests to "
-"my github repo."
-msgstr ""
-
-#. metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr ""
-
-#. metadata.json->contributors
-msgid "kehugter - Added configurability to middle click"
+#. settings-schema.json->showRecentsManual->description
+msgid "Show help about recent documents"
 msgstr ""

--- a/placesCenter@scollins/files/placesCenter@scollins/settings-schema.json
+++ b/placesCenter@scollins/files/placesCenter@scollins/settings-schema.json
@@ -45,7 +45,7 @@
         "recentSection": {
             "type": "section",
             "title": "Recent documents",
-            "keys": ["showRecentDocuments", "recentSizeLimit", "showRecentsManual"]
+            "keys": ["showRecentDocuments", "recentSizeLimit"]
         }
     },
 
@@ -167,10 +167,5 @@
         "description": "Number to show",
         "indent": true,
         "dependency": "showRecentDocuments"
-    },
-    "showRecentsManual": {
-        "type": "checkbox",
-        "description": "Show help about recent documents",
-        "default": true
     }
 }

--- a/placesCenter@scollins/files/placesCenter@scollins/settings-schema.json
+++ b/placesCenter@scollins/files/placesCenter@scollins/settings-schema.json
@@ -45,7 +45,7 @@
         "recentSection": {
             "type": "section",
             "title": "Recent documents",
-            "keys": ["showRecentDocuments", "recentSizeLimit"]
+            "keys": ["showRecentDocuments", "recentSizeLimit", "showRecentsManual"]
         }
     },
 
@@ -167,5 +167,10 @@
         "description": "Number to show",
         "indent": true,
         "dependency": "showRecentDocuments"
+    },
+    "showRecentsManual": {
+        "type": "checkbox",
+        "description": "Show help about recent documents",
+        "default": true
     }
 }


### PR DESCRIPTION
@collinss 

Hi Stephen,

I propose an option to show an help message about the Recent Files section (default value: true).

![Capture du 2019-09-03 09-43-27](https://user-images.githubusercontent.com/33965039/64155925-11935400-ce34-11e9-82ad-1a051f8983a6.png)

I did this because I manage the computers of several old people and some of them told me that they would not easily remember the use of the right click.

I also updated the .pot and fr.po. files

I hope this will suit you.

Best regards.
Claudiux