### PR TITLE
bash-sensors@pkkk: i18n should not contain \f escape sequence

### DIFF
--- a/bash-sensors@pkkk/files/bash-sensors@pkkk/po/bash-sensors@pkkk.pot
+++ b/bash-sensors@pkkk/files/bash-sensors@pkkk/po/bash-sensors@pkkk.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-15 12:28+0200\n"
+"POT-Creation-Date: 2021-02-16 20:27+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:71
+#: applet.js:79
 msgid "Error: Still waiting for command to finish!"
 msgstr ""
 
@@ -33,6 +33,14 @@ msgstr ""
 
 #. settings-schema.json->head->description
 msgid "Settings - Bash Sensors (write commands in Bash!)"
+msgstr ""
+
+#. settings-schema.json->title1->description
+msgid "Title"
+msgstr ""
+
+#. settings-schema.json->title1->tooltip
+msgid "Title used when displaying notifications"
 msgstr ""
 
 #. settings-schema.json->refreshInterval->units
@@ -60,9 +68,7 @@ msgid "Command 1"
 msgstr ""
 
 #. settings-schema.json->script1->tooltip
-msgid ""
-"first line of output (use "
-" for more lines)"
+msgid "first line of output (use \\f for more lines)"
 msgstr ""
 
 #. settings-schema.json->enableScript2->description
@@ -75,6 +81,22 @@ msgstr ""
 
 #. settings-schema.json->script2->tooltip
 msgid "second line of output (optional)"
+msgstr ""
+
+#. settings-schema.json->head2->description
+msgid "Icon"
+msgstr ""
+
+#. settings-schema.json->dynamicIcon->description
+msgid "Dynamic icon (use output of icon command as icon)"
+msgstr ""
+
+#. settings-schema.json->iconScript->description
+msgid "Static icon or command returning the full path to an icon"
+msgstr ""
+
+#. settings-schema.json->iconScript->tooltip
+msgid "command should return an icon (leave empty for no icon)"
 msgstr ""
 
 #. settings-schema.json->head3->description

--- a/bash-sensors@pkkk/files/bash-sensors@pkkk/po/da.po
+++ b/bash-sensors@pkkk/files/bash-sensors@pkkk/po/da.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-15 12:28+0200\n"
-"PO-Revision-Date: 2020-12-15 15:54+0100\n"
+"POT-Creation-Date: 2021-02-16 20:27+0100\n"
+"PO-Revision-Date: 2021-02-16 20:31+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
 "Language: da\n"
@@ -18,7 +18,7 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applet.js:71
+#: applet.js:79
 msgid "Error: Still waiting for command to finish!"
 msgstr "Fejl: Venter stadig på, at kommandoen bliver færdig!"
 
@@ -37,6 +37,14 @@ msgstr ""
 #. settings-schema.json->head->description
 msgid "Settings - Bash Sensors (write commands in Bash!)"
 msgstr "Indstillinger - Bash-sensorer (skriv kommandoer i Bash!)"
+
+#. settings-schema.json->title1->description
+msgid "Title"
+msgstr ""
+
+#. settings-schema.json->title1->tooltip
+msgid "Title used when displaying notifications"
+msgstr ""
 
 #. settings-schema.json->refreshInterval->units
 msgid "seconds"
@@ -63,8 +71,8 @@ msgid "Command 1"
 msgstr "Kommando 1"
 
 #. settings-schema.json->script1->tooltip
-msgid "first line of output (use \f for more lines)"
-msgstr "første linjes output (brug \f for flere linjer)"
+msgid "first line of output (use \\f for more lines)"
+msgstr "første linjes output (brug \\f for flere linjer)"
 
 #. settings-schema.json->enableScript2->description
 msgid "Two-line mode (command 2 enabled)"
@@ -77,6 +85,25 @@ msgstr "Kommando 2"
 #. settings-schema.json->script2->tooltip
 msgid "second line of output (optional)"
 msgstr "anden linjes output (valgfrit)"
