### PR TITLE
Fix missing images for Spotify Player

### DIFF
--- a/sound150@claudiux/files/sound150@claudiux/3.4/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/3.4/applet.js
@@ -794,7 +794,7 @@ Player.prototype = {
                 artUrl = artUrl.replace("/image/", "/300/"); // Spotify 0.27.x
             }
             if (this._trackCoverFile != artUrl) {
-                this._trackCoverFile = artUrl;
+                this._trackCoverFile = (this._name === "Spotify") ? artUrl.replace("open.spotify.com","i.scdn.co") :  artUrl;
                 change = true;
             }
         }


### PR DESCRIPTION
Hi I use linux mint as my distro, and recently I started writing a music script when I realized that the cover art of music on sound applet was missing, so I tried fix by myself, its a little hard for me understand the code but I did it, sorry if I open this pull request just update one line of code, my skills with Gobject are weak yet.
     This little fix just only update the url because spotify does not show cover art anymore by the old url.

### Additional notes: 
On old mode the artUrl could return a link like this for example: https://open.spotify.com/image/ab67616d00001e027ca89320e10bdc2bd343cdee and no image is returned.

Now with the change return something like this: https://i.scdn.co/image/ab67616d00001e027ca89320e10bdc2bd343cdee.