### PR TITLE
Screencapture+RecordDesktop honor display with mpdecimate optimization

### DIFF
--- a/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/recorder.sh
+++ b/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/recorder.sh
@@ -6,7 +6,7 @@ generate_filename() {
   . "$HOME/.config/user-dirs.dirs"
   ###   Date and time format   ###
   # 24-Hour time should not add pm/am, but is kept for compatibility for now
-  echo "Cinnamon-$( date +'%b-%d-%Y_%H:%M:%S%#p' )"   ## 24-Hour time
+  echo "Cinnamon-$( date +'%b-%d-%Y_%H:%M:%S%#p' ).mkv"   ## 24-Hour time
 }
 
 record_screen() {

--- a/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/recorder.sh
+++ b/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/recorder.sh
@@ -13,10 +13,10 @@ record_screen() {
   local size=$( /usr/bin/xdpyinfo | grep 'dimensions:' | awk '{print $2}' )
   parameters+=(
     -f x11grab
-    -i "$DISPLAY"
     -s "$size"
     -r 30
     -qscale 1
+    -i "$DISPLAY"
     -vf mpdecimate
   )
 }
@@ -30,10 +30,10 @@ record_window() {
 
   parameters+=(
     -f x11grab
-    -i "$DISPLAY+$x_offset,$y_offset"
     -s "${width}x${height}"
     -r 30
     -qscale 1
+    -i "$DISPLAY+$x_offset,$y_offset"
     -vf mpdecimate
   )
 }

--- a/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/recorder.sh
+++ b/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/recorder.sh
@@ -1,35 +1,49 @@
 #!/bin/bash
 
-function prepare_filename () {
+typeset -a parameters
+
+generate_filename() {
   . "$HOME/.config/user-dirs.dirs"
   ###   Date and time format   ###
-  #format="$( date +'%b-%d-%Y_%I:%M:%S%#p' )"   ## 12-Hour time
-  format="$( date +'%b-%d-%Y_%H:%M:%S%#p' )"   ## 24-Hour time
-  
-  name=Cinnamon-$format
-  parameters="$parameters $XDG_VIDEOS_DIR/$name.mkv"
+  # 24-Hour time should not add pm/am, but is kept for compatibility for now
+  echo "Cinnamon-$( date +'%b-%d-%Y_%H:%M:%S%#p' )"   ## 24-Hour time
 }
 
-function record_screen () {
-  size=$( /usr/bin/xdpyinfo | grep 'dimensions:' | awk '{print $2}' )
-  parameters="$parameters -f x11grab -s $size -r 30 -i :0.0 -qscale 1 $video"
+record_screen() {
+  local size=$( /usr/bin/xdpyinfo | grep 'dimensions:' | awk '{print $2}' )
+  parameters+=(
+    -f x11grab
+    -i ':0'
+    -s "$size"
+    -r 30
+    -qscale 1
+  )
 }
 
-function record_window () { 
-  id=`/usr/bin/xdotool getactivewindow`
-  width=`/usr/bin/xwininfo -id $id | grep Width | cut -d' ' -f4`
-  height=`/usr/bin/xwininfo -id $id | grep Height | cut -d' ' -f4`
-  y_offset=`/usr/bin/xwininfo -id $id | grep "Absolute upper-left Y" | cut -d' ' -f7`
-  x_offset=`/usr/bin/xwininfo -id $id | grep "Absolute upper-left X" | cut -d' ' -f7`
+record_window() {
+  id=$(/usr/bin/xdotool getactivewindow)
+  width=$(/usr/bin/xwininfo -id "$id" | grep Width | cut -d' ' -f4)
+  height=$(/usr/bin/xwininfo -id "$id" | grep Height | cut -d' ' -f4)
+  y_offset=$(/usr/bin/xwininfo -id "$id" | grep "Absolute upper-left Y" | cut -d' ' -f7)
+  x_offset=$(/usr/bin/xwininfo -id "$id" | grep "Absolute upper-left X" | cut -d' ' -f7)
 
-  parameters="$parameters -f x11grab -s ${width}x${height} -r 30 -i :0.0+$x_offset,$y_offset -qscale 1 $video"
+  parameters+=(
+    -f x11grab
+    -i ":0+$x_offset,$y_offset"
+    -s "${width}x${height}"
+    -r 30
+    -qscale 1
+  )
 }
 
-function record_audio () {
-  parameters="$parameters -f alsa -ac 2 -i pulse"
+record_audio() {
+  parameters+=(
+    -f alsa
+    -ac 2
+    -i pulse
+  )
 }
 
-function execute () {
-  prepare_filename
-  /usr/bin/ffmpeg $parameters
+execute() {
+  ffmpeg "${parameters[@]}" "$(generate_filename)"
 }

--- a/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/recorder.sh
+++ b/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/recorder.sh
@@ -17,6 +17,7 @@ record_screen() {
     -s "$size"
     -r 30
     -qscale 1
+    -vf mpdecimate
   )
 }
 
@@ -33,6 +34,7 @@ record_window() {
     -s "${width}x${height}"
     -r 30
     -qscale 1
+    -vf mpdecimate
   )
 }
 

--- a/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/recorder.sh
+++ b/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/recorder.sh
@@ -13,7 +13,7 @@ record_screen() {
   local size=$( /usr/bin/xdpyinfo | grep 'dimensions:' | awk '{print $2}' )
   parameters+=(
     -f x11grab
-    -i ':0'
+    -i "$DISPLAY"
     -s "$size"
     -r 30
     -qscale 1
@@ -29,7 +29,7 @@ record_window() {
 
   parameters+=(
     -f x11grab
-    -i ":0+$x_offset,$y_offset"
+    -i "$DISPLAY+$x_offset,$y_offset"
     -s "${width}x${height}"
     -r 30
     -qscale 1

--- a/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/screencapture.sh
+++ b/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/screencapture.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-dir=`/usr/bin/dirname $0`
-. ${dir}/recorder.sh
+dir="${0%/*}"
+. "${dir:-.}/recorder.sh"
 
 record_screen
 execute

--- a/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/screencapturesound.sh
+++ b/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/screencapturesound.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-dir=`dirname $0`
-. ${dir}/recorder.sh
+dir="${0%/*}"
+. "${dir:-.}/recorder.sh"
 
 record_audio
 record_screen

--- a/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/screencapturesoundwindow.sh
+++ b/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/screencapturesoundwindow.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-dir=`dirname $0`
-. ${dir}/recorder.sh
+dir="${0%/*}"
+. "${dir:-.}/recorder.sh"
 
 record_audio
 record_window

--- a/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/screencapturewindow.sh
+++ b/ScreenShot+RecordDesktop@tech71/files/ScreenShot+RecordDesktop@tech71/screencapturewindow.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-dir=`/usr/bin/dirname $0`
-. ${dir}/recorder.sh
+dir="${0%/*}"
+. "${dir:-.}/recorder.sh"
 
 record_window
 execute


### PR DESCRIPTION
* honor  DISPLAY environment variable instead of hard-coding \:0
* add mpdecimate as a video filter to significantly reduce recorded video sizes
  * mpdecimate only removes duplicate frames
  * mpdecimate has low overhead
* quote vars and convert parameters to an array to prevent whitespace issues