+
+#. settings-schema.json->head2->description
+msgid "Icon"
+msgstr ""
+
+#. settings-schema.json->dynamicIcon->description
+#, fuzzy
+#| msgid "Dynamic tooltip (use output of tooltip command as tooltip)"
+msgid "Dynamic icon (use output of icon command as icon)"
+msgstr ""
+"Dynamisk værktøjstip (brug output fra værktøjstipkommandoen som værktøjstip)"
+
+#. settings-schema.json->iconScript->description
+msgid "Static icon or command returning the full path to an icon"
+msgstr ""
+
+#. settings-schema.json->iconScript->tooltip
+msgid "command should return an icon (leave empty for no icon)"
+msgstr ""
 
 #. settings-schema.json->head3->description
 msgid "Tooltip"

--- a/bash-sensors@pkkk/files/bash-sensors@pkkk/po/it.po
+++ b/bash-sensors@pkkk/files/bash-sensors@pkkk/po/it.po
@@ -7,18 +7,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-15 12:28+0200\n"
-"PO-Revision-Date: 2019-10-19 17:59+0200\n"
+"POT-Creation-Date: 2021-02-16 20:27+0100\n"
+"PO-Revision-Date: 2021-02-16 20:32+0100\n"
+"Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
+"Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.6\n"
-"Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
+"X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: it_IT\n"
 
-#: applet.js:71
+#: applet.js:79
 msgid "Error: Still waiting for command to finish!"
 msgstr "Errore: sto ancora aspettando che il comando finisca!"
 
@@ -31,12 +31,20 @@ msgid ""
 "Write your Bash commands to specify applet output (temperature sensors and "
 "not only!)"
 msgstr ""
-"Scrivi i tuoi comandi Bash per specificare l'uscita dell'applet (sensori "
-"di temperatura e non solo!)"
+"Scrivi i tuoi comandi Bash per specificare l'uscita dell'applet (sensori di "
+"temperatura e non solo!)"
 
 #. settings-schema.json->head->description
 msgid "Settings - Bash Sensors (write commands in Bash!)"
 msgstr "Impostazioni - Sensori Bash (scrivi comandi in Bash!)"
+
+#. settings-schema.json->title1->description
+msgid "Title"
+msgstr ""
+
+#. settings-schema.json->title1->tooltip
+msgid "Title used when displaying notifications"
+msgstr ""
 
 #. settings-schema.json->refreshInterval->units
 msgid "seconds"
@@ -63,8 +71,8 @@ msgid "Command 1"
 msgstr "Comando 1"
 
 #. settings-schema.json->script1->tooltip
-msgid "first line of output (use \f for more lines)"
-msgstr "prima riga di output (usa \f per più righe)"
+msgid "first line of output (use \\f for more lines)"
+msgstr "prima riga di output (usa \\f per più righe)"
 
 #. settings-schema.json->enableScript2->description
 msgid "Two-line mode (command 2 enabled)"
@@ -77,6 +85,24 @@ msgstr "Comando 2"
 #. settings-schema.json->script2->tooltip
 msgid "second line of output (optional)"
 msgstr "seconda riga di output (opzionale)"
+
+#. settings-schema.json->head2->description
+msgid "Icon"
+msgstr ""
+
+#. settings-schema.json->dynamicIcon->description
+#, fuzzy
+#| msgid "Dynamic tooltip (use output of tooltip command as tooltip)"
+msgid "Dynamic icon (use output of icon command as icon)"
+msgstr "Tooltip dinamico (usa l'output del comando tooltip come tooltip)"
+
+#. settings-schema.json->iconScript->description
+msgid "Static icon or command returning the full path to an icon"
+msgstr ""
+
+#. settings-schema.json->iconScript->tooltip
+msgid "command should return an icon (leave empty for no icon)"
+msgstr ""
 
 #. settings-schema.json->head3->description
 msgid "Tooltip"
@@ -109,3 +135,13 @@ msgstr "permetti di mostrare molte informazioni nel menù popup"
 #. settings-schema.json->menuScriptDisplay->description
 msgid "Display output of menu command"
 msgstr "Mostra l'output del comando menù"
