### PR TITLE
ddcci-monitor-control@andr35: reset display values when menu is closed

### DIFF
--- a/ddcci-monitor-control@andr35/files/ddcci-monitor-control@andr35/applet.js
+++ b/ddcci-monitor-control@andr35/files/ddcci-monitor-control@andr35/applet.js
@@ -32,7 +32,7 @@ MyApplet.prototype = {
 
     currBrightnessValue: undefined,
     currContrastValue: undefined,
- 
+
 
     _init: function (orientation, panel_height, instance_id) {
         Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
@@ -117,7 +117,14 @@ MyApplet.prototype = {
                 }));
 
             this._update();
+        } else { // Menu has been closed
+
+            // Reset values
+            this.currBrightnessValue = undefined;
+            this.currContrastValue = undefined;
+
         }
+
     },
 
     _on_settings_changed() {


### PR DESCRIPTION
The commit introduces only a minor fix.
Values of brightness and contrast are reset once menu is closed to avoid that old values are used when the menu is open again.