### PR TITLE
download-and-upload-speed@cardsurf: Fix toString for ByteArrays

### DIFF
--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/files.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/files.js
@@ -2,6 +2,7 @@
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const Gettext = imports.gettext;
+const ByteArray = imports.byteArray;
 
 function _(str) {
     return Gettext.dgettext(uuid, str);
@@ -27,9 +28,20 @@ File.prototype = {
         return GLib.file_test(this.path, GLib.FileTest.IS_REGULAR) && GLib.file_test(this.path, GLib.FileTest.EXISTS);
     },
 
+    byte_array_to_string: function(byte_array) {
+        // Check Cinnamon version
+        let cinn_ver = GLib.getenv('CINNAMON_VERSION');
+        cinn_ver = cinn_ver.substring(0, cinn_ver.lastIndexOf("."))
+        if(parseFloat(cinn_ver) <= 4.6) {
+            return byte_array.toString();
+        } else {
+            return ByteArray.toString(byte_array);
+        }
+    },
+
     read: function() {
         let array_chars = this.read_chars();
-        let string = array_chars.toString().trim();
+        let string = this.byte_array_to_string(array_chars).trim();
         let array_strings = string.length == 0 ? [] : string.split(this.regex_newline);
         return array_strings;
     },

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/infos.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/infos.js
@@ -1,5 +1,6 @@
 
 const GLib = imports.gi.GLib;
+const ByteArray = imports.byteArray;
 
 const uuid = 'download-and-upload-speed@cardsurf';
 let AppletConstants, Files, FilesCsv, Dates;
@@ -119,10 +120,21 @@ NetworkInterfaceInfo.prototype = {
         this.bytes_received_total += this.bytes_received_iteration;
     },
 
+    byte_array_to_string: function(byte_array) {
+        // Check Cinnamon version
+        let cinn_ver = GLib.getenv('CINNAMON_VERSION');
+        cinn_ver = cinn_ver.substring(0, cinn_ver.lastIndexOf("."))
+        if(parseFloat(cinn_ver) <= 4.6) {
+            return byte_array.toString();
+        } else {
+            return ByteArray.toString(byte_array);
+        }
+    },
+
     read_number: function (file, default_number) {
         try {
             let array_bytes = file.read_chars();
-            let string = array_bytes.length > 0 ? array_bytes.toString() : default_number.toString();
+            let string = array_bytes.length > 0 ? this.byte_array_to_string(array_bytes) : default_number.toString();
             let number = parseInt(string);
             return number;
         }

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/shellUtils.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/shellUtils.js
@@ -2,7 +2,7 @@
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const Lang = imports.lang;
-
+const ByteArray = imports.byteArray;
 
 
 const SignalType = {
@@ -71,8 +71,19 @@ ShellOutputProcess.prototype = {
         this.standard_error_content = standard_error_content;
     },
 
+    byte_array_to_string: function(byte_array) {
+        // Check Cinnamon version
+        let cinn_ver = GLib.getenv('CINNAMON_VERSION');
+        cinn_ver = cinn_ver.substring(0, cinn_ver.lastIndexOf("."))
+        if(parseFloat(cinn_ver) <= 4.6) {
+            return byte_array.toString();
+        } else {
+            return ByteArray.toString(byte_array);
+        }
+    },
+
     get_standard_output_content: function() {
-        return this.standard_output_content.toString();
+        return this.byte_array_to_string(this.standard_output_content);
     },
 
     spawn_sync_and_get_error: function() {
@@ -82,7 +93,7 @@ ShellOutputProcess.prototype = {
     },
 
     get_standard_error_content: function() {
-        return this.standard_error_content.toString();
+        return this.byte_array_to_string(this.standard_error_content);
     },
 
     spawn_async: function() {


### PR DESCRIPTION
@cardsurf Your applet throws a lot of warnings in Cinnamon 4.8:

```
(cinnamon:2012143): Cjs-WARNING **: 13:26:27.848: Some code called array.toString() on a Uint8Array instance. Previously this would have interpreted the bytes of the array as a string, but that is nonstandard. In the future this will return the bytes as comma-separated digits. For the time being, the old behavior has been preserved, but please fix your code anyway to explicitly call ByteArray.toString(array). (Note that array.toString() may have been called implicitly.)

ByteArray.toString(array) is not backward compatible with previous (< 4.8) versions of Cinnamon. You will have add versioning support to your applet if it does not already have it, so that compatibility can be maintained for users on older Cinnamon versions.
```

I've tried to fix them, but you probably want to test, if I did it right?