### PR TITLE
Update applet.js

### DIFF
--- a/weather@mockturtl/files/weather@mockturtl/3.0/applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.0/applet.js
@@ -940,7 +940,7 @@ var UI = (function () {
             if (weather.condition.main != null) {
                 mainCondition = weather.condition.main;
                 if (config._translateCondition) {
-                    mainCondition = capitalizeFirstLetter(_(mainCondition));
+                    mainCondition = " " + capitalizeFirstLetter(_(mainCondition));
                 }
             }
             if (weather.condition.description != null) {


### PR DESCRIPTION
Same as for 3.8. Added space before capitalizeFirstLetter in Line 943:                    mainCondition = " " + capitalizeFirstLetter(_(mainCondition));
This improves optics in the Systemtray with a little bit of space between Icon and Main Condition Text