### PR TITLE
ShutdownApplet@shelley: Fixed broken Log Out command

### DIFF
--- a/ShutdownApplet@shelley/files/ShutdownApplet@shelley/applet.js
+++ b/ShutdownApplet@shelley/files/ShutdownApplet@shelley/applet.js
@@ -53,7 +53,7 @@ MyApplet.prototype = {
             });  
             
             this.menu.addAction(_("Log Out"), function(event) {
-                Util.spawnCommandLine("gnome-session-quit --no-prompt");
+                Util.spawnCommandLine("cinnamon-session-quit --no-prompt");
             });
             
              this.menu.addAction(_("Shutdown"), function(event) {


### PR DESCRIPTION
@icarter09

gnome-session-quit is not part of cinnamon-core, but cinnamon-session-quit is