### PR TITLE
Moves "Date and Time Settings" to the context menu

### DIFF
--- a/calendar@ccprog/files/calendar@ccprog/applet.js
+++ b/calendar@ccprog/files/calendar@ccprog/applet.js
@@ -66,7 +66,7 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
             let item = new PopupMenu.PopupMenuItem(_("Date and Time Settings"));
             item.connect("activate", this._onLaunchSettings.bind(this));
 
-            this.menu.addMenuItem(item);
+            this._applet_context_menu.addMenuItem(item);
 
             this._dateFormatFull = CinnamonDesktop.WallClock.lctime_format("cinnamon", "%A, %B %-e, %Y");
 


### PR DESCRIPTION
Moves the "Date and Time Settings" menu item to the context menu to unclutter the calendar display.

The idea was shamelessly stolen from [Wold Clock Calendar](https://cinnamon-spices.linuxmint.com/applets/view/108).

See issue #3313.