### PR TITLE
validate-spice: check po files for errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Validate spices
         run: |
           sudo apt-get update -y >/dev/null 2>&1
-          sudo apt-get install -y python3 python3-pil >/dev/null 2>&1
+          sudo apt-get install -y python3 python3-pil gettext >/dev/null 2>&1
           ./validate-spice --all

--- a/validate-spice
+++ b/validate-spice
@@ -2,6 +2,7 @@
 import json
 import os
 import sys
+import subprocess
 from PIL import Image
 
 if len(sys.argv) != 2:
@@ -85,6 +86,19 @@ def validate_xlet(uuid):
         if width != height:
             print("[%s] icon.png has to be square." % uuid)
             valid = False
+
+        # check po files
+        podir = "files/%s/po" % uuid
+        if os.path.isdir(podir):
+            for file in os.listdir(podir):
+                if file.endswith(".po"):
+                    pocheck = subprocess.run(["msgfmt", "-c", os.path.join(podir, file)], stderr=subprocess.PIPE, text=True)
+                    if pocheck.stderr:
+                        print("[%s] The following errors were found in translation file '%s':\n%s"
+                              "HINT: Most errors in translation file `%s` can usually be prevented and solved by using Poedit.\n"
+                              % (uuid, file, pocheck.stderr, file)
+                        )
+                        valid = False
 
     except Exception as error:
         print("[%s] Unknown error. %s" % (uuid, error))


### PR DESCRIPTION
Use `msgfmt -c xx.po` command to verify po-files.

According to the man page (https://www.gnu.org/software/gettext/manual/html_node/msgfmt-Invocation.html), the command does the following:

`-c`, `--check`

Perform all the checks implied by `--check-format`, `--check-header`.

`--check-format`

Check language dependent format strings.

If the string represents a format string used in a `printf`-like function both strings should have the same number of `%` format specifiers, with matching types. If the flag c-format or possible-c-format appears in the special comment #, for this entry a check is performed. For example, the check will diagnose using `%.*s` against `%s`, or `%d` against `%s`, or `%d` against `%x`. It can even handle positional parameters.

Normally the xgettext program automatically decides whether a string is a format string or not. This algorithm is not perfect, though. It might regard a string as a format string though it is not used in a printf-like function and so msgfmt might report errors where there are none.

To solve this problem the programmer can dictate the decision to the xgettext program (see c-format). The translator should not consider removing the flag from the #, line. This "fix" would be reversed again as soon as msgmerge is called the next time.

`--check-header`

Verify presence and contents of the header entry. See Header Entry, for a description of the various fields in the header entry.