### PR TITLE
Add world clocks to tooltip.

### DIFF
--- a/calendar@ccprog/files/calendar@ccprog/applet.js
+++ b/calendar@ccprog/files/calendar@ccprog/applet.js
@@ -72,6 +72,7 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
             this.settings.bind("use-custom-format", "use_custom_format", this._onSettingsChanged);
             this.settings.bind("custom-format", "custom_format", this._onSettingsChanged);
             this.settings.bind("keyOpen", "keyOpen", this._setKeybinding);
+            this.settings.bind("show-worldclocks-in-tooltip", "show_worldclocks_in_tooltip", this._onSettingsChanged)
             this._setKeybinding();
 
             /* FIXME: Add gobject properties to the WallClock class to allow easier access from
@@ -172,6 +173,8 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
 
     _updateClockAndDate() {
         let label_string = this.clock.get_clock();
+        
+        this._worldclocks.updateClocks();
 
         if (!this.use_custom_format) {
             label_string = label_string.capitalize();
@@ -184,9 +187,17 @@ class CinnamonCalendarApplet extends Applet.TextApplet {
         let dateFormattedFull = this.clock.get_clock_for_format(this._dateFormatFull).capitalize();
 
         this._date.set_text(dateFormattedFull);
-        this.set_applet_tooltip(dateFormattedFull);
-
-        this._worldclocks.updateClocks();
+        
+        if (this.show_worldclocks_in_tooltip) {
+            let tooltip = [];
+            tooltip.push(dateFormattedFull);
+            for (let clock of this._worldclocks.clocks) {
+                tooltip.push(clock.label + "   " + clock.display.get_text());
+            }
+            this.set_applet_tooltip(tooltip.join("\n"));
+        } else {
+            this.set_applet_tooltip(dateFormattedFull);
+        }
     }
 
     on_applet_added_to_panel() {

--- a/calendar@ccprog/files/calendar@ccprog/settings-schema.json
+++ b/calendar@ccprog/files/calendar@ccprog/settings-schema.json
@@ -59,7 +59,8 @@
             "type": "section",
             "title": "Show World Times",
             "keys": [
-                "worldclocks"
+                "worldclocks",
+                "show-worldclocks-in-tooltip"
             ]
         }
     },
@@ -404,5 +405,11 @@
             }
         ],
         "default": []
+    },
+    "show-worldclocks-in-tooltip": {
+        "type": "switch",
+        "default": false,
+        "description": "Show world clocks in the tooltip",
+        "tooltip": "Check this to show the world clocks in the tooltip."
     }
 }

--- a/calendar@ccprog/files/calendar@ccprog/worldclocks.js
+++ b/calendar@ccprog/files/calendar@ccprog/worldclocks.js
@@ -41,7 +41,7 @@ class Worldclocks {
 
             let tz = GLib.TimeZone.new(item.timezone);
             let display = new St.Label({ x_align: St.Align.END, style_class: "calendar-world-time" });
-            this.clocks.push({ display, tz });
+            this.clocks.push({ display, tz, label: item.label });
             this.actor.add(display, { row: i,  col: 1, x_align: St.Align.END });
         });
     }


### PR DESCRIPTION
This adds the world clocks to the tooltip (closes #3315).

It also adds an option to display them in the tooltip or not.

It would be preferable to be able to decide on a per-clock basis, if the world clock should be displayed in the tooltip by adding a third column to the `World Clocks > Show World Times` table, but I could not figure out, how to do it.

There might be a more elegant way to achieve this …