### PR TITLE
[cinnamon-timer@jake1164] Remove noisy messages in .xsession-errors

### DIFF
--- a/cinnamon-timer@jake1164/files/cinnamon-timer@jake1164/2.6/applet.js
+++ b/cinnamon-timer@jake1164/files/cinnamon-timer@jake1164/2.6/applet.js
@@ -389,9 +389,9 @@ MyApplet.prototype = {
         let icon = new St.Icon({ gicon: gicon });
         this._notification = new MessageTray.Notification(this._source, title, text, { icon: icon });
         this._notification.setTransient(false);
-        this._notification.connect('destroy', function () {
+        this._notification.connect('destroy', Lang.bind(this, function () {
             this._notification = null;
-        });
+        }));
 
         this._source.notify(this._notification);
 

--- a/cinnamon-timer@jake1164/files/cinnamon-timer@jake1164/3.4/applet.js
+++ b/cinnamon-timer@jake1164/files/cinnamon-timer@jake1164/3.4/applet.js
@@ -462,9 +462,9 @@ MyApplet.prototype = {
         let icon = new St.Icon({ gicon: gicon });
         this._notification = new MessageTray.Notification(this._source, title, text, { icon: icon });
         this._notification.setTransient(false);
-        this._notification.connect('destroy', function () {
+        this._notification.connect('destroy', Lang.bind(this, function () {
             this._notification = null;
-        });
+        }));
 
         this._source.notify(this._notification);
 


### PR DESCRIPTION
Hi @jake1164,

This PR removes noisy messages in `~/.xsession-errors`, such as: `TypeError: this._notification is null`.

Best regards.
Claudiux