### PR TITLE
Fix crashing bug in Sensors@claudiux where there is no LANGUAGE environment 

### DIFF
--- a/Sensors@claudiux/files/Sensors@claudiux/applet.js
+++ b/Sensors@claudiux/files/Sensors@claudiux/applet.js
@@ -679,7 +679,7 @@ class SensorsApplet extends Applet.TextApplet {
       //_minimumIntegerDigits = 3;
     }
 
-    let _lang = GLib.getenv("LANGUAGE").replace("_", "-");
+    let _lang = (GLib.getenv("LANGUAGE") + "").replace("_", "-");
     if (this.only_integer_part) {
       _t = Math.round(_t);
       ret = (new Intl.NumberFormat(_lang, { minimumIntegerDigits: this.minimumIntegerDigitsTemp }).format(_t)).toString();
@@ -758,7 +758,7 @@ class SensorsApplet extends Applet.TextApplet {
     let _unit = "V";
     let _sep = (vertical) ? "\n" : " ";
     let ret;
-    let _lang = GLib.getenv("LANGUAGE").replace("_", "-");
+    let _lang = (GLib.getenv("LANGUAGE") + "").replace("_", "-");
     let _padstart = 8;
 
     switch(this.volt_unit) {


### PR DESCRIPTION
If there's no LANGUAGE variable when running Sensors@claudiux, it causes a replacement on a null variable. This makes sure there is at least a blank string in the variable so the replace always "works"
