### PR TITLE
sound150@claudiux: add "Always show input controls" option

### DIFF
--- a/sound150@claudiux/files/sound150@claudiux/3.4/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/3.4/applet.js
@@ -1056,6 +1056,7 @@ MyApplet.prototype = {
             this.settings.bind("middleClickAction", "middleClickAction");
             this.settings.bind("showalbum", "showalbum", this.on_settings_changed);
             this.settings.bind("truncatetext", "truncatetext", this.on_settings_changed);
+            this.settings.bind("alwaysShowInput", "alwaysShowInput", this.on_settings_changed);
 
             this.settings.bind("magneticOn", "magneticOn", this.on_settings_changed);
 
@@ -1279,6 +1280,11 @@ MyApplet.prototype = {
         this.old_pcMaxVolume = this.pcMaxVolume;
         this._outputVolumeSection._onValueChanged();
         this._outputVolumeSection._update();
+
+        if(this._recordingAppsNum === 0 && !this.alwaysShowInput)
+            this._inputSection.actor.hide();
+        else if(this._recordingAppsNum > 0 || this.alwaysShowInput)
+            this._inputSection.actor.show();
     },
 
     on_applet_removed_from_panel : function() {
@@ -1790,7 +1796,8 @@ MyApplet.prototype = {
                         this._outputApplicationsMenu.actor.hide();
                 } else if (stream.type === "SourceOutput") {
                     if(--this._recordingAppsNum === 0)
-                        this._inputSection.actor.hide();
+                        if (this.alwaysShowInput == null || !this.alwaysShowInput)
+                            this._inputSection.actor.hide();
                 }
                 this._streams.splice(i, 1);
                 break;

--- a/sound150@claudiux/files/sound150@claudiux/3.4/settings-schema.json
+++ b/sound150@claudiux/files/sound150@claudiux/3.4/settings-schema.json
@@ -60,6 +60,12 @@
         "description" : "Hide system tray icons for compatible players",
         "default": true
     },
+    "alwaysShowInput": {
+        "type": "switch",
+        "description": "Always show input controls",
+        "tooltip": "When checked, input volume and source controls are always shown, even if no application is currently recording sound.",
+        "default": false
+    },
     "section3": {
         "type": "section",
         "description" : "Sound Settings"


### PR DESCRIPTION
I think the function is pretty straightforward based on the description.

I can try to add corresponding changes for other Cinnamon versions if there's interest in merging it.