### PR TITLE
force-quit@cinnamon.org: Fix tooltip l10n & use symbolic icon

### DIFF
--- a/force-quit@cinnamon.org/README.md
+++ b/force-quit@cinnamon.org/README.md
@@ -1,0 +1,4 @@
+**Required package in Arch Linux/Manjaro:**
+```
+xorg-xkill
+```

--- a/force-quit@cinnamon.org/files/force-quit@cinnamon.org/applet.js
+++ b/force-quit@cinnamon.org/files/force-quit@cinnamon.org/applet.js
@@ -10,15 +10,15 @@ function _(str) {
     return Gettext.dgettext(UUID, str);
 }
 
-function MyApplet(orientation) {
-    this._init(orientation);
+function MyApplet(metadata, orientation, panelHeight, instanceId) {
+    this._init(metadata, orientation, panelHeight, instanceId);
 }
 
 MyApplet.prototype = {
     __proto__: Applet.IconApplet.prototype,
 
-    _init: function(orientation) {
-        Applet.IconApplet.prototype._init.call(this, orientation);
+    _init: function(metadata, orientation, panelHeight, instanceId) {
+        Applet.IconApplet.prototype._init.call(this, orientation, panelHeight, instanceId);
 
         try {
             this.set_applet_icon_symbolic_name("window-close");
@@ -45,7 +45,7 @@ MyApplet.prototype = {
 
 };
 
-function main(metadata, orientation) {
-    let myApplet = new MyApplet(orientation);
+function main(metadata, orientation, panelHeight, instanceId) {
+    let myApplet = new MyApplet(metadata, orientation, panelHeight, instanceId);
     return myApplet;
 }

--- a/force-quit@cinnamon.org/files/force-quit@cinnamon.org/applet.js
+++ b/force-quit@cinnamon.org/files/force-quit@cinnamon.org/applet.js
@@ -4,10 +4,10 @@ const GLib = imports.gi.GLib;
 const Gettext = imports.gettext;
 const UUID = "force-quit@cinnamon.org";
 
-Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "./local/share/locale");
+Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
 
 function _(str) {
-    return Gettext.dgettext(UUID, str)
+    return Gettext.dgettext(UUID, str);
 }
 
 function MyApplet(orientation) {
@@ -21,7 +21,7 @@ MyApplet.prototype = {
         Applet.IconApplet.prototype._init.call(this, orientation);
 
         try {
-            this.set_applet_icon_name("window-close");
+            this.set_applet_icon_symbolic_name("window-close");
             this.set_applet_tooltip(_("Click here to kill a window"));
             this.actor.connect('button-release-event', Lang.bind(this, this._onButtonReleaseEvent));
         }

--- a/force-quit@cinnamon.org/files/force-quit@cinnamon.org/po/de.po
+++ b/force-quit@cinnamon.org/files/force-quit@cinnamon.org/po/de.po
@@ -7,25 +7,28 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-22 02:14+0200\n"
-"PO-Revision-Date: 2017-09-22 02:18+0200\n"
+"POT-Creation-Date: 2020-05-01 13:38+0200\n"
+"PO-Revision-Date: 2020-05-01 13:39+0200\n"
+"Last-Translator: \n"
 "Language-Team: \n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: \n"
+"X-Generator: Poedit 2.0.6\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: de\n"
 
 #: applet.js:25
 msgid "Click here to kill a window"
 msgstr "Hier klicken, um eine Anwendung zu beenden bzw. ein Fenster zu killen"
 
-#. force-quit@cinnamon.org->metadata.json->description
-msgid "Click on the applet to launch xkill and force any window to quit immediately"
-msgstr "Auf das Applet klicken, um »xkill« zu starten und das sofortige Beenden eines beliebiges Fenster zu erzwingen"
-
-#. force-quit@cinnamon.org->metadata.json->name
+#. metadata.json->name
 msgid "Force Quit"
 msgstr "Beenden erzwingen"
+
+#. metadata.json->description
+msgid ""
+"Click on the applet to launch xkill and force any window to quit immediately"
+msgstr ""
+"Auf das Applet klicken, um »xkill« zu starten und das sofortige Beenden "
+"eines beliebiges Fenster zu erzwingen"

--- a/force-quit@cinnamon.org/files/force-quit@cinnamon.org/po/force-quit@cinnamon.org.pot
+++ b/force-quit@cinnamon.org/files/force-quit@cinnamon.org/po/force-quit@cinnamon.org.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-06 00:46+0800\n"
+"POT-Creation-Date: 2020-05-01 13:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,11 +21,11 @@ msgstr ""
 msgid "Click here to kill a window"
 msgstr ""
 
-#. force-quit@cinnamon.org->metadata.json->description
-msgid ""
-"Click on the applet to launch xkill and force any window to quit immediately"
+#. metadata.json->name
+msgid "Force Quit"
 msgstr ""
 
-#. force-quit@cinnamon.org->metadata.json->name
-msgid "Force Quit"
+#. metadata.json->description
+msgid ""
+"Click on the applet to launch xkill and force any window to quit immediately"
 msgstr ""


### PR DESCRIPTION
Also fixes icon size memory:
If you use a custom height for your symbolic icons, the icon scales properly, but as soon as you restart Cinnamon, the icon gets back to its default size. (Fixes #2879)

Add instruction for Arch based distros (Closes https://github.com/linuxmint/cinnamon-spices-applets/issues/1294)