### PR TITLE
Lower number of API calls to data provider

### DIFF
--- a/cryptocoin@guantanamoe/files/cryptocoin@guantanamoe/applet.js
+++ b/cryptocoin@guantanamoe/files/cryptocoin@guantanamoe/applet.js
@@ -215,7 +215,7 @@ MyApplet.prototype = {
         }
 
         if (this.rates_update_interval == false) {
-            this.rates_update_interval = 5;
+            this.rates_update_interval = 30;
         }
 
         this._updateTimeout = Mainloop.timeout_add(this.rates_update_interval * 1000, Lang.bind(this, this._update_value));


### PR DESCRIPTION
cryptocompare.com seem to have changed their limits for number of api calls/month.
Currently the applet does one call every 5 seconds.
This makes the applet stop functioning after the quota is reached.
Change the value to make one call every 30 seconds to avoid hitting the limit and keep the applet working.