### PR TITLE
[radio@driglu4it] Add volume to tooltip

### DIFF
--- a/radio@driglu4it/files/radio@driglu4it/4.6/applet.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/applet.js
@@ -63,9 +63,13 @@ class CinnamonRadioApplet extends TextIconApplet {
       mprisPluginPath: mprisPluginPath,
       _handleRadioStopped: (...args) => this._handleRadioStopped(args),
       _getInitialVolume: () => this._getInitialVolume(),
-      _handleRadioChannelChangedPaused: (...args) => this._handleRadioChannelChangedPaused(...args)
+      _handleRadioChannelChangedPaused: (...args) => this._handleRadioChannelChangedPaused(...args),
+      _handleVolumeChanged: (...args) => this.set_applet_tooltip(...args)
 
     })
+
+    this.mpvPlayer.init()
+
   }
 
   _handleRadioChannelChangedPaused(channelUrl) {
@@ -249,8 +253,8 @@ class CinnamonRadioApplet extends TextIconApplet {
     }
   }
 
-  set_applet_tooltip(nameCurrentMenuItem) {
-    const text = (nameCurrentMenuItem === "Stop") ? "Radio++" : nameCurrentMenuItem
+  set_applet_tooltip(stop, volume) {
+    const text = (stop) ? "Radio++" : _("Volume: ") + volume.toString() + "%"
     super.set_applet_tooltip(text)
   }
 
@@ -259,7 +263,9 @@ class CinnamonRadioApplet extends TextIconApplet {
     const nameCurrentMenuItem = activatedMenuItem.label.text
 
     this._setIconToMenuItem({ menuItem: activatedMenuItem })
-    this.set_applet_tooltip(nameCurrentMenuItem)
+
+    if (nameCurrentMenuItem === "Stop") this.set_applet_tooltip(true)
+
     this.set_applet_label(nameCurrentMenuItem)
     this._setIconColor();
 


### PR DESCRIPTION
Currently the volume it isn't shown at all in the applet which multiple users have criticized. So I changed the content shown in the tooltip from the radio channel to the volume.  In the long term I want to add an option in the settings so the users can decide what to show in the tooltip but for now I think it is more important to show the volume than the Channel as the channel can be shown in the panel and is indicated by a play/pause icon in the list. 

This PR has no conflicts to #3527 (although it would be great If this would be merged as well. Any reason why it hasn't get merged already? 😕)