### PR TITLE
[radio@driglu4it] Fix bugs in mpv handler

### DIFF
--- a/radio@driglu4it/files/radio@driglu4it/4.6/applet.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/applet.js
@@ -70,12 +70,10 @@ class CinnamonRadioApplet extends TextIconApplet {
 
     this.mpvPlayer = new MpvPlayerHandler({
       mprisPluginPath: mprisPluginPath,
-      // TODO: hier auch ...args??
       _handleRadioStopped: (...args) => this._handleRadioStopped(...args),
       _getInitialVolume: () => this._getInitialVolume(),
       _handleRadioChannelChangedPaused: (...args) => this._handleRadioChannelChangedPaused(...args),
       _handleVolumeChanged: (...args) => this.set_applet_tooltip(false, ...args)
-
     })
 
     await this.mpvPlayer.init()

--- a/radio@driglu4it/files/radio@driglu4it/4.6/applet.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/applet.js
@@ -12,6 +12,9 @@ const { file_new_for_path } = imports.gi.Gio;
 const { MpvPlayerHandler } = require('./mpvPlayerHandler')
 const { PlayPauseIconMenuItem } = require('./playPauseIconMenuItem')
 
+const MPRIS_PLUGIN_URL = "https://github.com/hoyon/mpv-mpris/releases/download/0.5/mpris.so"
+
+
 // for i18n
 let UUID;
 function _(str) {

--- a/radio@driglu4it/files/radio@driglu4it/4.6/applet.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/applet.js
@@ -1,3 +1,4 @@
+// see: https://projects.linuxmint.com/reference/git/cinnamon-tutorials/importer.html
 const { TextIconApplet, AllowedLayout, AppletPopupMenu } = imports.ui.applet;
 const { PopupMenuManager, PopupSeparatorMenuItem, PopupMenuItem, PopupSubMenuMenuItem } = imports.ui.popupMenu;
 const { AppletSettings } = imports.ui.settings;
@@ -11,8 +12,6 @@ const { file_new_for_path } = imports.gi.Gio;
 const { MpvPlayerHandler } = require('./mpvPlayerHandler')
 const { PlayPauseIconMenuItem } = require('./playPauseIconMenuItem')
 
-const MPRIS_PLUGIN_URL = "https://github.com/hoyon/mpv-mpris/releases/download/0.5/mpris.so"
-
 // for i18n
 let UUID;
 function _(str) {
@@ -23,9 +22,9 @@ function _(str) {
   return Gettext.gettext(str);
 }
 
-
 class CinnamonRadioApplet extends TextIconApplet {
   constructor(orientation, panel_height, instance_id) {
+
     super(orientation, panel_height, instance_id);
 
     // Allow Applet to be used on vertical and horizontal panels. By default only horizontal panels are allowed
@@ -36,12 +35,18 @@ class CinnamonRadioApplet extends TextIconApplet {
     Gettext.bindtextdomain(UUID, get_home_dir() + "/.local/share/locale");
 
     this.settings = new AppletSettings(this, __meta.uuid, instance_id);
+
+  }
+
+  async init(orientation) {
+
     this._initSettings()
     this._trimChannelList()
+    await this._initMpvPlayer()
 
-    this._initMpvPlayer()
     const initialChannelName = this._getChannelName({ channelUrl: this.mpvPlayer.getRunningRadioUrl() })
     this._initGui(orientation, initialChannelName)
+
   }
 
   _initSettings() {
@@ -53,22 +58,24 @@ class CinnamonRadioApplet extends TextIconApplet {
     this.settings.bind("initial-volume", "custom_initial_volume");
     this.settings.bind("keep-volume-between-sessions", "keep_volume_between_sessions")
     this.settings.bind("last-volume", "last_volume")
+    this.settings.bind("music-download-dir-select", "music_dir")
   }
 
-  _initMpvPlayer() {
+  async _initMpvPlayer() {
     const configPath = `${get_home_dir()}/.cinnamon/configs/${__meta.uuid}`;
     const mprisPluginPath = configPath + '/.mpris.so'
 
     this.mpvPlayer = new MpvPlayerHandler({
       mprisPluginPath: mprisPluginPath,
-      _handleRadioStopped: (...args) => this._handleRadioStopped(args),
+      // TODO: hier auch ...args??
+      _handleRadioStopped: (...args) => this._handleRadioStopped(...args),
       _getInitialVolume: () => this._getInitialVolume(),
       _handleRadioChannelChangedPaused: (...args) => this._handleRadioChannelChangedPaused(...args),
-      _handleVolumeChanged: (...args) => this.set_applet_tooltip(...args)
+      _handleVolumeChanged: (...args) => this.set_applet_tooltip(false, ...args)
 
     })
 
-    this.mpvPlayer.init()
+    await this.mpvPlayer.init()
 
   }
 
@@ -90,7 +97,7 @@ class CinnamonRadioApplet extends TextIconApplet {
   }
 
   _setIconColor() {
-    const color = (this.mpvPlayer.getPlayPauseStatus() === "Playing") ? this.color_on : this._getThemeIconColor()
+    const color = (this.mpvPlayer.getPlaybackStatus() === "Playing") ? this.color_on : this._getThemeIconColor()
     this.actor.style = `color: ${color}`
   }
 
@@ -115,7 +122,7 @@ class CinnamonRadioApplet extends TextIconApplet {
   }
 
   set_applet_label(nameCurrentMenuItem) {
-    const text = (this.mpvPlayer.getPlayPauseStatus() === "Playing" && this.show_channel_on_panel)
+    const text = (this.mpvPlayer.getPlaybackStatus() === "Playing" && this.show_channel_on_panel)
       ? " " + nameCurrentMenuItem : ""
     super.set_applet_label(text)
   }
@@ -154,15 +161,17 @@ class CinnamonRadioApplet extends TextIconApplet {
   }
 
   _getInitialVolume() {
-    return this.keep_volume_between_sessions ? this.last_volume : this.custom_initial_volume
+    let initialVolume = this.keep_volume_between_sessions ? this.last_volume : this.custom_initial_volume
+    if (!initialVolume) global.logError(`couldn'T get valid initalVolume from settings. Have a look at  ~/.cinnamon/configs.json`)
+    return initialVolume
   }
 
   async _on_radio_channel_clicked(e, channel) {
-    //this._changeSetCurrentMenuItem(e)
+
     try {
       await this.mpvPlayer.startChangeRadioChannel(channel.url)
     } catch (error) {
-      this._notify_send(_("Can't play  %s").format(channel.name) + ". " + _("Make sure that the URL is valid and you have a stable internet connection. Don't hestitate to open an Issue on Github if the problem persists."))
+      notifySend(_("Can't play  %s").format(channel.name) + ". " + _("Make sure that the URL is valid and you have a stable internet connection. Don't hestitate to open an Issue on Github if the problem persists."))
       global.logError(error)
       return
     }
@@ -249,7 +258,7 @@ class CinnamonRadioApplet extends TextIconApplet {
     if (menuItem === this.stopitem) {
       menuItem.setShowDot(true);
     } else {
-      menuItem.changePlayPauseOffStatus(this.mpvPlayer.getPlayPauseStatus())
+      menuItem.changePlayPauseOffStatus(this.mpvPlayer.getPlaybackStatus())
     }
   }
 
@@ -271,9 +280,7 @@ class CinnamonRadioApplet extends TextIconApplet {
 
     this.currentMenuItem = activatedMenuItem;
 
-  }
-
-  // sends a notification but only if there hasn't been already the same notification in the last 10 seks
+  }  // sends a notification but only if there hasn't been already the same notification in the last 10 seks
   _notify_send(notificationMsg) {
     const currentTime = Date.now()
 
@@ -337,5 +344,7 @@ class CinnamonRadioApplet extends TextIconApplet {
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-  return new CinnamonRadioApplet(orientation, panel_height, instance_id);
+  const radioApplet = new CinnamonRadioApplet(orientation, panel_height, instance_id);
+  radioApplet.init(orientation)
+  return radioApplet;
 }

--- a/radio@driglu4it/files/radio@driglu4it/4.6/mpvPlayerHandler.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/mpvPlayerHandler.js
@@ -163,7 +163,7 @@ class MpvPlayerHandler {
         })
     }
 
-    async _updateVolume({ updateTarget, newVolume }) {
+    _updateVolume({ updateTarget, newVolume }) {
         if (updateTarget === "cvcStream") this._updateCvcStreamVolume(newVolume)
         if (updateTarget === "mpris") this._mediaServerPlayer.Volume = newVolume / 100
         if (updateTarget === "Both") {
@@ -176,7 +176,7 @@ class MpvPlayerHandler {
 
     }
 
-    async _updateCvcStreamVolume(newVolume) {
+    _updateCvcStreamVolume(newVolume) {
 
         if (this._stream.is_muted) this._stream.change_is_muted(false)
 

--- a/radio@driglu4it/files/radio@driglu4it/4.6/mpvPlayerHandler.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/mpvPlayerHandler.js
@@ -1,6 +1,6 @@
 const { spawnCommandLine } = imports.misc.util;
-const { getDBusProxyWithOwner, getDBusProperties, getDBus, ListNamesRemote } = imports.misc.interfaces;
-const Cvc = imports.gi.Cvc;
+const Cvc = imports.gi.Cvc; // sse https://gitlab.gnome.org/GNOME/libgnome-volume-control/blob/master/gvc-mixer-control.h
+const { getDBusProxyWithOwnerPromise, getDBusPropertiesPromise, getDBusPromise } = require('./utils')
 
 const MAX_VOLUME = 100 // see https://github.com/linuxmint/cinnamon-spices-applets/issues/3402#issuecomment-756430754 for an explanation of this value
 
@@ -15,71 +15,54 @@ const MPV_MPRIS_BUS_NAME = `${MEDIA_PLAYER_2_NAME}.mpv`
 class MpvPlayerHandler {
 
     constructor({ mprisPluginPath, _handleRadioStopped, _getInitialVolume, _handleVolumeChanged }) {
-
         Object.assign(this, arguments[0])
-        this._volume = this._getInitialVolume()
     }
 
     async init() {
-        this._initDbus() // used to to check if mpv is running
 
-        if (this._checkMpvRunning()) {
-            this._initMpris()
-            await this._initCvcSteam()
+        this._dbus = await getDBusPromise()
+        this._mediaServerPlayer = await getDBusProxyWithOwnerPromise(MEDIA_PLAYER_2_PLAYER_NAME, MPV_MPRIS_BUS_NAME)
+        this._mediaProps = await getDBusPropertiesPromise(MPV_MPRIS_BUS_NAME, MEDIA_PLAYER_2_PATH)
 
-            // updating the volume has several benefits: cvcStream and mpris is synched, handleVolumeChanged function is executed and it is ensured that the volume is not above the maxVolume
-            this._updateVolume({
-                updateTarget: "Both",
-                newVolume: Math.min(this._mediaServerPlayer.Volume * 100, MAX_VOLUME)
-            })
+        const mpvRunning = (await this._getAllMrisPlayerBusNames()).includes(MPV_MPRIS_BUS_NAME)
+
+        if (mpvRunning) {
+            this.stopped = false
+            await this._watchStreamAdded()
         } else {
-            this._dbus = null
+            this.stopped = true
+            this._watchStreamAdded()
         }
-    }
 
-    _initAllInterfaces() {
-        this._initMpris()
-        this._initDbus()
-        this._initCvcSteam()
-    }
-
-
-    _getMetadata() {
-        return this._mediaServerPlayer.Metadata
-    }
-
-    _initMpris() {
-        this._mediaServerPlayer = getDBusProxyWithOwner(MEDIA_PLAYER_2_PLAYER_NAME, MPV_MPRIS_BUS_NAME)
-        this._mediaProps = getDBusProperties(MPV_MPRIS_BUS_NAME, MEDIA_PLAYER_2_PATH)
-        this._listenToMediaPropsChanges()
-    }
-
-    _initDbus() {
-        this._dbus = getDBus()
+        this._listenToMediaPropsChanges() // must be after stream init for some reason
         this._listenToRadioStopped()
     }
 
-    async _initCvcSteam() {
-
+    // Method updates the stream as soon as a MPV Stream is added. Needs only to be called once - resolving in case it is necessary to ensure that this._stream is not null
+    _watchStreamAdded() {
         this._control = new Cvc.MixerControl({ name: 'Radio' });
         this._control.open();
 
-        this._stream = await this._getCvcStream()
-        this._stream.connect("notify::volume", () => {
-            this._handleCvcVolumeChanged()
-        })
-
-    }
-
-
-    _getCvcStream() {
         return new Promise((resolve, reject) => {
             this._control.connect('stream-added', (control, id) => {
                 const stream = this._control.lookup_stream_id(id);
                 if (!stream) return
-                if (stream.name === "mpv Media Player") resolve(stream)
+                if (stream.name === "mpv Media Player") {
+                    this._stream = stream
+                    // volume is not mandatory the same as in MPRIS
+                    const mprisVolume = Math.round(this._mediaServerPlayer.Volume * 100)
+                    this._updateVolume({ updateTarget: "cvcStream", newVolume: mprisVolume })
+                    this._stream.connect("notify::volume", () => {
+                        this._handleCvcVolumeChanged()
+                    })
+                    resolve()
+                }
             })
         })
+    }
+
+    _getMetadata() {
+        return this._mediaServerPlayer.Metadata
     }
 
     _handleCvcVolumeChanged() {
@@ -91,13 +74,13 @@ class MpvPlayerHandler {
 
     // converts the Stream Volume to a Number between 0 and 100 (as Integer)
     _normalizeStreamVolume(streamVolume) {
-        // plus 1 as parseInt rounds to next lower number
-        return parseInt(streamVolume / this._control.get_vol_max_norm() * 100 + 1)
+        return Math.round(streamVolume / this._control.get_vol_max_norm() * 100)
     }
 
     // convert normalized Volume (0-100) to Stream volume
     _normalizedVolumeToStreamVolume(volume) {
         return volume / 100 * this._control.get_vol_max_norm()
+
     }
 
     // theoretically it should also be possible to listen to props.PlaybackStatus but this doesn't work. 
@@ -106,33 +89,38 @@ class MpvPlayerHandler {
         this._dbus.connectSignal('NameOwnerChanged',
             (proxy, sender, [name, old_owner, new_owner]) => {
                 if (name === MPV_MPRIS_BUS_NAME && !new_owner) {
-                    this._mediaServerPlayer = this._mediaProps = this._dbus = null
+                    // this is a workaround as .getPlaybackStatus() still returns 'playing' for a short moment.
+                    this.stopped = true
                     this._handleRadioStopped(this._volume)
                 }
             }
         );
     }
 
-    async _checkMpvRunning() {
-        const mpvRunning = (await this._getAllMrisPlayerBusNames()).includes(MPV_MPRIS_BUS_NAME)
-        return mpvRunning
-    }
-
     _listenToMediaPropsChanges() {
 
         let previousUrl
-
         this._mediaProps.connectSignal('PropertiesChanged', (proxy, sender, [iface, props]) => {
+
+            // this method is sometimes called after the radio has stopped when another player (at least vlc) makes some changes. TODO: proper fix
+            if (this.stopped) return
 
             if (props.Volume) this._handleMprisVolumeChanged(props)
 
             if (props.Metadata) {
                 const metadata = props.Metadata.deep_unpack()
                 const newUrl = metadata["xesam:url"].unpack()
-                if (newUrl !== previousUrl) this._handleRadioChannelChangedPaused(newUrl)
+                if (newUrl !== previousUrl) {
+                    // this is executed when radio channel changes but not when radio starts
+                    this._updateVolume({ updateTarget: "Both", newVolume: this._volume })
+                    this._handleRadioChannelChangedPaused(newUrl)
+                    previousUrl = newUrl
+                }
             }
 
             if (props.PlaybackStatus) {
+                // this is executed when radio starts, pauses and resume play but (unfortunately) not when stopped or channel changed
+                this._updateVolume({ updateTarget: "Both", newVolume: this._volume })
                 this._handleRadioChannelChangedPaused(this.getRunningRadioUrl())
             }
         })
@@ -155,9 +143,9 @@ class MpvPlayerHandler {
     async _stopAllOtherMediaPlayer() {
         const allMprisPlayerBusNames = await this._getAllMrisPlayerBusNames()
 
-        allMprisPlayerBusNames.forEach(busName => {
+        allMprisPlayerBusNames.forEach(async busName => {
             if (busName != MPV_MPRIS_BUS_NAME) {
-                const mediaServerPlayer = getDBusProxyWithOwner(MEDIA_PLAYER_2_PLAYER_NAME, busName)
+                const mediaServerPlayer = await getDBusProxyWithOwnerPromise(MEDIA_PLAYER_2_PLAYER_NAME, busName)
                 mediaServerPlayer.StopRemote()
             }
         })
@@ -175,7 +163,7 @@ class MpvPlayerHandler {
         })
     }
 
-    _updateVolume({ updateTarget, newVolume }) {
+    async _updateVolume({ updateTarget, newVolume }) {
         if (updateTarget === "cvcStream") this._updateCvcStreamVolume(newVolume)
         if (updateTarget === "mpris") this._mediaServerPlayer.Volume = newVolume / 100
         if (updateTarget === "Both") {
@@ -183,25 +171,29 @@ class MpvPlayerHandler {
             this._mediaServerPlayer.Volume = newVolume / 100
         }
 
-        this._handleVolumeChanged(false, newVolume)
+        this._handleVolumeChanged(newVolume)
         this._volume = newVolume
+
     }
 
-    _updateCvcStreamVolume(newVolume) {
+    async _updateCvcStreamVolume(newVolume) {
+
+        if (this._stream.is_muted) this._stream.change_is_muted(false)
+
         this._stream.volume = this._normalizedVolumeToStreamVolume(newVolume)
         this._stream.push_volume();
     }
 
-    async startChangeRadioChannel(channelUrl) {
-
-        if (this._mediaServerPlayer === null) { this._initAllInterfaces() }
+    startChangeRadioChannel(channelUrl) {
 
         this._stopAllOtherMediaPlayer()
 
-        if (!await this._checkMpvRunning()) {
-            this._volume = this._getInitialVolume()
-            // without --volume it would be used 100
-            spawnCommandLine(`mpv --script=${this.mprisPluginPath} ${channelUrl} --volume=${this._volume}`)
+        if (this.stopped) {
+
+            this.stopped = false
+            const command = `mpv --script=${this.mprisPluginPath} ${channelUrl} --volume=${this._getInitialVolume()}`
+            spawnCommandLine(command)
+
         } else {
             this._mediaServerPlayer.PlayRemote(); // ensures that the method is working when radio is paused. Has no effect if playing/stopped 
             // this actually should also work when no radio is playing but it doesn't (probably due to --script)
@@ -210,8 +202,8 @@ class MpvPlayerHandler {
 
         // only in case of an error the mpv player doesn't play after 2 secs
         return new Promise((resolve, reject) => {
-            setTimeout(async () => {
-                (await this._checkMpvRunning()) ? resolve() : reject()
+            setTimeout(() => {
+                (!this.stopped) ? resolve() : reject()
             }, 2000)
         })
     }
@@ -219,7 +211,7 @@ class MpvPlayerHandler {
     // returns true when volume changed and false if not. This is the case when the increased volume would be higher than the max volume or lower than zero
     increaseDecreaseVolume(amount) {
 
-        if (!this._mediaServerPlayer) return
+        if (this.stopped) { return "" }
 
         let volumeChanged = false
         const newVolume = Math.min(MAX_VOLUME, Math.max(0, this._volume + amount))
@@ -233,28 +225,24 @@ class MpvPlayerHandler {
     }
 
     stopRadio() {
-        if (!this._mediaServerPlayer) { return "" }
-
+        if (this.stopped) return
         this._mediaServerPlayer.StopRemote()
     }
 
     getRunningRadioUrl() {
-
-        if (!this._mediaServerPlayer) { return "" }
+        if (this.stopped) return
 
         const radioUrl = this._getMetadata() ? this._getMetadata()["xesam:url"].unpack() : false
         return radioUrl
     }
 
-    // TODO: with proper JS getter setter
-    getPlayPauseStatus() {
-        if (!this._mediaServerPlayer) { return "Stopped" }
+    getPlaybackStatus() {
+        if (this.stopped) { return "Stopped" }
         return this._mediaServerPlayer.PlaybackStatus
     }
 
     getCurrentSong() {
-        if (!this._mediaServerPlayer) { return "" }
-
+        if (this.stopped) { return "" }
         return (this._getMetadata()["xesam:title"].unpack())
     }
 }

--- a/radio@driglu4it/files/radio@driglu4it/4.6/utils.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/utils.js
@@ -1,0 +1,26 @@
+const { spawnCommandLine, spawnCommandLineAsyncIO } = imports.misc.util;
+const { getDBusProxyWithOwnerAsync, getDBusPropertiesAsync, getDBusAsync } = imports.misc.interfaces;
+
+const getDBusProxyWithOwnerPromise = function (name, path) {
+    return new Promise((resolve, reject) => {
+        getDBusProxyWithOwnerAsync(...Object.values(arguments), (p, e) => {
+            resolve(p)
+        })
+    })
+}
+
+const getDBusPropertiesPromise = function (name, path) {
+    return new Promise((resolve, reject) => {
+        getDBusPropertiesAsync(...Object.values(arguments), (p, e) => {
+            resolve(p)
+        })
+    })
+}
+
+const getDBusPromise = function () {
+    return new Promise((resolve, reject) => {
+        getDBusAsync((p, e) => {
+            resolve(p)
+        })
+    })
+}


### PR DESCRIPTION
There has been some bugs in the MPV Handler which are fixed: 

- The volume of mpris and cvc (i.e. sound applet) haven't syncd when switching channel and changing volume afterwards
- The volume couldn't changed by scrolling after setting the cvc volume to zero
- When restarting cinnamon it could happen that volume N.A.N has been shown in toolitp or not rounded numbers
- Sometimes the volume in sound applet was shown +1 compared to the mpris volume

Unfortunately this will create some conflicts for my other open PR. I will update the other PR tomorrow to solve the conflicts. But it would be really useful when the other pr could be merged or rejected afterwards to prevent this circumstances in future ...  