### PR TITLE
Cinnamenu@json: check for null entry.get_app_info()

### DIFF
--- a/Cinnamenu@json/files/Cinnamenu@json/3.2/applet.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/3.2/applet.js
@@ -926,7 +926,8 @@ CinnamenuApplet.prototype = {
     while ((nextType = iter.next()) !== CMenu.TreeItemType.INVALID) {
       if (nextType === CMenu.TreeItemType.ENTRY) {
         let entry = iter.get_entry();
-        if (!entry.get_app_info().get_nodisplay()) {
+        let appInfo = entry.get_app_info();
+        if (appInfo && !appInfo.get_nodisplay()) {
           let id = entry.get_desktop_file_id();
           let app = this.appSystem.lookup_app(id);
           if (rootDir && typeof rootDir.get_menu_id === 'function') {

--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/applet.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/applet.js
@@ -1715,7 +1715,8 @@ class Apps {
         while ((nextType = iter.next()) !== CMenu.TreeItemType.INVALID) {
             if (nextType === CMenu.TreeItemType.ENTRY) {
                 const entry = iter.get_entry();
-                if (!entry.get_app_info().get_nodisplay()) {
+                const appInfo = entry.get_app_info();
+                if (appInfo && !appInfo.get_nodisplay()) {
                     const id = entry.get_desktop_file_id();
                     const app = this.appThis.appSystem.lookup_app(id);
                     let found = false;


### PR DESCRIPTION
`entry.get_app_info()` can be null and make the menu appear empty.

```
(cinnamon:3641): Cjs-WARNING **: 17:27:11.412: JS ERROR: Exception in callback for signal: open-state-changed: TypeError: entry.get_app_info() is null
loadAppCategories@/home/user/.local/share/cinnamon/applets/Cinnamenu@json/4.0/applet.js:1687:28
initAppCategories/<@/home/user/.local/share/cinnamon/applets/Cinnamenu@json/4.0/applet.js:1664:22
initAppCategories@/home/user/.local/share/cinnamon/applets/Cinnamenu@json/4.0/applet.js:1660:14
getAppsByCategory@/home/user/.local/share/cinnamon/applets/Cinnamenu@json/4.0/applet.js:1735:18
update/<@/home/user/.local/share/cinnamon/applets/Cinnamenu@json/4.0/applet.js:1453:64
update@/home/user/.local/share/cinnamon/applets/Cinnamenu@json/4.0/applet.js:1450:14
onOpenStateToggled@/home/user/.local/share/cinnamon/applets/Cinnamenu@json/4.0/applet.js:510:29
CinnamenuApplet/<@/home/user/.local/share/cinnamon/applets/Cinnamenu@json/4.0/applet.js:78:81
_emit@resource:///org/gnome/gjs/modules/core/_signals.js:133:47
open@/usr/share/cinnamon/js/ui/popupMenu.js:2324:14
toggle_with_options@/usr/share/cinnamon/js/ui/popupMenu.js:2066:18
on_applet_clicked@/home/user/.local/share/cinnamon/applets/Cinnamenu@json/4.0/applet.js:209:19
_onButtonPressEvent@/usr/share/cinnamon/js/ui/applet.js:283:18
```