### PR TITLE
[hwmonitor@sylfurd]: Update requirements for hwmonitor

### DIFF
--- a/hwmonitor@sylfurd/README.md
+++ b/hwmonitor@sylfurd/README.md
@@ -54,11 +54,11 @@ Issues can be reported here : [Issues](https://github.com/linuxmint/cinnamon-spi
 
 ### Requirements
 
-**Graphical Hardware Monitor** requires the **Gtop** package to collect system information. It might already be installed on your system, but if the applet or graph is not shown, you might need to install the **Gtop** package manually.
+**Graphical Hardware Monitor** requires the **Gtop** and **GUdev** packages to collect system information. It might already be installed on your system, but if the applet or graph is not shown, you might need to install the packages manually.
 
-* **Ubuntu/Mint**: install the package **gir1.2-gtop-2.0**
-* **Fedora**: install the package **libgtop2-devel**
-* **Arch/Manjaro**: install the package **libgtop**
+* **Debian/Ubuntu/Mint**: install the packages **gir1.2-gtop-2.0** and **gir1.2-gudev-1.0**
+* **Fedora**: install the package **libgtop2-devel** and **libgudev**
+* **Arch/Manjaro**: install the package **libgtop** and **libgudev**
 
 ### Example
 


### PR DESCRIPTION
GUdev was introduced in 802098c8 (via linuxmint/cinnamon-spices-applets#2983)
as a workaround for linuxmint/cinnamon-spices-applets#2801.

Without the GUdev package the applet crashes and can not be added to
the panel. The following error is shown in `~/.xsession-errors`:

```
  Cjs-Message: 20:07:01.690: JS LOG: [LookingGlass/error]
  [hwmonitor@sylfurd]: Requiring GUdev, version none: Typelib file for namespace 'GUdev' (any version) not found
  [hwmonitor@sylfurd]: Error importing applet.js from hwmonitor@sylfurd
  Cjs-Message: 20:07:01.690: JS LOG: [LookingGlass/trace]
  <----------------
  anonymous@/home/jkirk/.local/share/cinnamon/applets/hwmonitor@sylfurd/3.8/applet.js:32:7
  createExports@/usr/share/cinnamon/js/misc/fileUtils.js:210:31
  requireModule/</<@/usr/share/cinnamon/js/misc/fileUtils.js:288:25
  ---------------->
```

The documentation needs to be updated to reflect that new dependency.

To completely fix this issue a dependency check should be added.

Supports: linuxmint/cinnamon-spices-applets#3023