### PR TITLE
README.md: Update link to hwmonitor@sylfurd issues

### DIFF
--- a/hwmonitor@sylfurd/README.md
+++ b/hwmonitor@sylfurd/README.md
@@ -5,7 +5,7 @@ Graphical Hardware Monitor
 
 The code for this applet can be found under hwmonitor@sylfurd here : [cinnamon-spices-applets](https://github.com/linuxmint/cinnamon-spices-applets/)
 
-Issues can be reported here : [Issues](https://github.com/linuxmint/cinnamon-spices-applets/issues)
+Issues can be reported here : [Issues](https://github.com/linuxmint/cinnamon-spices-applets/issues?q=is%3Aissue+hwmonitor+user%3Asylfurd+is%3Aopen)
 
 ### Changes
 


### PR DESCRIPTION
The link to issues was pointing to the "generic" issues page of the 'cinnamon-spices-applets' project. It makes life a bit easier when the same filter is applied as in the [Graphical hardware monitor project page](https://cinnamon-spices.linuxmint.com/applets/view/12)