### PR TITLE
weather@mockturtl update 2.3.1 - Hotfixes

### DIFF
--- a/weather@mockturtl/files/weather@mockturtl/3.0/applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.0/applet.js
@@ -208,7 +208,7 @@ var WeatherApplet = (function (_super) {
             "unusal payload": _("Service Error"),
         };
         _this.currentLocale = _this.constructJsLocale(GLib.get_language_names()[0]);
-        _this.systemLanguage = _this.currentLocale.split('_')[0];
+        _this.systemLanguage = _this.currentLocale.split('-')[0];
         _this.settings = new Settings.AppletSettings(_this, UUID, instanceId);
         _this.log = new Log(instanceId);
         _this._httpSession.user_agent = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:37.0) Gecko/20100101 Firefox/37.0";

--- a/weather@mockturtl/files/weather@mockturtl/3.0/applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.0/applet.js
@@ -12,10 +12,11 @@ var __extends = (this && this.__extends) || (function () {
     };
 })();
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -120,26 +121,25 @@ var DATA_SERVICE = {
 };
 var WEATHER_LOCATION = "location";
 var WEATHER_USE_SYMBOLIC_ICONS_KEY = 'useSymbolicIcons';
-var KEYS;
-(function (KEYS) {
-    KEYS["WEATHER_DATA_SERVICE"] = "dataService";
-    KEYS["WEATHER_API_KEY"] = "apiKey";
-    KEYS["WEATHER_TEMPERATURE_UNIT_KEY"] = "temperatureUnit";
-    KEYS["WEATHER_TEMPERATURE_HIGH_FIRST_KEY"] = "temperatureHighFirst";
-    KEYS["WEATHER_WIND_SPEED_UNIT_KEY"] = "windSpeedUnit";
-    KEYS["WEATHER_CITY_KEY"] = "locationLabelOverride";
-    KEYS["WEATHER_TRANSLATE_CONDITION_KEY"] = "translateCondition";
-    KEYS["WEATHER_VERTICAL_ORIENTATION_KEY"] = "verticalOrientation";
-    KEYS["WEATHER_SHOW_TEXT_IN_PANEL_KEY"] = "showTextInPanel";
-    KEYS["WEATHER_SHOW_COMMENT_IN_PANEL_KEY"] = "showCommentInPanel";
-    KEYS["WEATHER_SHOW_SUNRISE_KEY"] = "showSunrise";
-    KEYS["WEATHER_SHOW_24HOURS_KEY"] = "show24Hours";
-    KEYS["WEATHER_FORECAST_DAYS"] = "forecastDays";
-    KEYS["WEATHER_REFRESH_INTERVAL"] = "refreshInterval";
-    KEYS["WEATHER_PRESSURE_UNIT_KEY"] = "pressureUnit";
-    KEYS["WEATHER_SHORT_CONDITIONS_KEY"] = "shortConditions";
-    KEYS["WEATHER_MANUAL_LOCATION"] = "manualLocation";
-})(KEYS || (KEYS = {}));
+var KEYS = {
+    WEATHER_DATA_SERVICE: "dataService",
+    WEATHER_API_KEY: "apiKey",
+    WEATHER_TEMPERATURE_UNIT_KEY: "temperatureUnit",
+    WEATHER_TEMPERATURE_HIGH_FIRST_KEY: "temperatureHighFirst",
+    WEATHER_WIND_SPEED_UNIT_KEY: "windSpeedUnit",
+    WEATHER_CITY_KEY: "locationLabelOverride",
+    WEATHER_TRANSLATE_CONDITION_KEY: "translateCondition",
+    WEATHER_VERTICAL_ORIENTATION_KEY: "verticalOrientation",
+    WEATHER_SHOW_TEXT_IN_PANEL_KEY: "showTextInPanel",
+    WEATHER_SHOW_COMMENT_IN_PANEL_KEY: "showCommentInPanel",
+    WEATHER_SHOW_SUNRISE_KEY: "showSunrise",
+    WEATHER_SHOW_24HOURS_KEY: "show24Hours",
+    WEATHER_FORECAST_DAYS: "forecastDays",
+    WEATHER_REFRESH_INTERVAL: "refreshInterval",
+    WEATHER_PRESSURE_UNIT_KEY: "pressureUnit",
+    WEATHER_SHORT_CONDITIONS_KEY: "shortConditions",
+    WEATHER_MANUAL_LOCATION: "manualLocation"
+};
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
 function _(str) {
     return Gettext.dgettext(UUID, str);

--- a/weather@mockturtl/files/weather@mockturtl/3.0/darkSky.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.0/darkSky.js
@@ -186,6 +186,7 @@ var DarkSky = (function () {
         if (isCoordinate(location)) {
             query = this.query + key + "/" + location +
                 "?exclude=minutely,hourly,flags" + "&units=" + this.unit;
+            this.app.log.Debug(this.app.systemLanguage);
             if (isLangSupported(this.app.systemLanguage, this.supportedLanguages) && this.app._translateCondition) {
                 query = query + "&lang=" + this.app.systemLanguage;
             }

--- a/weather@mockturtl/files/weather@mockturtl/3.0/darkSky.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.0/darkSky.js
@@ -1,8 +1,9 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -240,7 +241,7 @@ var DarkSky = (function () {
         var processed = summary.split(" ");
         var result = "";
         for (var i = 0; i < 2; i++) {
-            if (!/[\(\)]/.test(processed[i]) && (this.DarkSkyFilterWords.indexOf(processed[i]) != -1)) {
+            if (!/[\(\)]/.test(processed[i]) && !this.WordBanned(processed[i])) {
                 result = result + processed[i] + " ";
             }
         }
@@ -258,6 +259,9 @@ var DarkSky = (function () {
             }
         }
         return result;
+    };
+    DarkSky.prototype.WordBanned = function (word) {
+        return this.DarkSkyFilterWords.indexOf(word) != -1;
     };
     DarkSky.prototype.ResolveIcon = function (icon) {
         switch (icon) {

--- a/weather@mockturtl/files/weather@mockturtl/3.0/ipApi.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.0/ipApi.js
@@ -1,8 +1,9 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };

--- a/weather@mockturtl/files/weather@mockturtl/3.0/openWeatherMap.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.0/openWeatherMap.js
@@ -1,8 +1,9 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };

--- a/weather@mockturtl/files/weather@mockturtl/3.8/applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/applet.js
@@ -158,7 +158,7 @@ class WeatherApplet extends Applet.TextIconApplet {
             "unusal payload": _("Service Error"),
         };
         this.currentLocale = this.constructJsLocale(GLib.get_language_names()[0]);
-        this.systemLanguage = this.currentLocale.split('_')[0];
+        this.systemLanguage = this.currentLocale.split('-')[0];
         this.settings = new Settings.AppletSettings(this, UUID, instanceId);
         this.log = new Log(instanceId);
         this._httpSession.user_agent = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:37.0) Gecko/20100101 Firefox/37.0";

--- a/weather@mockturtl/files/weather@mockturtl/3.8/applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/applet.js
@@ -72,26 +72,25 @@ const DATA_SERVICE = {
 };
 const WEATHER_LOCATION = "location";
 const WEATHER_USE_SYMBOLIC_ICONS_KEY = 'useSymbolicIcons';
-var KEYS;
-(function (KEYS) {
-    KEYS["WEATHER_DATA_SERVICE"] = "dataService";
-    KEYS["WEATHER_API_KEY"] = "apiKey";
-    KEYS["WEATHER_TEMPERATURE_UNIT_KEY"] = "temperatureUnit";
-    KEYS["WEATHER_TEMPERATURE_HIGH_FIRST_KEY"] = "temperatureHighFirst";
-    KEYS["WEATHER_WIND_SPEED_UNIT_KEY"] = "windSpeedUnit";
-    KEYS["WEATHER_CITY_KEY"] = "locationLabelOverride";
-    KEYS["WEATHER_TRANSLATE_CONDITION_KEY"] = "translateCondition";
-    KEYS["WEATHER_VERTICAL_ORIENTATION_KEY"] = "verticalOrientation";
-    KEYS["WEATHER_SHOW_TEXT_IN_PANEL_KEY"] = "showTextInPanel";
-    KEYS["WEATHER_SHOW_COMMENT_IN_PANEL_KEY"] = "showCommentInPanel";
-    KEYS["WEATHER_SHOW_SUNRISE_KEY"] = "showSunrise";
-    KEYS["WEATHER_SHOW_24HOURS_KEY"] = "show24Hours";
-    KEYS["WEATHER_FORECAST_DAYS"] = "forecastDays";
-    KEYS["WEATHER_REFRESH_INTERVAL"] = "refreshInterval";
-    KEYS["WEATHER_PRESSURE_UNIT_KEY"] = "pressureUnit";
-    KEYS["WEATHER_SHORT_CONDITIONS_KEY"] = "shortConditions";
-    KEYS["WEATHER_MANUAL_LOCATION"] = "manualLocation";
-})(KEYS || (KEYS = {}));
+const KEYS = {
+    WEATHER_DATA_SERVICE: "dataService",
+    WEATHER_API_KEY: "apiKey",
+    WEATHER_TEMPERATURE_UNIT_KEY: "temperatureUnit",
+    WEATHER_TEMPERATURE_HIGH_FIRST_KEY: "temperatureHighFirst",
+    WEATHER_WIND_SPEED_UNIT_KEY: "windSpeedUnit",
+    WEATHER_CITY_KEY: "locationLabelOverride",
+    WEATHER_TRANSLATE_CONDITION_KEY: "translateCondition",
+    WEATHER_VERTICAL_ORIENTATION_KEY: "verticalOrientation",
+    WEATHER_SHOW_TEXT_IN_PANEL_KEY: "showTextInPanel",
+    WEATHER_SHOW_COMMENT_IN_PANEL_KEY: "showCommentInPanel",
+    WEATHER_SHOW_SUNRISE_KEY: "showSunrise",
+    WEATHER_SHOW_24HOURS_KEY: "show24Hours",
+    WEATHER_FORECAST_DAYS: "forecastDays",
+    WEATHER_REFRESH_INTERVAL: "refreshInterval",
+    WEATHER_PRESSURE_UNIT_KEY: "pressureUnit",
+    WEATHER_SHORT_CONDITIONS_KEY: "shortConditions",
+    WEATHER_MANUAL_LOCATION: "manualLocation"
+};
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
 function _(str) {
     return Gettext.dgettext(UUID, str);

--- a/weather@mockturtl/files/weather@mockturtl/3.8/darkSky.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/darkSky.js
@@ -193,7 +193,7 @@ class DarkSky {
         let processed = summary.split(" ");
         let result = "";
         for (let i = 0; i < 2; i++) {
-            if (!/[\(\)]/.test(processed[i]) && (this.DarkSkyFilterWords.indexOf(processed[i]) != -1)) {
+            if (!/[\(\)]/.test(processed[i]) && !this.WordBanned(processed[i])) {
                 result = result + processed[i] + " ";
             }
         }
@@ -211,6 +211,9 @@ class DarkSky {
             }
         }
         return result;
+    }
+    WordBanned(word) {
+        return this.DarkSkyFilterWords.indexOf(word) != -1;
     }
     ResolveIcon(icon) {
         switch (icon) {

--- a/weather@mockturtl/files/weather@mockturtl/3.8/darkSky.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/darkSky.js
@@ -138,6 +138,7 @@ class DarkSky {
         if (isCoordinate(location)) {
             query = this.query + key + "/" + location +
                 "?exclude=minutely,hourly,flags" + "&units=" + this.unit;
+            this.app.log.Debug(this.app.systemLanguage);
             if (isLangSupported(this.app.systemLanguage, this.supportedLanguages) && this.app._translateCondition) {
                 query = query + "&lang=" + this.app.systemLanguage;
             }

--- a/weather@mockturtl/files/weather@mockturtl/metadata.json
+++ b/weather@mockturtl/files/weather@mockturtl/metadata.json
@@ -3,7 +3,7 @@
   "name": "Weather",
   "description": "View your local weather forecast",
   "max-instances": 3,
-  "version": "2.3.0",
+  "version": "2.3.1",
   "multiversion": true,
   "cinnamon-version": ["2.2", "2.4", "2.6", "2.8", "3.0", "3.2", "3.4", "3.6", "3.8", "4.0", "4.2", "4.3"]
 }

--- a/weather@mockturtl/files/weather@mockturtl/po/fr.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/fr.po
@@ -80,6 +80,14 @@ msgstr "Pression :"
 msgid "Wind:"
 msgstr "Vent :"
 
+#: 3.0/applet.js:628 3.8/applet.js:537
+msgid "Today"
+msgstr "aujourd'hui"
+
+#: 3.0/applet.js:630 3.8/applet.js:539
+msgid "Tomorrow"
+msgstr "demain"
+
 #: applet.js:1026 3.6/applet.js:1026 3.8/applet.js:1209
 msgid "Sunday"
 msgstr "Dimanche"

--- a/weather@mockturtl/src/applet.ts
+++ b/weather@mockturtl/src/applet.ts
@@ -99,24 +99,24 @@ const DATA_SERVICE = {
 const WEATHER_LOCATION = "location"
 const WEATHER_USE_SYMBOLIC_ICONS_KEY = 'useSymbolicIcons'
 
-enum KEYS {
-  WEATHER_DATA_SERVICE = "dataService",
-  WEATHER_API_KEY = "apiKey",
-  WEATHER_TEMPERATURE_UNIT_KEY = "temperatureUnit",
-  WEATHER_TEMPERATURE_HIGH_FIRST_KEY = "temperatureHighFirst",
-  WEATHER_WIND_SPEED_UNIT_KEY = "windSpeedUnit",
-  WEATHER_CITY_KEY = "locationLabelOverride",
-  WEATHER_TRANSLATE_CONDITION_KEY = "translateCondition",
-  WEATHER_VERTICAL_ORIENTATION_KEY = "verticalOrientation",
-  WEATHER_SHOW_TEXT_IN_PANEL_KEY = "showTextInPanel",
-  WEATHER_SHOW_COMMENT_IN_PANEL_KEY = "showCommentInPanel",
-  WEATHER_SHOW_SUNRISE_KEY = "showSunrise",
-  WEATHER_SHOW_24HOURS_KEY = "show24Hours",
-  WEATHER_FORECAST_DAYS = "forecastDays",
-  WEATHER_REFRESH_INTERVAL = "refreshInterval",
-  WEATHER_PRESSURE_UNIT_KEY = "pressureUnit",
-  WEATHER_SHORT_CONDITIONS_KEY = "shortConditions",
-  WEATHER_MANUAL_LOCATION = "manualLocation"
+const  KEYS: SettingKeys  =  {
+  WEATHER_DATA_SERVICE : "dataService",
+  WEATHER_API_KEY:  "apiKey",
+  WEATHER_TEMPERATURE_UNIT_KEY: "temperatureUnit",
+  WEATHER_TEMPERATURE_HIGH_FIRST_KEY:  "temperatureHighFirst",
+  WEATHER_WIND_SPEED_UNIT_KEY: "windSpeedUnit",
+  WEATHER_CITY_KEY:  "locationLabelOverride",
+  WEATHER_TRANSLATE_CONDITION_KEY:  "translateCondition",
+  WEATHER_VERTICAL_ORIENTATION_KEY:  "verticalOrientation",
+  WEATHER_SHOW_TEXT_IN_PANEL_KEY:  "showTextInPanel",
+  WEATHER_SHOW_COMMENT_IN_PANEL_KEY:  "showCommentInPanel",
+  WEATHER_SHOW_SUNRISE_KEY: "showSunrise",
+  WEATHER_SHOW_24HOURS_KEY:  "show24Hours",
+  WEATHER_FORECAST_DAYS:  "forecastDays",
+  WEATHER_REFRESH_INTERVAL: "refreshInterval",
+  WEATHER_PRESSURE_UNIT_KEY: "pressureUnit",
+  WEATHER_SHORT_CONDITIONS_KEY:  "shortConditions",
+  WEATHER_MANUAL_LOCATION:  "manualLocation"
 }
 
 //----------------------------------------------------------------------
@@ -1148,6 +1148,10 @@ interface ForecastUI {
     Day: imports.gi.St.Label,
     Summary: imports.gi.St.Label,
     Temperature: imports.gi.St.Label,
+}
+
+type SettingKeys = {
+  [key: string]: string;
 }
 
 interface WeatherProvider {

--- a/weather@mockturtl/src/applet.ts
+++ b/weather@mockturtl/src/applet.ts
@@ -231,7 +231,7 @@ class WeatherApplet extends Applet.TextIconApplet {
   constructor(metadata: any, orientation: any, panelHeight: number, instanceId: number) {
     super(orientation, panelHeight, instanceId);
     this.currentLocale = this.constructJsLocale(GLib.get_language_names()[0]);
-    this.systemLanguage = this.currentLocale.split('_')[0];
+    this.systemLanguage = this.currentLocale.split('-')[0];
     this.settings = new Settings.AppletSettings(this, UUID, instanceId)
     this.log = new Log(instanceId);
     this._httpSession.user_agent = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:37.0) Gecko/20100101 Firefox/37.0"; // ipapi blocks non-browsers agents, imitating browser

--- a/weather@mockturtl/src/darkSky.ts
+++ b/weather@mockturtl/src/darkSky.ts
@@ -173,6 +173,7 @@ class DarkSky implements WeatherProvider {
         if (isCoordinate(location)) {
             query = this.query + key + "/" + location + 
             "?exclude=minutely,hourly,flags" + "&units=" + this.unit;
+            this.app.log.Debug(this.app.systemLanguage);
             if (isLangSupported(this.app.systemLanguage, this.supportedLanguages) && this.app._translateCondition) {
                 query = query + "&lang=" + this.app.systemLanguage;
             }

--- a/weather@mockturtl/src/darkSky.ts
+++ b/weather@mockturtl/src/darkSky.ts
@@ -231,7 +231,7 @@ class DarkSky implements WeatherProvider {
         let processed = summary.split(" ");
         let result = "";
         for (let i = 0; i < 2; i++) {
-            if (!/[\(\)]/.test(processed[i]) && (this.DarkSkyFilterWords.indexOf(processed[i]) != -1)) {
+            if (!/[\(\)]/.test(processed[i]) && !this.WordBanned(processed[i])) {
                 result = result + processed[i] + " ";
             }
         }
@@ -249,6 +249,10 @@ class DarkSky implements WeatherProvider {
             }
         }
         return result;
+    }
+
+    WordBanned(word: string): boolean {
+        return this.DarkSkyFilterWords.indexOf(word) != -1;
     }
 
     ResolveIcon(icon: string): string[] {


### PR DESCRIPTION
Opened Because https://github.com/linuxmint/cinnamon-spices-applets/issues/2603

Fixes: 
* DarkSky Conditions logic was inverted, it filtered out almost every word.
* SystemLanguage string was processed incorrectly (split by the wrong char)
* Updating French Translation to include Today and Tomorrow

The Rest of the changes are due to using new version of Typescript to build:
 * Have to explicitly declare object what are used with for...in loops
 * Async generator changed by them (version 3.0)