### PR TITLE
fix missing python(2) appearances in feeds spice

### DIFF
--- a/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/applet.js
+++ b/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/applet.js
@@ -143,14 +143,14 @@ FeedApplet.prototype = {
 
     _check_feedparser: function(output) {
         if (output == "FAIL") {
-            this.notify_installation('python-feedparser');
+            this.notify_installation('python3-feedparser');
             Util.spawnCommandLine("apturl apt://python-feedparser");
         }
     },
 
     /* private function to check, confirm and install any dependencies */
     _check_dependencies: function() {
-       Util.spawn_async(['python', APPLET_PATH + '/check_feedparser.py'], Lang.bind(this, this._check_feedparser));
+       Util.spawn_async(['python3', APPLET_PATH + '/check_feedparser.py'], Lang.bind(this, this._check_feedparser));
     },
 
     /* private function that connects to the settings-schema and initializes the variables */


### PR DESCRIPTION
There are still two instances of Python version 2 in the applet.js code,
one of which is functional (calls `python` instead of `python3`), one is
only informational. Fix both.