### PR TITLE
rust-menu@jerrywham: fix icon name

### DIFF
--- a/rust-menu@jerrywham/files/rust-menu@jerrywham/applet.js
+++ b/rust-menu@jerrywham/files/rust-menu@jerrywham/applet.js
@@ -87,7 +87,7 @@ MyApplet.prototype = {
           this.on_keybinding_doc_changed,
           null);
 
-      this.set_applet_icon_path(AppletDir + '/icon2.svg');
+      this.set_applet_icon_path(AppletDir + '/icon.svg');
       this.set_applet_tooltip("Rust Menu");
 
       this.on_keybinding_doc_changed();


### PR DESCRIPTION
Hi @jerrywham,

Thanks for the applet. The name used in the code didn't match the `svg` in the project folder. This PR fixes that.

Regards,
