### PR TITLE
mem-monitor-text: added warning on wigh memory usage

### DIFF
--- a/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/applet.js
+++ b/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/applet.js
@@ -21,14 +21,17 @@ function MyApplet(orientation) {
 }
 
 MyApplet.prototype = {
-    __proto__: Applet.TextApplet.prototype,
+__proto__:
+    Applet.TextApplet.prototype,
 
-    _init: function(orientation) {
+_init:
+    function(orientation) {
         Applet.TextApplet.prototype._init.call(this, orientation);
 
         try {
             this.settings = new Settings.AppletSettings(this, UUID, this.instance_id);
             this.settings.bindProperty(Settings.BindingDirection.IN, "mem-label", "mem_label", this._update, null);
+            this.settings.bindProperty(Settings.BindingDirection.IN, "warning-usage", "warn_label", this._update, null);
 
             this.itemOpenSysMon = new PopupMenu.PopupMenuItem(_("Open System Monitor"));
             this.itemOpenSysMon.connect('activate', Lang.bind(this, this._runSysMonActivate));
@@ -36,7 +39,10 @@ MyApplet.prototype = {
 
             this.gtop = new GTop.glibtop_mem();
 
-            this._applet_label.set_style('min-width: 2.5em; text-align: left');
+            this.defaultStyle = 'min-width: 2.5em; text-align: left;';
+            this.warningStyle = this.defaultStyle + ' color: red;'
+            this.toggleStyle = false;
+            this._applet_label.set_style(this.defaultStyle);
 
             this.usage = 0;
             this.maxmem = 0;
@@ -50,22 +56,34 @@ MyApplet.prototype = {
         }
     },
 
-    on_applet_clicked: function(event) {
+on_applet_clicked:
+    function(event) {
         this._runSysMon();
     },
 
-    _runSysMonActivate: function() {
+_runSysMonActivate:
+    function() {
         this._runSysMon();
     },
 
-    _update: function() {
+_update:
+    function() {
         try {
             GTop.glibtop_get_mem(this.gtop);
             this.maxmem = this.gtop.total;
-	    this.user = this.gtop.user;
+            this.user = this.gtop.user;
 
             let percent = Math.round((this.user * 100) / this.maxmem);
             this.set_applet_label(this.mem_label + " " + percent.toString().slice(-3) + "%");
+
+            // Warning high memory usage
+            if (percent > parseInt(this.warn_label)) {
+                this.toggleStyle = !this.toggleStyle;
+                this._applet_label.set_style(this.toggleStyle ? this.defaultStyle : this.warningStyle);
+            } else if (!this.toggleStyle) {
+                this._applet_label.set_style(this.defaultStyle);
+            }
+
             this.set_applet_tooltip(_("Click to open Gnome system monitor"));
         }
         catch (e) {
@@ -75,7 +93,8 @@ MyApplet.prototype = {
         Mainloop.timeout_add(2000, Lang.bind(this, this._update));
     },
 
-    _runSysMon: function() {
+_runSysMon:
+    function() {
         let _appSys = Cinnamon.AppSystem.get_default();
         let _gsmApp = _appSys.lookup_app('gnome-system-monitor.desktop');
         _gsmApp.activate();

--- a/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/settings-schema.json
+++ b/mem-monitor-text@datanom.net/files/mem-monitor-text@datanom.net/settings-schema.json
@@ -1,8 +1,26 @@
 {
- "mem-label" : {
-	"type" : "entry",
-	"default" : "mem:",
-	"description" : "Text:",
-	"tooltip" : "Enter custom text to show in the panel."
- }
+"mem-label" :
+    {
+"type" : "entry"
+        ,
+"default" : "mem:"
+        ,
+"description" : "Text:"
+        ,
+"tooltip" : "Enter custom text to show in the panel."
+    },
+"warning-usage" :
+    {
+"type": "spinbutton"
+        ,
+        "default" : 100,
+        "min" : 1,
+        "max" : 100,
+        "step" : 1,
+"units" : ""
+        ,
+"description" : "Warning Level:"
+        ,
+"tooltip" : "Percentage at which the text starts blinking to warn the user. Set at 100 to deactivate."
+    }
 }


### PR DESCRIPTION
My laptop has very little RAM (4Gb) I if I don't watch my browser tabs I end up with the system crashing on low memory. 

So I made this simple addition that the spice text start flashing red when the RAM usage is above a threshold specified in the spice settings. By default the feature is disabled. 

Have a nice day,
Luca