### PR TITLE
placesCenter@scollins: Improvement of Recent Files section

### DIFF
--- a/placesCenter@scollins/files/placesCenter@scollins/po/fr.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/fr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-04 01:32+0200\n"
-"PO-Revision-Date: 2019-09-04 01:33+0200\n"
+"POT-Creation-Date: 2019-09-08 19:11+0200\n"
+"PO-Revision-Date: 2019-09-08 19:13+0200\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -18,47 +18,47 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: applet.js:127
+#: applet.js:144
 msgid "(Right click to open folder)"
 msgstr "(Clic droit pour ouvrir son dossier)"
 
-#: applet.js:149
+#: applet.js:166
 msgid "Places"
 msgstr "Emplacements"
 
-#: applet.js:261
+#: applet.js:281
 msgid "Search Home Folder"
 msgstr "Rechercher dans mon dossier personnel"
 
-#: applet.js:284
+#: applet.js:304
 msgid "SYSTEM"
 msgstr "SYSTÈME"
 
-#: applet.js:293
+#: applet.js:313
 msgid "Search File System"
 msgstr "Rechercher dans le système de fichiers"
 
-#: applet.js:319
+#: applet.js:338
 msgid "RECENT DOCUMENTS"
 msgstr "DOCUMENTS RÉCENTS"
 
-#: applet.js:333
+#: applet.js:352
 msgid "Clear"
 msgstr "Effacer"
 
-#: applet.js:376
+#: applet.js:395
 msgid "Computer"
 msgstr "Ordinateur"
 
-#: applet.js:382
+#: applet.js:401
 msgid "File System"
 msgstr "Système de fichiers"
 
-#: applet.js:398
+#: applet.js:417
 msgid "Network"
 msgstr "Réseau"
 
-#: applet.js:507
+#: applet.js:554
 msgid "Trash"
 msgstr "Corbeille"
 
@@ -296,9 +296,41 @@ msgstr "Montrer le Réseau"
 msgid "Show recent documents"
 msgstr "Montrer les Documents Récents"
 
+#. settings-schema.json->recentSizeLimit->options
+msgid "5"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "10"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "15"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "20"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "25"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "30"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "All Recent Documents"
+msgstr "Tous les documents récents"
+
 #. settings-schema.json->recentSizeLimit->description
 msgid "Number to show"
 msgstr "Nombre de documents récents à afficher"
+
+#. settings-schema.json->btnPrivacy->description
+msgid "Privacy"
+msgstr "Confidentialité"
 
 #~ msgid "Click to open the file."
 #~ msgstr "Clic gauche pour ouvrir le fichier."

--- a/placesCenter@scollins/files/placesCenter@scollins/po/placesCenter@scollins.pot
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/placesCenter@scollins.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-04 01:32+0200\n"
+"POT-Creation-Date: 2019-09-08 19:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,47 +17,47 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:127
+#: applet.js:144
 msgid "(Right click to open folder)"
 msgstr ""
 
-#: applet.js:149
+#: applet.js:166
 msgid "Places"
 msgstr ""
 
-#: applet.js:261
+#: applet.js:281
 msgid "Search Home Folder"
 msgstr ""
 
-#: applet.js:284
+#: applet.js:304
 msgid "SYSTEM"
 msgstr ""
 
-#: applet.js:293
+#: applet.js:313
 msgid "Search File System"
 msgstr ""
 
-#: applet.js:319
+#: applet.js:338
 msgid "RECENT DOCUMENTS"
 msgstr ""
 
-#: applet.js:333
+#: applet.js:352
 msgid "Clear"
 msgstr ""
 
-#: applet.js:376
+#: applet.js:395
 msgid "Computer"
 msgstr ""
 
-#: applet.js:382
+#: applet.js:401
 msgid "File System"
 msgstr ""
 
-#: applet.js:398
+#: applet.js:417
 msgid "Network"
 msgstr ""
 
-#: applet.js:507
+#: applet.js:554
 msgid "Trash"
 msgstr ""
 
@@ -280,6 +280,38 @@ msgstr ""
 msgid "Show recent documents"
 msgstr ""
 
+#. settings-schema.json->recentSizeLimit->options
+msgid "5"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "10"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "15"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "20"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "25"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "30"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "All Recent Documents"
+msgstr ""
+
 #. settings-schema.json->recentSizeLimit->description
 msgid "Number to show"
+msgstr ""
+
+#. settings-schema.json->btnPrivacy->description
+msgid "Privacy"
 msgstr ""

--- a/placesCenter@scollins/files/placesCenter@scollins/settings-schema.json
+++ b/placesCenter@scollins/files/placesCenter@scollins/settings-schema.json
@@ -45,7 +45,7 @@
         "recentSection": {
             "type": "section",
             "title": "Recent documents",
-            "keys": ["showRecentDocuments", "recentSizeLimit"]
+            "keys": ["showRecentDocuments", "recentSizeLimit", "btnPrivacy"]
         }
     },
 
@@ -158,14 +158,25 @@
     },
 
     "recentSizeLimit": {
-        "type": "spinbutton",
+        "type": "combobox",
         "default": 10,
-        "min": 0,
-        "max": 30,
-        "units": "",
-        "step": 1,
+        "options": {
+            "5": 5,
+            "10": 10,
+            "15": 15,
+            "20": 20,
+            "25": 25,
+            "30": 30,
+            "All Recent Documents": 0
+        },
         "description": "Number to show",
         "indent": true,
         "dependency": "showRecentDocuments"
+    },
+
+    "btnPrivacy": {
+        "type": "button",
+        "description": "Privacy",
+        "callback": "on_btnPrivacy_pressed"
     }
 }


### PR DESCRIPTION
@collinss 

Hello Stephen,

I propose you some improvements to the Recent Files section.

1. No more files without an icon!
2. Whenever possible, replace the mime type icon with the icon of the last application that opened the file.
3. Do not show deleted files.
4. Do not show the Clear button when the list is empty.
5. Use default recentManager instead of a new recentManager, to be synchronized with  the `menu@cinnamon.org` applet.
6. In settings:
   * the type of the `recentSizeLimit` parameter becomes `combobox` to avoid to call 10 times the `buildRecentDocumentsSection()` method when the user wants to display 10 more files in the Recent Files section.
   * a new button appears, to open the Privacy window of Cinnamon Settings.

To see the differences:

1. Example of Recent Files section in `menu@cinnamon.org`:
![menu-recents](https://user-images.githubusercontent.com/33965039/64492147-4444ae80-d271-11e9-8540-a23f67b37692.png)
2. Example of New Recent Files section in `placesCenter@scollins`:
![placesCenter-recents](https://user-images.githubusercontent.com/33965039/64492154-5de5f600-d271-11e9-8b67-12ac9e6a18c3.png)

Can you tell me if all this suits you, before I try to optimize and clean the code?

Best regards.
Claudiux