### PR TITLE
windowlist@cobinja.de Add support for desktop file actions

### DIFF
--- a/windowlist@cobinja.de/CHANGELOG.md
+++ b/windowlist@cobinja.de/CHANGELOG.md
@@ -1,5 +1,10 @@
 Changelog
 
+2.7
+==
+- Add support for launching desktop file actions
+- Show places in nemo's context menu
+
 2.6.1
 ==
 - Don't show "Visible on all workspaces" if there is only one workspace

--- a/windowlist@cobinja.de/README.md
+++ b/windowlist@cobinja.de/README.md
@@ -1,7 +1,7 @@
 This is a Cinnamon applet that intends to partially resemble the Windows 7 taskbar
 
 ## Requirements
-This applet requires Cinnamon 3.2
+This applet requires at least Cinnamon 3.2 (not for new features anymore). Best supported is Cinnamon 4.0 and newer
 
 ## Installation
 Download and enable via cinnamon settings.

--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/4.0/applet.js
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/4.0/applet.js
@@ -1436,6 +1436,48 @@ class CobiAppButton {
       }
     }
     
+    let appInfo = this._app.get_app_info();
+    if (appInfo != null) {
+      let actions = appInfo.list_actions();
+      if (actions.length > 0) {
+        let appId = this.get_app_id();
+        
+        if (appId == "nemo.desktop" || appId == "nemo-home.desktop") {
+          let defaultPlaces = Main.placesManager.getDefaultPlaces();
+          let bookmarks = Main.placesManager.getBookmarks();
+          let places = defaultPlaces.concat(bookmarks);
+          
+          if (places.length > 0) {
+            this._contextMenu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+            let placesMenu = new PopupMenu.PopupSubMenuMenuItem(_("Places"));
+            
+            for (let i = 0; i < places.length; i++) {
+              let place = places[i];
+              let placeItem = new PopupMenu.PopupMenuItem(place.name);
+              placeItem.connect("activate", Lang.bind(this, function() {
+                place.launch();
+              }));
+              placesMenu.menu.addMenuItem(placeItem);
+            }
+            this._contextMenu.addMenuItem(placesMenu);
+          }
+        }
+        
+        this._contextMenu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        for (let i = 0; i < actions.length; i++) {
+          let action = actions[i];
+          let displayName = appInfo.get_action_name(action);
+          
+          let actionItem = new PopupMenu.PopupMenuItem(displayName);
+          actionItem.connect("activate", Lang.bind(this, function() {
+            global.log("Launching action: " + action);
+            appInfo.launch_action(action, global.create_app_launch_context());
+          }));
+          this._contextMenu.addMenuItem(actionItem);
+        }
+      }
+    }
+    
     if (this._currentWindow) {
       this._contextMenu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
       // window ops for workspaces


### PR DESCRIPTION
This adds support for launching actions declared in applications' desktop files
and support for places in nemo's context menu
https://github.com/Cobinja/CobiWindowList/issues/33