### PR TITLE
Fix percentage not updating after hibernation

### DIFF
--- a/cpu-monitor-text@gnemonix/files/cpu-monitor-text@gnemonix/applet.js
+++ b/cpu-monitor-text@gnemonix/files/cpu-monitor-text@gnemonix/applet.js
@@ -90,9 +90,9 @@ MyApplet.prototype = {
 			this.usage = Math.round((this.current - this.last) / delta);
 			this.last = this.current;
 
-			this.last_total = this.gtop.total;
 		}
 
+		this.last_total = this.gtop.total;
 		let percent = Math.round(this.max_percentage - this.usage);
 		this.set_applet_label(this.cpu_label + " " + this._pad(percent) + "%");
 	},


### PR DESCRIPTION
After hibernating gtop resets its counter causing the delta to be negative for quite some while. Instead we update the last total on every iteration.
This fixes the cpu percentage not updating for a long time after hibernation.
This is in relation to issue #1744 