### PR TITLE
Update compatibility for 4.4

### DIFF
--- a/collapsible-systray@feuerfuchs.eu/files/collapsible-systray@feuerfuchs.eu/metadata.json
+++ b/collapsible-systray@feuerfuchs.eu/files/collapsible-systray@feuerfuchs.eu/metadata.json
@@ -10,7 +10,9 @@
         "3.6",
         "3.8",
         "4.0",
-        "4.2"
+        "4.2",
+        "4.4",
+        "4.6"
     ], 
     "max-instances": 1, 
     "description": "A replacement for the abandoned System Tray Collapsible Cinnamon applet", 

--- a/collapsible-systray@feuerfuchs.eu/files/collapsible-systray@feuerfuchs.eu/metadata.json
+++ b/collapsible-systray@feuerfuchs.eu/files/collapsible-systray@feuerfuchs.eu/metadata.json
@@ -16,7 +16,7 @@
     ], 
     "max-instances": 1, 
     "description": "A replacement for the abandoned System Tray Collapsible Cinnamon applet", 
-    "version": "1.20", 
+    "version": "1.21",
     "icon": "indicator-applet", 
     "name": "Collapsible Systray"
 }

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
@@ -4,5 +4,5 @@
     "version": "1.8.9",
     "description": "Displays in realtime the cpu usage for each core/cpu and overall memory usage.",
     "multiversion": true,
-    "cinnamon-version": ["2.8", "3.0", "3.2", "3.4", "3.6", "3.8", "4.0", "4.2", "4.3"]
+    "cinnamon-version": ["2.8", "3.0", "3.2", "3.4", "3.6", "3.8", "4.0", "4.2", "4.4", "4.6"]
 }

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
@@ -1,7 +1,7 @@
 {
     "uuid": "multicore-sys-monitor@ccadeptic23",
     "name": "Multi-Core System Monitor",
-    "version": "1.8.9",
+    "version": "1.8.91",
     "description": "Displays in realtime the cpu usage for each core/cpu and overall memory usage.",
     "multiversion": true,
     "cinnamon-version": ["2.8", "3.0", "3.2", "3.4", "3.6", "3.8", "4.0", "4.2", "4.4", "4.6"]

--- a/weather@mockturtl/files/weather@mockturtl/metadata.json
+++ b/weather@mockturtl/files/weather@mockturtl/metadata.json
@@ -3,7 +3,7 @@
   "name": "Weather",
   "description": "View your local weather forecast",
   "max-instances": 3,
-  "version": "2.3.2",
+  "version": "2.3.3",
   "multiversion": true,
-  "cinnamon-version": ["2.2", "2.4", "2.6", "2.8", "3.0", "3.2", "3.4", "3.6", "3.8", "4.0", "4.2", "4.3"]
+  "cinnamon-version": ["2.2", "2.4", "2.6", "2.8", "3.0", "3.2", "3.4", "3.6", "3.8", "4.0", "4.2", "4.4", "4.6"]
 }


### PR DESCRIPTION
I did this 1 month ago to prepare for the next version, then decided to write _4.3_ into the array.

I must be retarded.

Resolves this: https://github.com/linuxmint/cinnamon-spices-applets/issues/2698

Edit:

I Include some other Applets as well, as they work on 4.4