### PR TITLE
cryptocoin@guantanamoe Add rates update interval configuration

### DIFF
--- a/cryptocoin@guantanamoe/files/cryptocoin@guantanamoe/settings-schema.json
+++ b/cryptocoin@guantanamoe/files/cryptocoin@guantanamoe/settings-schema.json
@@ -37,7 +37,8 @@
                 "ticker",
                 "show-ticker-icon",
                 "show-ticker-name",
-                "show-currency"
+                "show-currency",
+                "rates-update-interval"
             ]
         },
         "graph-section" : {
@@ -113,6 +114,12 @@
             "Symbol": "symbol",
             "None": "none"
         }
+    },
+    "rates-update-interval" : {
+        "type" : "entry",
+        "default" : "5",
+        "description" : "Rates update interval (in seconds)",
+        "tooltip" : "Set the delay between each rates update."
     },
     "graph-unit" : {
 		"type" : "combobox",


### PR DESCRIPTION
To refresh the countervalue of a ticker, calls are made every 5 seconds
to the cryptocompare API, which can lead to reaching the API rate free
tier limit.

To avoid that, a configuration field has been added to set a custom
interval and reduce the frequency of calls made to the API.
This configuration field default value is set to 5 seconds to avoid
behavior change.