### PR TITLE
[turn-off-monitor@zablotski] Turn Off Monitor v2.0.0: Add Settings

### DIFF
--- a/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/applet.js
+++ b/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/applet.js
@@ -3,49 +3,154 @@ const Util = imports.misc.util;
 const GLib = imports.gi.GLib;
 const Mainloop = imports.mainloop;
 const Gettext = imports.gettext;
+const Settings = imports.ui.settings;
+const Main = imports.ui.main;
 
-const UUID = "turn-off-monitor@zablotski";
-Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale")
-
-function _(str) {
-    return Gettext.dgettext(UUID, str);
-  }
-
-const APPLET_PATH = GLib.get_home_dir() + "/.local/share/cinnamon/applets/turn-off-monitor@zablotski";
+const UUID = "turn-off-monitor@zablotski"; // version 2.0.0 made by @claudiux
+const HOME_DIR = GLib.get_home_dir();
+const APPLET_PATH = HOME_DIR + "/.local/share/cinnamon/applets/" + UUID;
 const ICON_PATH = APPLET_PATH + "/icon.png";
 
-function MyApplet(orientation, panel_height, instance_id) {
-    this._init(orientation, panel_height, instance_id);
+Gettext.bindtextdomain(UUID, HOME_DIR + "/.local/share/locale")
+
+function _(str) {
+    let customTrans = Gettext.dgettext(UUID, str);
+    if (customTrans !== str && customTrans !== "")
+        return customTrans;
+    return Gettext.gettext(str);
+}
+
+/**
+ * Execute a function only once after a few seconds.
+ * @callback: function to execute.
+ * @s: number of seconds.
+ */
+function setTimeoutInSeconds(callback, s) {
+    return Mainloop.timeout_add_seconds(s, () => {
+        callback();
+        return false;
+    }, null);
+}
+
+function MyApplet(metadata, orientation, panel_height, instance_id) {
+    this._init(metadata, orientation, panel_height, instance_id);
 }
 
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function(orientation, panel_height, instance_id) {
+    _init: function(metadata, orientation, panel_height, instance_id) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
 
-        this.set_applet_icon_path(ICON_PATH);
         this.set_applet_tooltip(_("Turn off monitor"));
+
+        this.settings = new Settings.AppletSettings(this, UUID, instance_id);
+
+        this.settings.bindProperty(Settings.BindingDirection.IN,
+            'mouse-deactivation-duration',
+            'mouseDeactivationDuration',
+            null,
+            null
+        );
+
+        // Keybinding:
+        this.settings.bindProperty(Settings.BindingDirection.IN,
+            "keybinding",
+            "keybinding",
+            this.on_shortcut_changed,
+            null
+        );
+        Main.keybindingManager.addHotKey(UUID, this.keybinding, () => this.on_shortcut_used());
+
+        // Icon
+        this.settings.bindProperty(Settings.BindingDirection.IN,
+            "use-symbolic-icon",
+            "useSymbolicIcon",
+            this.on_icon_settings_changed,
+            null
+        );
+        this.settings.bindProperty(Settings.BindingDirection.IN,
+            "icon-color",
+            "iconColor",
+            this.on_icon_settings_changed,
+            null
+        );
+        this.on_icon_settings_changed();
     },
 
+    /**
+     * Turn off the monitor(s) and disable the mouse for a few seconds
+     * to prevent the monitor from waking up when moving the mouse.
+     */
     on_applet_clicked: function () {
+        let duration = Math.trunc(this.mouseDeactivationDuration);
+        Util.spawn_async(
+            ['/bin/bash', '-c',
+            'for m in $(xinput | grep -i Mouse | tr -d " " | tr "\t" " " | cut -d" " -f2 | cut -d"=" -f2); do \
+            xinput disable $m; done'],
+            null
+        );
         Util.spawnCommandLine('xset dpms force off');
-        Util.spawnCommandLine(APPLET_PATH +'/disable_mouse.sh');
-        setTimeout(function () {
-            Util.spawnCommandLine(APPLET_PATH + '/enable_mouse.sh');
-        }, 1000);
+        setTimeoutInSeconds(
+            function () {
+                Util.spawn_async(
+                    ['/bin/bash', '-c',
+                    'for m in $(xinput | grep -i Mouse | tr -d " " | tr "\t" " " | cut -d" " -f2 | cut -d"=" -f2); do \
+                    xinput enable $m; done'],
+                    null);
+                },
+            duration
+        );
+    },
 
+    /**
+     * Remove old keyboard shortcut, if any. Then, install the new keyboard shortcut.
+     */
+    on_shortcut_changed: function () {
+        try{
+            Main.keybindingManager.removeHotKey(UUID);
+        } catch(e) {}
+        if (this.keybinding != null) {
+            Main.keybindingManager.addHotKey(UUID, this.keybinding, () => this.on_shortcut_used())
+        }
+    },
 
+    /**
+     * Turn off the monitor(s) by disabling the keyboard for 1 second
+     * to prevent the monitor(s) from waking up when the keys are released.
+     */
+    on_shortcut_used: function () {
+        Util.spawn_async(
+            ['/bin/bash', '-c',
+            'for m in $(xinput | grep Keyboard | tr -d " " | tr "\t" " " | cut -d" " -f2 | cut -d"=" -f2); do \
+            xinput disable $m; done'],
+            null
+        );
+        Util.spawnCommandLine('xset dpms force off');
+        setTimeoutInSeconds(
+            function () {
+                Util.spawn_async(
+                    ['/bin/bash', '-c',
+                    'for m in $(xinput | grep Keyboard | tr -d " " | tr "\t" " " | cut -d" " -f2 | cut -d"=" -f2); do \
+                    xinput enable $m; done'],
+                    null);
+            },
+            1
+        );
+
+    },
+
+    on_icon_settings_changed: function () {
+        if (this.useSymbolicIcon) {
+            this.set_applet_icon_symbolic_name("video-display");
+            this._applet_icon.style = "color: %s;".format(this.iconColor.toString());
+        } else {
+            this.set_applet_icon_path(ICON_PATH);
+            this._applet_icon.style = "";
+        }
     }
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-    return new MyApplet(orientation, panel_height, instance_id);
-}
-
-function setTimeout(callback, ms) {
-    return Mainloop.timeout_add(ms, () => {
-        callback();
-        return false;
-    }, null);
+    return new MyApplet(metadata, orientation, panel_height, instance_id);
 }

