### PR TITLE
[gputemperature@silentage.com] Changed unicode symbol U+1D3C (ᴼ) to U+00B0 (°) (minor aesthetic change)

### DIFF
--- a/gputemperature@silentage.com/files/gputemperature@silentage.com/applet.js
+++ b/gputemperature@silentage.com/files/gputemperature@silentage.com/applet.js
@@ -55,7 +55,7 @@ GPUTemp.prototype =
 		Applet.TextApplet.prototype._init.call(this, orientation);
 		try 
 		{
-			this.set_applet_label(_("GPU: ??\u1d3cC"));
+			this.set_applet_label(_("GPU: ?? \u00B0C"));
 			
 			this.menuManager = new PopupMenu.PopupMenuManager(this);
 			this.menu = new GPUMenu(this, orientation);
@@ -841,7 +841,7 @@ GPUTemp.prototype =
 	},
 	_noGpuSource: function()
 	{
-		this.set_applet_label(_(" GPU: ??\u1d3cC ERROR"));
+		this.set_applet_label(_(" GPU: ?? \u00B0C ERROR"));
 		this.menu.removeAll();
 		this.menu.addMenuItem(new PopupMenu.PopupMenuItem(_("We couldn't determine your GPU's temperature.")), {reactive:false});
 		this.menu.addMenuItem(new PopupMenu.PopupMenuItem(""), {reactive:false});
@@ -854,7 +854,7 @@ GPUTemp.prototype =
 	},
 	_formatTemperature: function(t) 
 	{
-		return (Math.round(t)).toString()+"\u1d3cC";
+		return (Math.round(t)).toString()+" \u00B0C";
 		//return ((t*100)/100).toString()+"\u1d3cC";
 	},
 	_hasCommand: function(test, match)


### PR DESCRIPTION
Change U+1D3C (ᴼ) to U+00B0 (°) and added a space between degree value and degree symbol to make the format consistent with other applets (such as the weather or CPU temp applets).

**Current applet display:**
![image](https://user-images.githubusercontent.com/25296775/107274322-09661d80-6a05-11eb-8755-d205565095ca.png)

**Proposed applet display:**
![image](https://user-images.githubusercontent.com/25296775/107274448-43372400-6a05-11eb-96dc-fae26cdae02e.png)
