### PR TITLE
Validate spice: stop script from creating messages.mo files

### DIFF
--- a/validate-spice
+++ b/validate-spice
@@ -92,14 +92,14 @@ def validate_xlet(uuid):
         if os.path.isdir(podir):
             for file in os.listdir(podir):
                 if file.endswith(".po"):
-                    pocheck = subprocess.run(["msgfmt", "-c", os.path.join(podir, file)], stderr=subprocess.PIPE, text=True)
+                    pocheck = subprocess.run(["msgfmt", "-c", os.path.join(podir, file), "-o", "-"], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
                     if pocheck.stderr:
                         print("[%s] The following errors were found in translation file '%s':\n%s"
                               "HINT: Most errors in translation file `%s` can usually be prevented and solved by using Poedit.\n"
                               % (uuid, file, pocheck.stderr, file)
                         )
                         valid = False
-                if file.endswith(".pot"):
+                elif file.endswith(".pot"):
                     potcheck = subprocess.run(["xgettext", os.path.join(podir, file), "-o", "-"], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
                     if potcheck.stderr:
                         print("[%s] The following errors were found in translation template '%s':\n%s" % (uuid, file, potcheck.stderr))


### PR DESCRIPTION
The msgfmt command created messages.mo files.
Stop it from doing this.