### PR TITLE
[SpicesUpdate@claudiux] v4.2.0 - Animated icon during refresh - Can renew the download of Spices (Cin. 4.2 and followings)

### DIFF
--- a/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,7 +1,9 @@
+### v4.2.0~20190927
+  * Animated icon during refresh.
+    * Only for Cinnamon 4.2 and following.
+
 ### v4.1.0~20190925
   * Adds the ability to renew the download of the latest version of a Spice.
-    * Only for Cinnamon 4.2 and following.
-  * Animated icon during refresh.
     * Only for Cinnamon 4.2 and following.
   * `SpicesUpdate@claudiux.pot` file updated.
   * French translation: `fr.po` file updated.

--- a/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,3 +1,10 @@
+### v4.1.0~20190925
+  * Adds the ability to renew the download of the latest version of a Spice.
+    * Only for Cinnamon 4.2 and following.
+  * `SpicesUpdate@claudiux.pot` file updated.
+  * French translation: `fr.po` file updated.
+  * Minor bugs fixed.
+
 ### v4.0.2~20190920
   * Removes unnecessary notifications like '(Refresh to see the description)'.
   * Minor CSS changes.

--- a/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### v4.1.0~20190925
   * Adds the ability to renew the download of the latest version of a Spice.
     * Only for Cinnamon 4.2 and following.
+  * Animated icon during refresh.
+    * Only for Cinnamon 4.2 and following.
   * `SpicesUpdate@claudiux.pot` file updated.
   * French translation: `fr.po` file updated.
   * Minor bugs fixed.

--- a/SpicesUpdate@claudiux/README.md
+++ b/SpicesUpdate@claudiux/README.md
@@ -2,7 +2,7 @@
 
 ## Important!
 In order to be sure to download the latest version of Spices Update, use
