### PR TITLE
temperature@fevimu: Adding label prefix support to applet panel display

### DIFF
--- a/temperature@fevimu/files/temperature@fevimu/applet.js
+++ b/temperature@fevimu/files/temperature@fevimu/applet.js
@@ -53,6 +53,8 @@ CPUTemperatureApplet.prototype = {
     this.settings.bindProperty(Settings.BindingDirection.IN, 'only-integer-part', 'onlyIntegerPart', () => this.on_settings_changed(), null);
     this.settings.bindProperty(Settings.BindingDirection.IN, 'show-unit', 'showUnit', () => this.on_settings_changed(), null);
     this.settings.bindProperty(Settings.BindingDirection.IN, 'show-unit-letter', 'showUnitLetter', () => this.on_settings_changed(), null);
+    this.settings.bindProperty(Settings.BindingDirection.IN, 'show-label-prefix', 'showLabelPrefix', () => this.on_settings_changed(), null);
+    this.settings.bindProperty(Settings.BindingDirection.IN, 'label-prefix', 'labelPrefix', () => this.on_settings_changed(), null);
     this.settings.bindProperty(Settings.BindingDirection.IN, 'interval', 'interval');
     this.settings.bindProperty(Settings.BindingDirection.IN, 'change-color', 'changeColor', () => this.on_settings_changed(), null);
     this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL, 'only-colors', 'onlyColors', () => this.on_settings_changed(), null);
@@ -253,6 +255,10 @@ CPUTemperatureApplet.prototype = {
           items.push(_('Critical Temperature') + ': ' + this._formatTemp(tempInfo.crit));
         }
       }
+    }
+
+    if (this.state.showLabelPrefix) {
+      this.title = this.state.labelPrefix + this.title;
     }
 
     if (this._applet_label.text !== this.title) {

--- a/temperature@fevimu/files/temperature@fevimu/applet.js
+++ b/temperature@fevimu/files/temperature@fevimu/applet.js
@@ -258,7 +258,7 @@ CPUTemperatureApplet.prototype = {
     }
 
     if (this.state.showLabelPrefix) {
-      this.title = this.state.labelPrefix + this.title;
+      this.title = "%s %s".format(this.state.labelPrefix, this.title);
     }
 
     if (this._applet_label.text !== this.title) {

--- a/temperature@fevimu/files/temperature@fevimu/settings-schema.json
+++ b/temperature@fevimu/files/temperature@fevimu/settings-schema.json
@@ -22,6 +22,20 @@
     "tooltip": "Whether or not show the unit letter (C or F).",
     "dependency": "show-unit"
   },
+  "show-label-prefix": {
+    "type": "switch",
+    "default": false,
+    "description": "Show label prefix",
+    "tooltip": "Whether or not to add a label before the temperature value."
+  },
+  "label-prefix": {
+    "type": "entry",
+    "default": "🌡 ",
+    "description": "Label prefix",
+    "indent": true,
+    "tooltip": "The label to be shown before the temperature value.",
+    "dependency": "show-label-prefix"
+  },
   "interval": {
     "type": "spinbutton",
     "default": 5000,

--- a/temperature@fevimu/files/temperature@fevimu/settings-schema.json
+++ b/temperature@fevimu/files/temperature@fevimu/settings-schema.json
@@ -30,9 +30,8 @@
   },
   "label-prefix": {
     "type": "entry",
-    "default": "🌡 ",
+    "default": "🌡",
     "description": "Label prefix",
-    "indent": true,
     "tooltip": "The label to be shown before the temperature value.",
     "dependency": "show-label-prefix"
   },


### PR DESCRIPTION
Simple change to add a customizable prefix to the temperate display in the panel.
Default included prefix (disabled by default) is the Unicode thermometer character (U+1F321). 

![screencap](https://user-images.githubusercontent.com/546177/77869404-4cefd880-71f3-11ea-8288-aecd90f1c905.png)

Triggering a notification to @claudiux 