### PR TITLE
[hwmonitor@sylfurd]: Workaround for glibtop disk I/O for LVM bug (#2801)

### DIFF
--- a/hwmonitor@sylfurd/README.md
+++ b/hwmonitor@sylfurd/README.md
@@ -9,6 +9,12 @@ Issues can be reported here : [Issues](https://github.com/linuxmint/cinnamon-spi
 
 ### Changes
 
+**Version 1.3**:
+* **Bug Fixes and Feature Enhancements**: Disk Usage Stats
+    * Fixed a bug that prevented device mapper volumes (LVM, dm-crypt LUKS, etc.) from displaying usage statistics details or graphs.
+    * Disk usage graphs and details statistics are now displayed as throughput with unit and graph scaling (B/s, KB/s, MB/s, etc.).
+    * It is now possible to select the disk to monitor from a drop down menu in the settings UI that lists the available storage devices on the system.
+
 **Version 1.2.1**:
  * **New setting**, a new minor UI setting, you can now choose how to draw the grid lines in the graphs. You can choose between:
     * Don't draw grid lines at all
@@ -83,3 +89,4 @@ Vertical pane examples:
 *  giwhub
 *  andreevlex
 *  clefebvre
+*  jacobwills

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.2/providers.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.2/providers.js
@@ -226,59 +226,85 @@ function DiskDataProvider(frequency, type_read, mount_dir) {
 }
 
 DiskDataProvider.prototype = {
-	init : function(frequency, type_read, mount_dir) {
-        this.gtop = new GTop.glibtop_fsusage();
-        this.frequency = frequency;
-        this.last = -1;
-        this.max = 1;
-        this.type_read = type_read;
-        this.mount_dir = mount_dir;
-        if (this.type_read) {
+	init : function(frequency, sample_size, type_read, device_name) {
+if (type_read) {
             this.name = _("DISK (read)");
             this.type = "DISKREAD";
         } else {
             this.name = _("DISK (write)");
             this.type = "DISKWRITE";
         }
+        this.frequency = frequency;
+        this.type_read = type_read;
+        this.device_name = device_name;
+        this.sample_size = sample_size;
+        this.sample_history = [1,];
+        this.disk_stat_path = "/sys/block/" + this.device_name + "/stat";
+        this.min_speed = 33554414;
+        // this.max_speed = 268435318;
+
+        [this.read_last, this.written_last] = this.getDiskLoad();
     },
 
     getData : function() {
         try {
-            GTop.glibtop_get_fsusage(this.gtop, this.mount_dir);
-
-            let current = 0;
-            if (this.type_read) {
-                current = this.gtop.read;
-            } else {
-                current = this.gtop.write;
-            }
+            let [read, written] = this.getDiskLoad();
+            let read_delta = (read - this.read_last) / this.frequency;
+            let written_delta = (written - this.written_last) / this.frequency;
+            this.read_last = read;
+            this.written_last = written;
+            let format = new Tools();
             
-            if (this.last==-1) {
-                this.text = "0 %";
-                this.last = current;
-                return 0;
-            } else {
-                // Drive usage (percent of drive full)
-                // let usage = (this.gtop.blocks - this.gtop.bfree) / this.gtop.blocks;
-                // var text = (usage*100).toFixed(1);
-                // return tools.limit(usage, 0, 1);
+            this.max = Math.max(...this.sample_history);
+            this.max_speed = (this.max > this.min_speed) ? this.max : this.min_speed ;
 
-                // Calculate percent being used
-                let usage = current - this.last;
-                this.last = current;                            // Save number of read/write blocks for next check
-                if (usage > this.max)                           // Save the max value so that we can calculate the percentage
-                    this.max = usage;
-                let percent = usage/this.max;                   // Calculate percentage being used
-                this.text = ((percent)*100).toFixed(1) + "%";   // Set detailed text
-                let tools = new Tools();
-                return tools.limit(percent, 0, 1);              // Return percentage
-            }    
+            if (this.type_read) {
+                this.text = format.formatBytes(read_delta);
+                this.data = this.getLinearValue(read_delta, this.max_speed);
+
+                if (this.sample_history.length >= this.sample_size) {
+                    this.sample_history.shift();
+                }
+                this.sample_history.push(read_delta);
+
+                return this.data;
+            }
+            else {
+                this.text = format.formatBytes(written_delta);
+                this.data = this.getLinearValue(written_delta, this.max_speed);
+
+                if (this.sample_history.length >= this.sample_size) {
+                    this.sample_history.shift();
+                }
+                this.sample_history.push(written_delta);
+
+                return this.data;
+            }
         }
         catch (e) {
-            global.logError(e);
-            this.text = "0 %";
-            return 0;
+            global.logError("Exception in getData():" + e.message);
         }
+    },
+
+    getDiskLoad() {
+        try {
+            // if ( GLib.file_test(this.disk_stat_path, GLib.FileTest.IS_REGULAR) && GLib.file_test(this.disk_stat_path, GLib.FileTest.EXISTS) ) {
+            let stats_data = GLib.file_get_contents(this.disk_stat_path).toString().trim().split(/\s+/);
+            let read = stats_data[3] * 512;
+            let written = stats_data[7] * 512;
+            return [read, written];
+        }
+        catch (e) {
+            global.logError("Exception in getDiskLoad(): " + e.message);
+        }
+    },
+
+    getLinearValue(value, max) {
+        if (max<=1 || value<=0)
+            return 0;
+
+        let tools = new Tools();
+        return tools.limit(value/max, 0, 1);
     }
 }
 

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.2/settings-schema.json
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.2/settings-schema.json
@@ -158,8 +158,8 @@
       "keys": [
         "diskread_enable_graph",
         "diskread_size",
+        "diskread_device_name",
         "diskread_use_custom_label",
-        "diskread_mount_dir",
         "diskread_custom_label",
         "diskread_show_detail_label"
       ]
@@ -170,8 +170,8 @@
       "keys": [
         "diskwrite_enable_graph",
         "diskwrite_size",
+        "diskwrite_device_name",
         "diskwrite_use_custom_label",
-        "diskwrite_mount_dir",
         "diskwrite_custom_label",
         "diskwrite_show_detail_label"
       ]
@@ -563,19 +563,24 @@
       "tooltip":"Set the width of the graph for horizontal panels, or the height of the graph for vertical panels.",
       "dependency": "diskread_enable_graph"
   },
+  "diskread_device_name": {
+    "type": "combobox",
+    "default": "sda",
+    "options": {
+        "sda": "sda",
+        "sdb": "sdb",
+        "sdc": "sdc"
+    },
+    "description": "Set the device name to monitor for the DISK (read) graph.",
+    "tooltip": "Set the device name to monitor for the DISK (read) graph.",
+    "dependency": "diskread_enable_graph"
+  },
   "diskread_use_custom_label": {
       "type": "checkbox",
       "default": false,
       "description": "Use custom graph label.",
       "tooltip": "Choose your own label for the DISK (read) graph.",
       "dependency": "diskread_enable_graph"
-  },
-  "diskread_mount_dir": {
-    "type": "entry",
-    "default": "/",
-    "description": "Set the mount dir to monitor for the DISK (read) graph.",
-    "tooltip": "Set the mount dir to monitor for the DISK (read) graph. By default it monitors the root drive (/), but you could change it to monitor another drive by setting it to for example /mnt/another_drive.",
-    "dependency": "diskread_enable_graph"
   },
   "diskread_custom_label": {
       "type": "entry",
@@ -607,11 +612,16 @@
       "tooltip":"Set the width of the graph for horizontal panels, or the height of the graph for vertical panels.",
       "dependency": "diskwrite_enable_graph"
   },
-  "diskwrite_mount_dir": {
-    "type": "entry",
-    "default": "/",
-    "description": "Set the mount dir to monitor for the DISK (write) graph.",
-    "tooltip": "Set the mount dir to monitor for the DISK (write) graph. By default it monitors the root drive (/), but you could change it to monitor another drive by setting it to for example /mnt/another_drive.",
+  "diskwrite_device_name": {
+    "type": "combobox",
+    "default": "sda",
+    "options": {
+        "sda": "sda",
+        "sdb": "sdb",
+        "sdc": "sdc"
+    },
+    "description": "Set the device name to monitor for the DISK (write) graph.",
+    "tooltip": "Set the device name to monitor for the DISK (write) graph.",
     "dependency": "diskwrite_enable_graph"
   },
   "diskwrite_use_custom_label": {

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/applet.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/applet.js
@@ -29,6 +29,7 @@ const Clutter = imports.gi.Clutter;
 const St = imports.gi.St;
 const Gettext = imports.gettext;
 const GLib = imports.gi.GLib;
+const GUdev = imports.gi.GUdev;
 const Settings = imports.ui.settings;
 const UUID = "hwmonitor@sylfurd";
 
@@ -145,14 +146,14 @@ GraphicalHWMonitorApplet.prototype = {
         // DISK (read) settings
         this.settings.bind("diskread_enable_graph", "diskread_enable_graph", this.settingsChanged);
         this.settings.bind("diskread_size", "diskread_size", this.settingsChanged);
+        this.settings.bind("diskread_device_name", "diskread_device_name", this.settingsChanged);
         this.settings.bind("diskread_use_custom_label", "diskread_use_custom_label", this.settingsChanged);
-        this.settings.bind("diskread_mount_dir", "diskread_mount_dir", this.settingsChanged);
         this.settings.bind("diskread_custom_label", "diskread_custom_label", this.settingsChanged);
         this.settings.bind("diskread_show_detail_label", "diskread_show_detail_label", this.settingsChanged);
         // DISK (write) settings
         this.settings.bind("diskwrite_enable_graph", "diskwrite_enable_graph", this.settingsChanged);
         this.settings.bind("diskwrite_size", "diskwrite_size", this.settingsChanged);
-        this.settings.bind("diskwrite_mount_dir", "diskwrite_mount_dir", this.settingsChanged);
+        this.settings.bind("diskwrite_device_name", "diskwrite_device_name", this.settingsChanged);
         this.settings.bind("diskwrite_use_custom_label", "diskwrite_use_custom_label", this.settingsChanged);
         this.settings.bind("diskwrite_custom_label", "diskwrite_custom_label", this.settingsChanged);
         this.settings.bind("diskwrite_show_detail_label", "diskwrite_show_detail_label", this.settingsChanged);
@@ -162,8 +163,9 @@ GraphicalHWMonitorApplet.prototype = {
         this.settings.bind("bat_use_custom_label", "bat_use_custom_label", this.settingsChanged);
         this.settings.bind("bat_custom_label", "bat_custom_label", this.settingsChanged);
         this.settings.bind("bat_show_detail_label", "bat_show_detail_label", this.settingsChanged);
-        
         this.createThemeObject();
+
+        this.getAvailableDisks();
 
         this.createAppletArea();
 
@@ -235,7 +237,7 @@ GraphicalHWMonitorApplet.prototype = {
             else
                 diskReadGraphArea = this.appletArea.addGraph(this.panel_height, this.diskread_size);
 
-            let diskReadProvider =  new Providers.DiskDataProvider(this.frequency, true, this.diskread_mount_dir);
+            let diskReadProvider =  new Providers.DiskDataProvider(this.frequency, this.diskread_size, true, this.diskread_device_name);
             this.graphs.push(new Graph.Graph(diskReadProvider, diskReadGraphArea, this.theme_object, this.diskread_show_detail_label));
         }    
                 
@@ -247,7 +249,7 @@ GraphicalHWMonitorApplet.prototype = {
             else
                 diskWriteGraphArea = this.appletArea.addGraph(this.panel_height, this.diskwrite_size);
 
-            let diskWriteProvider =  new Providers.DiskDataProvider(this.frequency, false, this.diskwrite_mount_dir);
+            let diskWriteProvider =  new Providers.DiskDataProvider(this.frequency, this.diskwrite_size, false, this.diskwrite_device_name);
             this.graphs.push(new Graph.Graph(diskWriteProvider, diskWriteGraphArea, this.theme_object, this.diskwrite_show_detail_label));
         }    
 
@@ -371,6 +373,23 @@ GraphicalHWMonitorApplet.prototype = {
         return colors;
     },
 
+    // Queries the system for available block devices which the user may select from
+    getAvailableDisks: function() {
+        let devices_options = {};
+        let block_devices = new GUdev.Client().query_by_subsystem("block");
+        for (var n = 0; n < block_devices.length; n++) {
+            let name = block_devices[n].get_name();
+            let label = block_devices[n].get_property("ID_FS_LABEL_ENC");
+            devices_options[name + (label == null ? "" : ("   " + label.replace(/\\x20/g, " ")))] = name;
+        }
+        let ordered_devices_options = {};
+        Object.keys(devices_options).filter(x => !x.includes("loop")).sort().forEach(function(key) {
+            ordered_devices_options[key] = devices_options[key];
+        });
+        this.settings.setOptions("diskread_device_name", ordered_devices_options);
+        this.settings.setOptions("diskwrite_device_name", ordered_devices_options);
+    },
+
     // Creates an object containing the users selected theme settings
     createThemeObject: function() {
         this.theme_object = new Object();
@@ -411,7 +430,8 @@ GraphicalHWMonitorApplet.prototype = {
         this.createThemeObject();
         this.removeUpdateLoop();
         this.addUpdateLoop(this.frequency);
-        this.updateAppletArea();        
+        this.updateAppletArea();
+        this.getAvailableDisks();
     },
 
     _runSysMon: function() {

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/settings-schema.json
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/settings-schema.json
@@ -158,8 +158,8 @@
         "keys": [
           "diskread_enable_graph",
           "diskread_size",
+          "diskread_device_name",
           "diskread_use_custom_label",
-          "diskread_mount_dir",
           "diskread_custom_label",
           "diskread_show_detail_label"
         ]
@@ -170,8 +170,8 @@
         "keys": [
           "diskwrite_enable_graph",
           "diskwrite_size",
+          "diskwrite_device_name",
           "diskwrite_use_custom_label",
-          "diskwrite_mount_dir",
           "diskwrite_custom_label",
           "diskwrite_show_detail_label"
         ]
@@ -563,19 +563,24 @@
         "tooltip":"Set the width of the graph for horizontal panels, or the height of the graph for vertical panels.",
         "dependency": "diskread_enable_graph"
     },
+    "diskread_device_name": {
+      "type": "combobox",
+      "default": "sda",
+      "options": {
+          "sda": "sda",
+          "sdb": "sdb",
+          "sdc": "sdc"
+      },
+      "description": "Set the device name to monitor for the DISK (read) graph.",
+      "tooltip": "Set the device name to monitor for the DISK (read) graph.",
+      "dependency": "diskread_enable_graph"
+    },
     "diskread_use_custom_label": {
         "type": "checkbox",
         "default": false,
         "description": "Use custom graph label.",
         "tooltip": "Choose your own label for the DISK (read) graph.",
         "dependency": "diskread_enable_graph"
-    },
-    "diskread_mount_dir": {
-      "type": "entry",
-      "default": "/",
-      "description": "Set the mount dir to monitor for the DISK (read) graph.",
-      "tooltip": "Set the mount dir to monitor for the DISK (read) graph. By default it monitors the root drive (/), but you could change it to monitor another drive by setting it to for example /mnt/another_drive.",
-      "dependency": "diskread_enable_graph"
     },
     "diskread_custom_label": {
         "type": "entry",
@@ -607,11 +612,16 @@
         "tooltip":"Set the width of the graph for horizontal panels, or the height of the graph for vertical panels.",
         "dependency": "diskwrite_enable_graph"
     },
-    "diskwrite_mount_dir": {
-      "type": "entry",
-      "default": "/",
-      "description": "Set the mount dir to monitor for the DISK (write) graph.",
-      "tooltip": "Set the mount dir to monitor for the DISK (write) graph. By default it monitors the root drive (/), but you could change it to monitor another drive by setting it to for example /mnt/another_drive.",
+    "diskwrite_device_name": {
+      "type": "combobox",
+      "default": "sda",
+      "options": {
+          "sda": "sda",
+          "sdb": "sdb",
+          "sdc": "sdc"
+      },
+      "description": "Set the device name to monitor for the DISK (write) graph.",
+      "tooltip": "Set the device name to monitor for the DISK (write) graph.",
       "dependency": "diskwrite_enable_graph"
     },
     "diskwrite_use_custom_label": {

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/settings-schema.json
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/settings-schema.json
@@ -571,8 +571,8 @@
           "sdb": "sdb",
           "sdc": "sdc"
       },
-      "description": "Set the device name to monitor for the DISK (read) graph.",
-      "tooltip": "Set the device name to monitor for the DISK (read) graph.",
+      "description": "Set the device to monitor for the DISK (read) graph.",
+      "tooltip": "Set the device to monitor for the DISK (read) graph.",
       "dependency": "diskread_enable_graph"
     },
     "diskread_use_custom_label": {
@@ -620,8 +620,8 @@
           "sdb": "sdb",
           "sdc": "sdc"
       },
-      "description": "Set the device name to monitor for the DISK (write) graph.",
-      "tooltip": "Set the device name to monitor for the DISK (write) graph.",
+      "description": "Set the device to monitor for the DISK (write) graph.",
+      "tooltip": "Set the device to monitor for the DISK (write) graph.",
       "dependency": "diskwrite_enable_graph"
     },
     "diskwrite_use_custom_label": {

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/metadata.json
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/metadata.json
@@ -1,5 +1,5 @@
 {
-    "multiversion": true, 
+    "multiversion": true,
     "cinnamon-version": [
         "3.2", 
         "3.4", 
@@ -8,10 +8,10 @@
         "4.0", 
         "4.2", 
         "4.4"
-    ], 
-    "max-instances": "-1", 
-    "description": "Displaying realtime system information (CPU, memory, network and disk load).", 
-    "uuid": "hwmonitor@sylfurd", 
-    "version": "1.2.1", 
+    ],
+    "max-instances": "-1",
+    "description": "Displaying realtime system information (CPU, memory, network and disk load).",
+    "uuid": "hwmonitor@sylfurd",
+    "version": "1.3",
     "name": "Graphical hardware monitor"
 }


### PR DESCRIPTION
This is a work in progress. I'm submitting this primarily for review/feedback. By the time I got this far, I realized that **there is a significant desktop performance impact when performing large transfers** to or from the device being monitored although I'm not sure if it is my crappy JS coding or something inherently wrong with the approach I'm taking here. Maybe if I were using async calls when reading the sysfs kernel exports it would perform better? **My plan is to rework this using the libgudev library** which I believe utilizes non-blocking, asynchronous I/O system calls which might be the ticket to speeding this up. Feedback and additional performance testing results welcome. Thanks.

* Enumerates block devices by reading directly from sysfs kernel exports.
* Provides combobox for device selection in settings menu. (Thoughts?)
* Disk I/O detail displayed as **throughput** with unit scaling (B/s, KB/s, MB/s, etc.) mirroring NET stats implementation. (Thoughts?)
* Graph history is also scaled by keeping track of max throughput achieved within time frame based on the graph display width and update frequency.
* confirmed working to display statistics for both physical block and virtual block device mounting facilities including those auto-mounted with device mapper framework and across several filesystems. Gvfs, dm-crypt, LVM on LUKS, ext3/4, BTRFS, NTFS, FAT, etc. across SATA and USB devices that I had available for testing. (I haven't tested with any software/hardware RAID configurations but it should work depending on the way they are mounted)
* tested on latest Manjaro and Arch Cinnamon Desktop environments

Fixes #2801 
@Hultan @ArnaudDovi @claudiux @brownsr 