### PR TITLE
Add GitHub Action "Update Translation Status Tables"

### DIFF
--- a/.github/workflows/tst.yml
+++ b/.github/workflows/tst.yml
@@ -1,0 +1,37 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Update Translation Status Tables
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  update-tables:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-20.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a set of commands using the runners shell
+      - name: Generate Translation Status Tables
+        run: |
+          sudo apt-get update -y >/dev/null 2>&1
+          sudo apt-get install -y python3 gettext >/dev/null 2>&1
+          cd .translation-tables
+          python3 translation-tables.py --quiet
+          git config user.name "NikoKrause"
+          git config user.email "8415124+NikoKrause@users.noreply.github.com"
+          git add .
+          git commit --quiet -m "Update Translation Status Tables (GitHub Actions)"
+          git push -f origin master:translation-status-tables

--- a/.translation-tables/LINGUAS
+++ b/.translation-tables/LINGUAS
@@ -5,7 +5,6 @@ cs:Czech
 da:Danish
 de:German
 el:Greek
-en_GB:English (United Kingdom)
 es:Spanish
 et:Estonian
 eu:Basque

--- a/.translation-tables/translation-tables.py
+++ b/.translation-tables/translation-tables.py
@@ -112,17 +112,19 @@ def check_hidden_dirs():
     Creates hidden dirs `po` and `tables` if they don't exist,
     else removes deleted spices in those dirs.
     """
-    try:
-        os.makedirs(HIDDEN_PO_DIR)
+
+    if not os.path.isdir(TABLES_DIR):
         os.makedirs(TABLES_DIR)
-    except OSError:
-        #% remove tables for deleted spices
-        if os.path.isdir(HIDDEN_PO_DIR):
-            for uuid in os.listdir(HIDDEN_PO_DIR):
-                if not os.path.isdir(os.path.join(REPO_FOLDER, uuid)):
-                    shutil.rmtree(os.path.join(HIDDEN_PO_DIR, uuid))
-                    if os.path.isfile(os.path.join(TABLES_DIR, uuid + '.md')):
-                        os.remove(os.path.join(TABLES_DIR, uuid + '.md'))
+
+    #% remove tables for deleted spices
+    if os.path.isdir(HIDDEN_PO_DIR):
+        for uuid in os.listdir(HIDDEN_PO_DIR):
+            if not os.path.isdir(os.path.join(REPO_FOLDER, uuid)):
+                shutil.rmtree(os.path.join(HIDDEN_PO_DIR, uuid))
+                if os.path.isfile(os.path.join(TABLES_DIR, uuid + '.md')):
+                    os.remove(os.path.join(TABLES_DIR, uuid + '.md'))
+    else:
+        os.makedirs(HIDDEN_PO_DIR)
 
 def populate_translation_matrix():
     """ POPULATE TRANSLATION MATRIX """
@@ -134,8 +136,9 @@ def populate_translation_matrix():
     #% for UUID
     for uuid in os.listdir(REPO_FOLDER):
         #% show progressbar in terminal
-        prog_iter += 1
-        terminal_progressbar_update(prog_iter, prog_total)
+        if len(sys.argv) != 2 or sys.argv[1] != "--quiet":
+            prog_iter += 1
+            terminal_progressbar_update(prog_iter, prog_total)
 
         #% ignore files and hidden dirs
         if uuid.startswith('.') or not os.path.isdir(os.path.join(REPO_FOLDER, uuid)):


### PR DESCRIPTION
This GitHub Action updates the Translation Status Tables (see
https://github.com/linuxmint/cinnamon-spices-applets/issues/3588) after
every push to the master branch by running the `translation-tables.py`
script. The generated tables are pushed to the
`translation-status-tables` branch.

The above mentioned issue is pinned and therefore shows up at the top of
the issues page for greater visibility.