### PR TITLE
sshlauncher@sumo update 

### DIFF
--- a/sshlauncher@sumo/files/sshlauncher@sumo/applet.js
+++ b/sshlauncher@sumo/files/sshlauncher@sumo/applet.js
@@ -102,7 +102,7 @@ MyApplet.prototype = {
       if (_symbolic) icon += "-symbolic";
 
       if (Gtk.IconTheme.get_default().has_icon(icon)) {
-        this.set_applet_icon_name(icon);
+        if (_symbolic) this.set_applet_icon_symbolic_name(icon); else this.set_applet_icon_name(icon);
         return;
       }
 

--- a/sshlauncher@sumo/files/sshlauncher@sumo/applet.js
+++ b/sshlauncher@sumo/files/sshlauncher@sumo/applet.js
@@ -18,6 +18,7 @@ const Settings = imports.ui.settings;
 /**
  * DEBUG:
  * Returns whether or not the DEBUG file is present in this applet directory (which can be created by the 'touch DEBUG' command).
+ * @returns {boolean}
  */
 function DEBUG() {
   let _debug = Gio.file_new_for_path(AppletDir + "/DEBUG");
@@ -121,7 +122,31 @@ MyApplet.prototype = {
     return (!t) ? null : t;
   },
 
-  buildTermFlags: function(termOptions, hostName) {
+  /**
+   * Trust our own options first, then
+   * the exec-arg stored in cinnamon-settings.
+   * @param {string} terminal name of terminal
+   * @returns {string} terminal's execute flag
+   */
+  getTermExecuteFlag: function(terminal) {
+      let termOptions = this.getTermOptions(terminal);
+      if (!!termOptions) {
+        return (termOptions.execute[0] + " ");
+      }
+      else {
+        let termArg = this.gsettings.get_string("exec-arg");
+        return (termArg + " ");
+      }
+  },
+
+  /**
+   * Adds title if option available in terminal.
+   * @param {string} terminal name of terminal
+   * @param {string} hostName hostname stored in ssh-config
+   * @returns {string} all extra terminal options if available
+   */
+  buildTermFlags: function(terminal, hostName) {
+    let termOptions = this.getTermOptions(terminal);
     let options = "";
     if (termOptions == null) return options;
     if (termOptions.title != null) options += (termOptions.title + " \"" + hostName + "\" ");
@@ -137,6 +162,11 @@ MyApplet.prototype = {
     return flags;
   },
 
+  /**
+   * @param {string} terminal name of terminal
+   * @param {string} arg execute argument of terminal
+   * @returns {boolean}
+   */
   isExecArgCorrect: function(terminal, arg) {
     let termOptions = this.getTermOptions(terminal);
     if (termOptions == null) return true; // No info stored on terminal, no way to validate
@@ -210,23 +240,20 @@ MyApplet.prototype = {
       terminal = command.split(" ")[0]; // Get terminal name from custom command
     }
     else {
-      let term = this.gsettings.get_string("exec");
-      if (this.empty(term)) {
+      terminal = this.gsettings.get_string("exec");
+      if (this.empty(terminal)) {
         this.sendNotification(_("SSH Launcher"), _("Error: I can't open the terminal.\nYou need to set a default terminal first in Preferred Applications!\n\n(More help in Right Click->About->More Info)"));
         return;
       }
-
-      terminal = term;
-      command = term + " ";
-      command += this.buildTermFlags(this.getTermOptions(term), hostname);
-
-      let termArg = this.gsettings.get_string("exec-arg");
-      if (!this.isExecArgCorrect(term, termArg)) {};
-      command += termArg + " ";
+      command = terminal + " ";
+      command += this.buildTermFlags(terminal, hostname);
+      command += this.getTermExecuteFlag(terminal);
     }
 
     command += (" ssh " + this.buildSshFlags() + hostname);
 
+    // TODO: capture of the command output in the event of success/failure
+    // to provide better feedback on issues
     Util.spawnCommandLine(command);
     if (DEBUG()) global.log("Terminal opened with command '" + command + "'");
     this.sendNotification(_("SSH Launcher"), _("Connection opened to ") + hostname + _(" using ") + terminal);

--- a/sshlauncher@sumo/files/sshlauncher@sumo/metadata.json
+++ b/sshlauncher@sumo/files/sshlauncher@sumo/metadata.json
@@ -3,5 +3,5 @@
 "name": "SSH Launcher",
 "description": "An applet to connect to SSH hosts configured in ~/.ssh/config",
 "icon": "network",
-"version": "0.1.0"
+"version": "0.1.1"
 }


### PR DESCRIPTION
Changes:
* Fixes symbolic icon setting (my fuckup), now it actually sets as symbolic.
* Makes terminal argument handing a bit more bulletproof.

@sumo 
Let me know if there is anything I need to change.

I tried to show notifications on ssh errors on exiting, but its more complicated as I thought. :( I can only get terminal's status code and message, not what goes on inside the terminal even tough that's the only process keeping alive the terminal.