### PR TITLE
[SpicesUpdate@claudiux] Update metadata.json: corrected version number: 5.2.1

### DIFF
--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/metadata.json
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/metadata.json
@@ -3,7 +3,7 @@
   "name": "Spices Update",
   "max-instances": "1",
   "hide-configuration": false,
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Warns you when installed Spices (applets, desklets, extensions, themes) require an update or new Spices are available.",
   "multiversion": true,
   "cinnamon-version": [


### PR DESCRIPTION
Hi @brownsr,

Just a minor change. Some users IRL told me that they were surprised that the version number displayed did not match that announced on the web page or in CHANGELOG.

Happy New Year!