### PR TITLE
[hwmonitor@sylfurd] Fix disk settings defaults bug (#3005)

### DIFF
--- a/hwmonitor@sylfurd/README.md
+++ b/hwmonitor@sylfurd/README.md
@@ -9,6 +9,10 @@ Issues can be reported here : [Issues](https://github.com/linuxmint/cinnamon-spi
 
 ### Changes
 
+**Version 1.3.1**:
+* **Bug Fix
+    * Fixed a bug that crashed the applet if the hardcoded default was not a valid device option. The default is now the first device listed after scanning for devices on the system instead of "sda".
+
 **Version 1.3**:
 * **Bug Fixes and Feature Enhancements**: Disk Usage Stats
     * Fixed a bug that prevented device mapper volumes (LVM, dm-crypt LUKS, etc.) from displaying usage statistics details or graphs.

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/applet.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/applet.js
@@ -163,18 +163,16 @@ GraphicalHWMonitorApplet.prototype = {
         this.settings.bind("bat_use_custom_label", "bat_use_custom_label", this.settingsChanged);
         this.settings.bind("bat_custom_label", "bat_custom_label", this.settingsChanged);
         this.settings.bind("bat_show_detail_label", "bat_show_detail_label", this.settingsChanged);
+
         this.createThemeObject();
-
-        this.getAvailableDisks();
-
         this.createAppletArea();
-
         this.actor.set_offscreen_redirect(Clutter.OffscreenRedirect.ALWAYS);
         this.addUpdateLoop(this.frequency);
-
     },
 
     createAppletArea: function(){
+        this.getAvailableDisks();
+
         this.graphs = [];
         if (this.isHorizontal)
             this.appletArea = new Support.AppletArea(this, this.isHorizontal,0, this.panel_height);
@@ -359,7 +357,7 @@ GraphicalHWMonitorApplet.prototype = {
     },
 
     // Called when the settings have changed
-    settingsChanged: function () {        
+    settingsChanged: function () {
         this.restartGHW();
     },
 
@@ -407,6 +405,12 @@ GraphicalHWMonitorApplet.prototype = {
 
         this.settings.setOptions("diskread_device_name", ordered_devices_options);
         this.settings.setOptions("diskwrite_device_name", ordered_devices_options);
+
+        if (this.diskread_device_name == "none" || this.diskwrite_device_name == "none") {
+            
+            this.diskread_device_name = ordered_devices_options[Object.keys(ordered_devices_options)[0]];
+            this.diskwrite_device_name = ordered_devices_options[Object.keys(ordered_devices_options)[0]];
+        }
     },
 
     // Creates an object containing the users selected theme settings
@@ -450,7 +454,6 @@ GraphicalHWMonitorApplet.prototype = {
         this.removeUpdateLoop();
         this.addUpdateLoop(this.frequency);
         this.updateAppletArea();
-        this.getAvailableDisks();
     },
 
     _runSysMon: function() {

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/settings-schema.json
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/settings-schema.json
@@ -565,12 +565,8 @@
     },
     "diskread_device_name": {
       "type": "combobox",
-      "default": "sda",
-      "options": {
-          "sda": "sda",
-          "sdb": "sdb",
-          "sdc": "sdc"
-      },
+      "default": "none",
+      "options": {"Select a device": "none"},
       "description": "Set the device to monitor for the DISK (read) graph.",
       "tooltip": "Set the device to monitor for the DISK (read) graph.",
       "dependency": "diskread_enable_graph"
@@ -614,12 +610,8 @@
     },
     "diskwrite_device_name": {
       "type": "combobox",
-      "default": "sda",
-      "options": {
-          "sda": "sda",
-          "sdb": "sdb",
-          "sdc": "sdc"
-      },
+      "default": "none",
+      "options": {"Select a device": "none"},
       "description": "Set the device to monitor for the DISK (write) graph.",
       "tooltip": "Set the device to monitor for the DISK (write) graph.",
       "dependency": "diskwrite_enable_graph"

--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/metadata.json
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/metadata.json
@@ -12,6 +12,6 @@
     "max-instances": "-1",
     "description": "Displaying realtime system information (CPU, memory, network and disk load).",
     "uuid": "hwmonitor@sylfurd",
-    "version": "1.3",
+    "version": "1.3.1",
     "name": "Graphical hardware monitor"
 }


### PR DESCRIPTION
@Hultan 
This should do the trick. After enumerating the available devices on the system the applet now selects the first device in the list as the default storage device to monitor for disk IO stats.

I also managed to resolve a small redundancy issue, where the `getAvailableDisks()` class method was being called more often than it ought to be when the applet gets reloaded/restarted by changing from where in the code it gets called.

Fixes #3005