### PR TITLE
CinnVIIStarkMenu: v1.29 (improved search)

### DIFF
--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/appUtils.js
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/appUtils.js
@@ -1,0 +1,111 @@
+const Cinnamon = imports.gi.Cinnamon;
+const CMenu = imports.gi.CMenu;
+
+const Util = imports.misc.util;
+
+let appsys = Cinnamon.AppSystem.get_default();
+
+// sort apps by their latinised name
+function appSort(a, b) {
+    a = Util.latinise(a[0].get_name().toLowerCase());
+    b = Util.latinise(b[0].get_name().toLowerCase());
+    return a > b;
+}
+
+// sort cmenu directories with admin and prefs categories last
+function dirSort(a, b) {
+    let menuIdA = a.get_menu_id().toLowerCase();
+    let menuIdB = b.get_menu_id().toLowerCase();
+
+    let prefCats = ["administration", "preferences"];
+    let prefIdA = prefCats.indexOf(menuIdA);
+    let prefIdB = prefCats.indexOf(menuIdB);
+
+    if (prefIdA < 0 && prefIdB >= 0) {
+        return -1;
+    }
+    if (prefIdA >= 0 && prefIdB < 0) {
+        return 1;
+    }
+
+    let nameA = a.get_name().toLowerCase();
+    let nameB = b.get_name().toLowerCase();
+
+    if (nameA > nameB) {
+        return 1;
+    }
+    if (nameA < nameB) {
+        return -1;
+    }
+    return 0;
+}
+
+/* returns all apps and the categories they belong to, and all top level categories
+ *
+ * [
+ *   [
+ *     app 1,
+ *     [
+ *       top level category 1,
+ *       random category,
+ *       random category
+ *     ]
+ *   ],
+ *   ...
+ * ],
+ * [
+ *   top level category 1,
+ *   top level category 2,
+ *   top level category 3,
+ *   top level category 4,
+ *   ...
+ * ] */
+function getApps() {
+    let apps = new Map();
+    let dirs = [];
+
+    let tree = appsys.get_tree();
+    let root = tree.get_root_directory();
+    let iter = root.iter();
+    let nextType;
+
+    while ((nextType = iter.next()) != CMenu.TreeItemType.INVALID) {
+        if (nextType == CMenu.TreeItemType.DIRECTORY) {
+            let dir = iter.get_directory();
+            if (dir.get_is_nodisplay())
+                continue;
+            if (loadDirectory(dir, dir, apps))
+                dirs.push(dir);
+        }
+    }
+
+    dirs.sort(dirSort);
+    let sortedApps = Array.from(apps.entries()).sort(appSort);
+
+    return [sortedApps, dirs];
+}
+
+// load all apps and their categories from a cmenu directory
+// into 'apps' Map
+function loadDirectory(dir, top_dir, apps) {
+    let iter = dir.iter();
+    let has_entries = false;
+    let nextType;
+    while ((nextType = iter.next()) != CMenu.TreeItemType.INVALID) {
+        if (nextType == CMenu.TreeItemType.ENTRY) {
+            let desktopId = iter.get_entry().get_desktop_file_id();
+            let app = appsys.lookup_app(desktopId);
+            if (!app || app.get_nodisplay())
+                continue;
+
+            has_entries = true;
+            if (apps.has(app))
+                apps.get(app).push(dir.get_menu_id());
+            else
+                apps.set(app, [top_dir.get_menu_id()]);
+        } else if (nextType == CMenu.TreeItemType.DIRECTORY) {
+            has_entries = loadDirectory(iter.get_directory(), top_dir, apps);
+        }
+    }
+    return has_entries;
+}