+
+#. settings-schema.json->head5->description
+#, fuzzy
+#| msgid "Command on applet click"
+msgid "Command on start-up"
+msgstr "Comando da eseguire al clic sull'applet"
+
+#. settings-schema.json->startupScript->description
+msgid "Command run at start-up"
+msgstr ""

--- a/bash-sensors@pkkk/files/bash-sensors@pkkk/po/tr.po
+++ b/bash-sensors@pkkk/files/bash-sensors@pkkk/po/tr.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-15 12:28+0200\n"
-"PO-Revision-Date: 2020-12-07 16:30+0300\n"
+"POT-Creation-Date: 2021-02-16 20:27+0100\n"
+"PO-Revision-Date: 2021-02-16 20:32+0100\n"
 "Last-Translator: Serkan ÖNDER <serkanonder@outlook.com>\n"
 "Language-Team: \n"
 "Language: tr\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.3\n"
 
-#: applet.js:71
+#: applet.js:79
 msgid "Error: Still waiting for command to finish!"
 msgstr "Hata: Hala komutun bitmesini bekliyorum!"
 
@@ -39,6 +39,14 @@ msgstr ""
 #. settings-schema.json->head->description
 msgid "Settings - Bash Sensors (write commands in Bash!)"
 msgstr "Ayarlar - Bash Sensörleri (Bash ile komutuları yazınız!)"
+
+#. settings-schema.json->title1->description
+msgid "Title"
+msgstr ""
+
+#. settings-schema.json->title1->tooltip
+msgid "Title used when displaying notifications"
+msgstr ""
 
 #. settings-schema.json->refreshInterval->units
 msgid "seconds"
@@ -65,8 +73,8 @@ msgid "Command 1"
 msgstr "Komut 1"
 
 #. settings-schema.json->script1->tooltip
-msgid "first line of output (use \f for more lines)"
-msgstr "ilk çıktı satırı (daha fazla satır için \f kullanın)"
+msgid "first line of output (use \\f for more lines)"
+msgstr "ilk çıktı satırı (daha fazla satır için \\f kullanın)"
 
 #. settings-schema.json->enableScript2->description
 msgid "Two-line mode (command 2 enabled)"
@@ -79,6 +87,24 @@ msgstr "Komut 2"
 #. settings-schema.json->script2->tooltip
 msgid "second line of output (optional)"
 msgstr "ikinci çıktı satırı (isteğe bağlı)"
+
+#. settings-schema.json->head2->description
+msgid "Icon"
+msgstr ""
+
+#. settings-schema.json->dynamicIcon->description
+#, fuzzy
+#| msgid "Dynamic tooltip (use output of tooltip command as tooltip)"
+msgid "Dynamic icon (use output of icon command as icon)"
+msgstr "Dinamik ipucu (ipucu komutunun çıktısını ipucu gibi kullan)"
+
+#. settings-schema.json->iconScript->description
+msgid "Static icon or command returning the full path to an icon"
+msgstr ""
+
+#. settings-schema.json->iconScript->tooltip
+msgid "command should return an icon (leave empty for no icon)"
+msgstr ""
 
 #. settings-schema.json->head3->description
 msgid "Tooltip"

--- a/bash-sensors@pkkk/files/bash-sensors@pkkk/settings-schema.json
+++ b/bash-sensors@pkkk/files/bash-sensors@pkkk/settings-schema.json
@@ -3,7 +3,7 @@
 		"type": "header",
 		"description": "Settings - Bash Sensors (write commands in Bash!)"
 	},
-	"title": {
+	"title1": {
 		"type": "entry",
 		"default": "Bash sensors",
 		"description": "Title",
@@ -32,7 +32,7 @@
 		"type": "entry",
 		"default": "echo 'hello, cinnamon!'",
 		"description": "Command 1",
-		"tooltip": "first line of output (use \f for more lines)"
+		"tooltip": "first line of output (use \\f for more lines)"
 	},
 	"enableScript2": {
 		"type": "checkbox",


### PR DESCRIPTION
The `cinnamon-spices-makepot` script crashes, if the settings-schema
contains a type called "title"