### PR TITLE
[sshlauncher@sumo] Removes noisy messages in .xsession-errors

### DIFF
--- a/sshlauncher@sumo/files/sshlauncher@sumo/applet.js
+++ b/sshlauncher@sumo/files/sshlauncher@sumo/applet.js
@@ -15,6 +15,15 @@ const AppletDir = imports.ui.appletManager.appletMeta[UUID].path;
 const Gtk = imports.gi.Gtk;
 const Settings = imports.ui.settings;
 
+/**
+ * DEBUG:
+ * Returns whether or not the DEBUG file is present in this applet directory (which can be created by the 'touch DEBUG' command).
+ */
+function DEBUG() {
+  let _debug = Gio.file_new_for_path(AppletDir + "/DEBUG");
+  return _debug.query_exists(null);
+};
+
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
 
 function _(str) {
@@ -39,7 +48,7 @@ MyApplet.prototype = {
 
     this.set_applet_tooltip(_("SSH Launcher"));
     // Settings
-    this._customCommand;
+    this._customCommand = "";
 
     try {
       this.settings = new Settings.AppletSettings(this, UUID, instance_id);
@@ -219,7 +228,7 @@ MyApplet.prototype = {
     command += (" ssh " + this.buildSshFlags() + hostname);
 
     Util.spawnCommandLine(command);
-    global.log("Terminal opened with command '" + command + "'");
+    if (DEBUG()) global.log("Terminal opened with command '" + command + "'");
     this.sendNotification(_("SSH Launcher"), _("Connection opened to ") + hostname + _(" using ") + terminal);
   },
 


### PR DESCRIPTION
Hi @sumo,

This PR removes noisy messages  in `~/.xsession-errors` such as:

- `Cjs-Message: 13:44:51.265: JS WARNING: [/usr/share/cinnamon/js/misc/fileUtils.js line 210 > Function 42]: reference to undefined property "_customCommand"`

- `Terminal opened with command...`. These latest messages can be displayed creating a DEBUG file in the same directory of the applet.js file (useful for developers).