### PR TITLE
[SpicesUpdate@claudiux] v4.0.2 - Removes unnecessary notifications

### DIFF
--- a/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v4.0.2~20190920
+  * Removes unnecessary notifications like '(Refresh to see the description)'.
+  * Minor CSS changes.
+
 ### v4.0.1~20190914
   * Improves the download of the latest versions of Spices. (Cinnamon 3.8 and following.)
 

--- a/SpicesUpdate@claudiux/README.md
+++ b/SpicesUpdate@claudiux/README.md
@@ -2,7 +2,7 @@
 
 ## Important!
 In order to be sure to download the latest version of Spices Update, use
-**[this link](https://cinnamon-spices.linuxmint.com/files/applets/SpicesUpdate@claudiux.zip?84e821c1-7ff5-4fd8-a833-f8d399a51582)** rather than the Download button at the top of this page.
+**[this link](https://cinnamon-spices.linuxmint.com/files/applets/SpicesUpdate@claudiux.zip?bb90ce7a-8249-460d-9ff6-7811d055a280)** rather than the Download button at the top of this page.
 
 ## Summary
 
@@ -23,6 +23,7 @@ Usable from Cinnamon 2.8 to Cinnamon 4.2.
 Fully supported by the author, under continuing development and in continuous use on several machines, running with **Linux Mint**, **Fedora** or **Archlinux**.
 
 From version v3.0.0 ~ 20190808:
+
   * Spices Update is compatible with Cinnamon 2.8 -> 4.2 (Mint 17.3 -> 19.2).
    * From Cinnamon 3.8 to 4.2 (Mint 19 -> 19.2): **Perfectly functional, as usual.**
    * From Cinnamon 2.8 to 3.6 (Mint 17.3 -> 18.3): Some features are reduced:
@@ -96,19 +97,36 @@ Here with the reason for update:
 ![notif_simple_with_details](https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_simple_with_details.png)
 
 ### Notifications with buttons
-Two buttons: firstly a button to open the System Settings page to download updates; secondly a button to refresh the notification to obtain details, if any.
-
-Here without details:
-
-![notif_without_details](https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_without_details.png)
-
-After refreshing, the reason for the update appears:
+Two buttons: firstly a button to open the System Settings page to download updates; secondly a button to refresh notifications.
 
 ![notif_with_details](https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_with_details2.png)
 
 ## Translations
 
 Any translation is welcome. Thank you for contributing to translate the applet's messages into new languages, or to improve or supplement existing translations.
+
+### Available translations and their authors
+
+  * Croatian (hr): muzena
+  * Dutch (nl): Jurien (French77)
+  * Finnish (fi): MahtiAnkka
+  * French (fr): claudiux
+  * German (de): Mintulix
+  * Italian (it): claudiux
+  * Spanish (es): claudiux
+  * Swedish (sv): Åke Engelbrektson (eson57)
+
+Many thanks to them!
+
+### How to offer a translation
+
+  1. Create an account on [Github](https://github.com/).
+  2. Fork the [cinnamon-spices-applets](https://github.com/linuxmint/cinnamon-spices-applets) repository.
+  3. In your fork, create a branch (named like `SpicesUpdate-YOUR_LANGUAGE_CODE`) from the master one.
+  4. On your computer, install git and poedit.
+  5. Clone your branch on your computer: `git clone -b SpicesUpdate-YOUR_LANGUAGE_CODE --single-branch https://github.com/YOUR_GITHUB_ACCOUNT/cinnamon-spices-applets.git SpicesUpdate-YOUR_LANGUAGE_CODE`
+  6. Open the `SpicesUpdate@claudiux.pot` file (which is in the `po` directory) with poedit and create your translation. You obtain a YOUR_LANGUAGE_CODE.po file.
+  7. On Github, upload this `YOUR_LANGUAGE_CODE.po` file at the right place into your branch then go to the root of your branch and make a Pull Request.
 
 ## Installation
 
@@ -119,7 +137,7 @@ Use the _Applets_ menu in Cinnamon Settings, or _Add Applets to Panel_ in the co
 ### Manual Installation:
 
    * Install the additional programs required.
-   * Download the **[latest version of Spices Update](https://cinnamon-spices.linuxmint.com/files/applets/SpicesUpdate@claudiux.zip?84e821c1-7ff5-4fd8-a833-f8d399a51582)** from the Spices Web Site.
+   * Download the **[latest version of Spices Update](https://cinnamon-spices.linuxmint.com/files/applets/SpicesUpdate@claudiux.zip?bb90ce7a-8249-460d-9ff6-7811d055a280)** from the Spices Web Site.
    * Unzip and extract the folder ```SpicesUpdate@claudiux``` into ```~/.local/share/cinnamon/applets/```
    * Enable this applet in System Settings -> Applets.
    * You can also access the Settings Screen from System Settings -> Applets, or from the context menu of this applet (right-clicking on its icon).

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/3.8/applet.js
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/3.8/applet.js
@@ -439,7 +439,7 @@ class SpicesUpdate extends Applet.TextIconApplet {
 
     // Badge
     this.badge = new St.BoxLayout({
-      style_class: 'grouped-window-list-badge',
+      style_class: 'SU-badge',
       important: true,
       width: 12 * global.ui_scale,
       height: 12 * global.ui_scale,
@@ -450,7 +450,7 @@ class SpicesUpdate extends Applet.TextIconApplet {
     });
     this.numberLabel = new St.Label({
       style: 'font-size: 10px;padding: 0px;',
-      style_class: 'grouped-window-list-number-label',
+      style_class: 'SU-number-label',
       important: true,
       text: '',
       anchor_x: -3 * global.ui_scale,
@@ -472,6 +472,7 @@ class SpicesUpdate extends Applet.TextIconApplet {
     this.first_loop = true; // To do nothing for 1 minute.
     this.on_settings_changed();
     // Run the loop !
+    this.iteration = 0;
     this.updateLoop();
   }; // End of constructor
 
@@ -1254,9 +1255,10 @@ class SpicesUpdate extends Applet.TextIconApplet {
                                                                         this._get_member_from_cache(type, uuid, "spices-id").toString());
     var msg = Soup.Message.new('GET', url);
 
+    let iteration = this.iteration;
     // Queue of the http request
     _httpSession.queue_message(msg, Lang.bind(this, function(_httpSession, message) {
-      if (message.status_code === Soup.KnownStatusCode.OK) {
+      if (message.status_code === Soup.KnownStatusCode.OK && iteration === this.iteration) {
         let data = message.response_body.data;
         let result = subject_regexp.exec(data.toString());
         this.details_by_uuid[uuid] = result[1].toString();
@@ -1265,7 +1267,7 @@ class SpicesUpdate extends Applet.TextIconApplet {
         this.details_by_uuid[uuid] = "";
       }
     }));
-    return (this.details_by_uuid[uuid] !== undefined)
+    return (this.details_by_uuid[uuid] !== undefined && this.details_by_uuid[uuid] !== "")
   }; // End of get_last_commit_subject
 
   is_to_check(type) {
@@ -1320,7 +1322,8 @@ class SpicesUpdate extends Applet.TextIconApplet {
                   ret.push("%s (%s)\n\t\t%s".format(_(this.get_spice_name(type, uuid)), uuid, _("(Description unavailable)")));
                 }
               } else {
-                ret.push("%s (%s)\n\t\t%s".format(_(this.get_spice_name(type, uuid)), uuid, _("(Refresh to see the description)")));
+                this.refreshInterval = 15; // Wait 15 more seconds to avoid the message "(Refresh to see the description)".
+                //ret.push("%s (%s)\n\t\t%s".format(_(this.get_spice_name(type, uuid)), uuid, _("(Refresh to see the description)")));
               }
             } else {
               ret.push("%s (%s)".format(_(this.get_spice_name(type, uuid)), uuid));
@@ -1604,6 +1607,8 @@ class SpicesUpdate extends Applet.TextIconApplet {
     }
     this.loopId = 0;
     this.check_dependencies();
+
+    this.iteration = (this.iteration + 1) % 10;
 
     // Inhibits also after the applet has been removed from the panel
     if (this.applet_running === true) {

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/3.8/stylesheet.css
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/3.8/stylesheet.css
@@ -1,0 +1,14 @@
+.SU-number-label {
+    z-index: 99;
+    text-shadow: black 1px 0px 2px;
+    font-size: 11px;
+    color:#fff;
+    background-color: #000000;
+    padding: 0px;
+    border-radius: 256px;
+}
+.SU-badge {
+    border-radius: 256px;
+    background-color: #000000;
+    margin: 0px;
+}

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/4.2/stylesheet.css
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/4.2/stylesheet.css
@@ -1,0 +1,14 @@
+.SU-number-label {
+    z-index: 99;
+    text-shadow: black 1px 0px 2px;
+    font-size: 11px;
+    color:#fff;
+    background-color: #000000;
+    padding: 0px;
+    border-radius: 256px;
+}
+.SU-badge {
+    border-radius: 256px;
+    background-color: #000000;
+    margin: 0px;
+}

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v4.0.2~20190920
+  * Removes unnecessary notifications like '(Refresh to see the description)'.
+  * Minor CSS changes.
+
 ### v4.0.1~20190914
   * Improves the download of the latest versions of Spices. (Cinnamon 3.8 and following.)
 

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/en/README.html
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/en/README.html
@@ -134,14 +134,36 @@
 <p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_simple_with_details.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_simple_with_details.png" alt="notif_simple_with_details" style="max-width:100%;"></a></p>
 <h3>
 <a id="user-content-notifications-with-buttons" class="anchor" href="#notifications-with-buttons" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Notifications with buttons</h3>
-<p>Two buttons: firstly a button to open the System Settings page to download updates; secondly a button to refresh the notification to obtain details, if any.</p>
-<p>Here without details:</p>
-<p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_without_details.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_without_details.png" alt="notif_without_details" style="max-width:100%;"></a></p>
-<p>After refreshing, the reason for the update appears:</p>
+<p>Two buttons: firstly a button to open the System Settings page to download updates; secondly a button to refresh notifications.</p>
 <p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_with_details2.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_with_details2.png" alt="notif_with_details" style="max-width:100%;"></a></p>
 <h2>
 <a id="user-content-translations" class="anchor" href="#translations" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Translations</h2>
 <p>Any translation is welcome. Thank you for contributing to translate the applet's messages into new languages, or to improve or supplement existing translations.</p>
+<h3>
+<a id="user-content-available-translations-and-their-authors" class="anchor" href="#available-translations-and-their-authors" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Available translations and their authors</h3>
+<ul>
+<li>Croatian (hr): muzena</li>
+<li>Dutch (nl): Jurien (French77)</li>
+<li>Finnish (fi): MahtiAnkka</li>
+<li>French (fr): claudiux</li>
+<li>German (de): Mintulix</li>
+<li>Italian (it): claudiux</li>
+<li>Spanish (es): claudiux</li>
+<li>Swedish (sv): Åke Engelbrektson (eson57)</li>
+</ul>
+<p>Many thanks to them!</p>
+<h3>
+<a id="user-content-how-to-offer-a-translation" class="anchor" href="#how-to-offer-a-translation" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>How to offer a translation</h3>
+<ol>
+<li>Create an account on <a href="https://github.com/">Github</a>.</li>
+<li>Fork the <a href="https://github.com/linuxmint/cinnamon-spices-applets">cinnamon-spices-applets</a> repository.</li>
+<li>In your fork, create a branch (named like <code>SpicesUpdate-YOUR_LANGUAGE_CODE</code>) from the master one.</li>
+<li>On your computer, install git and poedit.</li>
+<li>Clone your branch on your computer: <code>git clone -b SpicesUpdate-YOUR_LANGUAGE_CODE --single-branch https://github.com/YOUR_GITHUB_ACCOUNT/cinnamon-spices-applets.git SpicesUpdate-YOUR_LANGUAGE_CODE</code>
+</li>
+<li>Open the <code>SpicesUpdate@claudiux.pot</code> file (which is in the <code>po</code> directory) with poedit and create your translation. You obtain a YOUR_LANGUAGE_CODE.po file.</li>
+<li>On Github, upload this <code>YOUR_LANGUAGE_CODE.po</code> file at the right place into your branch then go to the root of your branch and make a Pull Request.</li>
+</ol>
 <h2>
 <a id="user-content-installation" class="anchor" href="#installation" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Installation</h2>
 <h3>
@@ -151,7 +173,7 @@
 <a id="user-content-manual-installation" class="anchor" href="#manual-installation" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Manual Installation:</h3>
 <ul>
 <li>Install the additional programs required.</li>
-<li>Download the Spices Update from the Spices Web Site.</li>
+<li>Download the Spices Update from the <a href="https://cinnamon-spices.linuxmint.com/applets/view/309" rel="nofollow">Spices Web Site</a>.</li>
 <li>Unzip and extract the folder <code>SpicesUpdate@claudiux</code> into <code>~/.local/share/cinnamon/applets/</code>
 </li>
 <li>Enable this applet in System Settings -&gt; Applets.</li>

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/en/README.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/en/README.md
@@ -19,6 +19,7 @@ Usable from Cinnamon 2.8 to Cinnamon 4.2.
 Fully supported by the author, under continuing development and in continuous use on several machines, running with **Linux Mint**, **Fedora** or **Archlinux**.
 
 From version v3.0.0 ~ 20190808:
+
   * Spices Update is compatible with Cinnamon 2.8 -> 4.2 (Mint 17.3 -> 19.2).
    * From Cinnamon 3.8 to 4.2 (Mint 19 -> 19.2): **Perfectly functional, as usual.**
    * From Cinnamon 2.8 to 3.6 (Mint 17.3 -> 18.3): Some features are reduced:
@@ -92,19 +93,36 @@ Here with the reason for update:
 ![notif_simple_with_details](https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_simple_with_details.png)
 
 ### Notifications with buttons
-Two buttons: firstly a button to open the System Settings page to download updates; secondly a button to refresh the notification to obtain details, if any.
-
-Here without details:
-
-![notif_without_details](https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_without_details.png)
-
-After refreshing, the reason for the update appears:
+Two buttons: firstly a button to open the System Settings page to download updates; secondly a button to refresh notifications.
 
 ![notif_with_details](https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_with_details2.png)
 
 ## Translations
 
 Any translation is welcome. Thank you for contributing to translate the applet's messages into new languages, or to improve or supplement existing translations.
+
+### Available translations and their authors
+
+  * Croatian (hr): muzena
+  * Dutch (nl): Jurien (French77)
+  * Finnish (fi): MahtiAnkka
+  * French (fr): claudiux
+  * German (de): Mintulix
+  * Italian (it): claudiux
+  * Spanish (es): claudiux
+  * Swedish (sv): Åke Engelbrektson (eson57)
+
+Many thanks to them!
+
+### How to offer a translation
+
+  1. Create an account on [Github](https://github.com/).
+  2. Fork the [cinnamon-spices-applets](https://github.com/linuxmint/cinnamon-spices-applets) repository.
+  3. In your fork, create a branch (named like `SpicesUpdate-YOUR_LANGUAGE_CODE`) from the master one.
+  4. On your computer, install git and poedit.
+  5. Clone your branch on your computer: `git clone -b SpicesUpdate-YOUR_LANGUAGE_CODE --single-branch https://github.com/YOUR_GITHUB_ACCOUNT/cinnamon-spices-applets.git SpicesUpdate-YOUR_LANGUAGE_CODE`
+  6. Open the `SpicesUpdate@claudiux.pot` file (which is in the `po` directory) with poedit and create your translation. You obtain a YOUR_LANGUAGE_CODE.po file.
+  7. On Github, upload this `YOUR_LANGUAGE_CODE.po` file at the right place into your branch then go to the root of your branch and make a Pull Request.
 
 ## Installation
 
@@ -115,7 +133,7 @@ Use the _Applets_ menu in Cinnamon Settings, or _Add Applets to Panel_ in the co
 ### Manual Installation:
 
    * Install the additional programs required.
-   * Download the Spices Update from the Spices Web Site.
+   * Download the Spices Update from the [Spices Web Site](https://cinnamon-spices.linuxmint.com/applets/view/309).
    * Unzip and extract the folder ```SpicesUpdate@claudiux``` into ```~/.local/share/cinnamon/applets/```
    * Enable this applet in System Settings -> Applets.
    * You can also access the Settings Screen from System Settings -> Applets, or from the context menu of this applet (right-clicking on its icon).

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/fr/README.html
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/fr/README.html
@@ -136,14 +136,36 @@
 <p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_simple_with_details-fr.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_simple_with_details-fr.png" alt="notif_simple_with_details" style="max-width:100%;"></a></p>
 <h3>
 <a id="user-content-notifications-avec-boutons" class="anchor" href="#notifications-avec-boutons" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Notifications avec boutons</h3>
-<p>Deux boutons sont présents : l'un pour ouvrir la page Paramètres système afin de télécharger les mises à jour ; l'autre pour actualiser la notification afin d’obtenir des détails, le cas échéant.</p>
-<p>Ici sans les détails :</p>
-<p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_without_details-fr.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_without_details-fr.png" alt="notif_without_details" style="max-width:100%;"></a></p>
-<p>Après actualisation, le motif de la mise à jour apparaît :</p>
+<p>Deux boutons sont présents : l'un pour ouvrir la page Paramètres système afin de télécharger les mises à jour ; l'autre pour actualiser les notifications.</p>
 <p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_with_details2-fr.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_with_details2-fr.png" alt="notif_with_details" style="max-width:100%;"></a></p>
 <h2>
 <a id="user-content-traductions" class="anchor" href="#traductions" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Traductions</h2>
 <p>Toute traduction est la bienvenue. Merci de contribuer en traduisant les messages de l'applet dans de nouvelles langues ou en améliorant/complétant les traductions existantes.</p>
+<h3>
+<a id="user-content-traductions-disponibles-et-leurs-auteurs" class="anchor" href="#traductions-disponibles-et-leurs-auteurs" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Traductions disponibles et leurs auteurs</h3>
+<ul>
+<li>Croate (hr): muzena</li>
+<li>Néerlandais (nl): Jurien (French77)</li>
+<li>Finnois (fi): MahtiAnkka</li>
+<li>Français (fr): claudiux</li>
+<li>Allemand (de): Mintulix</li>
+<li>Italien (it): claudiux</li>
+<li>Espagnol (es): claudiux</li>
+<li>Suédois (sv): Åke Engelbrektson (eson57)</li>
+</ul>
+<p>Un grand merci à eux !</p>
+<h3>
+<a id="user-content-commant-proposer-une-traduction" class="anchor" href="#commant-proposer-une-traduction" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Commant proposer une traduction</h3>
+<ol>
+<li>Créer un compte dur <a href="https://github.com/">Github</a>.</li>
+<li>Faire un Fork du dépôt <a href="https://github.com/linuxmint/cinnamon-spices-applets">cinnamon-spices-applets</a>.</li>
+<li>Dans votre fork, créer une branche (la nommer comme <code>SpicesUpdate-CODE_LANGUE</code>) à partir de la branche master.</li>
+<li>Sur votre ordinateur, installer git et poedit.</li>
+<li>Cloner votre branche sur votre ordinateur : <code>git clone -b SpicesUpdate-CODE_LANGUE --single-branch https://github.com/VOTRE_COMPTE_GITHUB/cinnamon-spices-applets.git SpicesUpdate-CODE_LANGUE</code>
+</li>
+<li>Ouvrir le fichier <code>SpicesUpdate@claudiux.pot</code> (qui est dans le dossier <code>po</code>) avec poedit et créer votre traduction. Vous obtenez une fichier CODE_LANGUE.po.</li>
+<li>Sur Github, envoyer le fichier <code>CODE_LANGUE.po</code> au bon endroit dans votre branche puis aller à la racine de votre branche et faire un Pull Request.</li>
+</ol>
 <h2>
 <a id="user-content-installation" class="anchor" href="#installation" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Installation</h2>
 <h3>

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/fr/README.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/fr/README.md
@@ -98,19 +98,36 @@ Ici avec la raison de la mise à jour :
 ![notif_simple_with_details](https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_simple_with_details-fr.png)
 
 ### Notifications avec boutons
-Deux boutons sont présents : l'un pour ouvrir la page Paramètres système afin de télécharger les mises à jour ; l'autre pour actualiser la notification afin d’obtenir des détails, le cas échéant.
-
-Ici sans les détails :
-
-![notif_without_details](https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_without_details-fr.png)
-
-Après actualisation, le motif de la mise à jour apparaît :
+Deux boutons sont présents : l'un pour ouvrir la page Paramètres système afin de télécharger les mises à jour ; l'autre pour actualiser les notifications.
 
 ![notif_with_details](https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/notif_with_details2-fr.png)
 
 ## Traductions
 
 Toute traduction est la bienvenue. Merci de contribuer en traduisant les messages de l'applet dans de nouvelles langues ou en améliorant/complétant les traductions existantes.
+
+### Traductions disponibles et leurs auteurs
+
+  * Croate (hr): muzena
+  * Néerlandais (nl): Jurien (French77)
+  * Finnois (fi): MahtiAnkka
+  * Français (fr): claudiux
+  * Allemand (de): Mintulix
+  * Italien (it): claudiux
+  * Espagnol (es): claudiux
+  * Suédois (sv): Åke Engelbrektson (eson57)
+
+Un grand merci à eux !
+
+### Commant proposer une traduction
+
+  1. Créer un compte dur [Github](https://github.com/).
+  2. Faire un Fork du dépôt [cinnamon-spices-applets](https://github.com/linuxmint/cinnamon-spices-applets).
+  3. Dans votre fork, créer une branche (la nommer comme `SpicesUpdate-CODE_LANGUE`) à partir de la branche master.
+  4. Sur votre ordinateur, installer git et poedit.
+  5. Cloner votre branche sur votre ordinateur : `git clone -b SpicesUpdate-CODE_LANGUE --single-branch https://github.com/VOTRE_COMPTE_GITHUB/cinnamon-spices-applets.git SpicesUpdate-CODE_LANGUE`
+  6. Ouvrir le fichier `SpicesUpdate@claudiux.pot` (qui est dans le dossier `po`) avec poedit et créer votre traduction. Vous obtenez une fichier CODE_LANGUE.po.
+  7. Sur Github, envoyer le fichier `CODE_LANGUE.po` au bon endroit dans votre branche puis aller à la racine de votre branche et faire un Pull Request.
 
 ## Installation
 

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/metadata.json
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/metadata.json
@@ -3,7 +3,7 @@
   "name": "Spices Update",
   "max-instances": "1",
   "hide-configuration": false,
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Warns you when installed Spices (applets, desklets, extensions, themes) require an update or new Spices are available.",
   "multiversion": true,
   "cinnamon-version": [


### PR DESCRIPTION
Hi @brownsr,

This version 4.0.2 of Spices Update removes unnecessary notifications like '(Refresh to see the description)' and have some minor CSS changes.

Can you merge this branch into your master one, please?

Best regards.
Claudiux