### PR TITLE
world calendar is broken because uses python2 instead of python3

### DIFF
--- a/calendar@simonwiles.net/files/calendar@simonwiles.net/applet.js
+++ b/calendar@simonwiles.net/files/calendar@simonwiles.net/applet.js
@@ -282,7 +282,7 @@ MyApplet.prototype = {
     },
 
     _launch_worldclocks_config: function() {
-        Util.spawnCommandLine("/usr/bin/env python2 " + APPLET_DIR + "/world_clock_calendar_settings.py --instance-id " + this.instance_id);
+        Util.spawnCommandLine("/usr/bin/env python3 " + APPLET_DIR + "/world_clock_calendar_settings.py --instance-id " + this.instance_id);
     },
 
     _initRightClickMenu: function () {

--- a/calendar@simonwiles.net/files/calendar@simonwiles.net/world_clock_calendar_settings.py
+++ b/calendar@simonwiles.net/files/calendar@simonwiles.net/world_clock_calendar_settings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #-*- coding:utf-8 -*-
 
 """ Settings Dialogue for World Clock Calendar Applet """
@@ -175,7 +175,7 @@ class SettingsWindow(Gtk.Window):
 
         timezones = subprocess.check_output(
             ['/usr/bin/awk', '!/#/ {print $3}', timezones_tab])
-        timezones = sorted(timezones.strip('\n').split('\n'))
+        timezones = sorted(timezones.decode('utf-8').strip('\n').split('\n'))
 
         # https://github.com/simonwiles/cinnamon_applets/issues/7
         timezones.append('UTC')
@@ -266,7 +266,7 @@ class AppletSettings(object):
 
     def save(self):
         with io.open(self.settings_json, 'w', encoding='utf-8') as handle:
-            handle.write(unicode(json.dumps(
+            handle.write(str(json.dumps(
                 self.settings, ensure_ascii=True, indent=2)))
 
 


### PR DESCRIPTION
The settings app for world calendar is built on python2, and is therefore obsolete which needs to modified to use python3.