### PR TITLE
Update nl.po with nicer generic translation for "Units, Icons and Keys"

### DIFF
--- a/weather@mockturtl/files/weather@mockturtl/po/nl.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/nl.po
@@ -1951,7 +1951,7 @@ msgstr "Locatie"
 
 #. 3.8->settings-schema.json->units-page->title
 msgid "Units, Icons and Keys"
-msgstr "Eenheden, pictogr., toets"
+msgstr "Overige keuzes"
 
 #. 3.8->settings-schema.json->info-section->title
 msgid "Help"


### PR DESCRIPTION
"Other options" would in my opinion be a better short generic tab name than "Units, Icons and Keys", so I've modified the Dutch translation for that string accordingly (thanks for the tip, @French77  ).