### PR TITLE
clipboard-qr@wrousnel: added parentheses to make clipboard-qr.py work…

### DIFF
--- a/clipboard-qr@wrouesnel/files/clipboard-qr@wrouesnel/clipboard-qr.py
+++ b/clipboard-qr@wrouesnel/files/clipboard-qr@wrouesnel/clipboard-qr.py
@@ -28,4 +28,4 @@ proc.visible = False
 # extract results
 for symbol in proc.results:
     # do something useful with results
-    print symbol.data
+    print( symbol.data )


### PR DESCRIPTION
… under python 3.7.7