### PR TITLE
v5.2.2 - Cinnamon 4.2: Let Gtk determine the right size of dialog window

### DIFF
--- a/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v5.2.2~20200109
+  * Cinnamon 4.2: Let Gtk determine the right size of dialog window ([see @mtwebster's commit for Cinnamon](https://github.com/linuxmint/cinnamon/commit/d57677b5ae306115139be98be62e3fb7cc6a27a8#diff-c4641b580bb45b188c5ae94c7f7a33cf))
+
 ### v5.2.1~20191230
   * Make it configurable for Cinnamon 2.8 -> 4.0.
 

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v5.2.2~20200109
+  * Cinnamon 4.2: Let Gtk determine the right size of dialog window ([see @mtwebster's commit for Cinnamon](https://github.com/linuxmint/cinnamon/commit/d57677b5ae306115139be98be62e3fb7cc6a27a8#diff-c4641b580bb45b188c5ae94c7f7a33cf))
+
 ### v5.2.1~20191230
   * Make it configurable for Cinnamon 2.8 -> 4.0.
 

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/cs/4.2/bin/SUExtensionCore.py
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/cs/4.2/bin/SUExtensionCore.py
@@ -96,7 +96,7 @@ def show_prompt(msg, window=None):
                                destroy_with_parent = True,
                                message_type = Gtk.MessageType.QUESTION,
                                buttons = Gtk.ButtonsType.YES_NO)
-    dialog.set_default_size(400, 200)
+    #dialog.set_default_size(400, 200)
     esc = html.escape(msg)
     dialog.set_markup(esc)
     dialog.show_all()

--- a/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/metadata.json
+++ b/SpicesUpdate@claudiux/files/SpicesUpdate@claudiux/metadata.json
@@ -3,7 +3,7 @@
   "name": "Spices Update",
   "max-instances": "1",
   "hide-configuration": false,
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "Warns you when installed Spices (applets, desklets, extensions, themes) require an update or new Spices are available.",
   "multiversion": true,
   "cinnamon-version": [


### PR DESCRIPTION
@brownsr 
Hi Simon,

Minor change to bring Spices Update into line with [this mtwebster commit](https://github.com/linuxmint/cinnamon/commit/d57677b5ae306115139be98be62e3fb7cc6a27a8#diff-c4641b580bb45b188c5ae94c7f7a33cf).

Can you merge this branch with your master one, please?

Kind regards
Claudiux