--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/applet.js
@@ -3735,8 +3735,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
     }
 
     _onSearchTextChanged (se, prop) {
-        if (this.leftPane.get_child() == this.favsBox)
-            this.switchPanes("apps");
         let searchString = this.searchEntry.get_text().trim();
         let searchActive = !(searchString == '' || searchString == this.searchEntry.hint_text);
         if (!this.searchActive && !searchActive)
@@ -3751,6 +3749,9 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this._clearAllSelections();
 
         if (searchActive) {
+            if (this.leftPane.get_child() == this.favsBox)
+                this.switchPanes("apps");
+
             this.searchEntry.set_secondary_icon(this._searchActiveIcon);
             if (!this._searchIconClickedId) {
                 this._searchIconClickedId =
@@ -3787,7 +3788,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         let regexpPattern = new RegExp(Util.escapeRegExp(pattern));
 
         for (let i = 0; i < buttons.length; i++) {
-            if (buttons[i].type == "recent-clear") {
+            if (buttons[i].type == "recent-clear" || buttons[i].type == "no-recent") {
                 continue;
             }
             let res = buttons[i].searchStrings[0].match(regexpPattern);

--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/applet.js
@@ -678,7 +678,7 @@ class PlaceButton extends SimpleMenuItem {
             selectedAppId = selectedAppId.substr(fileIndex + 7);
 
         if (selectedAppId === "home" || selectedAppId === "desktop" || selectedAppId === "connect") {
-        	selectedAppId = place.name
+            selectedAppId = place.name
         }
 
         super(applet, { name: place.name,
@@ -2314,11 +2314,11 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
             this._previousTreeSelectedActor = null;
             this._previousSelectedActor = null;
             this.closeContextMenu(false);
-	    this._previousVisibleIndex = null;
+            this._previousVisibleIndex = null;
 
             this._clearAllSelections(false);
             this._scrollToButton(null, this.applicationsScrollBox);
-	    this._scrollToButton(null, this.categoriesScrollBox);
+            this._scrollToButton(null, this.categoriesScrollBox);
             this.destroyVectorBox();
         }
     }
@@ -3162,7 +3162,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                 break;
             }
         }
-        
+
         if (!this.showPlaces) {
             return;
         }
@@ -3192,7 +3192,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         }
 
         this._recentButtons = [];
-        
+
         for (let i = 0; i < this._categoryButtons.length; i++) {
             if (this._categoryButtons[i].categoryId === 'recent') {
                 this._categoryButtons[i].destroy();
@@ -3201,7 +3201,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                 break;
             }
         }
-            
+
         if (!this.privacy_settings.get_boolean(REMEMBER_RECENT_KEY)) {
             return;
         }
@@ -3853,7 +3853,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         }
 
         this._displayButtons(null, buttons, acResults);
-	
+
         let numberResults = buttons.length + acResults.length;
         if (numberResults == 0)
             this.resultsFoundButton.label.set_text(_("No results found"));

--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/applet.js
@@ -1847,7 +1847,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this.settings.bind("show-category-icons", "showCategoryIcons", () => this._updateShowIcons(this.categoriesBox, this.showCategoryIcons));
         this.settings.bind("show-application-icons", "showApplicationIcons", () => this._updateShowIcons(this.applicationsBox, this.showApplicationIcons));
         this.settings.bind("show-favorite-icons", "showFavoriteIcons", () => this._updateShowIcons(this.favoritesBox, this.showFavoriteIcons));
-        this.settings.bind("show-apps-description-on-buttons", "showAppsDescriptionOnButtons", this._doRefresh);
+        this.settings.bind("show-apps-description-on-buttons", "showAppsDescriptionOnButtons", () => this.queueRefresh(REFRESH_ALL_MASK));
 
         this.settings.bind("enable-animation", "enableAnimation", null);
 

--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/applet.js
@@ -1,6 +1,5 @@
 const Applet = imports.ui.applet;
 const Mainloop = imports.mainloop;
-const CMenu = imports.gi.CMenu;
 const Lang = imports.lang;
 const Cinnamon = imports.gi.Cinnamon;
 const St = imports.gi.St;
@@ -45,8 +44,27 @@ const USER_DESKTOP_PATH = FileUtils.getUserDesktopDir();
 const PRIVACY_SCHEMA = "org.cinnamon.desktop.privacy";
 const REMEMBER_RECENT_KEY = "remember-recent-files";
 
+const AppUtils = require('./appUtils');
+
 let appsys = Cinnamon.AppSystem.get_default();
 let visiblePane = "favs";
+const RefreshFlags = Object.freeze({
+    APP:    0b00001,
+    FAV:    0b00010,
+    PLACE:  0b00100,
+    RECENT: 0b01000,
+    SYSTEM: 0b10000
+});
+const REFRESH_ALL_MASK = 0b11111;
+
+const NO_MATCH = 99999;
+const APP_MATCH_ADDERS = [
+    0, // name
+    1000, // keywords
+    2000, // desc
+    3000 // id
+];
+const RECENT_PLACES_ADDER = 4000;
 
 /* VisibleChildIterator takes a container (boxlayout, etc.)
  * and creates an array of its visible children and their index
@@ -168,6 +186,8 @@ class SimpleMenuItem {
         this.applet = applet;
         this.label = null;
         this.icon = null;
+
+        this.matchIndex = NO_MATCH;
 
         for (let prop in params)
             this[prop] = params[prop];
@@ -377,6 +397,13 @@ class ApplicationContextMenuItem extends PopupMenu.PopupBaseMenuItem {
             case "run_with_nvidia_gpu":
                 Util.spawnCommandLine("optirun gtk-launch " + this._appButton.app.get_id());
                 break;
+            case "offload_launch":
+                try {
+                    this._appButton.app.launch_offloaded(0, [], -1);
+                } catch (e) {
+                    logError(e, "Could not launch app with dedicated gpu: ");
+                }
+                break;
             default:
                 return true;
         }
@@ -422,6 +449,14 @@ class GenericApplicationButton extends SimpleMenuItem {
 
     populateMenu(menu) {
         let menuItem;
+        if (Main.gpu_offload_supported) {
+            menuItem = new ApplicationContextMenuItem(this, _("Run with NVIDIA GPU"), "offload_launch", "cpu");
+            menu.addMenuItem(menuItem);
+        } else if (this.applet._isBumblebeeInstalled) {
+            menuItem = new ApplicationContextMenuItem(this, _("Run with NVIDIA GPU"), "run_with_nvidia_gpu", "cpu");
+            menu.addMenuItem(menuItem);
+        }
+
         menuItem = new ApplicationContextMenuItem(this, _("Add to panel"), "add_to_panel", "list-add");
         menu.addMenuItem(menuItem);
 
@@ -440,11 +475,6 @@ class GenericApplicationButton extends SimpleMenuItem {
 
         if (this.applet._canUninstallApps) {
             menuItem = new ApplicationContextMenuItem(this, _("Uninstall"), "uninstall", "edit-delete");
-            menu.addMenuItem(menuItem);
-        }
-
-        if (this.applet._isBumblebeeInstalled) {
-            menuItem = new ApplicationContextMenuItem(this, _("Run with NVIDIA GPU"), "run_with_nvidia_gpu", "cpu");
             menu.addMenuItem(menuItem);
         }
     }
@@ -566,6 +596,13 @@ class ApplicationButton extends GenericApplicationButton {
         this._signals.connect(this._draggable, 'drag-end', Lang.bind(this, this._onDragEnd));
         this.isDraggableApp = true;
 
+        this.searchStrings = [
+            Util.latinise(app.get_name().toLowerCase()),
+            app.get_keywords() ? Util.latinise(app.get_keywords().toLowerCase()) : "",
+            app.get_description() ? Util.latinise(app.get_description().toLowerCase()) : "",
+            app.get_id() ? Util.latinise(app.get_id().toLowerCase()) : ""
+        ];
+
         this.tooltip = new TooltipCustom(this.actor, this.description, true);
     }
 
@@ -640,6 +677,10 @@ class PlaceButton extends SimpleMenuItem {
         if (fileIndex !== -1)
             selectedAppId = selectedAppId.substr(fileIndex + 7);
 
+        if (selectedAppId === "home" || selectedAppId === "desktop" || selectedAppId === "connect") {
+        	selectedAppId = place.name
+        }
+
         super(applet, { name: place.name,
                         description: selectedAppId,
                         type: 'place',
@@ -656,6 +697,10 @@ class PlaceButton extends SimpleMenuItem {
             this.icon.visible = false;
 
         this.addLabel(this.name, 'menu-application-button-label');
+
+        this.searchStrings = [
+            Util.latinise(place.name.toLowerCase())
+        ];
 
         if (applet.showAppsDescriptionOnButtons) {
             this.addDescription(this.name, this.description);
@@ -710,6 +755,10 @@ class RecentButton extends SimpleMenuItem {
             this.icon.visible = false;
 
         this.addLabel(this.name, 'menu-application-button-label');
+
+        this.searchStrings = [
+            Util.latinise(recent.name.toLowerCase())
+        ];
 
         if (applet.showAppsDescriptionOnButtons) {
             this.addDescription(this.name, this.description);
@@ -1776,7 +1825,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
         this.settings = new Settings.AppletSettings(this, "CinnVIIStarkMenu@NikoKrause", instance_id);
 
-        this.settings.bind("show-places", "showPlaces", this._refreshBelowApps);
+        this.settings.bind("show-places", "showPlaces", () => this.queueRefresh(RefreshFlags.PLACE));
 
         this._appletEnterEventId = 0;
         this._appletLeaveEventId = 0;
@@ -1798,7 +1847,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this.settings.bind("show-category-icons", "showCategoryIcons", () => this._updateShowIcons(this.categoriesBox, this.showCategoryIcons));
         this.settings.bind("show-application-icons", "showApplicationIcons", () => this._updateShowIcons(this.applicationsBox, this.showApplicationIcons));
         this.settings.bind("show-favorite-icons", "showFavoriteIcons", () => this._updateShowIcons(this.favoritesBox, this.showFavoriteIcons));
-        this.settings.bind("show-apps-description-on-buttons", "showAppsDescriptionOnButtons", this._refreshAll);
+        this.settings.bind("show-apps-description-on-buttons", "showAppsDescriptionOnButtons", this._doRefresh);
 
         this.settings.bind("enable-animation", "enableAnimation", null);
 
@@ -1833,7 +1882,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this._previousTreeSelectedActor = null;
         this._activeContainer = null;
         this._activeActor = null;
-        this.menuIsOpening = false;
         this._knownApps = new Set(); // Used to keep track of apps that are already installed, so we can highlight newly installed ones
         this._appsWereRefreshed = false;
         this._canUninstallApps = GLib.file_test("/usr/bin/cinnamon-remove-application", GLib.FileTest.EXISTS);
@@ -1848,11 +1896,11 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this._updateCustomLabels();
         this._appsBoxWidthResized = false;
 
-        appsys.connect('installed-changed', Lang.bind(this, this.onAppSysChanged));
-        AppFavorites.getAppFavorites().connect('changed', Lang.bind(this, this._refreshFavs));
-        Main.placesManager.connect('places-updated', Lang.bind(this, this._refreshBelowApps));
-        this.RecentManager.connect('changed', Lang.bind(this, this._refreshRecent));
-        this.privacy_settings.connect("changed::" + REMEMBER_RECENT_KEY, Lang.bind(this, this._refreshRecent));
+        appsys.connect('installed-changed', () => this.queueRefresh(RefreshFlags.APP | RefreshFlags.FAV));
+        AppFavorites.getAppFavorites().connect('changed', () => this.queueRefresh(RefreshFlags.FAV));
+        Main.placesManager.connect('places-updated', () => this.queueRefresh(RefreshFlags.PLACE));
+        this.RecentManager.connect('changed', () => this.queueRefresh(RefreshFlags.RECENT));
+        this.privacy_settings.connect("changed::" + REMEMBER_RECENT_KEY, () => this.queueRefresh(RefreshFlags.RECENT));
 
         this.settings.bind("show-sidebar", "showSidebar", this._updateQuickLinksView);
         this._updateQuickLinksView();
@@ -1866,10 +1914,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this._pathCompleter.set_dirs_only(false);
         this.lastAcResults = [];
         this.settings.bind("search-filesystem", "searchFilesystem");
-        this.refreshing = false; // used as a flag to know if we're currently refreshing (so we don't do it more than once concurrently)
-
         this.contextMenu = null;
-
         this.lastSelectedCategory = null;
 
         this.settings.bind("quicklauncher-places", "quicklauncher_places", this._updateQuickLinks);
@@ -1887,7 +1932,9 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         // We shouldn't need to call refreshAll() here... since we get a "icon-theme-changed" signal when CSD starts.
         // The reason we do is in case the Cinnamon icon theme is the same as the one specificed in GTK itself (in .config)
         // In that particular case we get no signal at all.
-        this._refreshAll();
+        this.refreshId = 0;
+        this.refreshMask = REFRESH_ALL_MASK;
+        this._doRefresh();
 
         this.set_show_label_in_vertical_panels(false);
     }
@@ -1909,29 +1956,43 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         }));
     }
 
-    onAppSysChanged() {
-        if (this.refreshing == false) {
-            this.refreshing = true;
-            Mainloop.timeout_add_seconds(1, () => this._refreshAll());
-        }
+    queueRefresh(refreshFlags) {
+        if (!refreshFlags)
+            return;
+        this.refreshMask |= refreshFlags;
+        if (this.refreshId)
+            Mainloop.source_remove(this.refreshId);
+        this.refreshId = Mainloop.timeout_add(500, () => this._doRefresh(), Mainloop.PRIORITY_LOW);
     }
 
-    _refreshAll() {
-        try {
+    _doRefresh() {
+        this.refreshId = 0;
+        if (this.refreshMask === 0)
+            return;
+
+        let m = this.refreshMask;
+        if ((m & RefreshFlags.APP) === RefreshFlags.APP)
             this._refreshApps();
+        if ((m & RefreshFlags.FAV) === RefreshFlags.FAV)
             this._refreshFavs();
+        if ((m & RefreshFlags.PLACE) === RefreshFlags.PLACE)
             this._refreshPlaces();
+        if ((m & RefreshFlags.RECENT) === RefreshFlags.RECENT)
             this._refreshRecent();
-        }
-        catch (exception) {
-            global.log(exception);
-        }
-        this.refreshing = false;
-    }
 
-    _refreshBelowApps() {
-        this._refreshPlaces();
-        this._refreshRecent();
+        this.refreshMask = 0;
+
+        // recent category is always last
+        if (this.recentButton)
+            this.categoriesBox.set_child_at_index(this.recentButton.actor, -1);
+
+        // places is before recents, or last in list if recents is disabled/not generated
+        if (this.placesButton) {
+            if (this.recentButton)
+                this.categoriesBox.set_child_below_sibling(this.placesButton.actor, this.recentButton.actor);
+            else
+                this.categoriesBox.set_child_at_index(this.placesButton.actor, -1);
+        }
     }
 
     openMenu() {
@@ -1961,20 +2022,21 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
         this._clearDelayCallbacks();
 
-        if (this.activateOnHover) {
-            this._appletEnterEventId = this.actor.connect('enter-event', Lang.bind(this, function() {
-                if (this.hover_delay_ms > 0) {
-                    this._appletLeaveEventId = this.actor.connect('leave-event', Lang.bind(this, this._clearDelayCallbacks));
-                    this._appletHoverDelayId = Mainloop.timeout_add(this.hover_delay_ms,
-                        Lang.bind(this, function() {
-                            this.openMenu();
-                            this._clearDelayCallbacks();
-                        }));
-                } else {
-                    this.openMenu();
-                }
-            }));
-        }
+        if (!this.activateOnHover)
+            return;
+
+        this._appletEnterEventId = this.actor.connect('enter-event', () => {
+            if (this.hover_delay_ms > 0) {
+                this._appletLeaveEventId = this.actor.connect('leave-event', () => { this._clearDelayCallbacks });
+                this._appletHoverDelayId = Mainloop.timeout_add(this.hover_delay_ms,
+                    () => {
+                        this.openMenu();
+                        this._clearDelayCallbacks();
+                    });
+            } else {
+                this.openMenu();
+            }
+        });
     }
 
     _resizeAppsBoxHeight() {
@@ -2213,7 +2275,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
     _onOpenStateChanged(menu, open) {
         if (open) {
-            this.menuIsOpening = true;
             this.actor.add_style_pseudo_class('active');
             global.stage.set_key_focus(this.searchEntry);
             this._selectedItemIndex = null;
@@ -2580,7 +2641,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                             } else {
                                 this._activeContainer = this.categoriesBox;
                                 item_actor = this.catBoxIter.getLastVisible();
-                                this._scrollToButton();
+                                this._scrollToButton(item_actor._delegate, this.categoriesScrollBox);
                             }
                             break;
                         case "down":
@@ -2591,7 +2652,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                                 this._activeContainer = this.categoriesBox;
                                 item_actor = this.catBoxIter.getFirstVisible();
                                 item_actor = this._activeContainer._vis_iter.getNextVisible(item_actor);
-                                this._scrollToButton();
+                                this._scrollToButton(item_actor._delegate, this.categoriesScrollBox);
                             }
                             break;
                         case "right":
@@ -2618,7 +2679,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                             } else {
                                 this._activeContainer = this.categoriesBox;
                                 item_actor = this.catBoxIter.getFirstVisible();
-                                this._scrollToButton();
+                                this._scrollToButton(item_actor._delegate, this.categoriesScrollBox);
                             }
                             break;
                         case "bottom":
@@ -2628,7 +2689,7 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                             } else {
                                 this._activeContainer = this.categoriesBox;
                                 item_actor = this.catBoxIter.getLastVisible();
-                                this._scrollToButton();
+                                this._scrollToButton(item_actor._delegate, this.categoriesScrollBox);
                             }
                             break;
                     }
@@ -2639,13 +2700,13 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                             this._previousTreeSelectedActor = this.categoriesBox.get_child_at_index(index);
                             this._previousTreeSelectedActor._delegate.isHovered = false;
                             item_actor = this.catBoxIter.getPrevVisible(this._activeActor);
-                            this._scrollToButton();
+                            this._scrollToButton(item_actor._delegate, this.categoriesScrollBox);
                             break;
                         case "down":
                             this._previousTreeSelectedActor = this.categoriesBox.get_child_at_index(index);
                             this._previousTreeSelectedActor._delegate.isHovered = false;
                             item_actor = this.catBoxIter.getNextVisible(this._activeActor);
-                            this._scrollToButton();
+                            this._scrollToButton(item_actor._delegate, this.categoriesScrollBox);
                             break;
                         case "right":
                             if ((this.categoriesBox.get_child_at_index(index))._delegate.categoryId === "recent" &&
@@ -2670,13 +2731,13 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
                             this._previousTreeSelectedActor = this.categoriesBox.get_child_at_index(index);
                             this._previousTreeSelectedActor._delegate.isHovered = false;
                             item_actor = this.catBoxIter.getFirstVisible();
-                            this._scrollToButton();
+                            this._scrollToButton(item_actor._delegate, this.categoriesScrollBox);
                             break;
                         case "bottom":
                             this._previousTreeSelectedActor = this.categoriesBox.get_child_at_index(index);
                             this._previousTreeSelectedActor._delegate.isHovered = false;
                             item_actor = this.catBoxIter.getLastVisible();
-                            this._scrollToButton();
+                            this._scrollToButton(item_actor._delegate, this.categoriesScrollBox);
                             break;
                     }
                     break;
@@ -3096,100 +3157,102 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         this._placesButtons = [];
 
         for (let i = 0; i < this._categoryButtons.length; i++) {
-            if (this._categoryButtons[i].categoryId === "places") {
+            if (this._categoryButtons[i].categoryId === 'place') {
                 this._categoryButtons[i].destroy();
                 this._categoryButtons.splice(i, 1);
                 this.placesButton = null;
                 break;
             }
         }
-
-        // Now generate Places category and places buttons and add to the list
-        if (this.showPlaces) {
-            this.placesButton = new CategoryButton(this, 'places', _('Places'),  'folder');
-            this._categoryButtons.push(this.placesButton);
-            this.categoriesBox.add_actor(this.placesButton.actor);
-
-            let bookmarks = this._listBookmarks()[0];
-            let devices = this._listDevices()[0];
-            let places = bookmarks.concat(devices);
-
-            for (let i = 0; i < places.length; i++) {
-                let place = places[i];
-                let button = new PlaceButton(this, place);
-                this._placesButtons.push(button);
-                this.applicationsBox.add_actor(button.actor);
-            }
+        
+        if (!this.showPlaces) {
+            return;
         }
 
-        this._setCategoriesButtonActive(!this.searchActive);
+        // Now generate Places category and places buttons and add to the list
+        if (!this.placesButton) {
+            this.placesButton = new CategoryButton(this, 'place', _('Places'),  'folder');
+            this._categoryButtons.push(this.placesButton);
+            this.categoriesBox.add_actor(this.placesButton.actor);
+        }
+
+        // places go after applications. we add them in reverse starting below the last ApplicationButton
+        let sibling = this._applicationsButtons[this._applicationsButtons.length - 1].actor;
+        let places = Main.placesManager.getAllPlaces();
+        for (let i = places.length - 1; i >= 0; i--) {
+            let button = new PlaceButton(this, places[i]);
+            this._placesButtons.push(button);
+            this.applicationsBox.insert_child_below(button.actor, sibling);
+            button.actor.visible = this.menu.isOpen;
+            sibling = button.actor;
+        }
     }
 
     _refreshRecent () {
-
-        for (let i = 0; i < this._recentButtons.length; i ++) {
+        for (let i = 0; i < this._recentButtons.length; i++) {
             this._recentButtons[i].destroy();
         }
 
         this._recentButtons = [];
-
+        
         for (let i = 0; i < this._categoryButtons.length; i++) {
-            if (this._categoryButtons[i].categoryId === "recent") {
+            if (this._categoryButtons[i].categoryId === 'recent') {
                 this._categoryButtons[i].destroy();
                 this._categoryButtons.splice(i, 1);
                 this.recentButton = null;
                 break;
             }
         }
+            
+        if (!this.privacy_settings.get_boolean(REMEMBER_RECENT_KEY)) {
+            return;
+        }
 
-        if (this.privacy_settings.get_boolean(REMEMBER_RECENT_KEY)) {
+        if (!this.recentButton) {
             this.recentButton = new CategoryButton(this, 'recent', _('Recent Files'), 'folder-recent');
             this._categoryButtons.push(this.recentButton);
             this.categoriesBox.add_actor(this.recentButton.actor);
+        }
 
-            /* Make sure the recent category is at the bottom (can happen when refreshing places
-             * or apps, since we don't destroy the recent category button each time we refresh recents,
-             * as it happens a lot) */
-            this.categoriesBox.set_child_above_sibling(this.recentButton.actor, null);
-
-            if (this.RecentManager._infosByTimestamp.length > 0) {
-                this.noRecentDocuments = false;
-
-                Util.each(this.RecentManager._infosByTimestamp, (info) => {
-                    let button = new RecentButton(this, info);
-                    this._recentButtons.push(button);
-                    this.applicationsBox.add_actor(button.actor);
-                });
-                let button = new SimpleMenuItem(this, { name: _("Clear list"),
-                                                        description: ("Clear all recent documents"),
-                                                        styleClass: 'menu-application-button' });
-                button.addIcon(APPLICATION_ICON_SIZE, 'edit-clear', null, true);
-                button.addLabel(button.name, 'menu-application-button-label');
-                button.activate = () => {
-                    this.menu.close();
-                    (new Gtk.RecentManager()).purge_items();
-                };
+        let recents = this.RecentManager._infosByTimestamp.filter(info => !info.name.startsWith("."));
+        if (recents.length > 0) {
+            this.noRecentDocuments = false;
+            Util.each(recents, (info) => {
+                let button = new RecentButton(this, info);
                 this._recentButtons.push(button);
                 this.applicationsBox.add_actor(button.actor);
-            } else {
-                this.noRecentDocuments = true;
-                let button = new SimpleMenuItem(this, { name: _("No recent documents"),
-                                                        styleClass: 'menu-application-button',
-                                                        reactive: false,
-                                                        activatable: false });
-                button.addLabel(button.name, 'menu-application-button-label');
-                this._recentButtons.push(button);
-                this.applicationsBox.add_actor(button.actor);
-            }
+                button.actor.visible = this.menu.isOpen;
+            });
+
+            let button = new SimpleMenuItem(this, { name: _("Clear list"),
+                                                    description: _("Clear all recent documents"),
+                                                    type: 'recent-clear',
+                                                    styleClass: 'menu-application-button' });
+            button.addIcon(APPLICATION_ICON_SIZE, 'edit-clear', null, true);
+            button.addLabel("", 'menu-application-button-label');
+            button.label.clutter_text.set_markup(`<b>${button.name}</b>`);
+            button.activate = () => {
+                this.menu.close();
+                (new Gtk.RecentManager()).purge_items();
+            };
+
+            if (!this.showApplicationIcons)
+                button.icon.visible = false;
+
+            this._recentButtons.push(button);
+            this.applicationsBox.add_actor(button.actor);
+            button.actor.visible = this.menu.isOpen;
         } else {
-            for (let i = 0; i < this._categoryButtons.length; i++) {
-                if (this._categoryButtons[i].categoryId === "recent") {
-                    this._categoryButtons[i].destroy();
-                    this._categoryButtons.splice(i, 1);
-                    this.recentButton = null;
-                    break;
-                }
-            }
+            this.noRecentDocuments = true;
+            let button = new SimpleMenuItem(this, { name: _("No recent documents"),
+                                                    type: 'no-recent',
+                                                    styleClass: 'menu-application-button',
+                                                    reactive: false,
+                                                    activatable: false });
+            button.addLabel(button.name, 'menu-application-button-label');
+            this._recentButtons.push(button);
+            this.applicationsBox.add_actor(button.actor);
+            button.actor.visible = this.menu.isOpen;
         }
 
     }
@@ -3198,94 +3261,57 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         /* iterate in reverse, so multiple splices will not upset
          * the remaining elements */
         for (let i = this._categoryButtons.length - 1; i > -1; i--) {
-            if (this._categoryButtons[i].categoryId != 'places' &&
-                this._categoryButtons[i].categoryId != 'recent') {
-                this._categoryButtons[i].destroy();
-                this._categoryButtons.splice(i, 1);
-            }
+            let b = this._categoryButtons[i];
+            if (b === this._allAppsCategoryButton ||
+                ['place', 'recent'].includes(b.categoryId))
+                continue;
+            this._categoryButtons[i].destroy();
+            this._categoryButtons.splice(i, 1);
         }
 
         this._applicationsButtons.forEach(button => button.destroy());
         this._applicationsButtons = [];
 
-        this._applicationsButtonFromApp = {};
-
-        this._allAppsCategoryButton = new CategoryButton(this);
-
-        this.categoriesBox.add_actor(this._allAppsCategoryButton.actor);
-        this._categoryButtons.push(this._allAppsCategoryButton);
-
-        let trees = [appsys.get_tree()];
-
-        for (var i in trees) {
-            let tree = trees[i];
-            let root = tree.get_root_directory();
-            let dirs = [];
-            let iter = root.iter();
-            let nextType;
-
-            while ((nextType = iter.next()) != CMenu.TreeItemType.INVALID) {
-                if (nextType == CMenu.TreeItemType.DIRECTORY) {
-                    dirs.push(iter.get_directory());
-                }
-            }
-
-            let prefCats = ["administration", "preferences"];
-
-            let sortDirs = function(a, b) {
-                let menuIdA = a.get_menu_id().toLowerCase();
-                let menuIdB = b.get_menu_id().toLowerCase();
-
-                let prefIdA = prefCats.indexOf(menuIdA);
-                let prefIdB = prefCats.indexOf(menuIdB);
-
-                if (prefIdA < 0 && prefIdB >= 0) {
-                    return -1;
-                }
-                if (prefIdA >= 0 && prefIdB < 0) {
-                    return 1;
-                }
-
-                let nameA = a.get_name().toLowerCase();
-                let nameB = b.get_name().toLowerCase();
-
-                if (nameA > nameB) {
-                    return 1;
-                }
-                if (nameA < nameB) {
-                    return -1;
-                }
-                return 0;
-            };
-
-            dirs = dirs.sort(sortDirs);
-
-            for (let i = 0; i < dirs.length; i++) {
-                let dir = dirs[i];
-                if (dir.get_is_nodisplay())
-                    continue;
-                if (this._loadCategory(dir)) {
-                    let categoryButton = new CategoryButton(this, dir.get_menu_id(), dir.get_name(), dir.get_icon());
-                    this._categoryButtons.push(categoryButton);
-                    this.categoriesBox.add_actor(categoryButton.actor);
-                }
-            }
+        if (!this._allAppsCategoryButton) {
+            this._allAppsCategoryButton = new CategoryButton(this);
+            this.categoriesBox.add_actor(this._allAppsCategoryButton.actor);
+            this._categoryButtons.push(this._allAppsCategoryButton);
         }
-        // Sort apps and add to applicationsBox
-        this._applicationsButtons.sort(function(a, b) {
-            a = Util.latinise(a.name.toLowerCase());
-            b = Util.latinise(b.name.toLowerCase());
-            return a > b;
+
+        // grab top level directories and all apps in them
+        let [apps, dirs] = AppUtils.getApps();
+
+        // generate all category buttons from top-level directories
+        Util.each(dirs, (d) => {
+            let categoryButton = new CategoryButton(this, d.get_menu_id(), d.get_name(), d.get_icon());
+            this._categoryButtons.push(categoryButton);
+            this.categoriesBox.add_actor(categoryButton.actor);
         });
 
-        for (let i = 0; i < this._applicationsButtons.length; i++) {
-            this.applicationsBox.add_actor(this._applicationsButtons[i].actor);
+        /* we add them in reverse at index 0 so they are always above places and
+         * recent buttons, and below */
+        for (let i = apps.length - 1; i > -1; i--) {
+            let app = apps[i][0];
+            let button = new ApplicationButton(this, app);
+            button.category = apps[i][1];
+            let appKey = app.get_id() || `${app.get_name()}:${app.get_description()}`;
+
+            // appsWereRefreshed if this is not initial load. on initial load every
+            // app is marked known.
+            if (this._appsWereRefreshed && !this._knownApps.has(appKey))
+                button.highlight();
+            else
+                this._knownApps.add(appKey);
+
+            this._applicationsButtons.push(button);
+            this.applicationsBox.insert_child_at_index(button.actor, 0);
+            button.actor.visible = this.menu.isOpen;
         }
 
+        // we expect this array to be in the same order as the child list
+        this._applicationsButtons.reverse();
         this._appsWereRefreshed = true;
     }
-
-
 
     _refreshFavs() {
         //Remove all favorites
@@ -3294,62 +3320,16 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         //Load favorites again
         this._favoritesButtons = [];
         let launchers = global.settings.get_strv('favorite-apps');
-        let appSys = Cinnamon.AppSystem.get_default();
         for ( let i = 0; i < launchers.length; ++i ) {
-            let app = appSys.lookup_app(launchers[i]);
+            let app = appsys.lookup_app(launchers[i]);
             if (app) {
                 let button = new FavoritesButton(this, app, launchers.length, this.favorite_button_size, this.showFavoriteIcons); // + 3 because we're adding 3 system buttons at the bottom
-                this._favoritesButtons.push(button);
+                this._favoritesButtons[app] = button;
                 this.favoritesBox.add(button.actor, { y_align: St.Align.END, y_fill: false });
             }
         }
     }
 
-    _loadCategory(dir, top_dir) {
-        let iter = dir.iter();
-        let has_entries = false;
-        let nextType;
-        if (!top_dir) top_dir = dir;
-        while ((nextType = iter.next()) != CMenu.TreeItemType.INVALID) {
-            if (nextType == CMenu.TreeItemType.ENTRY) {
-                let entry = iter.get_entry();
-                let appInfo = entry.get_app_info();
-                if (appInfo && !appInfo.get_nodisplay()) {
-                    has_entries = true;
-                    let app = appsys.lookup_app(entry.get_desktop_file_id());
-                    let app_key = app.get_id();
-                    if (app_key == null) {
-                        app_key = app.get_name() + ":" +
-                            app.get_description();
-                    }
-                    if (!(app_key in this._applicationsButtonFromApp)) {
-
-                        let applicationButton = new ApplicationButton(this, app);
-
-                        if (!this._knownApps.has(app_key)) {
-                            if (this._appsWereRefreshed) {
-                                applicationButton.highlight();
-                            } else {
-                                this._knownApps.add(app_key);
-                            }
-                        }
-
-                        this._applicationsButtons.push(applicationButton);
-                        applicationButton.category.push(top_dir.get_menu_id());
-                        this._applicationsButtonFromApp[app_key] = applicationButton;
-                    } else {
-                        this._applicationsButtonFromApp[app_key].category.push(dir.get_menu_id());
-                    }
-                }
-            } else if (nextType == CMenu.TreeItemType.DIRECTORY) {
-                let subdir = iter.get_directory();
-                if (this._loadCategory(subdir, top_dir)) {
-                    has_entries = true;
-                }
-            }
-        }
-        return has_entries;
-    }
 
     _scrollToButton(button, scrollBox = null) {
         if (!scrollBox)
@@ -3617,22 +3597,27 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
         }
     }
 
+    _resetSortOrder() {
+        let pos = 0;
+
+        for (let i = 0; i < this._applicationsButtons.length; i++) {
+            this.applicationsBox.set_child_at_index(this._applicationsButtons[i].actor, pos++);
+        }
+
+        for (let i = 0; i < this._placesButtons.length; i++) {
+            this.applicationsBox.set_child_at_index(this._placesButtons[i].actor, pos++);
+        }
+
+        for (let i = 0; i < this._recentButtons.length; i++) {
+            this.applicationsBox.set_child_at_index(this._recentButtons[i].actor, pos++);
+        }
+    }
+
     _select_category (name) {
         if (name === this.lastSelectedCategory)
             return;
         this.lastSelectedCategory = name;
-
-        if (name === "places") {
-            this._displayButtons(null, -1);
-        } else if (name === "recent") {
-            this._displayButtons(null, null, -1);
-        } else if (name == null) {
-            this._displayButtons(-1);
-        } else {
-            // category id
-            this._displayButtons(name);
-        }
-
+        this._displayButtons(name || 'app');
         this.closeContextMenu(false);
     }
 
@@ -3646,48 +3631,79 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
             this.contextMenu.close();
     }
 
-    _displayButtons(appCategory, places, recent, apps, autocompletes, exactMatch){
-        // destroy temporary buttons
-        Util.each(this._transientButtons, item => item.destroy());
+    /**
+     * Reset the ApplicationsBox to a specific category or list of buttons.
+     * @param {String} category     (optional) The button type or application category to be displayed.
+     * @param {Array} buttons       (optional) A list of existing buttons to show.
+     * @param {Array} autoCompletes (optional) A list of autocomplete strings to add buttons for and show.
+     */
+    _displayButtons(category, buttons=[], autoCompletes=[]){
+        /* We only operate on SimpleMenuItems here. If any other menu item types
+         * are added, they should be managed independently. */
+        if (category) {
+            if (this.orderDirty) {
+                this._resetSortOrder();
+                this.orderDirty = false;
+            }
+
+            Util.each(this.applicationsBox.get_children(), c => {
+                let b = c._delegate;
+                if (!(b instanceof SimpleMenuItem))
+                    return;
+
+                // destroy temporary buttons
+                if (b.type === 'transient' || b.type === 'search-provider') {
+                    b.destroy();
+                    return;
+                }
+
+                c.visible = b.type.includes(category) || b.type === 'app' && b.category.includes(category);
+            });
+        } else {
+            this.orderDirty = true;
+
+            Util.each(this.applicationsBox.get_children(), c => {
+                let b = c._delegate;
+                if (!(b instanceof SimpleMenuItem))
+                    return;
+
+                // destroy temporary buttons
+                if (b.type === 'transient' || b.type === 'search-provider' || b.type === 'search-result') {
+                    b.destroy();
+                    return;
+                }
+
+                c.visible = false;
+            });
+
+            buttons.sort((ba, bb) => {
+                if (ba.matchIndex < bb.matchIndex) {
+                    return -1;
+                } else
+                if (bb.matchIndex < ba.matchIndex) {
+                    return 1;
+                }
+
+                return ba.searchStrings < bb.searchStrings ? -1 : 1;
+            });
+
+            for (let i = 0; i < buttons.length; i++) {
+                this.applicationsBox.set_child_at_index(buttons[i].actor, i);
+                buttons[i].actor.visible = true;
+            }
+        }
+
+        // reset temporary button storage
         this._transientButtons = [];
-        Util.each(this._searchProviderButtons, item => item.destroy());
         this._searchProviderButtons = [];
 
-        let selectedActor = null;
-        if (appCategory) {
-            Util.each(this._applicationsButtons, item => { item.actor.visible = appCategory === -1 || item.category.includes(appCategory) });
-        } else if (apps) {
-            Util.each(this._applicationsButtons, item => {
-                let appId = item.app.get_id();
-                item.actor.visible = apps.includes(appId);
-                if (appId === exactMatch)
-                    selectedActor = item.actor;
-            });
-        } else {
-            Util.each(this._applicationsButtons, item => { item.actor.visible = false });
-        }
-
-        if (places) {
-            Util.each(this._placesButtons, item => {
-                item.actor.visible =  places === -1 || places.includes(item.name)
-                if (!selectedActor && item.name === exactMatch)
-                    selectedActor = item.actor;
-            });
-        } else {
-            Util.each(this._placesButtons, item => { item.actor.visible = false });
-        }
-
-        Util.each(this._recentButtons, item => { item.actor.visible = recent == null ? false : recent === -1 || recent.includes(item.name) });
-
-        if (autocompletes) {
-            Util.each(autocompletes, item => {
+        if (autoCompletes) {
+            Util.each(autoCompletes, item => {
                 let button = new TransientButton(this, item);
                 this._transientButtons.push(button);
                 this.applicationsBox.add_actor(button.actor);
             });
         }
-
-        return selectedActor;
     }
 
     _setCategoriesButtonActive(active) {
@@ -3721,161 +3737,137 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
     }
 
     _onSearchTextChanged (se, prop) {
-        if (this.menuIsOpening) {
-            this.menuIsOpening = false;
+        if (this.leftPane.get_child() == this.favsBox)
+            this.switchPanes("apps");
+        let searchString = this.searchEntry.get_text().trim();
+        let searchActive = !(searchString == '' || searchString == this.searchEntry.hint_text);
+        if (!this.searchActive && !searchActive)
             return;
-        } else {
-            let searchString = this.searchEntry.get_text();
-            if (searchString == '' && !this.searchActive)
-                return;
-            this.searchActive = searchString != '';
-            this._fileFolderAccessActive = this.searchActive && this.searchFilesystem;
-            this._clearAllSelections();
 
-            if (this.searchActive) {
-                this.searchEntry.set_secondary_icon(this._searchActiveIcon);
-                if (this._searchIconClickedId == 0) {
-                    this._searchIconClickedId = this.searchEntry.connect('secondary-icon-clicked',
-                        Lang.bind(this, function() {
-                            this.resetSearch();
-                            this._select_category(null);
-                        }));
-                }
-                this._setCategoriesButtonActive(false);
-                this.lastSelectedCategory = "search"
-                this._doSearch();
-                this.appsButton.actor.hide();
-                this.resultsFoundButton.actor.show();
-            } else {
-                if (this._searchIconClickedId > 0)
-                    this.searchEntry.disconnect(this._searchIconClickedId);
-                this._searchIconClickedId = 0;
-                this.searchEntry.set_secondary_icon(this._searchInactiveIcon);
-                this._previousSearchPattern = "";
-                this._setCategoriesButtonActive(true);
-                this._select_category(null);
-                this._allAppsCategoryButton.actor.style_class = "menu-category-button-selected";
-                this._activeContainer = null;
-                this.selectedAppTitle.set_text("");
-                this.selectedAppDescription.set_text("");
-                this.appsButton.actor.show();
-                this.resultsFoundButton.actor.hide();
+        if (searchString == this._previousSearchPattern)
+            return;
+        this._previousSearchPattern = searchString;
+
+        this.searchActive = searchActive;
+        this._fileFolderAccessActive = searchActive && this.searchFilesystem;
+        this._clearAllSelections();
+
+        if (searchActive) {
+            this.searchEntry.set_secondary_icon(this._searchActiveIcon);
+            if (!this._searchIconClickedId) {
+                this._searchIconClickedId =
+                    this.searchEntry.connect('secondary-icon-clicked', () => {
+                        this.resetSearch();
+                        this._select_category();
+                    });
             }
-            return;
+            this._setCategoriesButtonActive(false);
+            this.lastSelectedCategory = "search"
+
+            this._doSearch(searchString);
+            this.appsButton.actor.hide();
+            this.resultsFoundButton.actor.show();
+        } else {
+            if (this._searchIconClickedId > 0)
+                this.searchEntry.disconnect(this._searchIconClickedId);
+            this._searchIconClickedId = 0;
+            this.searchEntry.set_secondary_icon(this._searchInactiveIcon);
+            this._previousSearchPattern = "";
+            this._setCategoriesButtonActive(true);
+            this._select_category();
+            this._allAppsCategoryButton.actor.style_class = "menu-category-button-selected";
+            this._activeContainer = null;
+            this.selectedAppTitle.set_text("");
+            this.selectedAppDescription.set_text("");
+            this.appsButton.actor.show();
+            this.resultsFoundButton.actor.hide();
         }
     }
 
-    _matchNames(names, pattern){
-        let res = [];
-        let exactMatch = null;
-        for (let id = 0; id < names.length; id++) {
-            if (pattern) {
-                let name = names[id].name;
-                let lowerName = name.toLowerCase();
-                if (lowerName.indexOf(pattern) !== -1) res.push(names[id]);
-                if (!exactMatch && lowerName === pattern) exactMatch = name;
-            } else res.push(names[id]);
+    _matchNames(buttons, pattern){
+        let ret = [];
+        let regexpPattern = new RegExp(Util.escapeRegExp(pattern));
+
+        for (let i = 0; i < buttons.length; i++) {
+            if (buttons[i].type == "recent-clear") {
+                continue;
+            }
+            let res = buttons[i].searchStrings[0].match(regexpPattern);
+            if (res) {
+                buttons[i].matchIndex = res.index + RECENT_PLACES_ADDER;
+                ret.push(buttons[i]);
+            } else {
+                buttons[i].matchIndex = NO_MATCH;
+            }
         }
-        return [res, exactMatch];
-    }
 
-    _listBookmarks(pattern){
-        return this._matchNames(Main.placesManager.getBookmarks(), pattern);
-    }
-
-    _listDevices(pattern){
-        return this._matchNames(Main.placesManager.getMounts(), pattern);
+        return ret;
     }
 
     _listApplications(pattern){
-        let res = [];
-        let exactMatch = null;
-        if (pattern){
-            res = [];
-            let regexpPattern = new RegExp("\\b"+pattern);
-            for (let i in this._applicationsButtons) {
-                let app = this._applicationsButtons[i].app;
-                let latinisedLowerName = Util.latinise(app.get_name().toLowerCase());
-                if (latinisedLowerName.match(regexpPattern) !== null) {
-                    res.push(app.get_id());
-                    if (!exactMatch && latinisedLowerName === pattern)
-                        exactMatch = app.get_id();
-                }
-            }
-            if (!exactMatch) {
-                for (let i in this._applicationsButtons) {
-                    let app = this._applicationsButtons[i].app;
-                    if (Util.latinise(app.get_name().toLowerCase()).indexOf(pattern)!==-1 ||
-                        (app.get_keywords() && Util.latinise(app.get_keywords().toLowerCase()).indexOf(pattern)!==-1) ||
-                        (app.get_description() && Util.latinise(app.get_description().toLowerCase()).indexOf(pattern)!==-1) ||
-                        (app.get_id() && Util.latinise(app.get_id().slice(0, -8).toLowerCase()).indexOf(pattern)!==-1))
-                        res.push(app.get_id());
+        if (!pattern)
+            return [];
+
+        let apps = [];
+        let regexpPattern = new RegExp(Util.escapeRegExp(pattern));
+
+        for (let i in this._applicationsButtons) {
+            let button = this._applicationsButtons[i];
+
+            for (let j = 0; j < button.searchStrings.length; j++) {
+                let res = button.searchStrings[j].match(regexpPattern);
+                if (res) {
+                    button.matchIndex = res.index + APP_MATCH_ADDERS[j];
+                    apps.push(button);
+                    break;
+                } else {
+                    button.matchIndex = NO_MATCH;
                 }
             }
         }
-        return [res, exactMatch];
+
+        return apps;
     }
 
-    _doSearch(){
-        if (this.leftPane.get_child() == this.favsBox)
-            this.switchPanes("apps");
+    _doSearch(rawPattern){
+        let pattern = Util.latinise(rawPattern.toLowerCase());
+
         this._searchTimeoutId = 0;
-        let pattern = this.searchEntryText.get_text().replace(/^\s+/g, '').replace(/\s+$/g, '').toLowerCase();
-        pattern = Util.latinise(pattern);
-        if (pattern==this._previousSearchPattern) return false;
-        this._previousSearchPattern = pattern;
         this._activeContainer = null;
         this._activeActor = null;
         this._selectedItemIndex = null;
         this._previousTreeSelectedActor = null;
         this._previousSelectedActor = null;
 
-        let result = this._listApplications(pattern);
-        let appResults = result[0];
-        let exactMatch = result[1];
-        let placesResults = [];
+        let buttons = this._listApplications(pattern);
 
-        result = this._listBookmarks(pattern);
-        let bookmarks = result[0];
-        exactMatch = exactMatch || result[1];
-        for (let i in bookmarks)
-            placesResults.push(bookmarks[i].name);
+        let result = this._matchNames(this._placesButtons, pattern);
+        buttons = buttons.concat(result);
 
-        result = this._listDevices(pattern);
-        let devices = result[0];
-        exactMatch = exactMatch || result[1];
-        for (let i in devices)
-            placesResults.push(devices[i].name);
-
-        let recentResults = [];
-        for (let i = 0; i < this._recentButtons.length; i++) {
-            if (!(this._recentButtons[i] === this._recentClearButton) && this._recentButtons[i].name.toLowerCase().indexOf(pattern) != -1)
-                recentResults.push(this._recentButtons[i].name);
-        }
+        result = this._matchNames(this._recentButtons, pattern);
+        buttons = buttons.concat(result);
 
         var acResults = []; // search box autocompletion results
         if (this.searchFilesystem) {
             // Don't use the pattern here, as filesystem is case sensitive
-            acResults = this._getCompletions(this.searchEntryText.get_text());
+            acResults = this._getCompletions(rawPattern);
         }
 
-        let selectedActor = this._displayButtons(null, placesResults, recentResults, appResults, acResults, exactMatch);
-
-        let numberResults = appResults.length + placesResults.length + recentResults.length + acResults.length;
+        this._displayButtons(null, buttons, acResults);
+	
+        let numberResults = buttons.length + acResults.length;
         if (numberResults == 0)
             this.resultsFoundButton.label.set_text(_("No results found"));
         else
             this.resultsFoundButton.label.set_text(Gettext.dngettext(UUID, "%d result found", "%d results found", numberResults).format(numberResults));
 
-        this.appBoxIter.reloadVisible();
-        if (this.appBoxIter.getNumVisibleChildren() > 0) {
-            let item_actor = selectedActor || this.appBoxIter.getFirstVisible();
+        if (buttons.length || acResults.length) {
+            this.appBoxIter.reloadVisible();
+            let item_actor = this.appBoxIter.getFirstVisible();
             this._selectedItemIndex = this.appBoxIter.getAbsoluteIndexOfChild(item_actor);
             this._activeContainer = this.applicationsBox;
             this._scrollToButton(item_actor._delegate);
-            if (item_actor && item_actor != this.searchEntry) {
-                this._buttonEnterEvent(item_actor._delegate);
-            }
+            this._buttonEnterEvent(item_actor._delegate);
         } else {
             this.selectedAppTitle.set_text("");
             this.selectedAppDescription.set_text("");

--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/applet.js
@@ -1388,8 +1388,8 @@ class ShutdownMenu extends AppPopupSubMenuMenuItem {
         this.label.destroy();
         this.icon = new St.Icon({
             style_class: 'popup-menu-icon',
-            icon_type: St.IconType.FULLCOLOR,
-            icon_name: 'forward',
+            icon_type: St.IconType.SYMBOLIC,
+            icon_name: 'pan-end',
             icon_size: ICON_SIZE
         });
         this.addActor(this.icon);

--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/applet.js
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/4.2/applet.js
@@ -2284,11 +2284,6 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
 
             this.lastSelectedCategory = null;
 
-            if(visiblePane == "apps") {
-                this._allAppsCategoryButton.actor.style_class = "menu-category-button-selected";
-                this._select_category(null);
-            }
-
             if(this.menuLayout == "stark-menu" || this.quicklinksupdated) {
                 if (visiblePane == "apps")
                     this.switchPanes("favs");
@@ -2319,8 +2314,11 @@ class CinnamonMenuApplet extends Applet.TextIconApplet {
             this._previousTreeSelectedActor = null;
             this._previousSelectedActor = null;
             this.closeContextMenu(false);
+	    this._previousVisibleIndex = null;
 
             this._clearAllSelections(false);
+            this._scrollToButton(null, this.applicationsScrollBox);
+	    this._scrollToButton(null, this.categoriesScrollBox);
             this.destroyVectorBox();
         }
     }

--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/metadata.json
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "CinnVIIStarkMenu@NikoKrause",
     "name": "CinnVIIStarkMenu",
     "description": "Cinnamon Menu with the look of the Windows 7 Start Menu or the MATE Menu",
-    "version": 1.23,
+    "version": 1.29,
     "max-instances": -1,
     "multiversion": true
 }

--- a/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/po/de.po
+++ b/CinnVIIStarkMenu@NikoKrause/files/CinnVIIStarkMenu@NikoKrause/po/de.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cinnviistarkmenu\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-08 10:42+0200\n"
-"PO-Revision-Date: 2017-09-08 10:42+0200\n"
+"POT-Creation-Date: 2020-04-23 22:07+0200\n"
+"PO-Revision-Date: 2020-10-04 14:42+0200\n"
 "Last-Translator: Niko Krause <nikokrause@gmx.de>\n"
 "Language-Team: German <de@li.org>\n"
 "Language: de\n"
@@ -17,913 +17,285 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Launchpad-Export-Date: 2017-04-14 06:03+0000\n"
-"X-Generator: Poedit 1.8.7.1\n"
+"X-Generator: Poedit 2.0.6\n"
 
-#: 3.2/applet.js:175 2.6/applet.js:176 3.4/applet.js:175
+#: 3.2/applet.js:175 2.6/applet.js:176
 msgid "Please enter your password to uninstall this application"
 msgstr "Bitte Ihr Passwort eingeben, um diese Anwendung zu deinstallieren"
 
-#: 3.2/applet.js:258 2.6/applet.js:259 3.4/applet.js:258
+#: 3.2/applet.js:258 2.6/applet.js:259 3.4/applet.js:258 4.2/applet.js:358
 msgid "Add to panel"
 msgstr "Zur Leiste hinzufügen"
 
-#: 3.2/applet.js:261 2.6/applet.js:262 3.4/applet.js:261
+#: 3.2/applet.js:261 2.6/applet.js:262 3.4/applet.js:261 4.2/applet.js:362
 msgid "Add to desktop"
 msgstr "Zum Schreibtisch hinzufügen"
 
-#: 3.2/applet.js:265 2.6/applet.js:266 3.4/applet.js:265
+#: 3.2/applet.js:265 2.6/applet.js:266 3.4/applet.js:265 4.2/applet.js:367
 msgid "Remove from favorites"
 msgstr "Aus den Favoriten entfernen"
 
-#: 3.2/applet.js:268 2.6/applet.js:269 3.4/applet.js:268
+#: 3.2/applet.js:268 2.6/applet.js:269 3.4/applet.js:268 4.2/applet.js:370
 msgid "Add to favorites"
 msgstr "Zu den Favoriten hinzufügen"
 
-#: 3.2/applet.js:272 2.6/applet.js:273 3.4/applet.js:272
+#: 3.2/applet.js:272 2.6/applet.js:273 3.4/applet.js:272 4.2/applet.js:375
 msgid "Uninstall"
 msgstr "Deinstallieren"
 
-#: 3.2/applet.js:276 2.6/applet.js:277 3.4/applet.js:276
+#: 3.2/applet.js:276 2.6/applet.js:277 3.4/applet.js:276 4.2/applet.js:380
 msgid "Run with NVIDIA GPU"
 msgstr "Mit NVIDIA-GPU ausführen"
 
 #: 3.2/applet.js:439 3.2/applet.js:473 2.6/applet.js:426 2.6/applet.js:460
-#: 3.4/applet.js:439 3.4/applet.js:473
+#: 3.4/applet.js:436 3.4/applet.js:470 4.2/applet.js:223 4.2/applet.js:468
 msgid "No description available"
 msgstr "Keine Beschreibung vorhanden"
 
-#: 3.2/applet.js:740 2.6/applet.js:3327 3.4/applet.js:740
+#: 3.2/applet.js:740 2.6/applet.js:3327 3.4/applet.js:737 4.2/applet.js:648
 msgid "This file is no longer available"
 msgstr "Diese Datei ist nicht mehr verfügbar"
 
-#: 3.2/applet.js:790 2.6/applet.js:761 3.4/applet.js:790
+#: 3.2/applet.js:790 2.6/applet.js:761 3.4/applet.js:787 4.2/applet.js:662
 msgid "Open with"
 msgstr "Öffnen mit"
 
-#: 3.2/applet.js:836 2.6/applet.js:807 3.4/applet.js:836
+#: 3.2/applet.js:836 2.6/applet.js:807 3.4/applet.js:833 4.2/applet.js:708
 msgid "Other application..."
 msgstr "Andere Anwendung …"
 
-#: 3.2/applet.js:911 2.6/applet.js:884 3.4/applet.js:911
+#: 3.2/applet.js:911 2.6/applet.js:884 3.4/applet.js:908 4.2/applet.js:3088
 msgid "Clear list"
 msgstr "Liste leeren"
 
-#: 3.2/applet.js:957 2.6/applet.js:932 3.4/applet.js:957
+#: 3.2/applet.js:957 2.6/applet.js:932 3.4/applet.js:954 4.2/applet.js:723
 msgid "All Applications"
 msgstr "Alle Anwendungen"
 
-#: 3.2/applet.js:986 2.6/applet.js:960 3.4/applet.js:986
+#: 3.2/applet.js:986 2.6/applet.js:960 3.4/applet.js:983 4.2/applet.js:3034
 msgid "Places"
 msgstr "Orte"
 
-#: 3.2/applet.js:1010 2.6/applet.js:984 3.4/applet.js:1010
+#: 3.2/applet.js:1010 2.6/applet.js:984 3.4/applet.js:1007 4.2/applet.js:3071
 msgid "Recent Files"
 msgstr "Zuletzt verwendete Dateien"
 
 #: 3.2/applet.js:1637 3.2/applet.js:1831 2.6/applet.js:1611 2.6/applet.js:1798
-#: 3.4/applet.js:1637 3.4/applet.js:1831
+#: 3.4/applet.js:1580 3.4/applet.js:1765 4.2/applet.js:1270 4.2/applet.js:1450
 msgid "Logout"
 msgstr "Abmelden"
 
-#: 3.2/applet.js:1639 2.6/applet.js:1613 3.4/applet.js:1639
+#: 3.2/applet.js:1639 2.6/applet.js:1613 3.4/applet.js:1582 4.2/applet.js:1272
 msgid "Lock Screen"
 msgstr "Bildschirm sperren"
 
-#: 3.2/applet.js:1824 2.6/applet.js:1791 3.4/applet.js:1824
+#: 3.2/applet.js:1824 2.6/applet.js:1791 3.4/applet.js:1758 4.2/applet.js:1443
 msgid "Shutdown the computer"
 msgstr "Den Rechner herunterfahren"
 
-#: 3.2/applet.js:1825 2.6/applet.js:1792 3.4/applet.js:1825
+#: 3.2/applet.js:1825 2.6/applet.js:1792 3.4/applet.js:1759 4.2/applet.js:1444
 msgid "Leave the session"
 msgstr "Sitzung verlassen"
 
-#: 3.2/applet.js:1826 2.6/applet.js:1793 3.4/applet.js:1826
+#: 3.2/applet.js:1826 2.6/applet.js:1793 3.4/applet.js:1760 4.2/applet.js:1445
 msgid "Lock the screen"
 msgstr "Diesen Bildschirm sperren"
 
 #: 3.2/applet.js:1828 3.2/applet.js:1829 2.6/applet.js:1795 2.6/applet.js:1796
-#: 3.4/applet.js:1828 3.4/applet.js:1829
+#: 3.4/applet.js:1762 3.4/applet.js:1763 4.2/applet.js:1447 4.2/applet.js:1448
 msgid "Quit"
 msgstr "Beenden"
 
 #: 3.2/applet.js:1840 3.2/applet.js:1844 2.6/applet.js:1807 2.6/applet.js:1811
-#: 3.4/applet.js:1840 3.4/applet.js:1844
+#: 3.4/applet.js:1774 3.4/applet.js:1778 4.2/applet.js:1459 4.2/applet.js:1463
 msgid "Lock screen"
 msgstr "Bildschirm sperren"
 
-#: 3.2/applet.js:2051 3.4/applet.js:2051
+#: 3.2/applet.js:2051
 msgid "All Programs"
 msgstr "Alle Programme"
 
-#: 3.2/applet.js:2051 3.4/applet.js:2051
+#: 3.2/applet.js:2051
 msgid "Favorites"
 msgstr "Favoriten"
 
-#: 3.2/applet.js:2052 3.4/applet.js:2052
+#: 3.2/applet.js:2052
 msgid "Documents"
 msgstr "Dokumente"
 
-#: 3.2/applet.js:2052 3.4/applet.js:2052
+#: 3.2/applet.js:2052
 msgid "nemo Documents"
 msgstr "nemo Dokumente"
 
-#: 3.2/applet.js:2053 3.4/applet.js:2053
+#: 3.2/applet.js:2053
 msgid "Pictures"
 msgstr "Bilder"
 
-#: 3.2/applet.js:2053 3.4/applet.js:2053
+#: 3.2/applet.js:2053
 msgid "nemo Pictures"
 msgstr "nemo Bilder"
 
-#: 3.2/applet.js:2054 3.4/applet.js:2054
+#: 3.2/applet.js:2054
 msgid "Music"
 msgstr "Musik"
 
-#: 3.2/applet.js:2054 3.4/applet.js:2054
+#: 3.2/applet.js:2054
 msgid "nemo Music"
 msgstr "nemo Musik"
 
-#: 3.2/applet.js:2055 3.4/applet.js:2055
+#: 3.2/applet.js:2055
 msgid "Videos"
 msgstr "Videos"
 
-#: 3.2/applet.js:2055 3.4/applet.js:2055
+#: 3.2/applet.js:2055
 msgid "nemo Videos"
 msgstr "nemo Videos"
 
-#: 3.2/applet.js:2056 3.4/applet.js:2056
+#: 3.2/applet.js:2056
 msgid "Downloads"
 msgstr "Downloads"
 
-#: 3.2/applet.js:2056 3.4/applet.js:2056
+#: 3.2/applet.js:2056
 msgid "nemo Downloads"
 msgstr "nemo Downloads"
 
 #. 3.2->settings-schema.json->menu->title
 #. 3.4->settings-schema.json->menu->title
-#: 3.2/applet.js:2072 2.6/applet.js:2022 3.4/applet.js:2072
+#. 4.2->settings-schema.json->menu->title
+#: 3.2/applet.js:2072 2.6/applet.js:2022 3.4/applet.js:1998 4.2/applet.js:1673
 msgid "Menu"
 msgstr "Menü"
 
-#: 3.2/applet.js:3513 2.6/applet.js:3359 3.4/applet.js:3551
+#: 3.2/applet.js:3513 2.6/applet.js:3359 3.4/applet.js:3469 4.2/applet.js:3101
 msgid "No recent documents"
 msgstr "Keine kürzlich verwendeten Dokumente"
 
-#: 3.2/applet.js:3901 2.6/applet.js:3672 3.4/applet.js:3939
+#: 3.2/applet.js:3899 2.6/applet.js:3670 3.4/applet.js:3849 4.2/applet.js:3324
 msgid "Type to search..."
 msgstr "Suchbegriff eingeben …"
 
-#: 3.2/applet.js:4429 2.6/applet.js:4174 3.4/applet.js:4467
+#: 3.2/applet.js:4427 2.6/applet.js:4172 3.4/applet.js:4376 4.2/applet.js:3795
 msgid "No results found"
 msgstr "Keine Ergebnisse gefunden"
 
-#: 3.2/applet.js:4431 2.6/applet.js:4176 3.4/applet.js:4469
+#: 3.2/applet.js:4429 2.6/applet.js:4174 3.4/applet.js:4378 4.2/applet.js:3797
 #, javascript-format
 msgid "%d result found"
 msgid_plural "%d results found"
 msgstr[0] "%d Ergebnis gefunden"
 msgstr[1] "%d Ergebnisse gefunden"
 
-#. 3.2->settings-schema.json->quicklauncher-9-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-3-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-14-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-10-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-0-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-2-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-11-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-13-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-7-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-15-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-4-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-1-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-18-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-5-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-8-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-12-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-16-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-19-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-6-checkbox->description
-#. 3.2->settings-schema.json->quicklauncher-17-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-9-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-3-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-14-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-10-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-0-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-2-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-11-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-13-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-7-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-15-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-4-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-1-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-12-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-18-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-5-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-8-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-16-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-19-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-6-checkbox->description
-#. 2.6->settings-schema.json->quicklauncher-17-checkbox->description
-msgid "Show quicklauncher on the sidebar"
-msgstr "Schnellstarter auf der Seitenleiste anzeigen"
+#. metadata.json->name
+msgid "CinnVIIStarkMenu"
+msgstr "CinnVIIStarkMenü"
 
-#. 3.2->settings-schema.json->quicklauncher-9-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-3-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-14-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-10-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-0-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-2-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-11-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-13-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-7-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-15-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-4-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-1-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-18-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-5-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-8-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-12-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-16-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-19-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-6-checkbox->tooltip
-#. 3.2->settings-schema.json->quicklauncher-17-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-9-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-3-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-14-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-10-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-0-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-2-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-11-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-13-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-7-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-15-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-4-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-1-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-12-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-18-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-5-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-8-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-16-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-19-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-6-checkbox->tooltip
-#. 2.6->settings-schema.json->quicklauncher-17-checkbox->tooltip
-msgid "Choose whether or not to show this quicklauncher in the sidebar."
+#. metadata.json->description
+msgid ""
+"Cinnamon Menu with the look of the Windows 7 Start Menu or the MATE Menu"
 msgstr ""
-"Legt fest, ob dieser Schnellstarter in der Seitenleiste angezeigt wird."
+"Cinnamon-Menü mit dem Aussehen des Windows 7 Start-Menüs oder des MATE-Menüs"
 
-#. 3.2->settings-schema.json->quicklauncher-19-label->description
-#. 3.2->settings-schema.json->quicklauncher-2-label->description
-#. 3.2->settings-schema.json->quicklauncher-5-label->description
-#. 3.2->settings-schema.json->quicklauncher-10-label->description
-#. 3.2->settings-schema.json->quicklauncher-18-label->description
-#. 3.2->settings-schema.json->quicklauncher-1-label->description
-#. 3.2->settings-schema.json->quicklauncher-0-label->description
-#. 3.2->settings-schema.json->quicklauncher-11-label->description
-#. 3.2->settings-schema.json->quicklauncher-8-label->description
-#. 3.2->settings-schema.json->quicklauncher-13-label->description
-#. 3.2->settings-schema.json->quicklauncher-17-label->description
-#. 3.2->settings-schema.json->quicklauncher-15-label->description
-#. 3.2->settings-schema.json->quicklauncher-4-label->description
-#. 3.2->settings-schema.json->quicklauncher-12-label->description
-#. 3.2->settings-schema.json->quicklauncher-14-label->description
-#. 3.2->settings-schema.json->quicklauncher-6-label->description
-#. 3.2->settings-schema.json->quicklauncher-3-label->description
-#. 3.2->settings-schema.json->quicklauncher-7-label->description
-#. 3.2->settings-schema.json->quicklauncher-16-label->description
-#. 3.2->settings-schema.json->quicklauncher-9-label->description
-#. 2.6->settings-schema.json->quicklauncher-19-label->description
-#. 2.6->settings-schema.json->quicklauncher-2-label->description
-#. 2.6->settings-schema.json->quicklauncher-5-label->description
-#. 2.6->settings-schema.json->quicklauncher-10-label->description
-#. 2.6->settings-schema.json->quicklauncher-18-label->description
-#. 2.6->settings-schema.json->quicklauncher-1-label->description
-#. 2.6->settings-schema.json->quicklauncher-0-label->description
-#. 2.6->settings-schema.json->quicklauncher-11-label->description
-#. 2.6->settings-schema.json->quicklauncher-8-label->description
-#. 2.6->settings-schema.json->quicklauncher-13-label->description
-#. 2.6->settings-schema.json->quicklauncher-14-label->description
-#. 2.6->settings-schema.json->quicklauncher-15-label->description
-#. 2.6->settings-schema.json->quicklauncher-4-label->description
-#. 2.6->settings-schema.json->quicklauncher-12-label->description
-#. 2.6->settings-schema.json->quicklauncher-6-label->description
-#. 2.6->settings-schema.json->quicklauncher-17-label->description
-#. 2.6->settings-schema.json->quicklauncher-3-label->description
-#. 2.6->settings-schema.json->quicklauncher-7-label->description
-#. 2.6->settings-schema.json->quicklauncher-16-label->description
-#. 2.6->settings-schema.json->quicklauncher-9-label->description
-msgid "Quicklauncher label"
-msgstr "Schnellstarterbeschriftung"
+#. 3.2->settings-schema.json->panel->title
+#. 3.4->settings-schema.json->panel->title
+#. 4.2->settings-schema.json->panel->title
+msgid "Panel"
+msgstr "Leiste"
 
-#. 3.2->settings-schema.json->quicklauncher-19-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-2-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-5-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-10-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-18-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-1-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-0-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-11-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-8-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-13-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-17-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-15-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-4-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-12-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-14-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-6-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-3-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-7-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-16-label->tooltip
-#. 3.2->settings-schema.json->quicklauncher-9-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-19-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-2-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-5-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-10-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-18-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-1-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-0-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-11-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-8-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-13-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-14-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-15-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-4-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-12-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-6-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-17-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-3-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-7-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-16-label->tooltip
-#. 2.6->settings-schema.json->quicklauncher-9-label->tooltip
-msgid "Enter label for the quicklauncher"
-msgstr "Beschriftung für den Schnellstarter eingeben"
+#. 3.2->settings-schema.json->sidebar->title
+#. 3.4->settings-schema.json->sidebar->title
+#. 4.2->settings-schema.json->sidebar->title
+msgid "Sidebar"
+msgstr "Seitenleiste"
 
-#. 3.2->settings-schema.json->favorite-button-size->description
-#. 2.6->settings-schema.json->favorite-button-size->description
-#. 3.4->settings-schema.json->favorite-button-size->description
-msgid "Size of the favorite buttons"
-msgstr "Größe der Favoritenknöpfe"
+#. 3.2->settings-schema.json->quicklauncher->title
+#. 3.4->settings-schema.json->quicklauncher->title
+#. 4.2->settings-schema.json->quicklauncher->title
+msgid "Quicklauncher"
+msgstr "Schnellstarter"
 
-#. 3.2->settings-schema.json->favorite-button-size->tooltip
-#. 2.6->settings-schema.json->favorite-button-size->tooltip
-#. 3.4->settings-schema.json->favorite-button-size->tooltip
-msgid "Change the size of the favorite buttons"
-msgstr "Die Größe der Favoritenknöpfe ändern"
+#. 3.2->settings-schema.json->panel-appear->title
+#. 3.4->settings-schema.json->panel-appear->title
+#. 4.2->settings-schema.json->panel-appear->title
+msgid "Appearance"
+msgstr "Erscheinungsbild"
 
-#. 3.2->settings-schema.json->favorite-button-size->units
-#. 2.6->settings-schema.json->favorite-button-size->units
-#. 3.4->settings-schema.json->favorite-button-size->units
-msgid "pixels"
-msgstr "Pixel"
-
-#. 3.2->settings-schema.json->activate-on-hover->description
-#. 2.6->settings-schema.json->activate-on-hover->description
-#. 3.4->settings-schema.json->activate-on-hover->description
-msgid "Open the menu when I move my mouse over it"
-msgstr "Das Menü öffnen, wenn die Maus darüber bewegt wird"
-
-#. 3.2->settings-schema.json->activate-on-hover->tooltip
-#. 2.6->settings-schema.json->activate-on-hover->tooltip
-#. 3.4->settings-schema.json->activate-on-hover->tooltip
-msgid "Enable opening the menu when the mouse enters the applet"
-msgstr "Öffnen des Menüs aktivieren, wenn sich die Maus auf das Applet bewegt"
-
-#. 3.2->settings-schema.json->quicklauncher-6-command->description
-#. 3.2->settings-schema.json->quicklauncher-10-command->description
-#. 3.2->settings-schema.json->quicklauncher-7-command->description
-#. 3.2->settings-schema.json->quicklauncher-16-command->description
-#. 3.2->settings-schema.json->quicklauncher-8-command->description
-#. 3.2->settings-schema.json->quicklauncher-19-command->description
-#. 3.2->settings-schema.json->quicklauncher-12-command->description
-#. 3.2->settings-schema.json->quicklauncher-15-command->description
-#. 3.2->settings-schema.json->quicklauncher-13-command->description
-#. 3.2->settings-schema.json->quicklauncher-9-command->description
-#. 3.2->settings-schema.json->quicklauncher-4-command->description
-#. 3.2->settings-schema.json->quicklauncher-5-command->description
-#. 3.2->settings-schema.json->quicklauncher-14-command->description
-#. 3.2->settings-schema.json->quicklauncher-11-command->description
-#. 3.2->settings-schema.json->quicklauncher-17-command->description
-#. 3.2->settings-schema.json->quicklauncher-2-command->description
-#. 3.2->settings-schema.json->quicklauncher-0-command->description
-#. 3.2->settings-schema.json->quicklauncher-1-command->description
-#. 3.2->settings-schema.json->quicklauncher-3-command->description
-#. 3.2->settings-schema.json->quicklauncher-18-command->description
-#. 2.6->settings-schema.json->quicklauncher-6-command->description
-#. 2.6->settings-schema.json->quicklauncher-10-command->description
-#. 2.6->settings-schema.json->quicklauncher-7-command->description
-#. 2.6->settings-schema.json->quicklauncher-16-command->description
-#. 2.6->settings-schema.json->quicklauncher-8-command->description
-#. 2.6->settings-schema.json->quicklauncher-19-command->description
-#. 2.6->settings-schema.json->quicklauncher-12-command->description
-#. 2.6->settings-schema.json->quicklauncher-15-command->description
-#. 2.6->settings-schema.json->quicklauncher-13-command->description
-#. 2.6->settings-schema.json->quicklauncher-9-command->description
-#. 2.6->settings-schema.json->quicklauncher-4-command->description
-#. 2.6->settings-schema.json->quicklauncher-5-command->description
-#. 2.6->settings-schema.json->quicklauncher-14-command->description
-#. 2.6->settings-schema.json->quicklauncher-11-command->description
-#. 2.6->settings-schema.json->quicklauncher-17-command->description
-#. 2.6->settings-schema.json->quicklauncher-2-command->description
-#. 2.6->settings-schema.json->quicklauncher-0-command->description
-#. 2.6->settings-schema.json->quicklauncher-1-command->description
-#. 2.6->settings-schema.json->quicklauncher-3-command->description
-#. 2.6->settings-schema.json->quicklauncher-18-command->description
-msgid "Command to launch"
-msgstr "Auszuführender Befehl"
-
-#. 3.2->settings-schema.json->quicklauncher-6-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-10-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-8-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-9-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-4-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-5-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-11-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-2-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-1-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-3-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-6-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-10-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-8-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-9-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-4-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-5-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-11-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-2-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-1-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-3-command->tooltip
-msgid "Enter command for the quicklauncher"
-msgstr "Befehl für den Schnellstarter eingeben"
-
-#. 3.2->settings-schema.json->all-programs-label->description
-#. 2.6->settings-schema.json->all-programs-label->description
-#. 3.4->settings-schema.json->all-programs-label->description
-msgid "'All Programs'-Button label"
-msgstr "»Alle Programme«-Knopfbeschriftung"
-
-#. 3.2->settings-schema.json->all-programs-label->tooltip
-#. 2.6->settings-schema.json->all-programs-label->tooltip
-#. 3.4->settings-schema.json->all-programs-label->tooltip
-msgid "Enter custom text for the 'All Programs' button."
-msgstr "Eigenen Text für den »Alle Programme«-Knopf eingeben."
+#. 3.2->settings-schema.json->panel-behave->title
+#. 3.2->settings-schema.json->menu-behave->title
+#. 3.4->settings-schema.json->panel-behave->title
+#. 3.4->settings-schema.json->menu-behave->title
+#. 4.2->settings-schema.json->panel-behave->title
+#. 4.2->settings-schema.json->menu-behave->title
+msgid "Behavior"
+msgstr "Verhalten"
 
 #. 3.2->settings-schema.json->menu-appear->title
 #. 3.4->settings-schema.json->menu-appear->title
+#. 4.2->settings-schema.json->menu-appear->title
 msgid "Layout and content"
 msgstr "Anordnung und Inhalt"
+
+#. 3.2->settings-schema.json->menu-icons->title
+#. 3.2->settings-schema.json->quicklauncher-layout->options
+#. 2.6->settings-schema.json->quicklauncher-layout->options
+#. 3.4->settings-schema.json->menu-icons->title
+#. 3.4->settings-schema.json->quicklauncher-layout->options
+#. 4.2->settings-schema.json->menu-icons->title
+#. 4.2->settings-schema.json->quicklauncher-layout->options
+msgid "Icons and Labels"
+msgstr "Symbole und Beschriftungen"
 
 #. 3.2->settings-schema.json->sidebar-layout->title
 #. 2.6->settings-schema.json->head-sidebar-layout->description
 #. 3.4->settings-schema.json->sidebar-layout->title
+#. 4.2->settings-schema.json->sidebar-layout->title
 msgid "Sidebar Layout"
 msgstr "Seitenleistenlayout"
 
-#. 3.2->settings-schema.json->quicklauncher->title
-#. 3.4->settings-schema.json->quicklauncher->title
-msgid "Quicklauncher"
-msgstr "Schnellstarter"
-
-#. 3.2->settings-schema.json->menu-behave->title
-#. 3.2->settings-schema.json->panel-behave->title
-#. 3.4->settings-schema.json->menu-behave->title
-#. 3.4->settings-schema.json->panel-behave->title
-msgid "Behavior"
-msgstr "Verhalten"
+#. 3.2->settings-schema.json->quitmenu-layout->title
+#. 3.4->settings-schema.json->quitmenu-layout->title
+#. 4.2->settings-schema.json->quitmenu-layout->title
+msgid "Quit Menu Layout"
+msgstr "Beendenmenü-Layout"
 
 #. 3.2->settings-schema.json->custom-quicklauncher->title
 #. 2.6->settings-schema.json->head-custom-quicklauncher->description
 msgid "Custom Quicklauncher"
 msgstr "Benutzerdefinierte Schnellstarter"
 
-#. 3.2->settings-schema.json->quitmenu-layout->title
-#. 3.4->settings-schema.json->quitmenu-layout->title
-msgid "Quit Menu Layout"
-msgstr "Beendenmenü-Layout"
-
-#. 3.2->settings-schema.json->menu-icons->title
-#. 3.2->settings-schema.json->quicklauncher-layout->options
-#. 2.6->settings-schema.json->quicklauncher-layout->options
-#. 3.4->settings-schema.json->quicklauncher-layout->options
-#. 3.4->settings-schema.json->menu-icons->title
-msgid "Icons and Labels"
-msgstr "Symbole und Beschriftungen"
-
-#. 3.2->settings-schema.json->panel-appear->title
-#. 3.4->settings-schema.json->panel-appear->title
-msgid "Appearance"
-msgstr "Erscheinungsbild"
-
-#. 3.2->settings-schema.json->sidebar->title
-#. 3.4->settings-schema.json->sidebar->title
-msgid "Sidebar"
-msgstr "Seitenleiste"
-
-#. 3.2->settings-schema.json->panel->title
-#. 3.4->settings-schema.json->panel->title
-msgid "Panel"
-msgstr "Leiste"
-
-#. 3.2->settings-schema.json->quicklauncher-17-icon->description
-#. 3.2->settings-schema.json->quicklauncher-15-icon->description
-#. 3.2->settings-schema.json->quicklauncher-11-icon->description
-#. 3.2->settings-schema.json->quicklauncher-12-icon->description
-#. 3.2->settings-schema.json->quicklauncher-3-icon->description
-#. 3.2->settings-schema.json->quicklauncher-5-icon->description
-#. 3.2->settings-schema.json->quicklauncher-1-icon->description
-#. 3.2->settings-schema.json->quicklauncher-4-icon->description
-#. 3.2->settings-schema.json->quicklauncher-8-icon->description
-#. 3.2->settings-schema.json->quicklauncher-6-icon->description
-#. 3.2->settings-schema.json->quicklauncher-13-icon->description
-#. 3.2->settings-schema.json->quicklauncher-2-icon->description
-#. 3.2->settings-schema.json->quicklauncher-16-icon->description
-#. 3.2->settings-schema.json->quicklauncher-7-icon->description
-#. 3.2->settings-schema.json->quicklauncher-0-icon->description
-#. 3.2->settings-schema.json->quicklauncher-14-icon->description
-#. 3.2->settings-schema.json->quicklauncher-19-icon->description
-#. 3.2->settings-schema.json->quicklauncher-18-icon->description
-#. 3.2->settings-schema.json->quicklauncher-9-icon->description
-#. 3.2->settings-schema.json->quicklauncher-10-icon->description
-#. 2.6->settings-schema.json->quicklauncher-17-icon->description
-#. 2.6->settings-schema.json->quicklauncher-15-icon->description
-#. 2.6->settings-schema.json->quicklauncher-11-icon->description
-#. 2.6->settings-schema.json->quicklauncher-12-icon->description
-#. 2.6->settings-schema.json->quicklauncher-3-icon->description
-#. 2.6->settings-schema.json->quicklauncher-5-icon->description
-#. 2.6->settings-schema.json->quicklauncher-1-icon->description
-#. 2.6->settings-schema.json->quicklauncher-4-icon->description
-#. 2.6->settings-schema.json->quicklauncher-8-icon->description
-#. 2.6->settings-schema.json->quicklauncher-6-icon->description
-#. 2.6->settings-schema.json->quicklauncher-13-icon->description
-#. 2.6->settings-schema.json->quicklauncher-2-icon->description
-#. 2.6->settings-schema.json->quicklauncher-16-icon->description
-#. 2.6->settings-schema.json->quicklauncher-7-icon->description
-#. 2.6->settings-schema.json->quicklauncher-0-icon->description
-#. 2.6->settings-schema.json->quicklauncher-14-icon->description
-#. 2.6->settings-schema.json->quicklauncher-19-icon->description
-#. 2.6->settings-schema.json->quicklauncher-18-icon->description
-#. 2.6->settings-schema.json->quicklauncher-9-icon->description
-#. 2.6->settings-schema.json->quicklauncher-10-icon->description
-msgid "Quicklauncher icon"
-msgstr "Schnellstartersymbol"
-
-#. 3.2->settings-schema.json->quicklauncher-17-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-15-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-11-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-12-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-3-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-5-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-1-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-4-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-8-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-6-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-13-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-2-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-16-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-7-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-0-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-14-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-19-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-18-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-9-icon->tooltip
-#. 3.2->settings-schema.json->quicklauncher-10-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-17-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-15-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-11-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-12-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-3-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-5-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-1-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-4-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-8-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-6-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-13-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-2-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-16-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-7-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-0-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-14-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-19-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-18-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-9-icon->tooltip
-#. 2.6->settings-schema.json->quicklauncher-10-icon->tooltip
-msgid ""
-"Select an icon file or type an icon name into the entry box for the "
-"quicklauncher"
-msgstr ""
-"Für den Schnellstarter eine Symboldatei wählen oder einen Symbolnamen in das "
-"Eingabefeld tippen"
-
-#. 3.2->settings-schema.json->search-filesystem->description
-#. 2.6->settings-schema.json->search-filesystem->description
-#. 3.4->settings-schema.json->search-filesystem->description
-msgid "Enable filesystem path entry in search box"
-msgstr "Eingabe des Dateisystempfades im Suchfeld erlauben"
-
-#. 3.2->settings-schema.json->search-filesystem->tooltip
-#. 2.6->settings-schema.json->search-filesystem->tooltip
-#. 3.4->settings-schema.json->search-filesystem->tooltip
-msgid "Allows path entry in the menu search box."
-msgstr "Ermöglicht die Pfadeingabe im Suchfeld des Menüs."
-
-#. 3.2->settings-schema.json->show-shutdown-menu->description
-#. 2.6->settings-schema.json->show-shutdown-menu->description
-#. 3.4->settings-schema.json->show-shutdown-menu->description
-msgid "Show quit buttons"
-msgstr "Beendenknöpfe anzeigen"
-
-#. 3.2->settings-schema.json->show-shutdown-menu->tooltip
-#. 2.6->settings-schema.json->show-shutdown-menu->tooltip
-#. 3.4->settings-schema.json->show-shutdown-menu->tooltip
-msgid "Choose whether or not to show the quit buttons."
-msgstr "Legt fest, ob die Beendenknöpfe angezeigt werden."
-
 #. 3.2->settings-schema.json->menu-layout->options
 #. 2.6->settings-schema.json->menu-layout->options
 #. 3.4->settings-schema.json->menu-layout->options
+#. 4.2->settings-schema.json->menu-layout->options
 msgid "Stark-Menu"
 msgstr "Stark-Menü"
 
 #. 3.2->settings-schema.json->menu-layout->options
 #. 2.6->settings-schema.json->menu-layout->options
 #. 3.4->settings-schema.json->menu-layout->options
+#. 4.2->settings-schema.json->menu-layout->options
 msgid "MATE-Menu"
 msgstr "MATE-Menü"
-
-#. 3.2->settings-schema.json->menu-layout->tooltip
-#. 2.6->settings-schema.json->menu-layout->tooltip
-#. 3.4->settings-schema.json->menu-layout->tooltip
-msgid "Choose between Stark-Menu and MATE-Menu layout"
-msgstr "Zwischen Stark-Menü- und MATE-Menü-Layout wählen"
 
 #. 3.2->settings-schema.json->menu-layout->description
 #. 2.6->settings-schema.json->menu-layout->description
 #. 3.4->settings-schema.json->menu-layout->description
+#. 4.2->settings-schema.json->menu-layout->description
 msgid "Menu layout"
 msgstr "Menü-Layout"
 
-#. 3.2->settings-schema.json->quicklauncher-7-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-16-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-19-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-12-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-15-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-13-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-14-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-17-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-0-command->tooltip
-#. 3.2->settings-schema.json->quicklauncher-18-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-7-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-16-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-19-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-12-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-15-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-13-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-14-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-17-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-0-command->tooltip
-#. 2.6->settings-schema.json->quicklauncher-18-command->tooltip
-msgid "Enter command to start the quicklauncher"
-msgstr "Befehl eingeben, welcher den Schnellstarter startet"
-
-#. 3.2->settings-schema.json->show-favorite-icons->description
-#. 2.6->settings-schema.json->show-favorite-icons->description
-#. 3.4->settings-schema.json->show-favorite-icons->description
-msgid "Show favorite icons"
-msgstr "Favoritensymbole anzeigen"
-
-#. 3.2->settings-schema.json->show-favorite-icons->tooltip
-#. 2.6->settings-schema.json->show-favorite-icons->tooltip
-#. 3.4->settings-schema.json->show-favorite-icons->tooltip
-msgid "Choose whether or not to show icons on favorites."
-msgstr "Legt fest, ob Symbole an Favoriten angezeigt werden."
-
-#. 3.2->settings-schema.json->show-context-menu-icons->description
-#. 2.6->settings-schema.json->show-context-menu-icons->description
-#. 3.4->settings-schema.json->show-context-menu-icons->description
-msgid "Show context menu icons"
-msgstr "Kontextmenüsymbole anzeigen"
-
-#. 3.2->settings-schema.json->show-context-menu-icons->tooltip
-#. 2.6->settings-schema.json->show-context-menu-icons->tooltip
-#. 3.4->settings-schema.json->show-context-menu-icons->tooltip
-msgid "Choose whether or not to show icons on context menus."
-msgstr "Legt fest, ob Symbole in Kontextmenüs angezeigt werden."
-
-#. 3.2->settings-schema.json->show-apps-description-on-buttons->description
-#. 2.6->settings-schema.json->show-apps-description-on-buttons->description
-#. 3.4->settings-schema.json->show-apps-description-on-buttons->description
-msgid "Show application's description under their titles"
-msgstr "Beschreibung der Anwendung unter Anwendungsnamen anzeigen"
-
-#. 3.2->settings-schema.json->show-apps-description-on-buttons->tooltip
-#. 2.6->settings-schema.json->show-apps-description-on-buttons->tooltip
-#. 3.4->settings-schema.json->show-apps-description-on-buttons->tooltip
-msgid ""
-"Choose whether or not to show the application description on the application "
-"buttons."
-msgstr ""
-"Legt fest, ob die Anwendungsbeschreibung auf den Anwendungsknöpfen angezeigt "
-"wird."
-
-#. 3.2->settings-schema.json->menu-label->description
-#. 2.6->settings-schema.json->menu-label->description
-#. 3.4->settings-schema.json->menu-label->description
-msgid "'Menu'-Button label"
-msgstr "»Menü«-Knopfbeschriftung"
-
-#. 3.2->settings-schema.json->menu-label->tooltip
-#. 2.6->settings-schema.json->menu-label->tooltip
-#. 3.4->settings-schema.json->menu-label->tooltip
-msgid "Enter custom text to show in the panel."
-msgstr "Einen eigenen Text eingeben, der in der Leiste angezeigt werden soll."
-
-#. 3.2->settings-schema.json->menu-icon->description
-#. 2.6->settings-schema.json->menu-icon->description
-#. 3.4->settings-schema.json->menu-icon->description
-msgid "Icon"
-msgstr "Symbol"
-
-#. 3.2->settings-schema.json->menu-icon->tooltip
-#. 2.6->settings-schema.json->menu-icon->tooltip
-#. 3.4->settings-schema.json->menu-icon->tooltip
-msgid "Select an icon to show in the panel."
-msgstr "Symbol auswählen, welches in der Leiste angezeigt wird."
-
-#. 3.2->settings-schema.json->quicklauncher-layout->description
-#. 2.6->settings-schema.json->quicklauncher-layout->description
-#. 3.4->settings-schema.json->quicklauncher-layout->description
-msgid "Quicklauncher button style"
-msgstr "Stil der Schnellstarterknöpfe"
-
-#. 3.2->settings-schema.json->quicklauncher-layout->tooltip
-#. 2.6->settings-schema.json->quicklauncher-layout->tooltip
-#. 3.4->settings-schema.json->quicklauncher-layout->tooltip
-msgid ""
-"Choose whether to show icons and/or labels on the quicklauncher buttons."
-msgstr ""
-"Legt fest, ob Symbole und/oder Beschriftungen an den Schnellstarterknöpfen "
-"angezeigt werden."
-
-#. 3.2->settings-schema.json->quicklauncher-layout->options
-#. 2.6->settings-schema.json->quicklauncher-layout->options
-#. 3.4->settings-schema.json->quicklauncher-layout->options
-msgid "Labels only"
-msgstr "Nur Beschriftungen"
-
-#. 3.2->settings-schema.json->quicklauncher-layout->options
-#. 2.6->settings-schema.json->quicklauncher-layout->options
-#. 3.4->settings-schema.json->quicklauncher-layout->options
-msgid "Icons only"
-msgstr "Nur Symbole"
-
-#. 3.2->settings-schema.json->user-box-layout->description
-#. 2.6->settings-schema.json->user-box-layout->description
-#. 3.4->settings-schema.json->user-box-layout->description
-msgid "User account info box style"
-msgstr "Stil der Benutzerkonto-Info-Box"
-
-#. 3.2->settings-schema.json->user-box-layout->tooltip
-#. 2.6->settings-schema.json->user-box-layout->tooltip
-#. 3.4->settings-schema.json->user-box-layout->tooltip
-msgid "Choose whether to show the user name and/or user picture."
-msgstr ""
-"Legt fest, ob der Benutzername und/oder das Benutzerbild angezeigt werden."
-
-#. 3.2->settings-schema.json->user-box-layout->options
-#. 2.6->settings-schema.json->user-box-layout->options
-#. 3.4->settings-schema.json->user-box-layout->options
-msgid "Hide"
-msgstr "Verbergen"
-
-#. 3.2->settings-schema.json->user-box-layout->options
-#. 2.6->settings-schema.json->user-box-layout->options
-#. 3.4->settings-schema.json->user-box-layout->options
-msgid "User picture only"
-msgstr "Nur Benutzerbild"
-
-#. 3.2->settings-schema.json->user-box-layout->options
-#. 2.6->settings-schema.json->user-box-layout->options
-#. 3.4->settings-schema.json->user-box-layout->options
-msgid "User picture and user name"
-msgstr "Benutzerbild und -name"
-
-#. 3.2->settings-schema.json->shutdown-menu-layout->description
-#. 2.6->settings-schema.json->shutdown-menu-layout->description
-#. 3.4->settings-schema.json->shutdown-menu-layout->description
-msgid "Quit buttons layout"
-msgstr "Layout der Beendenknöpfe"
-
-#. 3.2->settings-schema.json->shutdown-menu-layout->tooltip
-#. 2.6->settings-schema.json->shutdown-menu-layout->tooltip
-#. 3.4->settings-schema.json->shutdown-menu-layout->tooltip
-msgid "Choose the layout of the quit options."
-msgstr "Das Layout der Beendenknöpfe wählen."
-
-#. 3.2->settings-schema.json->shutdown-menu-layout->options
-#. 2.6->settings-schema.json->shutdown-menu-layout->options
-#. 3.4->settings-schema.json->shutdown-menu-layout->options
-msgid "Horizontal"
-msgstr "Horizontal"
-
-#. 3.2->settings-schema.json->shutdown-menu-layout->options
-#. 2.6->settings-schema.json->shutdown-menu-layout->options
-#. 3.4->settings-schema.json->shutdown-menu-layout->options
-msgid "Vertical"
-msgstr "Vertikal"
-
-#. 3.2->settings-schema.json->shutdown-menu-layout->options
-#. 2.6->settings-schema.json->shutdown-menu-layout->options
-#. 3.4->settings-schema.json->shutdown-menu-layout->options
-msgid "DropDown"
-msgstr "Dropdown"
-
-#. 3.2->settings-schema.json->show-application-icons->description
-#. 2.6->settings-schema.json->show-application-icons->description
-#. 3.4->settings-schema.json->show-application-icons->description
-msgid "Show application icons"
-msgstr "Anwendungssymbole anzeigen"
-
-#. 3.2->settings-schema.json->show-application-icons->tooltip
-#. 2.6->settings-schema.json->show-application-icons->tooltip
-#. 3.4->settings-schema.json->show-application-icons->tooltip
-msgid "Choose whether or not to show icons on applications."
-msgstr "Legt fest, ob Symbole an Anwendungen angezeigt werden."
+#. 3.2->settings-schema.json->menu-layout->tooltip
+#. 2.6->settings-schema.json->menu-layout->tooltip
+#. 3.4->settings-schema.json->menu-layout->tooltip
+#. 4.2->settings-schema.json->menu-layout->tooltip
+msgid "Choose between Stark-Menu and MATE-Menu layout"
+msgstr "Zwischen Stark-Menü- und MATE-Menü-Layout wählen"
 
 #. 3.2->settings-schema.json->overlay-key->description
 #. 2.6->settings-schema.json->overlay-key->description
 #. 3.4->settings-schema.json->overlay-key->description
+#. 4.2->settings-schema.json->overlay-key->description
 msgid "Keyboard shortcut to open and close the menu"
 msgstr "Tastenkombinationen zum Öffnen und Schließen des Menüs"
-
-#. 3.2->settings-schema.json->enable-autoscroll->description
-#. 2.6->settings-schema.json->enable-autoscroll->description
-#. 3.4->settings-schema.json->enable-autoscroll->description
-msgid "Enable autoscrolling in application list"
-msgstr "Automatischen Bildlauf in der Anwendungsliste aktivieren"
-
-#. 3.2->settings-schema.json->enable-autoscroll->tooltip
-#. 2.6->settings-schema.json->enable-autoscroll->tooltip
-#. 3.4->settings-schema.json->enable-autoscroll->tooltip
-msgid ""
-"Choose whether or not to enable smooth autoscrolling in the application list."
-msgstr "Legt fest, ob weicher Bildlauf in der Anwendungsliste aktiviert wird."
-
-#. 3.2->settings-schema.json->enable-animation->description
-#. 2.6->settings-schema.json->enable-animation->description
-#. 3.4->settings-schema.json->enable-animation->description
-msgid "Use menu animations"
-msgstr "Menüanimationen verwenden"
-
-#. 3.2->settings-schema.json->enable-animation->tooltip
-#. 2.6->settings-schema.json->enable-animation->tooltip
-#. 3.4->settings-schema.json->enable-animation->tooltip
-msgid "Allow the menu to animate on open and close"
-msgstr "Dem Menü erlauben beim Öffnen und Schließen zu animieren"
-
-#. 3.2->settings-schema.json->show-places->description
-#. 2.6->settings-schema.json->show-places->description
-#. 3.4->settings-schema.json->show-places->description
-msgid "Show bookmarks and places"
-msgstr "Lesezeichen und Orte anzeigen"
-
-#. 3.2->settings-schema.json->show-places->tooltip
-#. 2.6->settings-schema.json->show-places->tooltip
-#. 3.4->settings-schema.json->show-places->tooltip
-msgid "Choose whether or not to show bookmarks and places in the menu."
-msgstr "Legt fest, ob Lesezeichen und Orte im Menü angezeigt werden."
-
-#. 3.2->settings-schema.json->shutdown-label->description
-#. 2.6->settings-schema.json->shutdown-label->description
-#. 3.4->settings-schema.json->shutdown-label->description
-msgid "'Quit'-Button label"
-msgstr "»Beenden«-Knopfbeschriftung"
-
-#. 3.2->settings-schema.json->shutdown-label->tooltip
-#. 2.6->settings-schema.json->shutdown-label->tooltip
-#. 3.4->settings-schema.json->shutdown-label->tooltip
-msgid "Enter custom text for the 'Quit' button."
-msgstr "Eigenen Text für den »Beenden«-Knopf eingeben."
-
-#. 3.2->settings-schema.json->show-category-icons->description
-#. 2.6->settings-schema.json->show-category-icons->description
-#. 3.4->settings-schema.json->show-category-icons->description
-msgid "Show category icons"
-msgstr "Kategoriesymbole anzeigen"
-
-#. 3.2->settings-schema.json->show-category-icons->tooltip
-#. 2.6->settings-schema.json->show-category-icons->tooltip
-#. 3.4->settings-schema.json->show-category-icons->tooltip
-msgid "Choose whether or not to show icons on categories."
-msgstr "Legt fest, ob Symbole an Kategorien angezeigt werden."
-
-#. 3.2->settings-schema.json->menu-editor-button->description
-#. 2.6->settings-schema.json->menu-editor-button->description
-#. 3.4->settings-schema.json->menu-editor-button->description
-msgid "Open the menu editor"
-msgstr "Den Menüeditor öffnen"
-
-#. 3.2->settings-schema.json->menu-editor-button->tooltip
-#. 2.6->settings-schema.json->menu-editor-button->tooltip
-#. 3.4->settings-schema.json->menu-editor-button->tooltip
-msgid "Press this button to customize your menu entries."
-msgstr "Diesen Knopf drücken um die Menüeinträge anzupassen."
 
 #. 3.2->settings-schema.json->menu-icon-custom->description
 #. 2.6->settings-schema.json->menu-icon-custom->description
@@ -937,45 +309,755 @@ msgstr "Ein benutzerdefiniertes Symbol benutzen"
 msgid "Unchecking this allows the theme to set the icon"
 msgstr "Durch Abwählen wird es dem Thema erlaubt, das Symbol einzustellen"
 
-#. 3.2->settings-schema.json->hover-delay->description
-#. 3.4->settings-schema.json->hover-delay->description
-msgid "Menu hover delay"
-msgstr "Verzögerung beim Darüberbewegen über das Menü"
+#. 3.2->settings-schema.json->menu-icon->description
+#. 2.6->settings-schema.json->menu-icon->description
+#. 3.4->settings-schema.json->menu-icon->description
+#. 4.2->settings-schema.json->menu-icon->description
+msgid "Icon"
+msgstr "Symbol"
 
-#. 3.2->settings-schema.json->hover-delay->tooltip
-#. 3.4->settings-schema.json->hover-delay->tooltip
-msgid "Delay before the menu opens when hovered"
-msgstr "Verzögerung bevor das Menü beim Darüberbewegen geöffnet wird"
+#. 3.2->settings-schema.json->menu-icon->tooltip
+#. 2.6->settings-schema.json->menu-icon->tooltip
+#. 3.4->settings-schema.json->menu-icon->tooltip
+#. 4.2->settings-schema.json->menu-icon->tooltip
+msgid "Select an icon to show in the panel."
+msgstr "Symbol auswählen, welches in der Leiste angezeigt wird."
 
-#. 3.2->settings-schema.json->hover-delay->units
-#. 2.6->settings-schema.json->hover-delay->units
-#. 3.4->settings-schema.json->hover-delay->units
-msgid "milliseconds"
-msgstr "Millisekunden"
+#. 3.2->settings-schema.json->menu-label->description
+#. 2.6->settings-schema.json->menu-label->description
+#. 3.4->settings-schema.json->menu-label->description
+msgid "'Menu'-Button label"
+msgstr "»Menü«-Knopfbeschriftung"
 
-#. 3.2->settings-schema.json->show-sidebar->description
-#. 2.6->settings-schema.json->show-sidebar->description
-#. 3.4->settings-schema.json->show-sidebar->description
-msgid "Show sidebar on menu"
-msgstr "Seitenleiste im Menü anzeigen"
+#. 3.2->settings-schema.json->menu-label->tooltip
+#. 2.6->settings-schema.json->menu-label->tooltip
+#. 3.4->settings-schema.json->menu-label->tooltip
+#. 4.2->settings-schema.json->menu-label->tooltip
+msgid "Enter custom text to show in the panel."
+msgstr "Einen eigenen Text eingeben, der in der Leiste angezeigt werden soll."
 
-#. 3.2->settings-schema.json->show-sidebar->tooltip
-#. 2.6->settings-schema.json->show-sidebar->tooltip
-#. 3.4->settings-schema.json->show-sidebar->tooltip
-msgid "Choose whether or not to show the sidebar."
-msgstr "Legt fest, ob die Seitenleiste angezeigt wird."
+#. 3.2->settings-schema.json->all-programs-label->description
+#. 2.6->settings-schema.json->all-programs-label->description
+#. 3.4->settings-schema.json->all-programs-label->description
+#. 4.2->settings-schema.json->all-programs-label->description
+msgid "'All Programs'-Button label"
+msgstr "»Alle Programme«-Knopfbeschriftung"
+
+#. 3.2->settings-schema.json->all-programs-label->tooltip
+#. 2.6->settings-schema.json->all-programs-label->tooltip
+#. 3.4->settings-schema.json->all-programs-label->tooltip
+#. 4.2->settings-schema.json->all-programs-label->tooltip
+msgid "Enter custom text for the 'All Programs' button."
+msgstr "Eigenen Text für den »Alle Programme«-Knopf eingeben."
 
 #. 3.2->settings-schema.json->favorites-label->description
 #. 2.6->settings-schema.json->favorites-label->description
 #. 3.4->settings-schema.json->favorites-label->description
+#. 4.2->settings-schema.json->favorites-label->description
 msgid "'Favorites'-Button label"
 msgstr "»Favoriten«-Knopfbeschriftung"
 
 #. 3.2->settings-schema.json->favorites-label->tooltip
 #. 2.6->settings-schema.json->favorites-label->tooltip
 #. 3.4->settings-schema.json->favorites-label->tooltip
+#. 4.2->settings-schema.json->favorites-label->tooltip
 msgid "Enter custom text for the 'Favorites' button."
 msgstr "Eigenen Text für den »Favoriten«-Knopf eingeben."
+
+#. 3.2->settings-schema.json->show-apps-description-on-buttons->description
+#. 2.6->settings-schema.json->show-apps-description-on-buttons->description
+#. 3.4->settings-schema.json->show-apps-description-on-buttons->description
+#. 4.2->settings-schema.json->show-apps-description-on-buttons->description
+msgid "Show application's description under their titles"
+msgstr "Beschreibung der Anwendung unter Anwendungsnamen anzeigen"
+
+#. 3.2->settings-schema.json->show-apps-description-on-buttons->tooltip
+#. 2.6->settings-schema.json->show-apps-description-on-buttons->tooltip
+#. 3.4->settings-schema.json->show-apps-description-on-buttons->tooltip
+#. 4.2->settings-schema.json->show-apps-description-on-buttons->tooltip
+msgid ""
+"Choose whether or not to show the application description on the application "
+"buttons."
+msgstr ""
+"Legt fest, ob die Anwendungsbeschreibung auf den Anwendungsknöpfen angezeigt "
+"wird."
+
+#. 3.2->settings-schema.json->show-places->description
+#. 2.6->settings-schema.json->show-places->description
+#. 3.4->settings-schema.json->show-places->description
+#. 4.2->settings-schema.json->show-places->description
+msgid "Show bookmarks and places"
+msgstr "Lesezeichen und Orte anzeigen"
+
+#. 3.2->settings-schema.json->show-places->tooltip
+#. 2.6->settings-schema.json->show-places->tooltip
+#. 3.4->settings-schema.json->show-places->tooltip
+#. 4.2->settings-schema.json->show-places->tooltip
+msgid "Choose whether or not to show bookmarks and places in the menu."
+msgstr "Legt fest, ob Lesezeichen und Orte im Menü angezeigt werden."
+
+#. 3.2->settings-schema.json->enable-autoscroll->description
+#. 2.6->settings-schema.json->enable-autoscroll->description
+#. 3.4->settings-schema.json->enable-autoscroll->description
+#. 4.2->settings-schema.json->enable-autoscroll->description
+msgid "Enable autoscrolling in application list"
+msgstr "Automatischen Bildlauf in der Anwendungsliste aktivieren"
+
+#. 3.2->settings-schema.json->enable-autoscroll->tooltip
+#. 2.6->settings-schema.json->enable-autoscroll->tooltip
+#. 3.4->settings-schema.json->enable-autoscroll->tooltip
+#. 4.2->settings-schema.json->enable-autoscroll->tooltip
+msgid ""
+"Choose whether or not to enable smooth autoscrolling in the application list."
+msgstr "Legt fest, ob weicher Bildlauf in der Anwendungsliste aktiviert wird."
+
+#. 3.2->settings-schema.json->search-filesystem->description
+#. 2.6->settings-schema.json->search-filesystem->description
+#. 3.4->settings-schema.json->search-filesystem->description
+#. 4.2->settings-schema.json->search-filesystem->description
+msgid "Enable filesystem path entry in search box"
+msgstr "Eingabe des Dateisystempfades im Suchfeld erlauben"
+
+#. 3.2->settings-schema.json->search-filesystem->tooltip
+#. 2.6->settings-schema.json->search-filesystem->tooltip
+#. 3.4->settings-schema.json->search-filesystem->tooltip
+#. 4.2->settings-schema.json->search-filesystem->tooltip
+msgid "Allows path entry in the menu search box."
+msgstr "Ermöglicht die Pfadeingabe im Suchfeld des Menüs."
+
+#. 3.2->settings-schema.json->activate-on-hover->description
+#. 2.6->settings-schema.json->activate-on-hover->description
+#. 3.4->settings-schema.json->activate-on-hover->description
+#. 4.2->settings-schema.json->activate-on-hover->description
+msgid "Open the menu when I move my mouse over it"
+msgstr "Das Menü öffnen, wenn die Maus darüber bewegt wird"
+
+#. 3.2->settings-schema.json->activate-on-hover->tooltip
+#. 2.6->settings-schema.json->activate-on-hover->tooltip
+#. 3.4->settings-schema.json->activate-on-hover->tooltip
+#. 4.2->settings-schema.json->activate-on-hover->tooltip
+msgid "Enable opening the menu when the mouse enters the applet"
+msgstr "Öffnen des Menüs aktivieren, wenn sich die Maus auf das Applet bewegt"
+
+#. 3.2->settings-schema.json->hover-delay->units
+#. 2.6->settings-schema.json->hover-delay->units
+#. 3.4->settings-schema.json->hover-delay->units
+#. 4.2->settings-schema.json->hover-delay->units
+msgid "milliseconds"
+msgstr "Millisekunden"
+
+#. 3.2->settings-schema.json->hover-delay->description
+#. 3.4->settings-schema.json->hover-delay->description
+#. 4.2->settings-schema.json->hover-delay->description
+msgid "Menu hover delay"
+msgstr "Verzögerung beim Darüberbewegen über das Menü"
+
+#. 3.2->settings-schema.json->hover-delay->tooltip
+#. 3.4->settings-schema.json->hover-delay->tooltip
+#. 4.2->settings-schema.json->hover-delay->tooltip
+msgid "Delay before the menu opens when hovered"
+msgstr "Verzögerung bevor das Menü beim Darüberbewegen geöffnet wird"
+
+#. 3.2->settings-schema.json->enable-animation->description
+#. 2.6->settings-schema.json->enable-animation->description
+#. 3.4->settings-schema.json->enable-animation->description
+#. 4.2->settings-schema.json->enable-animation->description
+msgid "Use menu animations"
+msgstr "Menüanimationen verwenden"
+
+#. 3.2->settings-schema.json->enable-animation->tooltip
+#. 2.6->settings-schema.json->enable-animation->tooltip
+#. 3.4->settings-schema.json->enable-animation->tooltip
+#. 4.2->settings-schema.json->enable-animation->tooltip
+msgid "Allow the menu to animate on open and close"
+msgstr "Dem Menü erlauben beim Öffnen und Schließen zu animieren"
+
+#. 3.2->settings-schema.json->menu-editor-button->description
+#. 2.6->settings-schema.json->menu-editor-button->description
+#. 3.4->settings-schema.json->menu-editor-button->description
+#. 4.2->settings-schema.json->menu-editor-button->description
+msgid "Open the menu editor"
+msgstr "Den Menüeditor öffnen"
+
+#. 3.2->settings-schema.json->menu-editor-button->tooltip
+#. 2.6->settings-schema.json->menu-editor-button->tooltip
+#. 3.4->settings-schema.json->menu-editor-button->tooltip
+#. 4.2->settings-schema.json->menu-editor-button->tooltip
+msgid "Press this button to customize your menu entries."
+msgstr "Diesen Knopf drücken um die Menüeinträge anzupassen."
+
+#. 3.2->settings-schema.json->show-category-icons->description
+#. 2.6->settings-schema.json->show-category-icons->description
+#. 3.4->settings-schema.json->show-category-icons->description
+#. 4.2->settings-schema.json->show-category-icons->description
+msgid "Show category icons"
+msgstr "Kategoriesymbole anzeigen"
+
+#. 3.2->settings-schema.json->show-category-icons->tooltip
+#. 2.6->settings-schema.json->show-category-icons->tooltip
+#. 3.4->settings-schema.json->show-category-icons->tooltip
+#. 4.2->settings-schema.json->show-category-icons->tooltip
+msgid "Choose whether or not to show icons on categories."
+msgstr "Legt fest, ob Symbole an Kategorien angezeigt werden."
+
+#. 3.2->settings-schema.json->show-application-icons->description
+#. 2.6->settings-schema.json->show-application-icons->description
+#. 3.4->settings-schema.json->show-application-icons->description
+#. 4.2->settings-schema.json->show-application-icons->description
+msgid "Show application icons"
+msgstr "Anwendungssymbole anzeigen"
+
+#. 3.2->settings-schema.json->show-application-icons->tooltip
+#. 2.6->settings-schema.json->show-application-icons->tooltip
+#. 3.4->settings-schema.json->show-application-icons->tooltip
+#. 4.2->settings-schema.json->show-application-icons->tooltip
+msgid "Choose whether or not to show icons on applications."
+msgstr "Legt fest, ob Symbole an Anwendungen angezeigt werden."
+
+#. 3.2->settings-schema.json->show-context-menu-icons->description
+#. 2.6->settings-schema.json->show-context-menu-icons->description
+#. 3.4->settings-schema.json->show-context-menu-icons->description
+#. 4.2->settings-schema.json->show-context-menu-icons->description
+msgid "Show context menu icons"
+msgstr "Kontextmenüsymbole anzeigen"
+
+#. 3.2->settings-schema.json->show-context-menu-icons->tooltip
+#. 2.6->settings-schema.json->show-context-menu-icons->tooltip
+#. 3.4->settings-schema.json->show-context-menu-icons->tooltip
+#. 4.2->settings-schema.json->show-context-menu-icons->tooltip
+msgid "Choose whether or not to show icons on context menus."
+msgstr "Legt fest, ob Symbole in Kontextmenüs angezeigt werden."
+
+#. 3.2->settings-schema.json->show-favorite-icons->description
+#. 2.6->settings-schema.json->show-favorite-icons->description
+#. 3.4->settings-schema.json->show-favorite-icons->description
+#. 4.2->settings-schema.json->show-favorite-icons->description
+msgid "Show favorite icons"
+msgstr "Favoritensymbole anzeigen"
+
+#. 3.2->settings-schema.json->show-favorite-icons->tooltip
+#. 2.6->settings-schema.json->show-favorite-icons->tooltip
+#. 3.4->settings-schema.json->show-favorite-icons->tooltip
+#. 4.2->settings-schema.json->show-favorite-icons->tooltip
+msgid "Choose whether or not to show icons on favorites."
+msgstr "Legt fest, ob Symbole an Favoriten angezeigt werden."
+
+#. 3.2->settings-schema.json->favorite-button-size->units
+#. 2.6->settings-schema.json->favorite-button-size->units
+#. 3.4->settings-schema.json->favorite-button-size->units
+#. 4.2->settings-schema.json->favorite-button-size->units
+msgid "pixels"
+msgstr "Pixel"
+
+#. 3.2->settings-schema.json->favorite-button-size->description
+#. 2.6->settings-schema.json->favorite-button-size->description
+#. 3.4->settings-schema.json->favorite-button-size->description
+#. 4.2->settings-schema.json->favorite-button-size->description
+msgid "Size of the favorite buttons"
+msgstr "Größe der Favoritenknöpfe"
+
+#. 3.2->settings-schema.json->favorite-button-size->tooltip
+#. 2.6->settings-schema.json->favorite-button-size->tooltip
+#. 3.4->settings-schema.json->favorite-button-size->tooltip
+#. 4.2->settings-schema.json->favorite-button-size->tooltip
+msgid "Change the size of the favorite buttons"
+msgstr "Die Größe der Favoritenknöpfe ändern"
+
+#. 3.2->settings-schema.json->show-sidebar->description
+#. 2.6->settings-schema.json->show-sidebar->description
+#. 3.4->settings-schema.json->show-sidebar->description
+#. 4.2->settings-schema.json->show-sidebar->description
+msgid "Show sidebar on menu"
+msgstr "Seitenleiste im Menü anzeigen"
+
+#. 3.2->settings-schema.json->show-sidebar->tooltip
+#. 2.6->settings-schema.json->show-sidebar->tooltip
+#. 3.4->settings-schema.json->show-sidebar->tooltip
+#. 4.2->settings-schema.json->show-sidebar->tooltip
+msgid "Choose whether or not to show the sidebar."
+msgstr "Legt fest, ob die Seitenleiste angezeigt wird."
+
+#. 3.2->settings-schema.json->user-box-layout->options
+#. 2.6->settings-schema.json->user-box-layout->options
+#. 3.4->settings-schema.json->user-box-layout->options
+#. 4.2->settings-schema.json->user-box-layout->options
+msgid "User picture and user name"
+msgstr "Benutzerbild und -name"
+
+#. 3.2->settings-schema.json->user-box-layout->options
+#. 2.6->settings-schema.json->user-box-layout->options
+#. 3.4->settings-schema.json->user-box-layout->options
+#. 4.2->settings-schema.json->user-box-layout->options
+msgid "User picture only"
+msgstr "Nur Benutzerbild"
+
+#. 3.2->settings-schema.json->user-box-layout->options
+#. 2.6->settings-schema.json->user-box-layout->options
+#. 3.4->settings-schema.json->user-box-layout->options
+#. 4.2->settings-schema.json->user-box-layout->options
+msgid "Hide"
+msgstr "Verbergen"
+
+#. 3.2->settings-schema.json->user-box-layout->description
+#. 2.6->settings-schema.json->user-box-layout->description
+#. 3.4->settings-schema.json->user-box-layout->description
+#. 4.2->settings-schema.json->user-box-layout->description
+msgid "User account info box style"
+msgstr "Stil der Benutzerkonto-Info-Box"
+
+#. 3.2->settings-schema.json->user-box-layout->tooltip
+#. 2.6->settings-schema.json->user-box-layout->tooltip
+#. 3.4->settings-schema.json->user-box-layout->tooltip
+#. 4.2->settings-schema.json->user-box-layout->tooltip
+msgid "Choose whether to show the user name and/or user picture."
+msgstr ""
+"Legt fest, ob der Benutzername und/oder das Benutzerbild angezeigt werden."
+
+#. 3.2->settings-schema.json->quicklauncher-layout->options
+#. 2.6->settings-schema.json->quicklauncher-layout->options
+#. 3.4->settings-schema.json->quicklauncher-layout->options
+#. 4.2->settings-schema.json->quicklauncher-layout->options
+msgid "Icons only"
+msgstr "Nur Symbole"
+
+#. 3.2->settings-schema.json->quicklauncher-layout->options
+#. 2.6->settings-schema.json->quicklauncher-layout->options
+#. 3.4->settings-schema.json->quicklauncher-layout->options
+#. 4.2->settings-schema.json->quicklauncher-layout->options
+msgid "Labels only"
+msgstr "Nur Beschriftungen"
+
+#. 3.2->settings-schema.json->quicklauncher-layout->description
+#. 2.6->settings-schema.json->quicklauncher-layout->description
+#. 3.4->settings-schema.json->quicklauncher-layout->description
+#. 4.2->settings-schema.json->quicklauncher-layout->description
+msgid "Quicklauncher button style"
+msgstr "Stil der Schnellstarterknöpfe"
+
+#. 3.2->settings-schema.json->quicklauncher-layout->tooltip
+#. 2.6->settings-schema.json->quicklauncher-layout->tooltip
+#. 3.4->settings-schema.json->quicklauncher-layout->tooltip
+#. 4.2->settings-schema.json->quicklauncher-layout->tooltip
+msgid ""
+"Choose whether to show icons and/or labels on the quicklauncher buttons."
+msgstr ""
+"Legt fest, ob Symbole und/oder Beschriftungen an den Schnellstarterknöpfen "
+"angezeigt werden."
+
+#. 3.2->settings-schema.json->show-shutdown-menu->description
+#. 2.6->settings-schema.json->show-shutdown-menu->description
+#. 3.4->settings-schema.json->show-shutdown-menu->description
+#. 4.2->settings-schema.json->show-shutdown-menu->description
+msgid "Show quit buttons"
+msgstr "Beendenknöpfe anzeigen"
+
+#. 3.2->settings-schema.json->show-shutdown-menu->tooltip
+#. 2.6->settings-schema.json->show-shutdown-menu->tooltip
+#. 3.4->settings-schema.json->show-shutdown-menu->tooltip
+#. 4.2->settings-schema.json->show-shutdown-menu->tooltip
+msgid "Choose whether or not to show the quit buttons."
+msgstr "Legt fest, ob die Beendenknöpfe angezeigt werden."
+
+#. 3.2->settings-schema.json->shutdown-menu-layout->options
+#. 2.6->settings-schema.json->shutdown-menu-layout->options
+#. 3.4->settings-schema.json->shutdown-menu-layout->options
+#. 4.2->settings-schema.json->shutdown-menu-layout->options
+msgid "DropDown"
+msgstr "Dropdown"
+
+#. 3.2->settings-schema.json->shutdown-menu-layout->options
+#. 2.6->settings-schema.json->shutdown-menu-layout->options
+#. 3.4->settings-schema.json->shutdown-menu-layout->options
+#. 4.2->settings-schema.json->shutdown-menu-layout->options
+msgid "Vertical"
+msgstr "Vertikal"
+
+#. 3.2->settings-schema.json->shutdown-menu-layout->options
+#. 2.6->settings-schema.json->shutdown-menu-layout->options
+#. 3.4->settings-schema.json->shutdown-menu-layout->options
+#. 4.2->settings-schema.json->shutdown-menu-layout->options
+msgid "Horizontal"
+msgstr "Horizontal"
+
+#. 3.2->settings-schema.json->shutdown-menu-layout->description
+#. 2.6->settings-schema.json->shutdown-menu-layout->description
+#. 3.4->settings-schema.json->shutdown-menu-layout->description
+#. 4.2->settings-schema.json->shutdown-menu-layout->description
+msgid "Quit buttons layout"
+msgstr "Layout der Beendenknöpfe"
+
+#. 3.2->settings-schema.json->shutdown-menu-layout->tooltip
+#. 2.6->settings-schema.json->shutdown-menu-layout->tooltip
+#. 3.4->settings-schema.json->shutdown-menu-layout->tooltip
+#. 4.2->settings-schema.json->shutdown-menu-layout->tooltip
+msgid "Choose the layout of the quit options."
+msgstr "Das Layout der Beendenknöpfe wählen."
+
+#. 3.2->settings-schema.json->shutdown-label->description
+#. 2.6->settings-schema.json->shutdown-label->description
+#. 3.4->settings-schema.json->shutdown-label->description
+#. 4.2->settings-schema.json->shutdown-label->description
+msgid "'Quit'-Button label"
+msgstr "»Beenden«-Knopfbeschriftung"
+
+#. 3.2->settings-schema.json->shutdown-label->tooltip
+#. 2.6->settings-schema.json->shutdown-label->tooltip
+#. 3.4->settings-schema.json->shutdown-label->tooltip
+#. 4.2->settings-schema.json->shutdown-label->tooltip
+msgid "Enter custom text for the 'Quit' button."
+msgstr "Eigenen Text für den »Beenden«-Knopf eingeben."
+
+#. 3.2->settings-schema.json->quicklauncher-0-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-1-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-2-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-3-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-4-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-5-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-6-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-7-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-8-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-9-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-10-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-11-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-12-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-13-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-14-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-15-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-16-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-17-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-18-checkbox->description
+#. 3.2->settings-schema.json->quicklauncher-19-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-0-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-1-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-2-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-3-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-4-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-5-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-6-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-7-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-8-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-9-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-10-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-11-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-12-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-13-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-14-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-15-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-16-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-17-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-18-checkbox->description
+#. 2.6->settings-schema.json->quicklauncher-19-checkbox->description
+msgid "Show quicklauncher on the sidebar"
+msgstr "Schnellstarter auf der Seitenleiste anzeigen"
+
+#. 3.2->settings-schema.json->quicklauncher-0-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-1-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-2-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-3-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-4-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-5-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-6-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-7-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-8-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-9-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-10-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-11-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-12-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-13-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-14-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-15-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-16-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-17-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-18-checkbox->tooltip
+#. 3.2->settings-schema.json->quicklauncher-19-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-0-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-1-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-2-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-3-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-4-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-5-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-6-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-7-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-8-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-9-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-10-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-11-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-12-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-13-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-14-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-15-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-16-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-17-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-18-checkbox->tooltip
+#. 2.6->settings-schema.json->quicklauncher-19-checkbox->tooltip
+msgid "Choose whether or not to show this quicklauncher in the sidebar."
+msgstr ""
+"Legt fest, ob dieser Schnellstarter in der Seitenleiste angezeigt wird."
+
+#. 3.2->settings-schema.json->quicklauncher-0-label->description
+#. 3.2->settings-schema.json->quicklauncher-1-label->description
+#. 3.2->settings-schema.json->quicklauncher-2-label->description
+#. 3.2->settings-schema.json->quicklauncher-3-label->description
+#. 3.2->settings-schema.json->quicklauncher-4-label->description
+#. 3.2->settings-schema.json->quicklauncher-5-label->description
+#. 3.2->settings-schema.json->quicklauncher-6-label->description
+#. 3.2->settings-schema.json->quicklauncher-7-label->description
+#. 3.2->settings-schema.json->quicklauncher-8-label->description
+#. 3.2->settings-schema.json->quicklauncher-9-label->description
+#. 3.2->settings-schema.json->quicklauncher-10-label->description
+#. 3.2->settings-schema.json->quicklauncher-11-label->description
+#. 3.2->settings-schema.json->quicklauncher-12-label->description
+#. 3.2->settings-schema.json->quicklauncher-13-label->description
+#. 3.2->settings-schema.json->quicklauncher-14-label->description
+#. 3.2->settings-schema.json->quicklauncher-15-label->description
+#. 3.2->settings-schema.json->quicklauncher-16-label->description
+#. 3.2->settings-schema.json->quicklauncher-17-label->description
+#. 3.2->settings-schema.json->quicklauncher-18-label->description
+#. 3.2->settings-schema.json->quicklauncher-19-label->description
+#. 2.6->settings-schema.json->quicklauncher-0-label->description
+#. 2.6->settings-schema.json->quicklauncher-1-label->description
+#. 2.6->settings-schema.json->quicklauncher-2-label->description
+#. 2.6->settings-schema.json->quicklauncher-3-label->description
+#. 2.6->settings-schema.json->quicklauncher-4-label->description
+#. 2.6->settings-schema.json->quicklauncher-5-label->description
+#. 2.6->settings-schema.json->quicklauncher-6-label->description
+#. 2.6->settings-schema.json->quicklauncher-7-label->description
+#. 2.6->settings-schema.json->quicklauncher-8-label->description
+#. 2.6->settings-schema.json->quicklauncher-9-label->description
+#. 2.6->settings-schema.json->quicklauncher-10-label->description
+#. 2.6->settings-schema.json->quicklauncher-11-label->description
+#. 2.6->settings-schema.json->quicklauncher-12-label->description
+#. 2.6->settings-schema.json->quicklauncher-13-label->description
+#. 2.6->settings-schema.json->quicklauncher-14-label->description
+#. 2.6->settings-schema.json->quicklauncher-15-label->description
+#. 2.6->settings-schema.json->quicklauncher-16-label->description
+#. 2.6->settings-schema.json->quicklauncher-17-label->description
+#. 2.6->settings-schema.json->quicklauncher-18-label->description
+#. 2.6->settings-schema.json->quicklauncher-19-label->description
+msgid "Quicklauncher label"
+msgstr "Schnellstarterbeschriftung"
+
+#. 3.2->settings-schema.json->quicklauncher-0-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-1-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-2-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-3-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-4-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-5-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-6-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-7-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-8-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-9-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-10-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-11-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-12-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-13-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-14-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-15-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-16-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-17-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-18-label->tooltip
+#. 3.2->settings-schema.json->quicklauncher-19-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-0-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-1-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-2-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-3-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-4-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-5-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-6-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-7-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-8-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-9-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-10-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-11-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-12-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-13-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-14-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-15-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-16-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-17-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-18-label->tooltip
+#. 2.6->settings-schema.json->quicklauncher-19-label->tooltip
+msgid "Enter label for the quicklauncher"
+msgstr "Beschriftung für den Schnellstarter eingeben"
+
+#. 3.2->settings-schema.json->quicklauncher-0-icon->description
+#. 3.2->settings-schema.json->quicklauncher-1-icon->description
+#. 3.2->settings-schema.json->quicklauncher-2-icon->description
+#. 3.2->settings-schema.json->quicklauncher-3-icon->description
+#. 3.2->settings-schema.json->quicklauncher-4-icon->description
+#. 3.2->settings-schema.json->quicklauncher-5-icon->description
+#. 3.2->settings-schema.json->quicklauncher-6-icon->description
+#. 3.2->settings-schema.json->quicklauncher-7-icon->description
+#. 3.2->settings-schema.json->quicklauncher-8-icon->description
+#. 3.2->settings-schema.json->quicklauncher-9-icon->description
+#. 3.2->settings-schema.json->quicklauncher-10-icon->description
+#. 3.2->settings-schema.json->quicklauncher-11-icon->description
+#. 3.2->settings-schema.json->quicklauncher-12-icon->description
+#. 3.2->settings-schema.json->quicklauncher-13-icon->description
+#. 3.2->settings-schema.json->quicklauncher-14-icon->description
+#. 3.2->settings-schema.json->quicklauncher-15-icon->description
+#. 3.2->settings-schema.json->quicklauncher-16-icon->description
+#. 3.2->settings-schema.json->quicklauncher-17-icon->description
+#. 3.2->settings-schema.json->quicklauncher-18-icon->description
+#. 3.2->settings-schema.json->quicklauncher-19-icon->description
+#. 2.6->settings-schema.json->quicklauncher-0-icon->description
+#. 2.6->settings-schema.json->quicklauncher-1-icon->description
+#. 2.6->settings-schema.json->quicklauncher-2-icon->description
+#. 2.6->settings-schema.json->quicklauncher-3-icon->description
+#. 2.6->settings-schema.json->quicklauncher-4-icon->description
+#. 2.6->settings-schema.json->quicklauncher-5-icon->description
+#. 2.6->settings-schema.json->quicklauncher-6-icon->description
+#. 2.6->settings-schema.json->quicklauncher-7-icon->description
+#. 2.6->settings-schema.json->quicklauncher-8-icon->description
+#. 2.6->settings-schema.json->quicklauncher-9-icon->description
+#. 2.6->settings-schema.json->quicklauncher-10-icon->description
+#. 2.6->settings-schema.json->quicklauncher-11-icon->description
+#. 2.6->settings-schema.json->quicklauncher-12-icon->description
+#. 2.6->settings-schema.json->quicklauncher-13-icon->description
+#. 2.6->settings-schema.json->quicklauncher-14-icon->description
+#. 2.6->settings-schema.json->quicklauncher-15-icon->description
+#. 2.6->settings-schema.json->quicklauncher-16-icon->description
+#. 2.6->settings-schema.json->quicklauncher-17-icon->description
+#. 2.6->settings-schema.json->quicklauncher-18-icon->description
+#. 2.6->settings-schema.json->quicklauncher-19-icon->description
+msgid "Quicklauncher icon"
+msgstr "Schnellstartersymbol"
+
+#. 3.2->settings-schema.json->quicklauncher-0-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-1-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-2-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-3-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-4-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-5-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-6-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-7-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-8-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-9-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-10-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-11-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-12-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-13-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-14-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-15-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-16-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-17-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-18-icon->tooltip
+#. 3.2->settings-schema.json->quicklauncher-19-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-0-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-1-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-2-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-3-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-4-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-5-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-6-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-7-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-8-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-9-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-10-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-11-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-12-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-13-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-14-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-15-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-16-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-17-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-18-icon->tooltip
+#. 2.6->settings-schema.json->quicklauncher-19-icon->tooltip
+msgid ""
+"Select an icon file or type an icon name into the entry box for the "
+"quicklauncher"
+msgstr ""
+"Für den Schnellstarter eine Symboldatei wählen oder einen Symbolnamen in das "
+"Eingabefeld tippen"
+
+#. 3.2->settings-schema.json->quicklauncher-0-command->description
+#. 3.2->settings-schema.json->quicklauncher-1-command->description
+#. 3.2->settings-schema.json->quicklauncher-2-command->description
+#. 3.2->settings-schema.json->quicklauncher-3-command->description
+#. 3.2->settings-schema.json->quicklauncher-4-command->description
+#. 3.2->settings-schema.json->quicklauncher-5-command->description
+#. 3.2->settings-schema.json->quicklauncher-6-command->description
+#. 3.2->settings-schema.json->quicklauncher-7-command->description
+#. 3.2->settings-schema.json->quicklauncher-8-command->description
+#. 3.2->settings-schema.json->quicklauncher-9-command->description
+#. 3.2->settings-schema.json->quicklauncher-10-command->description
+#. 3.2->settings-schema.json->quicklauncher-11-command->description
+#. 3.2->settings-schema.json->quicklauncher-12-command->description
+#. 3.2->settings-schema.json->quicklauncher-13-command->description
+#. 3.2->settings-schema.json->quicklauncher-14-command->description
+#. 3.2->settings-schema.json->quicklauncher-15-command->description
+#. 3.2->settings-schema.json->quicklauncher-16-command->description
+#. 3.2->settings-schema.json->quicklauncher-17-command->description
+#. 3.2->settings-schema.json->quicklauncher-18-command->description
+#. 3.2->settings-schema.json->quicklauncher-19-command->description
+#. 2.6->settings-schema.json->quicklauncher-0-command->description
+#. 2.6->settings-schema.json->quicklauncher-1-command->description
+#. 2.6->settings-schema.json->quicklauncher-2-command->description
+#. 2.6->settings-schema.json->quicklauncher-3-command->description
+#. 2.6->settings-schema.json->quicklauncher-4-command->description
+#. 2.6->settings-schema.json->quicklauncher-5-command->description
+#. 2.6->settings-schema.json->quicklauncher-6-command->description
+#. 2.6->settings-schema.json->quicklauncher-7-command->description
+#. 2.6->settings-schema.json->quicklauncher-8-command->description
+#. 2.6->settings-schema.json->quicklauncher-9-command->description
+#. 2.6->settings-schema.json->quicklauncher-10-command->description
+#. 2.6->settings-schema.json->quicklauncher-11-command->description
+#. 2.6->settings-schema.json->quicklauncher-12-command->description
+#. 2.6->settings-schema.json->quicklauncher-13-command->description
+#. 2.6->settings-schema.json->quicklauncher-14-command->description
+#. 2.6->settings-schema.json->quicklauncher-15-command->description
+#. 2.6->settings-schema.json->quicklauncher-16-command->description
+#. 2.6->settings-schema.json->quicklauncher-17-command->description
+#. 2.6->settings-schema.json->quicklauncher-18-command->description
+#. 2.6->settings-schema.json->quicklauncher-19-command->description
+msgid "Command to launch"
+msgstr "Auszuführender Befehl"
+
+#. 3.2->settings-schema.json->quicklauncher-0-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-7-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-12-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-13-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-14-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-15-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-16-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-17-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-18-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-19-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-0-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-7-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-12-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-13-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-14-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-15-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-16-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-17-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-18-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-19-command->tooltip
+msgid "Enter command to start the quicklauncher"
+msgstr "Befehl eingeben, welcher den Schnellstarter startet"
+
+#. 3.2->settings-schema.json->quicklauncher-1-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-2-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-3-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-4-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-5-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-6-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-8-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-9-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-10-command->tooltip
+#. 3.2->settings-schema.json->quicklauncher-11-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-1-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-2-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-3-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-4-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-5-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-6-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-8-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-9-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-10-command->tooltip
+#. 2.6->settings-schema.json->quicklauncher-11-command->tooltip
+msgid "Enter command for the quicklauncher"
+msgstr "Befehl für den Schnellstarter eingeben"
 
 #. 2.6->settings-schema.json->head-menu-layout->description
 msgid "Stark-Menu/MATE-Menu"
@@ -985,10 +1067,6 @@ msgstr "Stark-Menü/MATE-Menü"
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
-#. 2.6->settings-schema.json->head-button-show-hide-icons->description
-msgid "Icons"
-msgstr "Symbole"
-
 #. 2.6->settings-schema.json->hover-delay->description
 msgid "Category hover delay"
 msgstr "Verzögerung beim Darüberbewegen über Kategorien"
@@ -997,73 +1075,112 @@ msgstr "Verzögerung beim Darüberbewegen über Kategorien"
 msgid "Delay between switching categories"
 msgstr "Verzögerung beim Wechsel der Kategorien"
 
+#. 2.6->settings-schema.json->head-button-show-hide-icons->description
+msgid "Icons"
+msgstr "Symbole"
+
+#. 3.4->settings-schema.json->quicklauncher-separator-layout->title
+#. 4.2->settings-schema.json->quicklauncher-separator-layout->title
+msgid "Quicklauncher Separators"
+msgstr "Schnellstarter-Trennsymbole"
+
 #. 3.4->settings-schema.json->custom-quicklauncher-places->title
+#. 4.2->settings-schema.json->custom-quicklauncher-places->title
 msgid "Quicklauncher Places"
 msgstr "Schnellstarter-Orte"
 
 #. 3.4->settings-schema.json->custom-quicklauncher-apps->title
+#. 4.2->settings-schema.json->custom-quicklauncher-apps->title
 msgid "Quicklauncher Applications"
 msgstr "Schnellstarter-Anwendungen"
 
-#. 3.4->settings-schema.json->quicklauncher-separator-layout->title
-msgid "Quicklauncher Separators"
-msgstr "Schnellstarter-Trennsymbole"
-
 #. 3.4->settings-schema.json->quicklauncher-separator1->description
+#. 4.2->settings-schema.json->quicklauncher-separator1->description
 msgid "Separator below user account info box"
 msgstr "Trennsymbol unter Benutzerkonto-Info-Box"
 
 #. 3.4->settings-schema.json->quicklauncher-separator1->tooltip
-#. 3.4->settings-schema.json->quicklauncher-separator3->tooltip
 #. 3.4->settings-schema.json->quicklauncher-separator2->tooltip
+#. 3.4->settings-schema.json->quicklauncher-separator3->tooltip
+#. 4.2->settings-schema.json->quicklauncher-separator1->tooltip
+#. 4.2->settings-schema.json->quicklauncher-separator2->tooltip
+#. 4.2->settings-schema.json->quicklauncher-separator3->tooltip
 msgid "Choose whether or not to show this separator."
 msgstr "Legt fest, ob dieser Trenner angezeigt wird."
 
-#. 3.4->settings-schema.json->quicklauncher-separator3->description
-msgid "Separator above quit buttons"
-msgstr "Trennsymbol über Beenden-Knopf"
-
-#. 3.4->settings-schema.json->quicklauncher-separator2->description
-msgid "Separator below quicklauncher places"
-msgstr "Trennsymbol unter Schnellstarter-Orte"
-
-#. 3.4->settings-schema.json->quicklauncher-apps->description
-msgid "Custom Quicklauncher Applications"
-msgstr "Eigene Schnellstarter-Anwendungen"
-
-#. 3.4->settings-schema.json->quicklauncher-apps->columns->title
-#. 3.4->settings-schema.json->quicklauncher-places->columns->title
-msgid "Visible"
-msgstr "Sichtbar"
-
-#. 3.4->settings-schema.json->quicklauncher-apps->columns->title
-msgid "Command"
-msgstr "Befehl"
-
-#. 3.4->settings-schema.json->quicklauncher-apps->columns->title
-#. 3.4->settings-schema.json->quicklauncher-places->columns->title
-msgid "Custom Label"
-msgstr "Eigene Beschriftung"
-
-#. 3.4->settings-schema.json->quicklauncher-apps->columns->title
-#. 3.4->settings-schema.json->quicklauncher-places->columns->title
-msgid "Custom Icon"
-msgstr "Eigenes Symbol"
-
 #. 3.4->settings-schema.json->quicklauncher-places->description
+#. 4.2->settings-schema.json->quicklauncher-places->description
 msgid "Custom Quicklauncher Places"
 msgstr "Eigene Schnellstarter-Orte"
 
 #. 3.4->settings-schema.json->quicklauncher-places->columns->title
+#. 3.4->settings-schema.json->quicklauncher-apps->columns->title
+#. 4.2->settings-schema.json->quicklauncher-places->columns->title
+#. 4.2->settings-schema.json->quicklauncher-apps->columns->title
+msgid "Visible"
+msgstr "Sichtbar"
+
+#. 3.4->settings-schema.json->quicklauncher-places->columns->title
+#. 4.2->settings-schema.json->quicklauncher-places->columns->title
 msgid "Directory"
 msgstr "Verzeichnis"
 
-#. CinnVIIStarkMenu@NikoKrause->metadata.json->name
-msgid "CinnVIIStarkMenu"
-msgstr "CinnVIIStarkMenü"
+#. 3.4->settings-schema.json->quicklauncher-places->columns->title
+#. 3.4->settings-schema.json->quicklauncher-apps->columns->title
+#. 4.2->settings-schema.json->quicklauncher-places->columns->title
+#. 4.2->settings-schema.json->quicklauncher-apps->columns->title
+msgid "Custom Label"
+msgstr "Eigene Beschriftung"
 
-#. CinnVIIStarkMenu@NikoKrause->metadata.json->description
-msgid ""
-"Cinnamon Menu with the look of the Windows 7 Start Menu or the MATE Menu"
+#. 3.4->settings-schema.json->quicklauncher-places->columns->title
+#. 3.4->settings-schema.json->quicklauncher-apps->columns->title
+#. 4.2->settings-schema.json->quicklauncher-places->columns->title
+#. 4.2->settings-schema.json->quicklauncher-apps->columns->title
+msgid "Custom Icon"
+msgstr "Eigenes Symbol"
+
+#. 3.4->settings-schema.json->quicklauncher-separator2->description
+#. 4.2->settings-schema.json->quicklauncher-separator2->description
+msgid "Separator below quicklauncher places"
+msgstr "Trennsymbol unter Schnellstarter-Orte"
+
+#. 3.4->settings-schema.json->quicklauncher-apps->description
+#. 4.2->settings-schema.json->quicklauncher-apps->description
+msgid "Custom Quicklauncher Applications"
+msgstr "Eigene Schnellstarter-Anwendungen"
+
+#. 3.4->settings-schema.json->quicklauncher-apps->columns->title
+#. 4.2->settings-schema.json->quicklauncher-apps->columns->title
+msgid "Command"
+msgstr "Befehl"
+
+#. 3.4->settings-schema.json->quicklauncher-separator3->description
+#. 4.2->settings-schema.json->quicklauncher-separator3->description
+msgid "Separator above quit buttons"
+msgstr "Trennsymbol über Beenden-Knopf"
+
+#. 4.2->settings-schema.json->menu-custom->description
+msgid "Use a custom icon and label"
+msgstr "Ein benutzerdefiniertes Symbol und eine eigene Bezeichnung verwenden."
+
+#. 4.2->settings-schema.json->menu-custom->tooltip
+msgid "Check this to specify a custom icon and label"
 msgstr ""
-"Cinnamon-Menü mit dem Aussehen des Windows 7 Start-Menüs oder des MATE-Menüs"
+"Auswählen, um ein benutzerdefiniertes Symbol und eine eigene Bezeichnung "
+"festzulegen."
+
+#. 4.2->settings-schema.json->menu-label->description
+msgid "Text"
+msgstr "Text"
+
+#. 4.2->settings-schema.json->shutdown-menu-reverse-order->description
+msgid "Reverse quit button order"
+msgstr "Reihenfolge der Beendenknöpfe umkehren"
+
+#. 4.2->settings-schema.json->shutdown-menu-reverse-order->tooltip
+msgid ""
+"Choose whether to display the 'Quit' button first or last. (Has no effect on "
+"'DropDown' layout.)"
+msgstr ""
+"Legt fest, ob der »Beenden«-Knopf zuerst oder zuletzt angezeigt wird. (Hat "
+"keine Auswirkung auf das »Dropdown«-Layout.)"


### PR DESCRIPTION
* mainly backporting the new improved search, i.e. apps are reordered on search
* but also backporting other improvements/commits to catch up with upstream
* scroll to top of cats/apps, when closing menu
* fixing mate-layout not remembering, if favs or cats were shown last
* fix app description on buttons switch
* use symbolic dropdown icon
* update German translations