### PR TITLE
sysmonitor@orcus: Fixed crash in network provider

### DIFF
--- a/sysmonitor@orcus/CHANGELOG.md
+++ b/sysmonitor@orcus/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.6.5
+* Fixed crash in network provider when glibtop failed to retrieve network interface list and a fallback method was used
+
 ### 1.6.4
 * Fixed memory leak
 * Applet now uses one drawing area for all graphs, it should reduce drawing overhead

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.2/providers.js
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.2/providers.js
@@ -129,6 +129,7 @@ NetData.prototype = {
             this.devices = [];
             let d = Gio.File.new_for_path("/sys/class/net");
             let en = d.enumerate_children("standard::name", Gio.FileQueryInfoFlags.NONE, null);
+            let info;
             while ((info = en.next_file(null)))
                 this.devices.push(info.get_name())
         }

--- a/sysmonitor@orcus/files/sysmonitor@orcus/metadata.json
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/metadata.json
@@ -2,7 +2,7 @@
     "description": "Displays CPU, memory, swap and network usage and load in graphs", 
     "uuid": "sysmonitor@orcus", 
     "name": "System Monitor", 
-    "version": "1.6.4",
+    "version": "1.6.5",
     "icon": "utilities-system-monitor",
     "max-instances": -1,
     "multiversion": true


### PR DESCRIPTION
- Fixed crash in network provider when glibtop failed to retrieve network interface list and a fallback method was used, fixes #3432 