-**[this link](https://cinnamon-spices.linuxmint.com/files/applets/SpicesUpdate@claudiux.zip?bb90ce7a-8249-460d-9ff6-7811d055a280)** rather than the Download button at the top of this page.
+**[this link](https://cinnamon-spices.linuxmint.com/files/applets/SpicesUpdate@claudiux.zip?3a160f32-a3d6-437f-899e-afba9907e023)** rather than the Download button at the top of this page.
 
 ## Summary
 
@@ -15,6 +15,7 @@ The **Spices Update** applet plays these roles:
   * It warns you when the Spices you have installed need updates.
   * Optional: It can also warn you when new Spices are available.
   * It gives you direct access to Cinnamon Settings for Applets, Desklets, Extensions and Themes.
+  * It allows you to renew the download of the latest version of a Spice (only with Cinnamon 4.2 and following).
 
 ## Status
 
@@ -66,10 +67,12 @@ The first, _General_, allows you to:
 
 For the content of the other tabs (_Applets_, _Desklets_, etc), please look at the screenshot above and note that **the list of installed Spices is automatically filled** at startup, but a button allows you to reload it.
 
-Set to _FALSE_ all the Spices you _do not want_ to check updates. There are two reasons to do this:
+Set to _FALSE_ (or uncheck the first box of) all the Spices you _do not want_ to check updates. There are two reasons to do this:
 
   * A spice is OK for you, and you do not want to be notified of any changes to it.
   * You are a developer working on a spice and you do not want to be informed about changes during development.
+
+From Cinnamon 4.2, you can request to renew the download of the latest version of a Spice checking both boxes then clicking the Refresh button.
 
 ## Menu
 
@@ -84,6 +87,8 @@ In the menu of this applet:
 ## Icon
 
 The color of the icon changes when at least one of your Spices needs an update.
+
+From Cinnamon 4.2 (and Spices Update v4.1.0), the color of the icon darkens while data are being refreshed.
 
 Its tooltip (the message displayed when the icon is hovered) contains the list of spices to update, if any.
 
@@ -123,8 +128,10 @@ Many thanks to them!
   1. Create an account on [Github](https://github.com/).
   2. Fork the [cinnamon-spices-applets](https://github.com/linuxmint/cinnamon-spices-applets) repository.
   3. In your fork, create a branch (named like `SpicesUpdate-YOUR_LANGUAGE_CODE`) from the master one.
-  4. On your computer, install git and poedit.
-  5. Clone your branch on your computer: `git clone -b SpicesUpdate-YOUR_LANGUAGE_CODE --single-branch https://github.com/YOUR_GITHUB_ACCOUNT/cinnamon-spices-applets.git SpicesUpdate-YOUR_LANGUAGE_CODE`
+  4. On your computer, install _git_ and _poedit_.
+  5. Clone your branch on your computer:
+
+    `git clone -b SpicesUpdate-YOUR_LANGUAGE_CODE --single-branch https://github.com/YOUR_GITHUB_ACCOUNT/cinnamon-spices-applets.git SpicesUpdate-YOUR_LANGUAGE_CODE`
   6. Open the `SpicesUpdate@claudiux.pot` file (which is in the `po` directory) with poedit and create your translation. You obtain a YOUR_LANGUAGE_CODE.po file.
   7. On Github, upload this `YOUR_LANGUAGE_CODE.po` file at the right place into your branch then go to the root of your branch and make a Pull Request.
 
@@ -137,7 +144,7 @@ Use the _Applets_ menu in Cinnamon Settings, or _Add Applets to Panel_ in the co
 ### Manual Installation:
 
    * Install the additional programs required.
-   * Download the **[latest version of Spices Update](https://cinnamon-spices.linuxmint.com/files/applets/SpicesUpdate@claudiux.zip?bb90ce7a-8249-460d-9ff6-7811d055a280)** from the Spices Web Site.
+   * Download the **[latest version of Spices Update](https://cinnamon-spices.linuxmint.com/files/applets/SpicesUpdate@claudiux.zip?3a160f32-a3d6-437f-899e-afba9907e023)** from the Spices Web Site.
    * Unzip and extract the folder ```SpicesUpdate@claudiux``` into ```~/.local/share/cinnamon/applets/```
    * Enable this applet in System Settings -> Applets.
    * You can also access the Settings Screen from System Settings -> Applets, or from the context menu of this applet (right-clicking on its icon).

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/2.8/applet.js
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/2.8/applet.js
@@ -255,6 +255,38 @@ SpicesUpdate.prototype = {
       "themes": false
     };
 
+    // Default icon color
+    this.defaultColor = "#000000FF";
+
+    // Monitoring metadata.json files and png directories
+    this.monitors = new Array();
+
+    // Monitoring png directories: Ids
+    this.monitorsPngId = {
+      "applets": 0,
+      "desklets": 0,
+      "extensions": 0,
+      "themes": 0
+    }
+
+    // Count of Spices to update
+    this.nb_to_update = 0;
+    this.nb_in_menu = {
+      "applets": 0,
+      "desklets": 0,
+      "extensions": 0,
+      "themes": 0
+    }
+
+    // New Spices
+    this.nb_to_watch = 0;
+    this.new_Spices = {
+      "applets": [],
+      "desklets": [],
+      "extensions": [],
+      "themes": []
+    }
+
 
     // ++ Settings
     this.settings = new Settings.AppletSettings(this, UUID, instance_id);
@@ -416,38 +448,6 @@ SpicesUpdate.prototype = {
     this.menuManager = new PopupMenu.PopupMenuManager(this);
     this.menu = new Applet.AppletPopupMenu(this, orientation);
     this.menuManager.addMenu(this.menu);
-
-    // Default icon color
-    this.defaultColor = "#000000FF";
-
-    // Monitoring metadata.json files and png directories
-    this.monitors = new Array();
-
-    // Monitoring png directories: Ids
-    this.monitorsPngId = {
-      "applets": 0,
-      "desklets": 0,
-      "extensions": 0,
-      "themes": 0
-    }
-
-    // Count of Spices to update
-    this.nb_to_update = 0;
-    this.nb_in_menu = {
-      "applets": 0,
-      "desklets": 0,
-      "extensions": 0,
-      "themes": 0
-    }
-
-    // New Spices
-    this.nb_to_watch = 0;
-    this.new_Spices = {
-      "applets": [],
-      "desklets": [],
-      "extensions": [],
-      "themes": []
-    }
 
     // Badge
     this.badge = new St.BoxLayout({

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/3.8/applet.js
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/3.8/applet.js
@@ -247,6 +247,38 @@ class SpicesUpdate extends Applet.TextIconApplet {
       "themes": false
     };
 
+    // Default icon color
+    this.defaultColor = "#000000FF";
+
+    // Monitoring metadata.json files and png directories
+    this.monitors = new Array();
+
+    // Monitoring png directories: Ids
+    this.monitorsPngId = {
+      "applets": 0,
+      "desklets": 0,
+      "extensions": 0,
+      "themes": 0
+    }
+
+    // Count of Spices to update
+    this.nb_to_update = 0;
+    this.nb_in_menu = {
+      "applets": 0,
+      "desklets": 0,
+      "extensions": 0,
+      "themes": 0
+    }
+
+    // New Spices
+    this.nb_to_watch = 0;
+    this.new_Spices = {
+      "applets": [],
+      "desklets": [],
+      "extensions": [],
+      "themes": []
+    }
+
 
     // ++ Settings
     this.settings = new Settings.AppletSettings(this, UUID, instance_id);
@@ -404,38 +436,6 @@ class SpicesUpdate extends Applet.TextIconApplet {
     this.menuManager = new PopupMenu.PopupMenuManager(this);
     this.menu = new Applet.AppletPopupMenu(this, orientation);
     this.menuManager.addMenu(this.menu);
-
-    // Default icon color
-    this.defaultColor = "#000000FF";
-
-    // Monitoring metadata.json files and png directories
-    this.monitors = new Array();
-
-    // Monitoring png directories: Ids
-    this.monitorsPngId = {
-      "applets": 0,
-      "desklets": 0,
-      "extensions": 0,
-      "themes": 0
-    }
-
-    // Count of Spices to update
-    this.nb_to_update = 0;
-    this.nb_in_menu = {
-      "applets": 0,
-      "desklets": 0,
-      "extensions": 0,
-      "themes": 0
-    }
-
-    // New Spices
-    this.nb_to_watch = 0;
-    this.new_Spices = {
-      "applets": [],
-      "desklets": [],
-      "extensions": [],
-      "themes": []
-    }
 
     // Badge
     this.badge = new St.BoxLayout({

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/4.2/applet.js
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/4.2/applet.js
@@ -36,7 +36,9 @@ const {
   CACHE_MAP,
   DIR_MAP,
   DCONFCACHEUPDATED,
+  DOWNLOAD_TIME,
   _,
+  EXP1, EXP2, EXP3,
   DEBUG,
   capitalize,
   log,
@@ -159,6 +161,38 @@ class SpicesUpdate extends Applet.TextIconApplet {
       "themes": false
     };
 
+    // Default icon color
+    this.defaultColor = "#000000FF";
+
+    // Monitoring metadata.json files and png directories
+    this.monitors = new Array();
+
+    // Monitoring png directories: Ids
+    this.monitorsPngId = {
+      "applets": 0,
+      "desklets": 0,
+      "extensions": 0,
+      "themes": 0
+    }
+
+    // Count of Spices to update
+    this.nb_to_update = 0;
+    this.nb_in_menu = {
+      "applets": 0,
+      "desklets": 0,
+      "extensions": 0,
+      "themes": 0
+    }
+
+    // New Spices
+    this.nb_to_watch = 0;
+    this.new_Spices = {
+      "applets": [],
+      "desklets": [],
+      "extensions": [],
+      "themes": []
+    }
+
 
     // ++ Settings
     this.settings = new Settings.AppletSettings(this, UUID, instance_id);
@@ -175,6 +209,13 @@ class SpicesUpdate extends Applet.TextIconApplet {
       "check_new_applets",
       this.on_settings_changed,
       null);
+
+    this.settings.bindProperty(Settings.BindingDirection.OUT,
+      "exp_applets",
+      "exp_applets",
+      null,
+      null);
+    this.exp_applets = "%s\n%s\n%s".format(EXP1["applets"], EXP2["applets"], EXP3);
 
     this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL,
       "unprotected_applets",
@@ -195,6 +236,13 @@ class SpicesUpdate extends Applet.TextIconApplet {
       this.on_settings_changed,
       null);
 
+    this.settings.bindProperty(Settings.BindingDirection.OUT,
+      "exp_desklets",
+      "exp_desklets",
+      null,
+      null);
+    this.exp_desklets = "%s\n%s\n%s".format(EXP1["desklets"], EXP2["desklets"], EXP3);
+
     this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL,
       "unprotected_desklets",
       "unprotected_desklets",
@@ -214,6 +262,13 @@ class SpicesUpdate extends Applet.TextIconApplet {
       this.on_settings_changed,
       null);
 
+    this.settings.bindProperty(Settings.BindingDirection.OUT,
+      "exp_extensions",
+      "exp_extensions",
+      null,
+      null);
+    this.exp_extensions = "%s\n%s\n%s".format(EXP1["extensions"], EXP2["extensions"], EXP3);
+
     this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL,
       "unprotected_extensions",
       "unprotected_extensions",
@@ -232,6 +287,13 @@ class SpicesUpdate extends Applet.TextIconApplet {
       "check_new_themes",
       this.on_settings_changed,
       null);
+
+    this.settings.bindProperty(Settings.BindingDirection.OUT,
+      "exp_themes",
+      "exp_themes",
+      null,
+      null);
+    this.exp_themes = "%s\n%s\n%s".format(EXP1["themes"], EXP2["themes"], EXP3);
 
     this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL,
       "unprotected_themes",
@@ -353,38 +415,6 @@ class SpicesUpdate extends Applet.TextIconApplet {
     this.menu = new Applet.AppletPopupMenu(this, orientation);
     this.menuManager.addMenu(this.menu);
 
-    // Default icon color
-    this.defaultColor = "#000000FF";
-
-    // Monitoring metadata.json files and png directories
-    this.monitors = new Array();
-
-    // Monitoring png directories: Ids
-    this.monitorsPngId = {
-      "applets": 0,
-      "desklets": 0,
-      "extensions": 0,
-      "themes": 0
-    }
-
-    // Count of Spices to update
-    this.nb_to_update = 0;
-    this.nb_in_menu = {
-      "applets": 0,
-      "desklets": 0,
-      "extensions": 0,
-      "themes": 0
-    }
-
-    // New Spices
-    this.nb_to_watch = 0;
-    this.new_Spices = {
-      "applets": [],
-      "desklets": [],
-      "extensions": [],
-      "themes": []
-    }
-
     // Badge
     this.badge = new St.BoxLayout({
       style_class: 'SU-badge',
@@ -415,6 +445,7 @@ class SpicesUpdate extends Applet.TextIconApplet {
     this.notifications = new Array();
     this.testblink = [];
     this.forceRefresh = false;
+    this.refresh_requested = false;
     this.applet_running = true;
     this.loopId = 0;
     this.first_loop = true; // To do nothing for 1 minute.
@@ -629,16 +660,16 @@ class SpicesUpdate extends Applet.TextIconApplet {
     this._on_refresh_pressed()
   }; // End of on_btn_refresh_applets_pressed
   on_btn_cs_applets_pressed() {
-    GLib.spawn_command_line_async('bash -c \'%s applets\''.format(CS_PATH));
+    Util.spawnCommandLine("%s applets -t 1 -s date".format(CS_PATH));
   }; // End of on_btn_cs_applets_pressed
   on_btn_cs_desklets_pressed() {
-    GLib.spawn_command_line_async('bash -c \'%s desklets\''.format(CS_PATH));
+    Util.spawnCommandLine("%s desklets -t 1 -s date".format(CS_PATH));
   }; // End of on_btn_cs_desklets_pressed
   on_btn_cs_extensions_pressed() {
-    GLib.spawn_command_line_async('bash -c \'%s extensions\''.format(CS_PATH));
+    Util.spawnCommandLine("%s extensions -t 1 -s date".format(CS_PATH));
   }; // End of on_btn_cs_extensions_pressed
   on_btn_cs_themes_pressed() {
-    GLib.spawn_command_line_async('bash -c \'%s themes\''.format(CS_PATH));
+    Util.spawnCommandLine("%s themes -t 1 -s date".format(CS_PATH));
   }; // End of on_btn_cs_themes_pressed
 
   /**
@@ -672,33 +703,41 @@ class SpicesUpdate extends Applet.TextIconApplet {
     * (true when updates are requested by the user)
   */
   populateSettingsUnprotectedApplets() {
+    let type = "applets";
     if (this.OKtoPopulateSettingsApplets === true) {
       this.OKtoPopulateSettingsApplets = false; // Prevents multiple access to the json config file of SpiceUpdate@claudiux.
       this.unprotectedAppletsDico = {};
       this.unprotectedAppletsList = [];
       // populate this.unprotectedApplets with the this.unprotected_applets elements, removing uninstalled applets:
-      let a, d;
       for (var i=0; i < this.unprotected_applets.length; i++) {
-        a = this.unprotected_applets[i];
-        d = Gio.file_new_for_path("%s/%s".format(DIR_MAP["applets"], a["name"]));
+        let a = this.unprotected_applets[i];
+        let d = Gio.file_new_for_path("%s/%s".format(DIR_MAP[type], a["name"]));
         if (d.query_exists(null)) {
           this.unprotectedAppletsDico[a["name"]] = a["isunprotected"];
-          this.unprotectedAppletsList.push({"name": a["name"], "isunprotected": a["isunprotected"]});
+          if (a["isunprotected"] && a["requestnewdownload"] !== undefined && a["requestnewdownload"] === true) {
+            if (this.cache[type] === "{}") this._load_cache(type);
+            let created = this._get_member_from_cache(type, a["name"], "created");
+            let last_edited = this._get_last_edited_from_cache(type, a["name"]);
+            if (created !== null && last_edited !== null && created >= last_edited) created = last_edited - 1;
+            let metadataFileName = DIR_MAP[type] + "/" + a["name"] + "/metadata.json";
+            if (created !== null) this._rewrite_metadataFile(metadataFileName, created);
+          }
+          this.unprotectedAppletsList.push({"name": a["name"], "isunprotected": a["isunprotected"], "requestnewdownload": false});
         }
       }
 
       // Are there new applets installed? If there are, then push them in this.unprotectedApplets:
-      let dir = Gio.file_new_for_path(DIR_MAP["applets"]);
+      let dir = Gio.file_new_for_path(DIR_MAP[type]);
       if (dir.query_exists(null)) {
         let children = dir.enumerate_children('standard::name,standard::type', Gio.FileQueryInfoFlags.NONE, null);
-        let info, type;
+        let info, file_type;
         var name;
         while ((info = children.next_file(null)) != null) {
-          type = info.get_file_type();
-          if (type == Gio.FileType.DIRECTORY) {
+          file_type = info.get_file_type();
+          if (file_type == Gio.FileType.DIRECTORY) {
             name = info.get_name().toString();
             if (this.unprotectedAppletsDico[name] === undefined) {
-              this.unprotectedAppletsList.push({"name": name, "isunprotected": true});
+              this.unprotectedAppletsList.push({"name": name, "isunprotected": true, "requestnewdownload": false});
               this.unprotectedAppletsDico[name] = {"name": name, "isunprotected": true};
             }
           }
@@ -709,33 +748,41 @@ class SpicesUpdate extends Applet.TextIconApplet {
   }; // End of populateSettingsUnprotectedApplets
 
   populateSettingsUnprotectedDesklets() {
+    let type = "desklets";
     if (this.OKtoPopulateSettingsDesklets === true) {
       this.OKtoPopulateSettingsDesklets = false;
       this.unprotectedDeskletsDico = {};
       this.unprotectedDeskletsList = [];
       // populate this.unprotectedDesklets with the this.unprotected_desklets elements:
-      let a, d;
       for (var i=0; i < this.unprotected_desklets.length; i++) {
-        a = this.unprotected_desklets[i];
-        d = Gio.file_new_for_path("%s/%s".format(DIR_MAP["desklets"], a["name"]));
+        let a = this.unprotected_desklets[i];
+        let d = Gio.file_new_for_path("%s/%s".format(DIR_MAP[type], a["name"]));
         if (d.query_exists(null)) {
           this.unprotectedDeskletsDico[a["name"]] = a["isunprotected"];
-          this.unprotectedDeskletsList.push({"name": a["name"], "isunprotected": a["isunprotected"]});
+          if (a["isunprotected"] && a["requestnewdownload"] !== undefined && a["requestnewdownload"] === true) {
+            if (this.cache[type] === "{}") this._load_cache(type);
+            let created = this._get_member_from_cache(type, a["name"], "created");
+            let last_edited = this._get_last_edited_from_cache(type, a["name"]);
+            if (created !== null && last_edited !== null && created >= last_edited) created = last_edited - 1;
+            let metadataFileName = DIR_MAP[type] + "/" + a["name"] + "/metadata.json";
+            if (created !== null) this._rewrite_metadataFile(metadataFileName, created);
+          }
+          this.unprotectedDeskletsList.push({"name": a["name"], "isunprotected": a["isunprotected"], "requestnewdownload": false});
         }
       }
 
       // Are there new desklets installed? If there are, then push them in this.unprotectedDesklets:
-      let dir = Gio.file_new_for_path(DIR_MAP["desklets"]);
+      let dir = Gio.file_new_for_path(DIR_MAP[type]);
       if (dir.query_exists(null)) {
         let children = dir.enumerate_children('standard::name,standard::type', Gio.FileQueryInfoFlags.NONE, null);
-        let info, type;
+        let info, file_type;
         var name;
         while ((info = children.next_file(null)) != null) {
-          type = info.get_file_type();
-          if (type == Gio.FileType.DIRECTORY) {
+          file_type = info.get_file_type();
+          if (file_type == Gio.FileType.DIRECTORY) {
             name = info.get_name().toString();
             if (this.unprotectedDeskletsDico[name] === undefined) {
-              this.unprotectedDeskletsList.push({"name": name, "isunprotected": true});
+              this.unprotectedDeskletsList.push({"name": name, "isunprotected": true, "requestnewdownload": false});
               this.unprotectedDeskletsDico[name] = {"name": name, "isunprotected": true};
             }
           }
@@ -746,33 +793,41 @@ class SpicesUpdate extends Applet.TextIconApplet {
   }; // End of populateSettingsUnprotectedDesklets
 
   populateSettingsUnprotectedExtensions() {
+    let type = "extensions";
     if (this.OKtoPopulateSettingsExtensions === true) {
       this.OKtoPopulateSettingsExtensions = false;
       this.unprotectedExtensionsDico = {};
       this.unprotectedExtensionsList = [];
       // populate this.unprotectedExtensions with the this.unprotected_extensions elements:
-      let a, d;
       for (var i=0; i < this.unprotected_extensions.length; i++) {
-        a = this.unprotected_extensions[i];
-        d = Gio.file_new_for_path("%s/%s".format(DIR_MAP["extensions"], a["name"]));
+        let a = this.unprotected_extensions[i];
+        let d = Gio.file_new_for_path("%s/%s".format(DIR_MAP[type], a["name"]));
         if (d.query_exists(null)) {
           this.unprotectedExtensionsDico[a["name"]] = a["isunprotected"];
-          this.unprotectedExtensionsList.push({"name": a["name"], "isunprotected": a["isunprotected"]});
+          if (a["isunprotected"] && a["requestnewdownload"] !== undefined && a["requestnewdownload"] === true) {
+            if (this.cache[type] === "{}") this._load_cache(type);
+            let created = this._get_member_from_cache(type, a["name"], "created");
+            let last_edited = this._get_last_edited_from_cache(type, a["name"]);
+            if (created !== null && last_edited !== null && created >= last_edited) created = last_edited - 1;
+            let metadataFileName = DIR_MAP[type] + "/" + a["name"] + "/metadata.json";
+            if (created !== null) this._rewrite_metadataFile(metadataFileName, created);
+          }
+          this.unprotectedExtensionsList.push({"name": a["name"], "isunprotected": a["isunprotected"], "requestnewdownload": false});
         }
       }
 
       // Are there new extensions installed? If there are, then push them in this.unprotectedExtensions:
-      let dir = Gio.file_new_for_path(DIR_MAP["extensions"]);
+      let dir = Gio.file_new_for_path(DIR_MAP[type]);
       if (dir.query_exists(null)) {
         let children = dir.enumerate_children('standard::name,standard::type', Gio.FileQueryInfoFlags.NONE, null);
-        let info, type;
+        let info, file_type;
         var name;
         while ((info = children.next_file(null)) != null) {
-          type = info.get_file_type();
-          if (type == Gio.FileType.DIRECTORY) {
+          file_type = info.get_file_type();
+          if (file_type == Gio.FileType.DIRECTORY) {
             name = info.get_name().toString();
             if (this.unprotectedExtensionsDico[name] === undefined) {
-              this.unprotectedExtensionsList.push({"name": name, "isunprotected": true});
+              this.unprotectedExtensionsList.push({"name": name, "isunprotected": true, "requestnewdownload": false});
               this.unprotectedExtensionsDico[name] = {"name": name, "isunprotected": true};
             }
           }
@@ -783,6 +838,7 @@ class SpicesUpdate extends Applet.TextIconApplet {
   }; // End of populateSettingsUnprotectedExtensions
 
   populateSettingsUnprotectedThemes() {
+    let type = "themes";
     if (this.OKtoPopulateSettingsThemes === true) {
       this.OKtoPopulateSettingsThemes = false;
       this.unprotectedThemesDico = {};
@@ -791,25 +847,33 @@ class SpicesUpdate extends Applet.TextIconApplet {
       let a, d;
       for (var i=0; i < this.unprotected_themes.length; i++) {
         a = this.unprotected_themes[i];
-        d = Gio.file_new_for_path("%s/%s".format(DIR_MAP["themes"], a["name"]));
+        d = Gio.file_new_for_path("%s/%s".format(DIR_MAP[type], a["name"]));
         if (d.query_exists(null)) {
           this.unprotectedThemesDico[a["name"]] = a["isunprotected"];
-          this.unprotectedThemesList.push({"name": a["name"], "isunprotected": a["isunprotected"]});
+          if (a["isunprotected"] && a["requestnewdownload"] !== undefined && a["requestnewdownload"] === true) {
+            if (this.cache[type] === "{}") this._load_cache(type);
+            let created = this._get_member_from_cache(type, a["name"], "created");
+            let last_edited = this._get_last_edited_from_cache(type, a["name"]);
+            if (created !== null && last_edited !== null && created >= last_edited) created = last_edited - 1;
+            let metadataFileName = DIR_MAP[type] + "/" + a["name"] + "/metadata.json";
+            if (created !== null) this._rewrite_metadataFile(metadataFileName, created);
+          }
+          this.unprotectedThemesList.push({"name": a["name"], "isunprotected": a["isunprotected"], "requestnewdownload": false});
         }
       }
 
       // Are there new themes installed? If there are, then push them in this.unprotectedThemes:
-      let dir = Gio.file_new_for_path(DIR_MAP["themes"]);
+      let dir = Gio.file_new_for_path(DIR_MAP[type]);
       if (dir.query_exists(null)) {
         let children = dir.enumerate_children('standard::name,standard::type', Gio.FileQueryInfoFlags.NONE, null);
-        let info, type;
+        let info, file_type;
         var name;
         while ((info = children.next_file(null)) != null) {
-          type = info.get_file_type();
-          if (type == Gio.FileType.DIRECTORY) {
+          file_type = info.get_file_type();
+          if (file_type == Gio.FileType.DIRECTORY) {
             name = info.get_name().toString();
             if (this.unprotectedThemesDico[name] === undefined) {
-              this.unprotectedThemesList.push({"name": name, "isunprotected": true});
+              this.unprotectedThemesList.push({"name": name, "isunprotected": true, "requestnewdownload": false});
               this.unprotectedThemesDico[name] = {"name": name, "isunprotected": true};
             }
           }
@@ -1208,7 +1272,7 @@ class SpicesUpdate extends Applet.TextIconApplet {
                   ret.push("%s (%s)\n\t\t%s".format(_(this.get_spice_name(type, uuid)), uuid, _("(Description unavailable)")));
                 }
               } else {
-                this.refreshInterval = 15; // Wait 15 more seconds to avoid the message "(Refresh to see the description)".
+                this.refreshInterval = DOWNLOAD_TIME; // Wait DOWNLOAD_TIME more seconds to avoid the message "(Refresh to see the description)".
                 //ret.push("%s (%s)\n\t\t%s".format(_(this.get_spice_name(type, uuid)), uuid, _("(Refresh to see the description)")));
               }
             } else {
@@ -1345,9 +1409,13 @@ class SpicesUpdate extends Applet.TextIconApplet {
   }; // End of get_active_spices
 
   get_default_icon_color() {
-    let themeNode = this.actor.get_theme_node(); // get_theme_node() fails in constructor! (cause: widget not on stage)
-    let icon_color = themeNode.get_icon_colors();
-    this.defaultColor = icon_color.foreground.to_string();
+    try {
+      let themeNode = this.actor.get_theme_node(); // get_theme_node() fails in constructor! (cause: widget not on stage)
+      let icon_color = themeNode.get_icon_colors();
+      this.defaultColor = icon_color.foreground.to_string();
+    } catch(e) {
+      this.defaultColor = "white";
+    }
   }; // End of get_default_icon_color
 
   makeMenu() {
@@ -1417,6 +1485,7 @@ class SpicesUpdate extends Applet.TextIconApplet {
 
   _on_refresh_pressed() {
     this.first_loop = false;
+    this.refresh_requested = true;
     this.updateLoop();
   }; // End of _on_refresh_pressed
 
@@ -1444,10 +1513,22 @@ class SpicesUpdate extends Applet.TextIconApplet {
     return ret;
   }; // End of _clean_str
 
-  // This updates the display of the applet and the tooltip
-  updateUI() {
-    this.get_default_icon_color();
-    this._applet_icon.style = "color: %s;".format(this.defaultColor);
+  darken_color(str_color) {
+    let c = Clutter.Color.from_string(str_color)[1];
+    let lc = c.darken();
+    return lc.to_string().substr(0,7);
+  }
+
+  set_icon_color() {
+    if (this.refresh_requested) {
+      //this._applet_icon.style = "color: %s;".format("lightgray");
+      this._applet_icon.style = "color: %s;".format(this.darken_color(this.defaultColor));
+      this.refreshInterval = DOWNLOAD_TIME;
+    } else {
+      this.get_default_icon_color();
+      this._applet_icon.style = "color: %s;".format(this.defaultColor);
+    }
+    this.refresh_requested = false;
     if (this.general_warning === true) {
       for (let t of TYPES) {
         if (this.menuDots[t] === true) {
@@ -1456,6 +1537,11 @@ class SpicesUpdate extends Applet.TextIconApplet {
         }
       }
     }
+  }; // End of set_icon_color
+
+  // This updates the display of the applet and the tooltip
+  updateUI() {
+    this.set_icon_color();
     if (this.nb_to_update > 0 || this.nb_to_watch > 0) {
       var _tooltip = this.default_tooltip;
       for (let type of TYPES) {

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/4.2/constants.js
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/4.2/constants.js
@@ -18,6 +18,8 @@ function DEBUG() {
   return _debug.query_exists(null);
 };
 
+const DOWNLOAD_TIME = 1;
+
 const APPLET_DIR = HOME_DIR + "/.local/share/cinnamon/applets/" + UUID;
 const SCRIPTS_DIR = APPLET_DIR + "/scripts";
 const ICONS_DIR = APPLET_DIR + "/icons";
@@ -121,6 +123,22 @@ bidon = _("New extensions available:");
 bidon = _("New themes available:");
 bidon = null;
 
+const EXP1 = {
+  "applets": _("If you do not want an applet to be checked, uncheck its first box."),
+  "desklets": _("If you do not want a desklet to be checked, uncheck its first box."),
+  "extensions": _("If you do not want an extension to be checked, uncheck its first box."),
+  "themes": _("If you do not want a theme to be checked, uncheck its first box.")
+}
+
+const EXP2 = {
+  "applets": _("If you want to renew the download of an applet, check both boxes."),
+  "desklets": _("If you want to renew the download of a desklet, check both boxes."),
+  "extensions": _("If you want to renew the download of an extension, check both boxes."),
+  "themes": _("If you want to renew the download of a theme, check both boxes.")
+}
+
+const EXP3 = _("When all your choices are made, click the Refresh button.");
+
 module.exports = {
   UUID,
   HOME_DIR,
@@ -138,7 +156,9 @@ module.exports = {
   CACHE_MAP,
   DIR_MAP,
   DCONFCACHEUPDATED,
+  DOWNLOAD_TIME,
   _,
+  EXP1, EXP2, EXP3,
   DEBUG,
   capitalize,
   log,

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/4.2/constants.js
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/4.2/constants.js
@@ -18,7 +18,7 @@ function DEBUG() {
   return _debug.query_exists(null);
 };
 
-const DOWNLOAD_TIME = 1;
+const DOWNLOAD_TIME = 2;
 
 const APPLET_DIR = HOME_DIR + "/.local/share/cinnamon/applets/" + UUID;
 const SCRIPTS_DIR = APPLET_DIR + "/scripts";

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/4.2/settings-schema.json
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/4.2/settings-schema.json
@@ -1,102 +1,173 @@
 {
   "layout": {
     "type": "layout",
-    "pages": ["General", "Applets", "Desklets", "Extensions", "Themes"],
+    "pages": [
+      "General",
+      "Applets",
+      "Desklets",
+      "Extensions",
+      "Themes"
+    ],
     "Applets": {
       "type": "page",
       "title": "Applets",
-      "sections": ["section_applets1", "section_applets2"]
+      "sections": [
+        "section_applets1",
+        "section_applets2"
+      ]
     },
     "Desklets": {
       "type": "page",
       "title": "Desklets",
-      "sections": ["section_desklets1", "section_desklets2"]
+      "sections": [
+        "section_desklets1",
+        "section_desklets2"
+      ]
     },
     "Extensions": {
       "type": "page",
       "title": "Extensions",
-      "sections": ["section_extensions1", "section_extensions2"]
+      "sections": [
+        "section_extensions1",
+        "section_extensions2"
+      ]
     },
     "Themes": {
       "type": "page",
       "title": "Themes",
-      "sections": ["section_themes1", "section_themes2"]
+      "sections": [
+        "section_themes1",
+        "section_themes2"
+      ]
     },
     "General": {
       "type": "page",
       "title": "General",
-      "sections": ["section_general1", "section_general2", "section_general3"]
+      "sections": [
+        "section_general1",
+        "section_general2",
+        "section_general3"
+      ]
     },
     "section_applets1": {
       "type": "section",
       "title": "Checking",
-      "keys": ["check_applets", "check_new_applets"]
+      "keys": [
+        "check_applets",
+        "check_new_applets"
+      ]
     },
     "section_applets2": {
       "type": "section",
       "title": "Monitoring",
-      "keys": ["btn_refresh_applets", "unprotected_applets", "btn_cs_applets"]
+      "keys": [
+        "exp_applets",
+        "btn_refresh_applets",
+        "unprotected_applets",
+        "btn_cs_applets"
+      ]
     },
     "section_desklets1": {
       "type": "section",
       "title": "Checking",
-      "keys": ["check_desklets", "check_new_desklets"]
+      "keys": [
+        "check_desklets",
+        "check_new_desklets"
+      ]
     },
     "section_desklets2": {
       "type": "section",
       "title": "Monitoring",
-      "keys": ["btn_refresh_desklets","unprotected_desklets", "btn_cs_desklets"]
+      "keys": [
+        "exp_desklets",
+        "btn_refresh_desklets",
+        "unprotected_desklets",
+        "btn_cs_desklets"
+      ]
     },
     "section_extensions1": {
       "type": "section",
       "title": "Checking",
-      "keys": ["check_extensions", "check_new_extensions"]
+      "keys": [
+        "check_extensions",
+        "check_new_extensions"
+      ]
     },
     "section_extensions2": {
       "type": "section",
       "title": "Monitoring",
-      "keys": ["btn_refresh_extensions", "unprotected_extensions", "btn_cs_extensions"]
+      "keys": [
+        "exp_extensions",
+        "btn_refresh_extensions",
+        "unprotected_extensions",
+        "btn_cs_extensions"
+      ]
     },
     "section_themes1": {
       "type": "section",
       "title": "Checking",
-      "keys": ["check_themes", "check_new_themes"]
+      "keys": [
+        "check_themes",
+        "check_new_themes"
+      ]
     },
     "section_themes2": {
       "type": "section",
       "title": "Monitoring",
-      "keys": ["btn_refresh_themes", "unprotected_themes", "btn_cs_themes"]
+      "keys": [
+        "exp_themes",
+        "btn_refresh_themes",
+        "unprotected_themes",
+        "btn_cs_themes"
+      ]
     },
     "section_general1": {
       "type": "section",
       "title": "Frequency",
-      "keys": ["general_frequency"]
+      "keys": [
+        "general_frequency"
+      ]
     },
     "section_general2": {
       "type": "section",
       "title": "Notifications",
-      "keys": ["general_warning", "events_color", "general_notifications", "general_details_requested", "general_force_notifications", "general_type_notif", "general_test_notif"]
+      "keys": [
+        "general_warning",
+        "events_color",
+        "general_notifications",
+        "general_details_requested",
+        "general_force_notifications",
+        "general_type_notif",
+        "general_test_notif"
+      ]
     },
     "section_general3": {
       "type": "section",
       "title": "Display type",
-      "keys": ["displayType", "general_hide"]
+      "keys": [
+        "displayType",
+        "general_hide"
+      ]
     }
   },
   "check_applets": {
-    "type": "checkbox",
-    "indent": true,
+    "type": "switch",
     "default": true,
     "description": "Let regularly check if your applets are up to date",
     "tooltip": "If applets updates do not concern you, uncheck this box."
   },
   "check_new_applets": {
-    "type": "checkbox",
-    "indent": true,
+    "type": "switch",
     "default": true,
     "dependency": "check_applets",
     "description": "Let regularly check if new applets are available",
     "tooltip": "If new applets do not concern you, uncheck this box."
+  },
+  "exp_applets": {
+    "type" : "textview",
+    "default": "",
+    "description": "",
+    "height": 60
   },
   "btn_refresh_applets": {
     "type": "button",
@@ -106,19 +177,24 @@
   "unprotected_applets": {
     "type": "list",
     "description": "Update these applets:",
-    "tooltip": "If you do not want an applet to be checked, set it to FALSE.",
     "columns": [
-            {
-                "id": "name",
-                "title": "Your Applets",
-                "type": "string"
-            },
-            {
-                "id": "isunprotected",
-                "title": "Check for updates?",
-                "align": 0.5,
-                "type": "boolean"
-            }
+      {
+        "id": "name",
+        "title": "Your Applets",
+        "type": "string"
+      },
+      {
+        "id": "isunprotected",
+        "title": "Check for updates?",
+        "align": 0.5,
+        "type": "boolean"
+      },
+      {
+        "id": "requestnewdownload",
+        "title": "Renew last download",
+        "align": 0.5,
+        "type": "boolean"
+      }
     ],
     "default": []
   },
@@ -127,21 +203,24 @@
     "description": "Open Cinnamon Settings to manage all the Applets",
     "callback": "on_btn_cs_applets_pressed"
   },
-
   "check_desklets": {
-    "type": "checkbox",
-    "indent": true,
+    "type": "switch",
     "default": true,
     "description": "Let regularly check if your desklets are up to date",
     "tooltip": "If desklets updates do not concern you, uncheck this box."
   },
   "check_new_desklets": {
-    "type": "checkbox",
-    "indent": true,
+    "type": "switch",
     "default": true,
     "dependency": "check_desklets",
     "description": "Let regularly check if new desklets are available",
     "tooltip": "If new desklets do not concern you, uncheck this box."
+  },
+  "exp_desklets": {
+    "type" : "textview",
+    "default": "",
+    "description": "",
+    "height": 60
   },
   "btn_refresh_desklets": {
     "type": "button",
@@ -151,18 +230,24 @@
   "unprotected_desklets": {
     "type": "list",
     "description": "Update these desklets:",
-    "tooltip": "If you do not want a desklet to be checked, set it to FALSE.",
     "columns": [
-            {
-                "id": "name",
-                "title": "Your Desklets",
-                "type": "string"
-            },
-            {
-                "id": "isunprotected",
-                "title": "Check for updates?",
-                "type": "boolean"
-            }
+      {
+        "id": "name",
+        "title": "Your Desklets",
+        "type": "string"
+      },
+      {
+        "id": "isunprotected",
+        "title": "Check for updates?",
+        "align": 0.5,
+        "type": "boolean"
+      },
+      {
+        "id": "requestnewdownload",
+        "title": "Renew last download",
+        "align": 0.5,
+        "type": "boolean"
+      }
     ],
     "default": []
   },
@@ -171,21 +256,24 @@
     "description": "Open Cinnamon Settings to manage all the Desklets",
     "callback": "on_btn_cs_desklets_pressed"
   },
-
   "check_extensions": {
-    "type": "checkbox",
-    "indent": true,
+    "type": "switch",
     "default": true,
     "description": "Let regularly check if your extensions are up to date",
     "tooltip": "If extensions updates do not concern you, uncheck this box."
   },
   "check_new_extensions": {
-    "type": "checkbox",
-    "indent": true,
+    "type": "switch",
     "default": true,
     "dependency": "check_extensions",
     "description": "Let regularly check if new extensions are available",
     "tooltip": "If new extensions do not concern you, uncheck this box."
+  },
+  "exp_extensions": {
+    "type" : "textview",
+    "default": "",
+    "description": "",
+    "height": 60
   },
   "btn_refresh_extensions": {
     "type": "button",
@@ -195,18 +283,24 @@
   "unprotected_extensions": {
     "type": "list",
     "description": "Update these extensions:",
-    "tooltip": "If you do not want an extension to be checked, set it to FALSE.",
     "columns": [
-            {
-                "id": "name",
-                "title": "Your Extensions",
-                "type": "string"
-            },
-            {
-                "id": "isunprotected",
-                "title": "Check for updates?",
-                "type": "boolean"
-            }
+      {
+        "id": "name",
+        "title": "Your Extensions",
+        "type": "string"
+      },
+      {
+        "id": "isunprotected",
+        "title": "Check for updates?",
+        "align": 0.5,
+        "type": "boolean"
+      },
+      {
+        "id": "requestnewdownload",
+        "title": "Renew last download",
+        "align": 0.5,
+        "type": "boolean"
+      }
     ],
     "default": []
   },
@@ -215,21 +309,24 @@
     "description": "Open Cinnamon Settings to manage all the Extensions",
     "callback": "on_btn_cs_extensions_pressed"
   },
-
   "check_themes": {
-    "type": "checkbox",
-    "indent": true,
+    "type": "switch",
     "default": true,
     "description": "Let regularly check if your themes are up to date",
     "tooltip": "If themes updates do not concern you, uncheck this box."
   },
   "check_new_themes": {
-    "type": "checkbox",
-    "indent": true,
+    "type": "switch",
     "default": true,
     "dependency": "check_themes",
     "description": "Let regularly check if new themes are available",
     "tooltip": "If new themes do not concern you, uncheck this box."
+  },
+  "exp_themes": {
+    "type" : "textview",
+    "default": "",
+    "description": "",
+    "height": 60
   },
   "btn_refresh_themes": {
     "type": "button",
@@ -239,18 +336,24 @@
   "unprotected_themes": {
     "type": "list",
     "description": "Update these themes:",
-    "tooltip": "If you do not want a theme to be checked, set it to FALSE.",
     "columns": [
-            {
-                "id": "name",
-                "title": "Your Themes",
-                "type": "string"
-            },
-            {
-                "id": "isunprotected",
-                "title": "Check for updates?",
-                "type": "boolean"
-            }
+      {
+        "id": "name",
+        "title": "Your Themes",
+        "type": "string"
+      },
+      {
+        "id": "isunprotected",
+        "title": "Check for updates?",
+        "align": 0.5,
+        "type": "boolean"
+      },
+      {
+        "id": "requestnewdownload",
+        "title": "Renew last download",
+        "align": 0.5,
+        "type": "boolean"
+      }
     ],
     "default": []
   },
@@ -259,7 +362,6 @@
     "description": "Open Cinnamon Settings to manage all the Themes",
     "callback": "on_btn_cs_themes_pressed"
   },
-
   "general_frequency": {
     "type": "spinbutton",
     "default": 1,
@@ -271,38 +373,33 @@
     "tooltip": "Please note that the first check will take place one minute after starting this applet."
   },
   "general_warning": {
-    "type": "checkbox",
-    "indent": true,
+    "type": "switch",
     "default": true,
     "description": "Notify me by changing the icon when Spices need an update",
     "tooltip": "By checking this box, you allow this applet to modify its icon to warn you when at least one of the Spices requires an update."
   },
-  "events_color" : {
+  "events_color": {
     "type": "colorchooser",
-    "indent": true,
-    "default" : "#eb9122",
+    "default": "#eb9122",
     "dependency": "general_warning",
-    "description" : "The icon color when Spices need an update",
-    "tooltip" : "Click the button to select another color."
+    "description": "The icon color when Spices need an update",
+    "tooltip": "Click the button to select another color."
   },
   "general_notifications": {
-    "type": "checkbox",
-    "indent": true,
+    "type": "switch",
     "default": true,
     "description": "Show notification messages about Spices updates",
     "tooltip": "By checking this box, you allow this applet to display messages about Spices updates in notifications viewer."
   },
   "general_details_requested": {
-    "type": "checkbox",
-    "indent": true,
+    "type": "switch",
     "default": false,
     "dependency": "general_notifications",
     "description": "Display the description of each update or new Spice",
     "tooltip": "By checking this box, you'll know why an update is available, and get a description of any new Spice.\nThis information will be displayed in English."
   },
   "general_force_notifications": {
-    "type": "checkbox",
-    "indent": true,
+    "type": "switch",
     "default": false,
     "dependency": "general_notifications",
     "description": "Show notification messages even if they are unchanged",
@@ -314,7 +411,7 @@
     "options": {
       "Minimal (text only)": "minimal",
       "With button opening the System Settings": "button"
-     },
+    },
     "dependency": "general_notifications",
     "description": "Notification style",
     "tooltip": "Minimal:\n\tDisplays simple and short notifications.\nWith button opening the System Settings:\n\tNotifications also contain a button which has the same role of the menu one:\n\tOpen the Download tab in System Settings for the concerned type of Spices, with the Spices sorted by date."
@@ -331,13 +428,12 @@
     "options": {
       "Classic - Icon and Text": "classic",
       "Compact - Icon Only": "compact"
-     },
+    },
     "description": "Type of Display",
     "tooltip": "This feature offers the Classic (default) display with icon and text, and compact display (Icon Only)."
   },
   "general_hide": {
-    "type": "checkbox",
-    "indent": true,
+    "type": "switch",
     "default": false,
     "description": "Hide the icon as long as nothing is to report",
     "tooltip": "By checking this box, as long as nothing is to report the icon of Spices Update does not appear on the panel."

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,7 +1,9 @@
+### v4.2.0~20190927
+  * Animated icon during refresh.
+    * Only for Cinnamon 4.2 and following.
+
 ### v4.1.0~20190925
   * Adds the ability to renew the download of the latest version of a Spice.
-    * Only for Cinnamon 4.2 and following.
-  * Animated icon during refresh.
     * Only for Cinnamon 4.2 and following.
   * `SpicesUpdate@claudiux.pot` file updated.
   * French translation: `fr.po` file updated.

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,3 +1,10 @@
+### v4.1.0~20190925
+  * Adds the ability to renew the download of the latest version of a Spice.
+    * Only for Cinnamon 4.2 and following.
+  * `SpicesUpdate@claudiux.pot` file updated.
+  * French translation: `fr.po` file updated.
+  * Minor bugs fixed.
+
 ### v4.0.2~20190920
   * Removes unnecessary notifications like '(Refresh to see the description)'.
   * Minor CSS changes.

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### v4.1.0~20190925
   * Adds the ability to renew the download of the latest version of a Spice.
     * Only for Cinnamon 4.2 and following.
+  * Animated icon during refresh.
+    * Only for Cinnamon 4.2 and following.
   * `SpicesUpdate@claudiux.pot` file updated.
   * French translation: `fr.po` file updated.
   * Minor bugs fixed.

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/en/README.html
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/en/README.html
@@ -49,6 +49,7 @@
 <li>It warns you when the Spices you have installed need updates.</li>
 <li>Optional: It can also warn you when new Spices are available.</li>
 <li>It gives you direct access to Cinnamon Settings for Applets, Desklets, Extensions and Themes.</li>
+<li>It allows you to renew the download of the latest version of a Spice (only with Cinnamon 4.2 and following).</li>
 </ul>
 <h2>
 <a id="user-content-status" class="anchor" href="#status" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Status</h2>
@@ -105,11 +106,12 @@
 </ul>
 <p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/System_Settings_Applets.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/System_Settings_Applets.png" alt="system_settings_applet" style="max-width:100%;"></a></p>
 <p>For the content of the other tabs (<em>Applets</em>, <em>Desklets</em>, etc), please look at the screenshot above and note that <strong>the list of installed Spices is automatically filled</strong> at startup, but a button allows you to reload it.</p>
-<p>Set to <em>FALSE</em> all the Spices you <em>do not want</em> to check updates. There are two reasons to do this:</p>
+<p>Set to <em>FALSE</em> (or uncheck the first box of) all the Spices you <em>do not want</em> to check updates. There are two reasons to do this:</p>
 <ul>
 <li>A spice is OK for you, and you do not want to be notified of any changes to it.</li>
 <li>You are a developer working on a spice and you do not want to be informed about changes during development.</li>
 </ul>
+<p>From Cinnamon 4.2, you can request to renew the download of the latest version of a Spice checking both boxes then clicking the Refresh button.</p>
 <h2>
 <a id="user-content-menu" class="anchor" href="#menu" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Menu</h2>
 <p>In the menu of this applet:</p>
@@ -123,6 +125,7 @@
 <h2>
 <a id="user-content-icon" class="anchor" href="#icon" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Icon</h2>
 <p>The color of the icon changes when at least one of your Spices needs an update.</p>
+<p>From Cinnamon 4.2 (and Spices Update v4.1.0), the color of the icon darkens while data are being refreshed.</p>
 <p>Its tooltip (the message displayed when the icon is hovered) contains the list of spices to update, if any.</p>
 <p><a href="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/hovering_icon.png" target="_blank" rel="noopener noreferrer"><img src="https://github.com/claudiux/docs/raw/master/SpicesUpdate/images/hovering_icon.png" alt="hovering_icon" style="max-width:100%;"></a></p>
 <h2>
@@ -158,9 +161,12 @@
 <li>Create an account on <a href="https://github.com/">Github</a>.</li>
 <li>Fork the <a href="https://github.com/linuxmint/cinnamon-spices-applets">cinnamon-spices-applets</a> repository.</li>
 <li>In your fork, create a branch (named like <code>SpicesUpdate-YOUR_LANGUAGE_CODE</code>) from the master one.</li>
-<li>On your computer, install git and poedit.</li>
-<li>Clone your branch on your computer: <code>git clone -b SpicesUpdate-YOUR_LANGUAGE_CODE --single-branch https://github.com/YOUR_GITHUB_ACCOUNT/cinnamon-spices-applets.git SpicesUpdate-YOUR_LANGUAGE_CODE</code>
-</li>
+<li>On your computer, install <em>git</em> and <em>poedit</em>.</li>
+<li>Clone your branch on your computer:</li>
+</ol>
+<pre><code>`git clone -b SpicesUpdate-YOUR_LANGUAGE_CODE --single-branch https://github.com/YOUR_GITHUB_ACCOUNT/cinnamon-spices-applets.git SpicesUpdate-YOUR_LANGUAGE_CODE`
+</code></pre>
+<ol start="6">
 <li>Open the <code>SpicesUpdate@claudiux.pot</code> file (which is in the <code>po</code> directory) with poedit and create your translation. You obtain a YOUR_LANGUAGE_CODE.po file.</li>
 <li>On Github, upload this <code>YOUR_LANGUAGE_CODE.po</code> file at the right place into your branch then go to the root of your branch and make a Pull Request.</li>
 </ol>
@@ -173,7 +179,7 @@
 <a id="user-content-manual-installation" class="anchor" href="#manual-installation" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Manual Installation:</h3>
 <ul>
 <li>Install the additional programs required.</li>
-<li>Download the Spices Update from the <a href="https://cinnamon-spices.linuxmint.com/applets/view/309" rel="nofollow">Spices Web Site</a>.</li>
+<li>Download the <strong><a href="https://cinnamon-spices.linuxmint.com/files/applets/SpicesUpdate@claudiux.zip?3a160f32-a3d6-437f-899e-afba9907e023" rel="nofollow">latest version of Spices Update</a></strong> from the Spices Web Site.</li>
 <li>Unzip and extract the folder <code>SpicesUpdate@claudiux</code> into <code>~/.local/share/cinnamon/applets/</code>
 </li>
 <li>Enable this applet in System Settings -&gt; Applets.</li>

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/en/README.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/en/README.md
@@ -11,6 +11,7 @@ The **Spices Update** applet plays these roles:
   * It warns you when the Spices you have installed need updates.
   * Optional: It can also warn you when new Spices are available.
   * It gives you direct access to Cinnamon Settings for Applets, Desklets, Extensions and Themes.
+  * It allows you to renew the download of the latest version of a Spice (only with Cinnamon 4.2 and following).
 
 ## Status
 
@@ -62,10 +63,12 @@ The first, _General_, allows you to:
 
 For the content of the other tabs (_Applets_, _Desklets_, etc), please look at the screenshot above and note that **the list of installed Spices is automatically filled** at startup, but a button allows you to reload it.
 
-Set to _FALSE_ all the Spices you _do not want_ to check updates. There are two reasons to do this:
+Set to _FALSE_ (or uncheck the first box of) all the Spices you _do not want_ to check updates. There are two reasons to do this:
 
   * A spice is OK for you, and you do not want to be notified of any changes to it.
   * You are a developer working on a spice and you do not want to be informed about changes during development.
+
+From Cinnamon 4.2, you can request to renew the download of the latest version of a Spice checking both boxes then clicking the Refresh button.
 
 ## Menu
 
@@ -80,6 +83,8 @@ In the menu of this applet:
 ## Icon
 
 The color of the icon changes when at least one of your Spices needs an update.
+
+From Cinnamon 4.2 (and Spices Update v4.1.0), the color of the icon darkens while data are being refreshed.
 
 Its tooltip (the message displayed when the icon is hovered) contains the list of spices to update, if any.
 
@@ -119,8 +124,10 @@ Many thanks to them!
   1. Create an account on [Github](https://github.com/).
   2. Fork the [cinnamon-spices-applets](https://github.com/linuxmint/cinnamon-spices-applets) repository.
   3. In your fork, create a branch (named like `SpicesUpdate-YOUR_LANGUAGE_CODE`) from the master one.
-  4. On your computer, install git and poedit.
-  5. Clone your branch on your computer: `git clone -b SpicesUpdate-YOUR_LANGUAGE_CODE --single-branch https://github.com/YOUR_GITHUB_ACCOUNT/cinnamon-spices-applets.git SpicesUpdate-YOUR_LANGUAGE_CODE`
+  4. On your computer, install _git_ and _poedit_.
+  5. Clone your branch on your computer:
+
+    `git clone -b SpicesUpdate-YOUR_LANGUAGE_CODE --single-branch https://github.com/YOUR_GITHUB_ACCOUNT/cinnamon-spices-applets.git SpicesUpdate-YOUR_LANGUAGE_CODE`
   6. Open the `SpicesUpdate@claudiux.pot` file (which is in the `po` directory) with poedit and create your translation. You obtain a YOUR_LANGUAGE_CODE.po file.
   7. On Github, upload this `YOUR_LANGUAGE_CODE.po` file at the right place into your branch then go to the root of your branch and make a Pull Request.
 
@@ -133,7 +140,7 @@ Use the _Applets_ menu in Cinnamon Settings, or _Add Applets to Panel_ in the co
 ### Manual Installation:
 
    * Install the additional programs required.
-   * Download the Spices Update from the [Spices Web Site](https://cinnamon-spices.linuxmint.com/applets/view/309).
+   * Download the **[latest version of Spices Update](https://cinnamon-spices.linuxmint.com/files/applets/SpicesUpdate@claudiux.zip?3a160f32-a3d6-437f-899e-afba9907e023)** from the Spices Web Site.
    * Unzip and extract the folder ```SpicesUpdate@claudiux``` into ```~/.local/share/cinnamon/applets/```
    * Enable this applet in System Settings -> Applets.
    * You can also access the Settings Screen from System Settings -> Applets, or from the context menu of this applet (right-clicking on its icon).

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/fr/README.html
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/fr/README.html
@@ -49,7 +49,8 @@
 <ul>
 <li>vous avertit dès lors que des Spices que vous avez installées disposent d'une mise à jour ;</li>
 <li>peut vous avertir, si vous le désirez, lorsque de nouvelles Spices sont disponibles ;</li>
-<li>vous donne un accès direct aux Paramètres système des Applets, Desklets, Extensions et Thèmes.</li>
+<li>vous donne un accès direct aux Paramètres système des Applets, Desklets, Extensions et Thèmes ;</li>
+<li>vous permet de renouveler le téléchargement de la dernière version d'une Spice. (Cinnamon 4.2 et suivants.)</li>
 </ul>
 <h2>
 <a id="user-content-état" class="anchor" href="#%C3%A9tat" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>État</h2>
@@ -112,6 +113,7 @@
 <li>Une Spice vous convient pleinement et vous ne voulez pas être averti d'un quelconque changement la concernant.</li>
 <li>Vous êtes un développeur travaillant sur une Spice et vous ne souhaitez pas être informé de quelque modification que ce soit durant son développement.</li>
 </ul>
+<p>À partir de Cinnamon 4.2, pour re-télécharger la dernière version d'une Spice, cochez ses deux cases.</p>
 <h2>
 <a id="user-content-menu" class="anchor" href="#menu" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Menu</h2>
 <p>Dans le menu de Spices Update (accessible par un clic sur son icône) :</p>
@@ -160,7 +162,7 @@
 <li>Créer un compte dur <a href="https://github.com/">Github</a>.</li>
 <li>Faire un Fork du dépôt <a href="https://github.com/linuxmint/cinnamon-spices-applets">cinnamon-spices-applets</a>.</li>
 <li>Dans votre fork, créer une branche (la nommer comme <code>SpicesUpdate-CODE_LANGUE</code>) à partir de la branche master.</li>
-<li>Sur votre ordinateur, installer git et poedit.</li>
+<li>Sur votre ordinateur, installer <code>git</code> et <code>poedit</code>.</li>
 <li>Cloner votre branche sur votre ordinateur : <code>git clone -b SpicesUpdate-CODE_LANGUE --single-branch https://github.com/VOTRE_COMPTE_GITHUB/cinnamon-spices-applets.git SpicesUpdate-CODE_LANGUE</code>
 </li>
 <li>Ouvrir le fichier <code>SpicesUpdate@claudiux.pot</code> (qui est dans le dossier <code>po</code>) avec poedit et créer votre traduction. Vous obtenez une fichier CODE_LANGUE.po.</li>
@@ -183,7 +185,7 @@
 </ul>
 <h2>
 <a id="user-content-une-étoile-pour-remercier-lauteur" class="anchor" href="#une-%C3%A9toile-pour-remercier-lauteur" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Une Étoile pour remercier l'auteur</h2>
-<p>Si vous appréciez les services rendus par Spices Update, n'offrez ni argent ni café à l'auteur, mais connectez-vous et cliquez sur l'étoile en haut de <a href="https://cinnamon-spices.linuxmint.com/applets/view/309#" rel="nofollow">cette page</a>.</p>
+<p>Si vous appréciez les services rendus par Spices Update, n'offrez ni argent ni café à l'auteur, mais connectez-vous et cliquez sur l'étoile en haut de <a href="https://cinnamon-spices.linuxmint.com/applets/view/309" rel="nofollow">cette page</a>.</p>
 <p>Merci beaucoup.</p>
 
               </article>

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/fr/README.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/help/fr/README.md
@@ -12,7 +12,8 @@ L'applet **Spices Update** :
 
   * vous avertit dès lors que des Spices que vous avez installées disposent d'une mise à jour ;
   * peut vous avertir, si vous le désirez, lorsque de nouvelles Spices sont disponibles ;
-  * vous donne un accès direct aux Paramètres système des Applets, Desklets, Extensions et Thèmes.
+  * vous donne un accès direct aux Paramètres système des Applets, Desklets, Extensions et Thèmes ;
+  * vous permet de renouveler le téléchargement de la dernière version d'une Spice. (Cinnamon 4.2 et suivants.)
 
 ## État
 
@@ -21,6 +22,7 @@ Disponible de Cinnamon 2.8 à Cinnamon 4.2.
 Cette applet est active, c'est-à-dire développée et utilisée par l'auteur sur plusieurs machines fonctionnant sous **Linux Mint**, **Fedora** ou **Archlinux**.
 
 À partir de la version v3.0.0 ~ 20190808:
+
   * Spices Update est compatible avec Cinnamon 2.8 -> 4.2 (Mint 17.3 -> 19.2).
   * De Cinnamon 3.8 à 4.2 (Mint 19 à 19.2): **Parfaitement fonctionnel, comme d'habitude.**
   * De Cinnamon 2.8 à 3.6 (Mint 17.3 à 18.3): certaines fonctionnalités sont réduites:
@@ -70,6 +72,8 @@ Réglez sur _FALSE_ (ou décochez à partir de Cinnamon 4.2) toutes les Spices d
 
   * Une Spice vous convient pleinement et vous ne voulez pas être averti d'un quelconque changement la concernant.
   * Vous êtes un développeur travaillant sur une Spice et vous ne souhaitez pas être informé de quelque modification que ce soit durant son développement.
+
+À partir de Cinnamon 4.2, pour re-télécharger la dernière version d'une Spice, cochez ses deux cases.
 
 ## Menu
 
@@ -124,7 +128,7 @@ Un grand merci à eux !
   1. Créer un compte dur [Github](https://github.com/).
   2. Faire un Fork du dépôt [cinnamon-spices-applets](https://github.com/linuxmint/cinnamon-spices-applets).
   3. Dans votre fork, créer une branche (la nommer comme `SpicesUpdate-CODE_LANGUE`) à partir de la branche master.
-  4. Sur votre ordinateur, installer git et poedit.
+  4. Sur votre ordinateur, installer `git` et `poedit`.
   5. Cloner votre branche sur votre ordinateur : `git clone -b SpicesUpdate-CODE_LANGUE --single-branch https://github.com/VOTRE_COMPTE_GITHUB/cinnamon-spices-applets.git SpicesUpdate-CODE_LANGUE`
   6. Ouvrir le fichier `SpicesUpdate@claudiux.pot` (qui est dans le dossier `po`) avec poedit et créer votre traduction. Vous obtenez une fichier CODE_LANGUE.po.
   7. Sur Github, envoyer le fichier `CODE_LANGUE.po` au bon endroit dans votre branche puis aller à la racine de votre branche et faire un Pull Request.
@@ -145,6 +149,6 @@ Utilisez le menu _Applets_ dans les Paramètres système de Cinnamon ou _Ajouter
 
 ## Une Étoile pour remercier l'auteur
 
-Si vous appréciez les services rendus par Spices Update, n'offrez ni argent ni café à l'auteur, mais connectez-vous et cliquez sur l'étoile en haut de [cette page](https://cinnamon-spices.linuxmint.com/applets/view/309#).
+Si vous appréciez les services rendus par Spices Update, n'offrez ni argent ni café à l'auteur, mais connectez-vous et cliquez sur l'étoile en haut de [cette page](https://cinnamon-spices.linuxmint.com/applets/view/309).
 
 Merci beaucoup.

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/icons/spices-update-anim-symbolic.svg
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/icons/spices-update-anim-symbolic.svg
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   x="0px"
+   y="0px"
+   width="23px"
+   height="23px"
+   viewBox="0 0 23 23"
+   enable-background="new 0 0 23 23"
+   xml:space="preserve"
+   id="svg8"><metadata
+     id="metadata14"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs12" /><g
+     id="g38"><path
+       id="XMLID_9_"
+       d="M 12.97495,1.1983968 C 6.6239499,1.1983968 0,5.149 0,11.5 0,17.852 5.149,23 11.5,23 17.852,23 23,17.852 23,11.5 23,5.149 19.32695,1.1983968 12.97495,1.1983968 Z m -1.981964,0.2094345 c 5.269,0 10.046076,4.8231687 10.046076,10.0921687 0,0.810396 -0.110551,1.59242 -0.300781,2.34375 l -4.537109,-5.0429688 -5.800781,6.5996098 2.798828,-5.5996098 -1.398438,-2.5 -8.2460935,9.4765628 C 2.5486997,15.265661 1.9609375,13.451673 1.9609375,11.5 c 0,-5.269 3.7630485,-10.0921687 9.0320485,-10.0921687 z"
+       style="fill:#bebebe;fill-opacity:1" /><path
+       style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:#bebebe;stroke-width:0.30000001;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+       id="path816"
+       d="M 5.1623247,6.9599193 C 5.085604,6.9695094 3.5612436,5.039852 3.5145779,4.978205 3.4679123,4.916558 2.0244754,2.9256432 2.0545305,2.8544061 2.0845856,2.783169 4.5178981,2.4278627 4.5946188,2.4182727 4.6713395,2.4086826 7.1172408,2.1540869 7.1639064,2.215734 7.210572,2.277381 6.3016199,4.5623446 6.2715648,4.6335817 6.2415097,4.7048188 5.2390454,6.9503292 5.1623247,6.9599193 Z"
+       transform="matrix(1.4934177,0,0,1.511547,-2.0903237,-1.606652)" /><animateTransform attributeName="transform"
+                          attributeType="XML"
+                          type="rotate"
+                          from="0 11.5 11.5"
+                          to="360 11.5 11.5"
+                          dur="3s"
+                          repeatCount="indefinite"/></g></svg>

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/metadata.json
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/metadata.json
@@ -3,7 +3,7 @@
   "name": "Spices Update",
   "max-instances": "1",
   "hide-configuration": false,
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "Warns you when installed Spices (applets, desklets, extensions, themes) require an update or new Spices are available.",
   "multiversion": true,
   "cinnamon-version": [

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/metadata.json
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/metadata.json
@@ -3,7 +3,7 @@
   "name": "Spices Update",
   "max-instances": "1",
   "hide-configuration": false,
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Warns you when installed Spices (applets, desklets, extensions, themes) require an update or new Spices are available.",
   "multiversion": true,
   "cinnamon-version": [


### PR DESCRIPTION
Hi @brownsr,

Now this applet allows users to renew the download of the latest version of a Spice (only with Cinnamon 4.2 and following).

EDIT: Now, the icon of this applet is animated during refresh.

Minor bugs have been fixed.

The .pot, fr.po and help files have been updated.

Can you merge this branch with your master one, please?

Best regards.
Claudiux