### PR TITLE
sshlauncher@sumo: Fix: Use correct settings for terminal

### DIFF
--- a/sshlauncher@sumo/files/sshlauncher@sumo/applet.js
+++ b/sshlauncher@sumo/files/sshlauncher@sumo/applet.js
@@ -36,7 +36,7 @@ MyApplet.prototype = {
       this.menu = new Applet.AppletPopupMenu(this, orientation);
       this.menuManager.addMenu(this.menu);
       this.appletPath = metadata.path;
-      this.gsettings = Gio.Settings.new("org.gnome.desktop.default-applications.terminal");
+      this.gsettings = Gio.Settings.new("org.cinnamon.desktop.applications.terminal");
       this.sshHeadless = false;
       this.sshForwardX = false;
       this.homeDir = GLib.get_home_dir();


### PR DESCRIPTION
Right now the plugin is using `org.gnome.desktop.default-applications.terminal` setting, which is not present on my machine. I guess the correct value should be `org.cinnamon.desktop.applications.terminal`