### PR TITLE
[download-and-upload-speed@cardsurf] Moved method to separate file

### DIFF
--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/compatibility.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/compatibility.js
@@ -4,8 +4,8 @@ const ByteArray = imports.byteArray;
 
 
 
-function CinnamonVersionAdapter(path) {
-    this._init(path);
+function CinnamonVersionAdapter() {
+    this._init();
 };
 
 CinnamonVersionAdapter.prototype = {

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/compatibility.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/compatibility.js
@@ -1,0 +1,33 @@
+
+const GLib = imports.gi.GLib;
+const ByteArray = imports.byteArray;
+
+
+
+function CinnamonVersionAdapter(path) {
+    this._init(path);
+};
+
+CinnamonVersionAdapter.prototype = {
+
+    _init: function() {
+        this._cinnamon_version = 0;
+
+        this._init_cinnamon_version();
+    },
+
+    _init_cinnamon_version: function () {
+        let version = GLib.getenv('CINNAMON_VERSION');
+        version = version.substring(0, version.lastIndexOf("."));
+        this._cinnamon_version = parseFloat(version);
+    },
+
+    byte_array_to_string: function(byte_array) {
+        if(this._cinnamon_version <= 4.6) {
+            return byte_array.toString();
+        } else {
+            return ByteArray.toString(byte_array);
+        }
+    },
+
+};

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/files.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/files.js
@@ -2,7 +2,13 @@
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const Gettext = imports.gettext;
-const ByteArray = imports.byteArray;
+
+let Compatibility;
+if (typeof require !== 'undefined') {
+    Compatibility = require('./compatibility');
+} else {
+    Compatibility = AppletDirectory.compatibility;
+}
 
 function _(str) {
     return Gettext.dgettext(uuid, str);
@@ -20,6 +26,8 @@ File.prototype = {
     _init: function(path) {
         this.newline = "\n";
         this.regex_newline = /(?:[\n\r]+)/;
+        this.cinnamon_version_adapter = new Compatibility.CinnamonVersionAdapter();
+
         this.path = path;
         this.file = Gio.file_new_for_path(this.path);
     },
@@ -28,20 +36,9 @@ File.prototype = {
         return GLib.file_test(this.path, GLib.FileTest.IS_REGULAR) && GLib.file_test(this.path, GLib.FileTest.EXISTS);
     },
 
-    byte_array_to_string: function(byte_array) {
-        // Check Cinnamon version
-        let cinn_ver = GLib.getenv('CINNAMON_VERSION');
-        cinn_ver = cinn_ver.substring(0, cinn_ver.lastIndexOf("."))
-        if(parseFloat(cinn_ver) <= 4.6) {
-            return byte_array.toString();
-        } else {
-            return ByteArray.toString(byte_array);
-        }
-    },
-
     read: function() {
         let array_chars = this.read_chars();
-        let string = this.byte_array_to_string(array_chars).trim();
+        let string = this.cinnamon_version_adapter.byte_array_to_string(array_chars).trim();
         let array_strings = string.length == 0 ? [] : string.split(this.regex_newline);
         return array_strings;
     },

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/files.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/files.js
@@ -2,6 +2,7 @@
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const Gettext = imports.gettext;
+const ByteArray = imports.byteArray;
 
 function _(str) {
     return Gettext.dgettext(uuid, str);
@@ -27,9 +28,20 @@ File.prototype = {
         return GLib.file_test(this.path, GLib.FileTest.IS_REGULAR) && GLib.file_test(this.path, GLib.FileTest.EXISTS);
     },
 
+    byte_array_to_string: function(byte_array) {
+        // Check Cinnamon version
+        let cinn_ver = GLib.getenv('CINNAMON_VERSION');
+        cinn_ver = cinn_ver.substring(0, cinn_ver.lastIndexOf("."))
+        if(parseFloat(cinn_ver) <= 4.6) {
+            return byte_array.toString();
+        } else {
+            return ByteArray.toString(byte_array);
+        }
+    },
+
     read: function() {
         let array_chars = this.read_chars();
-        let string = array_chars.toString().trim();
+        let string = this.byte_array_to_string(array_chars).trim();
         let array_strings = string.length == 0 ? [] : string.split(this.regex_newline);
         return array_strings;
     },

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/infos.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/infos.js
@@ -1,20 +1,21 @@
 
 const GLib = imports.gi.GLib;
-const ByteArray = imports.byteArray;
 
 const uuid = 'download-and-upload-speed@cardsurf';
-let AppletConstants, Files, FilesCsv, Dates;
+let AppletConstants, Files, FilesCsv, Dates, Compatibility;
 if (typeof require !== 'undefined') {
     AppletConstants = require('./appletConstants')
     Files = require('./files');
     FilesCsv = require('./filesCsv');
     Dates = require('./dates');
+    Compatibility = require('./compatibility');
 } else {
     const AppletDirectory = imports.ui.appletManager.applets[uuid];
     AppletConstants = AppletDirectory.appletConstants
     Files = AppletDirectory.files;
     FilesCsv = AppletDirectory.filesCsv;
     Dates = AppletDirectory.dates;
+    Compatibility = AppletDirectory.compatibility;
 }
 
 
@@ -32,6 +33,7 @@ NetworkInterfaceInfo.prototype = {
         this.network_interface = network_interface;
         this.applet_directory = this._get_applet_directory();
         this.bytes_directory = this.applet_directory + "/bytes/";
+        this.cinnamon_version_adapter = new Compatibility.CinnamonVersionAdapter();
 
         this.bytes_received_previous = 0;
         this.bytes_received_iteration = 0;
@@ -120,21 +122,12 @@ NetworkInterfaceInfo.prototype = {
         this.bytes_received_total += this.bytes_received_iteration;
     },
 
-    byte_array_to_string: function(byte_array) {
-        // Check Cinnamon version
-        let cinn_ver = GLib.getenv('CINNAMON_VERSION');
-        cinn_ver = cinn_ver.substring(0, cinn_ver.lastIndexOf("."))
-        if(parseFloat(cinn_ver) <= 4.6) {
-            return byte_array.toString();
-        } else {
-            return ByteArray.toString(byte_array);
-        }
-    },
-
     read_number: function (file, default_number) {
         try {
             let array_bytes = file.read_chars();
-            let string = array_bytes.length > 0 ? this.byte_array_to_string(array_bytes) : default_number.toString();
+            let string = array_bytes.length > 0 ?
+                this.cinnamon_version_adapter.byte_array_to_string(array_bytes) :
+                default_number.toString();
             let number = parseInt(string);
             return number;
         }

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/infos.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/infos.js
@@ -1,5 +1,6 @@
 
 const GLib = imports.gi.GLib;
+const ByteArray = imports.byteArray;
 
 const uuid = 'download-and-upload-speed@cardsurf';
 let AppletConstants, Files, FilesCsv, Dates;
@@ -119,10 +120,21 @@ NetworkInterfaceInfo.prototype = {
         this.bytes_received_total += this.bytes_received_iteration;
     },
 
+    byte_array_to_string: function(byte_array) {
+        // Check Cinnamon version
+        let cinn_ver = GLib.getenv('CINNAMON_VERSION');
+        cinn_ver = cinn_ver.substring(0, cinn_ver.lastIndexOf("."))
+        if(parseFloat(cinn_ver) <= 4.6) {
+            return byte_array.toString();
+        } else {
+            return ByteArray.toString(byte_array);
+        }
+    },
+
     read_number: function (file, default_number) {
         try {
             let array_bytes = file.read_chars();
-            let string = array_bytes.length > 0 ? array_bytes.toString() : default_number.toString();
+            let string = array_bytes.length > 0 ? this.byte_array_to_string(array_bytes) : default_number.toString();
             let number = parseInt(string);
             return number;
         }

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/shellUtils.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/shellUtils.js
@@ -2,7 +2,7 @@
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const Lang = imports.lang;
-
+const ByteArray = imports.byteArray;
 
 
 const SignalType = {
@@ -71,8 +71,19 @@ ShellOutputProcess.prototype = {
         this.standard_error_content = standard_error_content;
     },
 
+    byte_array_to_string: function(byte_array) {
+        // Check Cinnamon version
+        let cinn_ver = GLib.getenv('CINNAMON_VERSION');
+        cinn_ver = cinn_ver.substring(0, cinn_ver.lastIndexOf("."))
+        if(parseFloat(cinn_ver) <= 4.6) {
+            return byte_array.toString();
+        } else {
+            return ByteArray.toString(byte_array);
+        }
+    },
+
     get_standard_output_content: function() {
-        return this.standard_output_content.toString();
+        return this.byte_array_to_string(this.standard_output_content);
     },
 
     spawn_sync_and_get_error: function() {
@@ -82,7 +93,7 @@ ShellOutputProcess.prototype = {
     },
 
     get_standard_error_content: function() {
-        return this.standard_error_content.toString();
+        return this.byte_array_to_string(this.standard_error_content);
     },
 
     spawn_async: function() {

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/shellUtils.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/shellUtils.js
@@ -2,8 +2,13 @@
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const Lang = imports.lang;
-const ByteArray = imports.byteArray;
 
+let Compatibility;
+if (typeof require !== 'undefined') {
+    Compatibility = require('./compatibility');
+} else {
+    Compatibility = AppletDirectory.compatibility;
+}
 
 const SignalType = {
     SIGHUP:    1,
@@ -51,6 +56,7 @@ ShellOutputProcess.prototype = {
         this.standard_input_file_descriptor = -1;
         this.standard_output_file_descriptor = -1;
         this.standard_error_file_descriptor = -1;
+        this.cinnamon_version_adapter = new Compatibility.CinnamonVersionAdapter();
     },
 
     spawn_sync_and_get_output: function() {
@@ -71,19 +77,8 @@ ShellOutputProcess.prototype = {
         this.standard_error_content = standard_error_content;
     },
 
-    byte_array_to_string: function(byte_array) {
-        // Check Cinnamon version
-        let cinn_ver = GLib.getenv('CINNAMON_VERSION');
-        cinn_ver = cinn_ver.substring(0, cinn_ver.lastIndexOf("."))
-        if(parseFloat(cinn_ver) <= 4.6) {
-            return byte_array.toString();
-        } else {
-            return ByteArray.toString(byte_array);
-        }
-    },
-
     get_standard_output_content: function() {
-        return this.byte_array_to_string(this.standard_output_content);
+        return this.cinnamon_version_adapter.byte_array_to_string(this.standard_output_content);
     },
 
     spawn_sync_and_get_error: function() {
@@ -93,7 +88,7 @@ ShellOutputProcess.prototype = {
     },
 
     get_standard_error_content: function() {
-        return this.byte_array_to_string(this.standard_error_content);
+        return this.cinnamon_version_adapter.byte_array_to_string(this.standard_error_content);
     },
 
     spawn_async: function() {


### PR DESCRIPTION
Hi @NikoKrause

The changes works fine locally.
I have moved the method to a separate file for easier maintenance and porting the solution to other applets.

Also got an improvement idea to consider in the future while working on this. For such cases having a module with compatibility functions in Cinnamon would even further ease maintenance of all applets. Then developers could import such module and use the function directly like:

```
const Compatibility = imports.misc.compatibility;
...
let str = Compatibility.byte_array_to_string(byte_array);
```