### PR TITLE
collapsible-systray@feuerfuchs.eu - Handle exception for deprecated indicatorManager

### DIFF
--- a/collapsible-systray@feuerfuchs.eu/files/collapsible-systray@feuerfuchs.eu/4.0/CinnamonSystray.js
+++ b/collapsible-systray@feuerfuchs.eu/files/collapsible-systray@feuerfuchs.eu/4.0/CinnamonSystray.js
@@ -72,6 +72,7 @@ class CinnamonSystrayApplet extends Applet.Applet {
 
     _addIndicatorSupport() {
         let manager = Main.indicatorManager;
+		if (!manager) return;
 
         // Blacklist some of the icons
         // quassel: The proper icon in Quassel is "QuasselIRC",


### PR DESCRIPTION
@Feuerfuchs 

"Fixes" the error message https://github.com/linuxmint/cinnamon-spices-applets/issues/3062, as indicatorManager was removed in Cinnamon 4.6.

I was too lazy to figure out what functionality was lost, so it just does a nullcheck.