--- a/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/disable_mouse.sh
+++ b/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/disable_mouse.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-xinput disable $(xinput | grep Mouse | tr -d " " | tr "\t" " " | cut -d" " -f2 | cut -d"=" -f2)

--- a/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/enable_mouse.sh
+++ b/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/enable_mouse.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-xinput enable $(xinput | grep Mouse | tr -d " " | tr "\t" " " | cut -d" " -f2 | cut -d"=" -f2)

--- a/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/metadata.json
+++ b/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/metadata.json
@@ -1,5 +1,6 @@
 {
   "uuid": "turn-off-monitor@zablotski",
   "name": "Turn Off Monitor",
+  "version": "2.0.0",
   "description": "Click on the applet to turn off monitor"
 }

--- a/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/po/fr.po
+++ b/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/po/fr.po
@@ -1,0 +1,75 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-12-01 20:00+0100\n"
+"PO-Revision-Date: 2019-12-01 20:08+0100\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.0.6\n"
+"Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: fr\n"
+
+#: applet.js:45
+msgid "Turn off monitor"
+msgstr "Éteindre l'écran"
+
+#. metadata.json->name
+msgid "Turn Off Monitor"
+msgstr "Extinction de l'écran (Turn Off Monitor)"
+
+#. metadata.json->description
+msgid "Click on the applet to turn off monitor"
+msgstr "Éteint l'écran d'un clic sur l'icône ou par un raccourci-clavier"
+
+#. settings-schema.json->General->title
+msgid "General"
+msgstr "Paramètres généraux"
+
+#. settings-schema.json->section-mouse->title
+msgid "Mouse"
+msgstr "Souris"
+
+#. settings-schema.json->section-keybinding->title
+msgid "Shortcuts"
+msgstr "Raccourcis-clavier"
+
+#. settings-schema.json->section-icon->title
+msgid "Icon"
+msgstr "Icône"
+
+#. settings-schema.json->mouse-deactivation-duration->units
+msgid "seconds"
+msgstr "secondes"
+
+#. settings-schema.json->mouse-deactivation-duration->description
+msgid "Duration of deactivation of the mouse"
+msgstr "Durée de désactivation de la souris"
+
+#. settings-schema.json->mouse-deactivation-duration->tooltip
+msgid ""
+"To prevent the monitor from turning on too soon after turning it off, the "
+"mouse will be disabled for the number of seconds set here."
+msgstr ""
+"Pour éviter que l'écran ne se rallume trop tôt après l'avoir éteint, la "
+"souris sera désactivée pendant le nombre de secondes défini ici."
+
+#. settings-schema.json->keybinding->description
+msgid "Keyboard shortcut to turn off your monitor"
+msgstr "Raccourci-clavier pour éteindre votre écran"
+
+#. settings-schema.json->use-symbolic-icon->description
+msgid "Use a symbolic icon"
+msgstr "Utiliser une icône symbolique"
+
+#. settings-schema.json->icon-color->description
+msgid "Color of the symbolic icon"
+msgstr "Couleur de l'icône symbolique"

