### PR TITLE
nightscout: Bug fix - Handled IOB not defined

### DIFF
--- a/nightscout@ranneft/files/nightscout@ranneft/applet.js
+++ b/nightscout@ranneft/files/nightscout@ranneft/applet.js
@@ -17,6 +17,7 @@ const log = function(message) {
 }
 
 const makeHttpRequest = function(method, uri, cb) {
+  uri = uri.replace(/([^:])\/{2,}/, '$1/');
   return new Promise((resolve, reject) => {
     log(`Making a ${method} request to ${uri}`);
     const request = Soup.Message.new(method, uri);

--- a/nightscout@ranneft/files/nightscout@ranneft/applet.js
+++ b/nightscout@ranneft/files/nightscout@ranneft/applet.js
@@ -18,6 +18,7 @@ const log = function(message) {
 
 const makeHttpRequest = function(method, uri, cb) {
   return new Promise((resolve, reject) => {
+    log(`Making a ${method} request to ${uri}`);
     const request = Soup.Message.new(method, uri);
     request.request_headers.append('accept', 'application/json');
     _httpSession.queue_message(request, (_httpSession, message) => {
@@ -142,7 +143,11 @@ NightscoutApplet.prototype = {
         break;
     }
     if(this.showiob) {
-      bgString += "  (IoB: " + status.pump.iob.bolusiob + "U)";
+      try {
+        bgString += "  (IoB: " + status.pump.iob.bolusiob + "U)";
+      } catch (e) {
+        bgString += "  (IoB: ?U)";
+      }
     }
     if(this.showMissing && this.last) {
       const lastDate = this.last.date;


### PR DESCRIPTION
When a user enables displaying the IOB, but one of the (sub-)properties isn't defined in `status.pump.iob.bolusiob`, the code silently stops execution and fails to update the applet label.

@ImmRanneft 