### PR TITLE
[scripts@paucapo.com] Manage how to execute scripts (#3194)

### DIFF
--- a/scripts@paucapo.com/CHANGELOG.md
+++ b/scripts@paucapo.com/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Change Log
 
+##### 1.03
+- Ability to chose how to execute scripts, on right click and on left click. 
+Four possibilities: Execute silently, Execute in terminal, Edit the script, Ask what to do.
+- Detection of default terminal.
+- Ability to customize the terminal and editor to use.
+- Not executable files can now only be opened with xdg-open.
+- Dependency check: terminal, xdg-open and notify-send.
+- Add of some icons to the menu.
+
 ##### 1.02
 - Fix screenshot.png link.
 - Some minor fixes.

--- a/scripts@paucapo.com/files/scripts@paucapo.com/applet.js
+++ b/scripts@paucapo.com/files/scripts@paucapo.com/applet.js
@@ -3,6 +3,7 @@
 const Lang = imports.lang;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
+const St = imports.gi.St;
 const Applet = imports.ui.applet;
 const PopupMenu = imports.ui.popupMenu;
 const Settings = imports.ui.settings;
@@ -15,6 +16,264 @@ Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
 function _(str) {
   return Gettext.dgettext(UUID, str);
 }
+
+function findTerminalEmulator() {
+    var returnStruct = {
+        found: false,
+        commandToExecuteInTerminal: "",
+        foundTerminalDescription: _("No terminals are found. Switch the setting <Find automatically a terminal> off to fix this.")
+    };
+
+    // Search method 1 : desktop env Gsettings
+    try {
+        let candidateSchemasRegex = [".*cinnamon.*default.*terminal.*",
+                                    ".*gnome.*default.*terminal.*"];
+
+        let source = Gio.SettingsSchemaSource.get_default();
+        let schemasStruct = source ? source.list_schemas(false) : new Array(0); 
+        // list_schemas returns two arrays: out string[] non_relocatable, out string[] relocatable)
+
+        // Simplification of schemasStruct
+        let schemaArray = new Array(0);
+        for (let array of schemasStruct) {
+            for (let schema of array) {
+                if (schema.includes("terminal"))
+                    schemaArray.push(schema); 
+            }
+        }
+
+        for (let regex of candidateSchemasRegex) {
+            for (let schema of schemaArray) {
+                if (schema.match(regex)) {
+                    let settingsSchema = source.lookup(schema, false);
+                    if (settingsSchema) {
+                        let exec = "";
+                        let execArg = "";
+                        if (settingsSchema.has_key("exec")) {
+                            let execKey = settingsSchema.get_key("exec");
+                            exec = execKey.get_default_value().get_string()[0];
+                        }
+                        if (settingsSchema.has_key("exec-arg")) {
+                            let execArgKey = settingsSchema.get_key("exec-arg");
+                            execArg = execArgKey.get_default_value().get_string()[0];
+                        }
+                        if (exec && execArg) {
+                            if (GLib.find_program_in_path(exec)) {
+                                returnStruct.commandToExecuteInTerminal = exec + " " + execArg;
+                                returnStruct.foundTerminalDescription = 
+                                    _("Desktop env default terminal: ") + exec + " (" + schema + ")" + "\n" 
+                                    + _("Command to execute a script: ") + returnStruct.commandToExecuteInTerminal;
+                                returnStruct.found = true;
+                                return returnStruct;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    } catch (e) {
+        global.logError(e);
+    }
+
+    // Search method 2 : x-terminal-emulator
+    try {
+        let xTermPath = GLib.find_program_in_path("x-terminal-emulator");
+        if (xTermPath) {
+            if (GLib.file_test(xTermPath, GLib.FileTest.IS_SYMLINK)) {
+                let xTermPathSymLink2 = GLib.file_read_link(xTermPath);
+                if (GLib.file_test(xTermPathSymLink2, GLib.FileTest.IS_SYMLINK)) {
+                    let termWrapper = GLib.file_read_link(xTermPathSymLink2);
+                    if (GLib.file_test(termWrapper, GLib.FileTest.IS_EXECUTABLE)) {
+                        returnStruct.commandToExecuteInTerminal = xTermPath + " -e";
+                        returnStruct.foundTerminalDescription = 
+                            _("Sym-link of x-terminal-emulator: ") + termWrapper + "\n" 
+                            + _("Command to execute a script: ") + returnStruct.commandToExecuteInTerminal;
+                        returnStruct.found = true;
+                        return returnStruct;
+                    }
+                }
+            }
+        }
+    } catch (e) {
+        global.logError(e);
+    }
+
+    // Search method 3 : we try to find a famous terminal emulator
+    try {
+        let candidateTerminals = ["gnome-terminal", "tilix", "konsole", "guake", "qterminal", "terminator", "uxterm", "nxterm", "color-xterm", "rxvt", "xterm", "dtterm"];
+        for (let termName of candidateTerminals) {
+            let termPath = GLib.find_program_in_path(termName);
+            if (termPath) {
+                if (GLib.file_test(termPath, GLib.FileTest.IS_EXECUTABLE)) {
+                    if (termName == "gnome-terminal") 
+                        returnStruct.commandToExecuteInTerminal = termPath + " --";
+                    else 
+                        returnStruct.commandToExecuteInTerminal = termPath + " -e";
+                    
+                    returnStruct.foundTerminalDescription = 
+                        termPath  + "\n" 
+                        + _("Command to execute a script: ") + returnStruct.commandToExecuteInTerminal;
+                    returnStruct.found = true;
+                    return returnStruct;
+                }
+
+            }
+        }
+    } catch (e) {
+        global.logError(e);
+    }
+    return returnStruct;
+}
+
+/**
+ * A PopupSubMenuMenuItem without arrow icon, so that the sub-menu looks like a context menu.
+ * The sub-menu is the "Ask what to do" menu.
+ * It has also a custom _onButtonReleaseEvent() 
+ * and handles how to execute the associated script.
+ */
+class PopupMenuItemWithContext extends PopupMenu.PopupSubMenuMenuItem {
+    _init (labelText, scriptsApplet, fileToExecute, params) {
+
+        // The constructor of PopupSubMenuMenuItem is not called on purpose
+        PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
+        this.scriptsApplet = scriptsApplet;
+        this.fileToExecute = fileToExecute;
+        this.isAskWhatToDoMenuCreated = false;
+
+        // Like PopupSubMenuMenuItem:
+        this.label = new St.Label({ text: labelText, y_expand: true});
+        this.addActor(this.label);
+        this.actor.label_actor = this.label;
+        this.menu = new PopupMenu.PopupSubMenu(this.actor);
+    }
+
+    destroy() { 
+        // Like PopupSubMenuMenuItem:
+        this.menu.destroy();
+        PopupMenu.PopupBaseMenuItem.prototype.destroy.call(this);
+    }
+
+    // override
+    _onButtonReleaseEvent(actor, event) {
+        let behavior;
+        switch (event.get_button()) {
+            case 1: // left click
+                behavior = this.scriptsApplet.leftClickBehavior;
+                break;
+            case 3: // right click
+                behavior = this.scriptsApplet.rightClickBehavior;
+                break;
+            default:
+                return;
+        }
+
+        let exists = GLib.file_test(this.fileToExecute, GLib.FileTest.IS_REGULAR);
+        if (!exists) {
+            this.scriptsApplet._showNotify( _("The script: <%s> doesn't exist").format(this.label.text));
+            return;
+        }
+
+        this.isFileExecutable = GLib.file_test(this.fileToExecute, GLib.FileTest.IS_EXECUTABLE);
+        if (this.isFileExecutable) {
+            switch (behavior) {
+                case "executeSilently":
+                    this._executeScriptSilently();
+                    break;
+                case "executeInTerminal":
+                    this._executeScriptInTerminal();
+                    break;
+                case "edit":
+                    this._editScript();
+                    break;
+                case "ask":
+                    this._toggleAskWhatToDoMenu();
+                    break;
+                default:
+                    this._executeScriptSilently();
+            }
+        }
+        else {
+            switch (behavior) {
+                case "ask":
+                    this._toggleAskWhatToDoMenu();
+                    break;
+                default:
+                    this._openFile();
+            }
+        }
+    }
+
+    _toggleAskWhatToDoMenu() {      
+        if (!this.isAskWhatToDoMenuCreated) {
+            this.isAskWhatToDoMenuCreated = true;
+            
+            if (this.isFileExecutable) {
+                let executeSilentlyItem = new PopupMenu.PopupIconMenuItem(_("Execute silently"), "user-not-tracked-symbolic", St.IconType.SYMBOLIC);
+                executeSilentlyItem.label.add_style_class_name('scripts-ask-menu');
+                executeSilentlyItem.connect('activate', Lang.bind(this, this._executeScriptSilently));
+                this.menu.addMenuItem(executeSilentlyItem);
+                
+                let executeInTerminalItem = new PopupMenu.PopupIconMenuItem(_("Execute in terminal"), "utilities-terminal-symbolic", St.IconType.SYMBOLIC);
+                executeInTerminalItem.label.add_style_class_name('scripts-ask-menu');
+                executeInTerminalItem.connect('activate', Lang.bind(this, this._executeScriptInTerminal));
+                this.menu.addMenuItem(executeInTerminalItem);
+
+                let editItem = new PopupMenu.PopupIconMenuItem(_("Edit the script"), "document-edit-symbolic", St.IconType.SYMBOLIC);
+                editItem.label.add_style_class_name('scripts-ask-menu');
+                editItem.connect('activate', Lang.bind(this, this._editScript));
+                this.menu.addMenuItem(editItem);
+            }
+            else {
+                let openItem = new PopupMenu.PopupIconMenuItem(_("Open the document"), "x-office-document-symbolic", St.IconType.SYMBOLIC);
+                openItem.label.add_style_class_name('scripts-ask-menu');
+                openItem.connect('activate', Lang.bind(this, this._openFile));
+                this.menu.addMenuItem(openItem);
+            }
+        }
+        this.menu.toggle();
+    }
+
+    _executeScriptSilently() {
+        try {
+            GLib.spawn_command_line_async("\"" + this.fileToExecute + "\"");
+        } catch (e) {
+            // notify showed prevent script errors
+            this.scriptsApplet._showNotify(e);
+        }
+        this.scriptsApplet.menu.close(true);
+    }
+
+    _executeScriptInTerminal() {
+        try {
+            GLib.spawn_command_line_async(this.scriptsApplet.commandToExecuteInTerminal + " \"" + this.fileToExecute + "\"");
+        } catch (e) {
+            // notify showed prevent script errors
+            this.scriptsApplet._showNotify(e);
+        }
+        this.scriptsApplet.menu.close(true);
+    }
+
+    _editScript() {
+        try {
+            global.log("this.scriptsApplet.commandToEditScripts = " + this.scriptsApplet.commandToEditScripts)
+            GLib.spawn_command_line_async(this.scriptsApplet.commandToEditScripts + " \"" + this.fileToExecute + "\"");
+        } catch (e) {
+            // notify showed prevent script errors
+            this.scriptsApplet._showNotify(e);
+        }
+        this.scriptsApplet.menu.close(true);
+    }
+
+    _openFile() {
+        try {
+            GLib.spawn_command_line_async("xdg-open \"" + this.fileToExecute + "\"");
+        } catch (e) {
+            // notify showed prevent script errors
+            this.scriptsApplet._showNotify(e);
+        }
+        this.scriptsApplet.menu.close(true);
+    }
+};
 
 function MyApplet(metadata, orientation, panelHeight, instance_id) {
    this._init(metadata, orientation, panelHeight, instance_id);
@@ -37,6 +296,18 @@ MyApplet.prototype = {
       this.settings.bindProperty(Settings.BindingDirection.IN, "customicon", "customicon", this._onSettingsIcon, null)
       this.settings.bindProperty(Settings.BindingDirection.IN, "icon", "icon", this._onSettingsIcon, null)
 
+      this.settings.bind("rightClickBehavior", "rightClickBehavior");
+      this.settings.bind("leftClickBehavior", "leftClickBehavior");
+      this.settings.bind("findTerminalAutomatically", "findTerminalAutomatically", this._onSettingsTerminal);
+      this.settings.bind("foundTerminalDescription", "foundTerminalDescription");
+      this.settings.bind("overrideCommandToExecuteInTerminal", "overrideCommandToExecuteInTerminal", this._onSettingsTerminal);
+      this.commandToExecuteInTerminal = "";
+      this.settings.bind("useDefaultTextEditorWithScripts", "useDefaultTextEditorWithScripts", this._onSettingsTextEditorWithScripts);
+      this.settings.bind("overrideCommandToEditScripts", "overrideCommandToEditScripts", this._onSettingsTextEditorWithScripts); 
+      // Dependencies are not checked here to make cinnamon start-up faster
+      this.depAreMet = false;
+      this._applet_context_menu._signals.connect(this._applet_context_menu, 'activate', this._checkDependenciesMet);
+      
       if (this.directory == "" || typeof this.directory == "undefined") {
          this.directory = GLib.get_home_dir()+"/.local/share/nemo/scripts";
       }
@@ -104,7 +375,82 @@ MyApplet.prototype = {
       }
    },
 
+    /**
+     * In addition of being settings callback, 
+     * this function returns the terminal availability status.
+     */
+    _onSettingsTerminal: function() {
+        if (this.findTerminalAutomatically) {
+            let term = findTerminalEmulator();
+            if (term.found) {
+                this.commandToExecuteInTerminal = term.commandToExecuteInTerminal;
+                this.foundTerminalDescription = term.foundTerminalDescription;
+                return true;
+            } 
+            else {
+                this.depAreMet = false;
+                this.commandToExecuteInTerminal = "";
+                this.foundTerminalDescription = ""; 
+                return false;
+            }
+        }
+        else {
+            this.commandToExecuteInTerminal = this.overrideCommandToExecuteInTerminal;
+            this.foundTerminalDescription = "";
+            return true;
+        }
+    },
+
+    _onSettingsTextEditorWithScripts: function() {      
+        if (this.useDefaultTextEditorWithScripts)
+            this.commandToEditScripts = "xdg-open";
+        else
+            this.commandToEditScripts = this.overrideCommandToEditScripts;
+    },
+
+    _checkDependenciesMet: function() {
+
+        if (this.depAreMet == false) 
+            this.depAreMet = this._are_dependencies_installed();
+        return this.depAreMet;
+    },
+
+    _are_dependencies_installed: function() {
+        this._onSettingsTextEditorWithScripts(); // to make sure that commandToEditScripts is set 
+        let isTerminalEmulatorFound = this._onSettingsTerminal();
+        let isNotifyInstalled = GLib.find_program_in_path("notify-send");
+        let isxdg_openInstalled = GLib.find_program_in_path("xdg-open");
+        let allDependencies = isxdg_openInstalled && isNotifyInstalled && isTerminalEmulatorFound;
+        if (!allDependencies) {
+            let message = _("The applet Script Menu cant run due to missing dependencies. The missing dependencies are:") + " -- ";
+            if (!isNotifyInstalled) 
+                message += "notify-send -- "
+    
+            if (!isxdg_openInstalled)
+                message += "xdg-open -- "
+    
+            if (!isTerminalEmulatorFound) 
+                message += _("Terminal emulator. Switch the setting <Find automatically a terminal> off to fix this.") + " -- ";
+    
+            if (isNotifyInstalled) {
+                this._showNotify(message);
+            }
+            else if (isTerminalEmulatorFound) {
+                try {
+                    GLib.spawn_command_line_async(this.commandToExecuteInTerminal
+                        + " 'sh -c \"echo " + message + "; sleep 1; exec bash\"'");
+                } catch (e) {
+                    global.logError(e);
+                }
+            }
+            global.logError(message);
+        }
+        return allDependencies;
+    },
+
    on_applet_clicked: function(event) {
+      if (!this._checkDependenciesMet()) 
+         return;
       if (this.autoupdate && !this.menu.isOpen) {
          this._updateMenu();
       }
@@ -121,19 +467,20 @@ MyApplet.prototype = {
 
       this._addSeparator();
 
-      let open = new PopupMenu.PopupMenuItem(_("Open scripts folder"));
+      let open = new PopupMenu.PopupIconMenuItem(_("Open scripts folder"), "folder-open-symbolic", St.IconType.SYMBOLIC);
       open.connect('activate', Lang.bind(this, this._openFolder));
       this.menu.addMenuItem(open);
 
       if (!this.autoupdate) {
-         let update = new PopupMenu.PopupMenuItem(_("Update menu"));
+         let update = new PopupMenu.PopupIconMenuItem(_("Update menu"), "emblem-synchronizing-symbolic", St.IconType.SYMBOLIC);
          update.connect('activate', Lang.bind(this, this._updateMenu));
          this.menu.addMenuItem(update);
       }
    },
 
    _showNotify: function(message){
-      GLib.spawn_command_line_async("notify-send --icon=system-run '"+message+"'");
+        let title = _("Applet 'Script Menu'");
+        GLib.spawn_command_line_async("notify-send --icon=system-run \"" + title + "\" \"" + message + "\"");
    },
 
    _addSeparator: function() {
@@ -148,14 +495,6 @@ MyApplet.prototype = {
       }
    },
 
-   _executeScript: function(script) {
-      try {
-         GLib.spawn_command_line_async("\"" + script + "\"");
-      } catch (e) {
-         // notify showed prevent script errors or inexistent file
-         this._showNotify(e);
-      }
-   },
 
    _loadDir: function(dir, m) {
 
@@ -198,13 +537,12 @@ MyApplet.prototype = {
 
          // populate files
          if (files.length > 0) {
-            files.sort();
-            for (let i = 0; i < files.length; i++) {
-               let script = currentDir.get_path() + "/" + files[i];
-               let item = new PopupMenu.PopupMenuItem(files[i]);
-               item.connect('activate', Lang.bind(this, function() {this._executeScript(script)} ));
-               m.addMenuItem(item);
-            }
+                files.sort();
+                for (let i = 0; i < files.length; i++) {
+                    let script = currentDir.get_path() + "/" + files[i];
+                    let item = new PopupMenuItemWithContext(files[i], this, script);
+                    m.addMenuItem(item);
+                }
          }
       }
 

--- a/scripts@paucapo.com/files/scripts@paucapo.com/metadata.json
+++ b/scripts@paucapo.com/files/scripts@paucapo.com/metadata.json
@@ -2,7 +2,7 @@
    "uuid": "scripts@paucapo.com",
    "name": "Scripts Menu",
    "description": "Menu applet for starting scripts",
-   "version": "1.02",
+   "version": "1.03",
    "icon": "system-run",
    "last-edited": "1408701315",
    "max-instances": "100"

--- a/scripts@paucapo.com/files/scripts@paucapo.com/po/localization-template.pot
+++ b/scripts@paucapo.com/files/scripts@paucapo.com/po/localization-template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: scripts@paucapo.com\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-18 20:53+0100\n"
+"POT-Creation-Date: 2021-01-20 15:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,51 +17,171 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: \n"
 
+#: applet.js:24
+msgid ""
+"No terminals are found. Switch the setting <Find automatically a terminal> "
+"off to fix this."
+msgstr ""
+
+#: applet.js:64
+msgid "Desktop env default terminal: "
+msgstr ""
+
+#: applet.js:65 applet.js:90 applet.js:115
+msgid "Command to execute a script: "
+msgstr ""
+
 #: applet.js:89
+msgid "Sym-link of x-terminal-emulator: "
+msgstr ""
+
+#: applet.js:172
+#, javascript-format
+msgid "The script: <%s> doesn't exist"
+msgstr ""
+
+#. settings-schema.json->leftClickBehavior->options
+#. settings-schema.json->rightClickBehavior->options
+#: applet.js:211
+msgid "Execute silently"
+msgstr ""
+
+#. settings-schema.json->leftClickBehavior->options
+#. settings-schema.json->rightClickBehavior->options
+#: applet.js:216
+msgid "Execute in terminal"
+msgstr ""
+
+#. settings-schema.json->leftClickBehavior->options
+#. settings-schema.json->rightClickBehavior->options
+#: applet.js:221
+msgid "Edit the script"
+msgstr ""
+
+#: applet.js:227
+msgid "Open the document"
+msgstr ""
+
+#: applet.js:360
 msgid "Scripts"
 msgstr ""
 
-#: applet.js:124
+#: applet.js:425
+msgid ""
+"The applet Script Menu cant run due to missing dependencies. The missing "
+"dependencies are:"
+msgstr ""
+
+#: applet.js:433
+msgid ""
+"Terminal emulator. Switch the setting <Find automatically a terminal> off to"
+" fix this."
+msgstr ""
+
+#: applet.js:470
 msgid "Open scripts folder"
 msgstr ""
 
-#: applet.js:129
+#: applet.js:475
 msgid "Update menu"
 msgstr ""
 
-#. scripts@paucapo.com->settings-schema.json->paneltitle->description
-#. scripts@paucapo.com->settings-schema.json->head_title->description
-msgid "Title"
+#: applet.js:482
+msgid "Applet 'Script Menu'"
 msgstr ""
 
-#. scripts@paucapo.com->settings-schema.json->directory->description
-msgid "Scripts directory"
-msgstr ""
-
-#. scripts@paucapo.com->settings-schema.json->customicon->description
-msgid "Custom icon"
-msgstr ""
-
-#. scripts@paucapo.com->settings-schema.json->autoupdate->description
+#. settings-schema.json->autoupdate->description
 msgid "Autoupdate. Update scripts list when the applet is opened."
 msgstr ""
 
-#. scripts@paucapo.com->settings-schema.json->head_icon->description
+#. settings-schema.json->directory->description
+msgid "Scripts directory"
+msgstr ""
+
+#. settings-schema.json->head_icon->description
 msgid "Icon"
 msgstr ""
 
-#. scripts@paucapo.com->settings-schema.json->showtitle->description
-msgid "Show title"
+#. settings-schema.json->customicon->description
+msgid "Custom icon"
 msgstr ""
 
-#. scripts@paucapo.com->settings-schema.json->icon->description
+#. settings-schema.json->icon->description
 msgid "Icon (empty to hide the icon)"
 msgstr ""
 
-#. scripts@paucapo.com->metadata.json->name
+#. settings-schema.json->showtitle->description
+msgid "Show title"
+msgstr ""
+
+#. settings-schema.json->paneltitle->description
+msgid "Title"
+msgstr ""
+
+#. settings-schema.json->head_scriptExecution->description
+msgid "Script execution"
+msgstr ""
+
+#. settings-schema.json->leftClickBehavior->description
+msgid "Script execution method on left click"
+msgstr ""
+
+#. settings-schema.json->leftClickBehavior->tooltip
+msgid "How the scripts are processed when you left click on them."
+msgstr ""
+
+#. settings-schema.json->leftClickBehavior->options
+#. settings-schema.json->rightClickBehavior->options
+msgid "Ask what to do"
+msgstr ""
+
+#. settings-schema.json->rightClickBehavior->description
+msgid "Script execution method on right click"
+msgstr ""
+
+#. settings-schema.json->rightClickBehavior->tooltip
+msgid "How the scripts are processed when you right click on them."
+msgstr ""
+
+#. settings-schema.json->findTerminalAutomatically->description
+msgid "Find automatically a terminal? (To execute the scripts in a terminal)"
+msgstr ""
+
+#. settings-schema.json->foundTerminalDescription->description
+msgid "The found terminal is:"
+msgstr ""
+
+#. settings-schema.json->overrideCommandToExecuteInTerminal->description
+msgid "Prepended command to execute the scripts in the terminal"
+msgstr ""
+
+#. settings-schema.json->overrideCommandToExecuteInTerminal->tooltip
+msgid ""
+"To execute the scripts 'in terminal', the scripts are executed with this command prepended.\n"
+"Some potential valid commands are:\n"
+"    gnome-terminal --\n"
+"    nxterm -e\n"
+"    rxvt -e\n"
+"    xterm -e"
+msgstr ""
+
+#. settings-schema.json->useDefaultTextEditorWithScripts->description
+msgid "Use the default editor to edit scripts?"
+msgstr ""
+
+#. settings-schema.json->overrideCommandToEditScripts->description
+msgid "Prepended command to edit the scripts"
+msgstr ""
+
+#. settings-schema.json->overrideCommandToEditScripts->tooltip
+msgid ""
+"To edit the scripts, the scripts are executed with this command prepended."
+msgstr ""
+
+#. metadata.json->name
 msgid "Scripts Menu"
 msgstr ""
 
-#. scripts@paucapo.com->metadata.json->description
+#. metadata.json->description
 msgid "Menu applet for starting scripts"
 msgstr ""

--- a/scripts@paucapo.com/files/scripts@paucapo.com/settings-schema.json
+++ b/scripts@paucapo.com/files/scripts@paucapo.com/settings-schema.json
@@ -10,20 +10,6 @@
       "description" : "Scripts directory",
       "select-dir" : true
    },
-   "head_title" : {
-      "type" : "header",
-      "description" : "Title"
-   },
-   "showtitle": {
-      "type" : "checkbox",
-      "default" : true,
-      "description" : "Show title"
-   },
-   "paneltitle": {
-      "type" : "entry",
-      "default" : "Scripts",
-      "description" : "Title"
-   },
    "head_icon" : {
       "type" : "header",
       "description" : "Icon"
@@ -38,5 +24,74 @@
       "default" : "",
       "description" : "Icon (empty to hide the icon)",
       "dependency": "customicon"
-   }
+   },
+   "showtitle": {
+      "type" : "checkbox",
+      "default" : true,
+      "description" : "Show title"
+   },
+   "paneltitle": {
+      "type" : "entry",
+      "default" : "Scripts",
+      "description" : "Title",
+      "dependency": "showtitle"
+   },
+   "head_scriptExecution" : {
+      "type" : "header",
+      "description" : "Script execution"
+   },
+    "leftClickBehavior": {
+      "type": "combobox",
+      "description": "Script execution method on left click",
+      "tooltip" : "How the scripts are processed when you left click on them.",
+      "options": {
+        "Execute silently": "executeSilently",
+        "Execute in terminal": "executeInTerminal",
+        "Edit the script": "edit",
+        "Ask what to do": "ask"
+      },
+    "default": "executeSilently"
+    },
+    "rightClickBehavior": {
+      "type": "combobox",
+      "description": "Script execution method on right click",
+      "tooltip" : "How the scripts are processed when you right click on them.",
+      "options": {
+          "Execute silently": "executeSilently",
+          "Execute in terminal": "executeInTerminal",
+          "Edit the script": "edit",
+          "Ask what to do": "ask"
+      },
+      "default": "ask"
+    },
+    "findTerminalAutomatically": {
+      "type" : "switch",
+      "description" : "Find automatically a terminal? (To execute the scripts in a terminal)",
+      "default" : true
+   },
+   "foundTerminalDescription": {
+      "type": "textview",
+      "description": "The found terminal is:",
+      "height" : 50,
+      "dependency": "findTerminalAutomatically"
+  },
+   "overrideCommandToExecuteInTerminal": {
+       "type" : "entry",
+       "description" : "Prepended command to execute the scripts in the terminal",
+       "tooltip" : "To execute the scripts 'in terminal', the scripts are executed with this command prepended.\nSome potential valid commands are:\n    gnome-terminal --\n    nxterm -e\n    rxvt -e\n    xterm -e",
+       "default" : "gnome-terminal --",
+       "dependency": "!findTerminalAutomatically"
+    },
+    "useDefaultTextEditorWithScripts": {
+      "type" : "switch",
+      "description" : "Use the default editor to edit scripts?",
+      "default" : true
+   },
+    "overrideCommandToEditScripts": {
+       "type" : "entry",
+       "description" : "Prepended command to edit the scripts",
+       "tooltip" : "To edit the scripts, the scripts are executed with this command prepended.",
+       "default" : "xed",
+       "dependency": "!useDefaultTextEditorWithScripts"
+    }
 }

--- a/scripts@paucapo.com/files/scripts@paucapo.com/stylesheet.css
+++ b/scripts@paucapo.com/files/scripts@paucapo.com/stylesheet.css
@@ -1,3 +1,6 @@
 .scripts-directory {
     font-weight: bold;
 }
+.scripts-ask-menu {
+    font-style: italic;
+}


### PR DESCRIPTION
- Ability to chose how to execute scripts, on right click and on left click.
Four possibilities: Execute silently, Execute in terminal, Edit the script, Ask what to do.
- Detection of default terminal.
- Ability to customize the terminal and editor to use.
- Not executable files can now only be opened with xdg-open.
- Dependency check: terminal, xdg-open and notify-send.
- Add of some icons to the menu.

This closes the ticket https://github.com/linuxmint/cinnamon-spices-applets/issues/3194

@paucapo Are you okay with this changes?