--- a/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/po/turn-off-monitor@zablotski.pot
+++ b/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/po/turn-off-monitor@zablotski.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-23 12:34+0800\n"
+"POT-Creation-Date: 2019-12-01 20:00+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,14 +17,56 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:27
+#: applet.js:45
 msgid "Turn off monitor"
 msgstr ""
 
-#. turn-off-monitor@zablotski->metadata.json->description
+#. metadata.json->name
+msgid "Turn Off Monitor"
+msgstr ""
+
+#. metadata.json->description
 msgid "Click on the applet to turn off monitor"
 msgstr ""
 
-#. turn-off-monitor@zablotski->metadata.json->name
-msgid "Turn Off Monitor"
+#. settings-schema.json->General->title
+msgid "General"
+msgstr ""
+
+#. settings-schema.json->section-mouse->title
+msgid "Mouse"
+msgstr ""
+
+#. settings-schema.json->section-keybinding->title
+msgid "Shortcuts"
+msgstr ""
+
+#. settings-schema.json->section-icon->title
+msgid "Icon"
+msgstr ""
+
+#. settings-schema.json->mouse-deactivation-duration->units
+msgid "seconds"
+msgstr ""
+
+#. settings-schema.json->mouse-deactivation-duration->description
+msgid "Duration of deactivation of the mouse"
+msgstr ""
+
+#. settings-schema.json->mouse-deactivation-duration->tooltip
+msgid ""
+"To prevent the monitor from turning on too soon after turning it off, the "
+"mouse will be disabled for the number of seconds set here."
+msgstr ""
+
+#. settings-schema.json->keybinding->description
+msgid "Keyboard shortcut to turn off your monitor"
+msgstr ""
+
+#. settings-schema.json->use-symbolic-icon->description
+msgid "Use a symbolic icon"
+msgstr ""
+
+#. settings-schema.json->icon-color->description
+msgid "Color of the symbolic icon"
 msgstr ""

--- a/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/settings-schema.json
+++ b/turn-off-monitor@zablotski/files/turn-off-monitor@zablotski/settings-schema.json
@@ -1,0 +1,66 @@
+{
+  "layout": {
+    "type": "layout",
+    "pages": [
+      "General"
+    ],
+    "General": {
+      "type": "page",
+      "title": "General",
+      "sections": [
+        "section-mouse",
+        "section-keybinding",
+        "section-icon"
+      ]
+    },
+    "section-mouse": {
+      "type": "section",
+      "title": "Mouse",
+      "keys": [
+        "mouse-deactivation-duration"
+      ]
+    },
+    "section-keybinding": {
+      "type": "section",
+      "title": "Shortcuts",
+      "keys": [
+        "keybinding"
+      ]
+    },
+    "section-icon": {
+      "type": "section",
+      "title": "Icon",
+      "keys": [
+        "use-symbolic-icon",
+        "icon-color"
+      ]
+    }
+  },
+  "mouse-deactivation-duration": {
+    "type": "scale",
+    "default": 5,
+    "min": 1,
+    "max": 15,
+    "step": 1,
+    "units": "seconds",
+    "show-value": true,
+    "description": "Duration of deactivation of the mouse",
+    "tooltip": "To prevent the monitor from turning on too soon after turning it off, the mouse will be disabled for the number of seconds set here."
+  },
+  "keybinding": {
+    "type": "keybinding",
+    "description": "Keyboard shortcut to turn off your monitor",
+    "default": "<Super>b"
+  },
+  "use-symbolic-icon": {
+    "type": "switch",
+    "default": true,
+    "description": "Use a symbolic icon"
+  },
+  "icon-color": {
+    "type": "colorchooser",
+    "default": "green",
+    "description": "Color of the symbolic icon",
+    "dependency": "use-symbolic-icon"
+  }
+}


### PR DESCRIPTION
Hi @brownsr,

This PR closes #2719, adding some settings to prevent the monitor turning on too soon after turning off. Also, I added a keybinding management and fixed some bugs (this applet did not work with certain mouse).

The author of this applet, @zablotski, is inactive on Github since at least one year.

Can you merge this branch with your master one, please?

Best regards.
Claudiux