### PR TITLE
calendar@ccprog: Add gettext support to python script

### DIFF
--- a/calendar@ccprog/files/calendar@ccprog/po/calendar@ccprog.pot
+++ b/calendar@ccprog/files/calendar@ccprog/po/calendar@ccprog.pot
@@ -8,26 +8,82 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-31 18:21+0200\n"
+"POT-Creation-Date: 2021-02-27 15:40+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: applet.js:65
+msgid "Date and Time Settings"
+msgstr ""
+
+#: settings_widgets.py:95
+msgid "Add new entry"
+msgstr ""
+
+#: settings_widgets.py:99
+msgid "Edit entry"
+msgstr ""
+
+#. settings-schema.json->region_aus->description
+#. settings-schema.json->region_can->description
+#. settings-schema.json->region_deu->description
+#. settings-schema.json->region_nzl->description
+#. settings-schema.json->region_svk->description
+#. settings-schema.json->region_che->description
+#. settings-schema.json->region_gbr->description
+#. settings-schema.json->region_usa->description
+#: settings_widgets.py:122
+msgid "Region"
+msgstr ""
+
+#: settings_widgets.py:123
+msgid "City"
+msgstr ""
+
+#. metadata.json->name
+msgid "Calendar with public Holidays"
+msgstr ""
+
+#. metadata.json->description
+msgid "Calendar applet with public holiday data provided by Enrico service"
+msgstr ""
+
+#. settings-schema.json->page1->title
+msgid "Calendar"
+msgstr ""
 
 #. settings-schema.json->page2->title
 #. settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr ""
 
+#. settings-schema.json->section1->title
+msgid "Display"
+msgstr ""
+
 #. settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr ""
 
+#. settings-schema.json->section3->title
+msgid "Keyboard shortcuts"
+msgstr ""
+
 #. settings-schema.json->section4->title
 msgid "Show World Times"
+msgstr ""
+
+#. settings-schema.json->show-week-numbers->description
+msgid "Show week numbers in calendar"
+msgstr ""
+
+#. settings-schema.json->show-week-numbers->tooltip
+msgid "Check this to show week numbers in the calendar."
 msgstr ""
 
 #. settings-schema.json->weekend-length->description
@@ -44,6 +100,31 @@ msgstr ""
 
 #. settings-schema.json->weekend-length->options
 msgid "Two days"
+msgstr ""
+
+#. settings-schema.json->use-custom-format->description
+msgid "Use a custom date format"
+msgstr ""
+
+#. settings-schema.json->use-custom-format->tooltip
+msgid ""
+"Check this to define a custom format for the date in the calendar applet."
+msgstr ""
+
+#. settings-schema.json->custom-format->description
+msgid "Date format"
+msgstr ""
+
+#. settings-schema.json->custom-format->tooltip
+msgid "Set your custom format here."
+msgstr ""
+
+#. settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr ""
+
+#. settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
 msgstr ""
 
 #. settings-schema.json->country->description
@@ -243,6 +324,10 @@ msgid "Switzerland"
 msgstr ""
 
 #. settings-schema.json->country->options
+msgid "Turkey"
+msgstr ""
+
+#. settings-schema.json->country->options
 msgid "Ukraine"
 msgstr ""
 
@@ -252,17 +337,6 @@ msgstr ""
 
 #. settings-schema.json->country->options
 msgid "United States of America"
-msgstr ""
-
-#. settings-schema.json->region_aus->description
-#. settings-schema.json->region_can->description
-#. settings-schema.json->region_deu->description
-#. settings-schema.json->region_nzl->description
-#. settings-schema.json->region_svk->description
-#. settings-schema.json->region_che->description
-#. settings-schema.json->region_gbr->description
-#. settings-schema.json->region_usa->description
-msgid "Region"
 msgstr ""
 
 #. settings-schema.json->region_aus->options
@@ -386,7 +460,7 @@ msgid "Mecklenburg-Vorpommern"
 msgstr ""
 
 #. settings-schema.json->region_deu->options
-msgid "Nordrhein-Westphalen"
+msgid "Nordrhein-Westfalen"
 msgstr ""
 
 #. settings-schema.json->region_deu->options
@@ -837,14 +911,6 @@ msgstr ""
 msgid "Wyoming"
 msgstr ""
 
-#. settings-schema.json->worldclocks->columns->title
-msgid "Display name"
-msgstr ""
-
-#. settings-schema.json->worldclocks->columns->title
-msgid "Timezone"
-msgstr ""
-
 #. settings-schema.json->keyOpen->description
 msgid "Show calendar"
 msgstr ""
@@ -853,10 +919,10 @@ msgstr ""
 msgid "Set keybinding(s) to show the calendar."
 msgstr ""
 
-#. metadata.json->name
-msgid "Calendar with public Holidays"
+#. settings-schema.json->worldclocks->columns->title
+msgid "Display name"
 msgstr ""
 
-#. metadata.json->description
-msgid "Calendar applet with public holiday data provided by Enrico service"
+#. settings-schema.json->worldclocks->columns->title
+msgid "Timezone"
 msgstr ""

--- a/calendar@ccprog/files/calendar@ccprog/po/da.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/da.po
@@ -7,29 +7,85 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-31 18:21+0200\n"
-"PO-Revision-Date: 2020-12-15 16:25+0100\n"
+"POT-Creation-Date: 2021-02-27 15:40+0100\n"
+"PO-Revision-Date: 2021-02-27 16:16+0100\n"
+"Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
+"Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: da\n"
+
+#: applet.js:65
+msgid "Date and Time Settings"
+msgstr ""
+
+#: settings_widgets.py:95
+msgid "Add new entry"
+msgstr ""
+
+#: settings_widgets.py:99
+msgid "Edit entry"
+msgstr ""
+
+#. settings-schema.json->region_aus->description
+#. settings-schema.json->region_can->description
+#. settings-schema.json->region_deu->description
+#. settings-schema.json->region_nzl->description
+#. settings-schema.json->region_svk->description
+#. settings-schema.json->region_che->description
+#. settings-schema.json->region_gbr->description
+#. settings-schema.json->region_usa->description
+#: settings_widgets.py:122
+msgid "Region"
+msgstr "Region"
+
+#: settings_widgets.py:123
+msgid "City"
+msgstr ""
+
+#. metadata.json->name
+msgid "Calendar with public Holidays"
+msgstr "Kalender med offentlige helligdage"
+
+#. metadata.json->description
+msgid "Calendar applet with public holiday data provided by Enrico service"
+msgstr "Kalender med offentlige helligdage leveret af Enrico"
+
+#. settings-schema.json->page1->title
+msgid "Calendar"
+msgstr ""
 
 #. settings-schema.json->page2->title
 #. settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Verdensure"
 
+#. settings-schema.json->section1->title
+msgid "Display"
+msgstr ""
+
 #. settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Hent offentlige helligdage for"
 
+#. settings-schema.json->section3->title
+msgid "Keyboard shortcuts"
+msgstr ""
+
 #. settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Vis verdenstid"
+
+#. settings-schema.json->show-week-numbers->description
+msgid "Show week numbers in calendar"
+msgstr ""
+
+#. settings-schema.json->show-week-numbers->tooltip
+msgid "Check this to show week numbers in the calendar."
+msgstr ""
 
 #. settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
@@ -46,6 +102,30 @@ msgstr "En dag"
 #. settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "To dage"
+
+#. settings-schema.json->use-custom-format->description
+msgid "Use a custom date format"
+msgstr ""
+
+#. settings-schema.json->use-custom-format->tooltip
+msgid "Check this to define a custom format for the date in the calendar applet."
+msgstr ""
+
+#. settings-schema.json->custom-format->description
+msgid "Date format"
+msgstr ""
+
+#. settings-schema.json->custom-format->tooltip
+msgid "Set your custom format here."
+msgstr ""
+
+#. settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr ""
+
+#. settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr ""
 
 #. settings-schema.json->country->description
 msgid "Country"
@@ -244,6 +324,10 @@ msgid "Switzerland"
 msgstr "Schweiz"
 
 #. settings-schema.json->country->options
+msgid "Turkey"
+msgstr ""
+
+#. settings-schema.json->country->options
 msgid "Ukraine"
 msgstr "Ukraine"
 
@@ -254,17 +338,6 @@ msgstr "Storbritannien"
 #. settings-schema.json->country->options
 msgid "United States of America"
 msgstr "USA"
-
-#. settings-schema.json->region_aus->description
-#. settings-schema.json->region_can->description
-#. settings-schema.json->region_deu->description
-#. settings-schema.json->region_nzl->description
-#. settings-schema.json->region_svk->description
-#. settings-schema.json->region_che->description
-#. settings-schema.json->region_gbr->description
-#. settings-schema.json->region_usa->description
-msgid "Region"
-msgstr "Region"
 
 #. settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
@@ -351,7 +424,7 @@ msgid "Yukon"
 msgstr "Yukon"
 
 #. settings-schema.json->region_deu->options
-msgid "Baden-WÃ¼rttemberg"
+msgid "Baden-Württemberg"
 msgstr "Baden-Württemberg"
 
 #. settings-schema.json->region_deu->options
@@ -387,8 +460,8 @@ msgid "Mecklenburg-Vorpommern"
 msgstr "Mecklenburg-Vorpommern"
 
 #. settings-schema.json->region_deu->options
-msgid "Nordrhein-Westphalen"
-msgstr "Nordrhein-Westphalen"
+msgid "Nordrhein-Westfalen"
+msgstr "Nordrhein-Westfalen"
 
 #. settings-schema.json->region_deu->options
 msgid "Rheinland-Pfalz"
@@ -411,7 +484,7 @@ msgid "Schleswig-Holstein"
 msgstr "Slesvig-holsten"
 
 #. settings-schema.json->region_deu->options
-msgid "ThÃ¼ringen"
+msgid "Thüringen"
 msgstr "Thüringen"
 
 #. settings-schema.json->region_nzl->options
@@ -483,15 +556,15 @@ msgid "Chatham Islands Territory"
 msgstr "Chatham Islands Territory"
 
 #. settings-schema.json->region_svk->options
-msgid "BanskobystrickÃ½ kraj"
+msgid "Banskobystrický kraj"
 msgstr "Banskobystrický kraj"
 
 #. settings-schema.json->region_svk->options
-msgid "BratislavskÃ½ kraj"
+msgid "Bratislavský kraj"
 msgstr "Bratislavský kraj"
 
 #. settings-schema.json->region_svk->options
-msgid "KoÅ¡ickÃ½ kraj"
+msgid "Košický kraj"
 msgstr "Košický kraj"
 
 #. settings-schema.json->region_svk->options
@@ -499,19 +572,19 @@ msgid "Nitriansky kraj"
 msgstr "Nitriansky kraj"
 
 #. settings-schema.json->region_svk->options
-msgid "PreÅ¡ovskÃ½ kraj"
+msgid "Prešovský kraj"
 msgstr "Prešovský kraj"
 
 #. settings-schema.json->region_svk->options
-msgid "TrnavskÃ½ kraj"
+msgid "Trnavský kraj"
 msgstr "Trnavský kraj"
 
 #. settings-schema.json->region_svk->options
-msgid "TrenÄiansky kraj"
+msgid "Trenčiansky kraj"
 msgstr "Trenčiansky kraj"
 
 #. settings-schema.json->region_svk->options
-msgid "Å½ilinskÃ½ kraj"
+msgid "Žilinský kraj"
 msgstr "Žilinský kraj"
 
 #. settings-schema.json->region_che->options
@@ -563,7 +636,7 @@ msgid "Luzern"
 msgstr "Luzern"
 
 #. settings-schema.json->region_che->options
-msgid "NeuchÃ¢tel"
+msgid "Neuchâtel"
 msgstr "Neuchâtel"
 
 #. settings-schema.json->region_che->options
@@ -615,7 +688,7 @@ msgid "Zug"
 msgstr "Zug"
 
 #. settings-schema.json->region_che->options
-msgid "ZÃ¼rich"
+msgid "Zürich"
 msgstr "Zürich"
 
 #. settings-schema.json->region_gbr->options
@@ -838,6 +911,14 @@ msgstr "Wisconsin"
 msgid "Wyoming"
 msgstr "Wyoming"
 
+#. settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr ""
+
+#. settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr ""
+
 #. settings-schema.json->worldclocks->columns->title
 msgid "Display name"
 msgstr "Vist navn"
@@ -845,11 +926,3 @@ msgstr "Vist navn"
 #. settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr "Tidszone"
-
-#. metadata.json->name
-msgid "Calendar with public Holidays"
-msgstr "Kalender med offentlige helligdage"
-
-#. metadata.json->description
-msgid "Calendar applet with public holiday data provided by Enrico service"
-msgstr "Kalender med offentlige helligdage leveret af Enrico"

--- a/calendar@ccprog/files/calendar@ccprog/po/de.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/de.po
@@ -3,8 +3,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: calendar@ccprog VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-31 18:21+0200\n"
-"PO-Revision-Date: 2020-05-25 10:28+0200\n"
+"POT-Creation-Date: 2021-02-27 15:40+0100\n"
+"PO-Revision-Date: 2021-02-27 15:40+0100\n"
 "Last-Translator: Claus Colloseus <ccprog@gmx.de>\n"
 "Language-Team: German\n"
 "Language: de\n"
@@ -12,19 +12,76 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.3\n"
+
+#: applet.js:65
+msgid "Date and Time Settings"
+msgstr "Datums- und Zeiteinstellungen"
+
+#: settings_widgets.py:95
+msgid "Add new entry"
+msgstr "Neuen Eintrag hinzufügen"
+
+#: settings_widgets.py:99
+msgid "Edit entry"
+msgstr "Eintrag bearbeiten"
+
+#. settings-schema.json->region_aus->description
+#. settings-schema.json->region_can->description
+#. settings-schema.json->region_deu->description
+#. settings-schema.json->region_nzl->description
+#. settings-schema.json->region_svk->description
+#. settings-schema.json->region_che->description
+#. settings-schema.json->region_gbr->description
+#. settings-schema.json->region_usa->description
+#: settings_widgets.py:122
+msgid "Region"
+msgstr "Region"
+
+#: settings_widgets.py:123
+msgid "City"
+msgstr "Stadt"
+
+#. metadata.json->name
+msgid "Calendar with public Holidays"
+msgstr "Kalender mit Feiertagen"
+
+#. metadata.json->description
+msgid "Calendar applet with public holiday data provided by Enrico service"
+msgstr "Kalender-Applet mit Feiertagsinformationen vom Enrico Webservice"
+
+#. settings-schema.json->page1->title
+msgid "Calendar"
+msgstr "Kalender"
 
 #. settings-schema.json->page2->title
 #. settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Weltzeituhren"
 
+#. settings-schema.json->section1->title
+msgid "Display"
+msgstr "Darstellung"
+
 #. settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Nutze Feiertage für"
 
+#. settings-schema.json->section3->title
+msgid "Keyboard shortcuts"
+msgstr "Tastenkombinationen"
+
 #. settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Zeige Weltzeiten"
+
+#. settings-schema.json->show-week-numbers->description
+msgid "Show week numbers in calendar"
+msgstr "Wochennummern im Kalender anzeigen"
+
+#. settings-schema.json->show-week-numbers->tooltip
+msgid "Check this to show week numbers in the calendar."
+msgstr "Aktivieren, um Wochennummern im Kalender anzuzeigen."
 
 #. settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
@@ -32,7 +89,9 @@ msgstr "Markiere als Wochenende"
 
 #. settings-schema.json->weekend-length->tooltip
 msgid "Set how many days are marked as non-working days per week."
-msgstr "Stellen Sie ein, wieviele Tage als arbeitsfrei markiert werden sollen"
+msgstr ""
+"Einstellen, wie viele Tage pro Woche als arbeitsfreie Tage markiert werden "
+"sollen."
 
 #. settings-schema.json->weekend-length->options
 msgid "One day"
@@ -41,6 +100,35 @@ msgstr "Ein Tag"
 #. settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Zwei Tage"
+
+#. settings-schema.json->use-custom-format->description
+msgid "Use a custom date format"
+msgstr "Ein benutzerdefiniertes Datumsformat verwenden"
+
+#. settings-schema.json->use-custom-format->tooltip
+msgid ""
+"Check this to define a custom format for the date in the calendar applet."
+msgstr ""
+"Aktivieren, um ein individuelles Datumsformat für die Kalenderanwendung "
+"festzulegen."
+
+#. settings-schema.json->custom-format->description
+msgid "Date format"
+msgstr "Datumsformat"
+
+#. settings-schema.json->custom-format->tooltip
+msgid "Set your custom format here."
+msgstr "Hier können Sie Ihr eigenes Datumsformat festlegen."
+
+#. settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr "Angaben zum Datumsformat anzeigen"
+
+#. settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr ""
+"Auf diesen Knopf klicken, um mehr über die Schreibweise von Datumsformaten "
+"zu erfahren."
 
 #. settings-schema.json->country->description
 msgid "Country"
@@ -136,7 +224,7 @@ msgstr "Irland"
 
 #. settings-schema.json->country->options
 msgid "Isle of Man"
-msgstr ""
+msgstr "Isle of Man"
 
 #. settings-schema.json->country->options
 msgid "Israel"
@@ -232,11 +320,15 @@ msgstr "Südafrika"
 
 #. settings-schema.json->country->options
 msgid "Sweden"
-msgstr ""
+msgstr "Schweden"
 
 #. settings-schema.json->country->options
 msgid "Switzerland"
 msgstr "Schweiz"
+
+#. settings-schema.json->country->options
+msgid "Turkey"
+msgstr "Türkei"
 
 #. settings-schema.json->country->options
 msgid "Ukraine"
@@ -250,588 +342,585 @@ msgstr "Vereinigtes Königreich"
 msgid "United States of America"
 msgstr "Vereinigte Staten von Amerika"
 
-#. settings-schema.json->region_aus->description
-#. settings-schema.json->region_can->description
-#. settings-schema.json->region_deu->description
-#. settings-schema.json->region_nzl->description
-#. settings-schema.json->region_svk->description
-#. settings-schema.json->region_che->description
-#. settings-schema.json->region_gbr->description
-#. settings-schema.json->region_usa->description
-msgid "Region"
-msgstr "Region"
-
 #. settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
-msgstr ""
+msgstr "Australian Capital Territory"
 
 #. settings-schema.json->region_aus->options
 msgid "Queensland"
-msgstr ""
+msgstr "Queensland"
 
 #. settings-schema.json->region_aus->options
 msgid "New South Wales"
-msgstr ""
+msgstr "New South Wales"
 
 #. settings-schema.json->region_aus->options
 msgid "Northern Territory"
-msgstr ""
+msgstr "Northern Territory"
 
 #. settings-schema.json->region_aus->options
 msgid "South Australia"
-msgstr ""
+msgstr "South Australia"
 
 #. settings-schema.json->region_aus->options
 msgid "Tasmania"
-msgstr ""
+msgstr "Tasmanien"
 
 #. settings-schema.json->region_aus->options
 msgid "Victoria"
-msgstr ""
+msgstr "Victoria"
 
 #. settings-schema.json->region_aus->options
 msgid "Western Australia"
-msgstr ""
+msgstr "Western Australia"
 
 #. settings-schema.json->region_can->options
 msgid "Alberta"
-msgstr ""
+msgstr "Alberta"
 
 #. settings-schema.json->region_can->options
 msgid "British Columbia"
-msgstr ""
+msgstr "British Columbia"
 
 #. settings-schema.json->region_can->options
 msgid "Manitoba"
-msgstr ""
+msgstr "Manitoba"
 
 #. settings-schema.json->region_can->options
 msgid "New Brunswick"
-msgstr ""
+msgstr "New Brunswick"
 
 #. settings-schema.json->region_can->options
 msgid "Newfoundland and Labrador"
-msgstr ""
+msgstr "Neufundland und Labrador"
 
 #. settings-schema.json->region_can->options
 msgid "Northwest Territories"
-msgstr ""
+msgstr "Nordwest-Territorien"
 
 #. settings-schema.json->region_can->options
 msgid "Nova Scotia"
-msgstr ""
+msgstr "Nova Scotia"
 
 #. settings-schema.json->region_can->options
 msgid "Nunavut"
-msgstr ""
+msgstr "Nunavut"
 
 #. settings-schema.json->region_can->options
 msgid "Ontario"
-msgstr ""
+msgstr "Ontario"
 
 #. settings-schema.json->region_can->options
 msgid "Prince Edward Island"
-msgstr ""
+msgstr "Prince Edward Island"
 
 #. settings-schema.json->region_can->options
 msgid "Quebec"
-msgstr ""
+msgstr "Québec"
 
 #. settings-schema.json->region_can->options
 msgid "Saskatchewan"
-msgstr ""
+msgstr "Saskatchewan"
 
 #. settings-schema.json->region_can->options
 msgid "Yukon"
-msgstr ""
+msgstr "Yukon"
 
 #. settings-schema.json->region_deu->options
 msgid "Baden-Württemberg"
-msgstr ""
+msgstr "Baden-Württemberg"
 
 #. settings-schema.json->region_deu->options
 msgid "Bayern"
-msgstr ""
+msgstr "Bayern"
 
 #. settings-schema.json->region_deu->options
 msgid "Berlin"
-msgstr ""
+msgstr "Berlin"
 
 #. settings-schema.json->region_deu->options
 msgid "Brandenburg"
-msgstr ""
+msgstr "Brandenburg"
 
 #. settings-schema.json->region_deu->options
 msgid "Bremen"
-msgstr ""
+msgstr "Bremen"
 
 #. settings-schema.json->region_deu->options
 msgid "Hamburg"
-msgstr ""
+msgstr "Hamburg"
 
 #. settings-schema.json->region_deu->options
 msgid "Hessen"
-msgstr ""
+msgstr "Hessen"
 
 #. settings-schema.json->region_deu->options
 msgid "Niedersachsen"
-msgstr ""
+msgstr "Niedersachsen"
 
 #. settings-schema.json->region_deu->options
 msgid "Mecklenburg-Vorpommern"
-msgstr ""
+msgstr "Mecklenburg-Vorpommern"
 
 #. settings-schema.json->region_deu->options
-msgid "Nordrhein-Westphalen"
-msgstr ""
+msgid "Nordrhein-Westfalen"
+msgstr "Nordrhein-Westfalen"
 
 #. settings-schema.json->region_deu->options
 msgid "Rheinland-Pfalz"
-msgstr ""
+msgstr "Rheinland-Pfalz"
 
 #. settings-schema.json->region_deu->options
 msgid "Saarland"
-msgstr ""
+msgstr "Saarland"
 
 #. settings-schema.json->region_deu->options
 msgid "Sachsen"
-msgstr ""
+msgstr "Sachsen"
 
 #. settings-schema.json->region_deu->options
 msgid "Sachsen-Anhalt"
-msgstr ""
+msgstr "Sachsen-Anhalt"
 
 #. settings-schema.json->region_deu->options
 msgid "Schleswig-Holstein"
-msgstr ""
+msgstr "Schleswig-Holstein"
 
 #. settings-schema.json->region_deu->options
 msgid "Thüringen"
-msgstr ""
+msgstr "Thüringen"
 
 #. settings-schema.json->region_nzl->options
 msgid "Auckland"
-msgstr ""
+msgstr "Auckland"
 
 #. settings-schema.json->region_nzl->options
 msgid "Bay of Plenty"
-msgstr ""
+msgstr "Bay of Plenty"
 
 #. settings-schema.json->region_nzl->options
 msgid "Canterbury"
-msgstr ""
+msgstr "Canterbury"
 
 #. settings-schema.json->region_nzl->options
 msgid "Gisborne"
-msgstr ""
+msgstr "Gisborne"
 
 #. settings-schema.json->region_nzl->options
 msgid "Hawke's Bay"
-msgstr ""
+msgstr "Hawke's Bay"
 
 #. settings-schema.json->region_nzl->options
 msgid "Marlborough"
-msgstr ""
+msgstr "Marlborough"
 
 #. settings-schema.json->region_nzl->options
 msgid "Manawatu-Wanganui"
-msgstr ""
+msgstr "Manawatu-Wanganui"
 
 #. settings-schema.json->region_nzl->options
 msgid "Nelson"
-msgstr ""
+msgstr "Nelson"
 
 #. settings-schema.json->region_nzl->options
 msgid "Northland"
-msgstr ""
+msgstr "Northland"
 
 #. settings-schema.json->region_nzl->options
 msgid "Otago"
-msgstr ""
+msgstr "Otago"
 
 #. settings-schema.json->region_nzl->options
 msgid "Southland"
-msgstr ""
+msgstr "Southland"
 
 #. settings-schema.json->region_nzl->options
 msgid "Tasman"
-msgstr ""
+msgstr "Tasman"
 
 #. settings-schema.json->region_nzl->options
 msgid "Taranaki"
-msgstr ""
+msgstr "Taranaki"
 
 #. settings-schema.json->region_nzl->options
 msgid "Waikato"
-msgstr ""
+msgstr "Waikato"
 
 #. settings-schema.json->region_nzl->options
 msgid "Wellington"
-msgstr ""
+msgstr "Wellington"
 
 #. settings-schema.json->region_nzl->options
 msgid "West Coast"
-msgstr ""
+msgstr "West Coast"
 
 #. settings-schema.json->region_nzl->options
 msgid "Chatham Islands Territory"
-msgstr ""
+msgstr "Chatham Islands Territory"
 
 #. settings-schema.json->region_svk->options
 msgid "Banskobystrický kraj"
-msgstr ""
+msgstr "Neusohler Kraj"
 
 #. settings-schema.json->region_svk->options
 msgid "Bratislavský kraj"
-msgstr ""
+msgstr "Bratislavaer Kraj"
 
 #. settings-schema.json->region_svk->options
 msgid "Košický kraj"
-msgstr ""
+msgstr "Kaschauer Kraj"
 
 #. settings-schema.json->region_svk->options
 msgid "Nitriansky kraj"
-msgstr ""
+msgstr "Neutraer Kraj"
 
 #. settings-schema.json->region_svk->options
 msgid "Prešovský kraj"
-msgstr ""
+msgstr "Eperieser Kraj"
 
 #. settings-schema.json->region_svk->options
 msgid "Trnavský kraj"
-msgstr ""
+msgstr "Tyrnauer Kreis"
 
 #. settings-schema.json->region_svk->options
 msgid "Trenčiansky kraj"
-msgstr ""
+msgstr "Trentschiner Kraj"
 
 #. settings-schema.json->region_svk->options
 msgid "Žilinský kraj"
-msgstr ""
+msgstr "Silleiner Kraj"
 
 #. settings-schema.json->region_che->options
 msgid "Aargau"
-msgstr ""
+msgstr "Kanton Aargau"
 
 #. settings-schema.json->region_che->options
 msgid "Appenzell Innerrhoden"
-msgstr ""
+msgstr "Kanton Appenzell Innerrhoden"
 
 #. settings-schema.json->region_che->options
 msgid "Appenzell Ausserrhoden"
-msgstr ""
+msgstr "Kanton Appenzell Ausserrhoden"
 
 #. settings-schema.json->region_che->options
 msgid "Basel-Landschaft"
-msgstr ""
+msgstr "Kanton Basel-Landschaft"
 
 #. settings-schema.json->region_che->options
 msgid "Basel-Stadt"
-msgstr ""
+msgstr "Kanton Basel-Stadt"
 
 #. settings-schema.json->region_che->options
 msgid "Bern"
-msgstr ""
+msgstr "Kanton Bern"
 
 #. settings-schema.json->region_che->options
 msgid "Fribourg"
-msgstr ""
+msgstr "Kanton Freiburg"
 
 #. settings-schema.json->region_che->options
 msgid "Geneva"
-msgstr ""
+msgstr "Kanton Genf"
 
 #. settings-schema.json->region_che->options
 msgid "Glarus"
-msgstr ""
+msgstr "Kanton Glarus"
 
 #. settings-schema.json->region_che->options
 msgid "Grisons"
-msgstr ""
+msgstr "Kanton Graubünden"
 
 #. settings-schema.json->region_che->options
 msgid "Jura"
-msgstr ""
+msgstr "Kanton Jura"
 
 #. settings-schema.json->region_che->options
 msgid "Luzern"
-msgstr ""
+msgstr "Kanton Luzern"
 
 #. settings-schema.json->region_che->options
 msgid "Neuchâtel"
-msgstr ""
+msgstr "Kanton Neuenburg"
 
 #. settings-schema.json->region_che->options
 msgid "Nidwalden"
-msgstr ""
+msgstr "Kanton Nidwalden"
 
 #. settings-schema.json->region_che->options
 msgid "Obwalden"
-msgstr ""
+msgstr "Kanton Obwalden"
 
 #. settings-schema.json->region_che->options
 msgid "St. Gallen"
-msgstr ""
+msgstr "Kanton St. Gallen"
 
 #. settings-schema.json->region_che->options
 msgid "Schaffhausen"
-msgstr ""
+msgstr "Kanton Schaffhausen"
 
 #. settings-schema.json->region_che->options
 msgid "Schwyz"
-msgstr ""
+msgstr "Kanton Schwyz"
 
 #. settings-schema.json->region_che->options
 msgid "Solothurn"
-msgstr ""
+msgstr "Kanton Solothurn"
 
 #. settings-schema.json->region_che->options
 msgid "Thurgau"
-msgstr ""
+msgstr "Kanton Thurgau"
 
 #. settings-schema.json->region_che->options
 msgid "Ticino"
-msgstr ""
+msgstr "Kanton Tessin"
 
 #. settings-schema.json->region_che->options
 msgid "Uri"
-msgstr ""
+msgstr "Kanton Uri"
 
 #. settings-schema.json->region_che->options
 msgid "Valais"
-msgstr ""
+msgstr "Kanton Wallis"
 
 #. settings-schema.json->region_che->options
 msgid "Vaud"
-msgstr ""
+msgstr "Kanton Waadt"
 
 #. settings-schema.json->region_che->options
 msgid "Zug"
-msgstr ""
+msgstr "Kanton Zug"
 
 #. settings-schema.json->region_che->options
 msgid "Zürich"
-msgstr ""
+msgstr "Kanton Zürich"
 
 #. settings-schema.json->region_gbr->options
 msgid "England"
-msgstr ""
+msgstr "England"
 
 #. settings-schema.json->region_gbr->options
 msgid "Northern Ireland"
-msgstr ""
+msgstr "Nordirland"
 
 #. settings-schema.json->region_gbr->options
 msgid "Scotland"
-msgstr ""
+msgstr "Schottland"
 
 #. settings-schema.json->region_gbr->options
 msgid "Wales"
-msgstr ""
+msgstr "Wales"
 
 #. settings-schema.json->region_usa->options
 msgid "Alabama"
-msgstr ""
+msgstr "Alabama"
 
 #. settings-schema.json->region_usa->options
 msgid "Alaska"
-msgstr ""
+msgstr "Alaska"
 
 #. settings-schema.json->region_usa->options
 msgid "Arizona"
-msgstr ""
+msgstr "Arizona"
 
 #. settings-schema.json->region_usa->options
 msgid "Arkansas"
-msgstr ""
+msgstr "Arkansas"
 
 #. settings-schema.json->region_usa->options
 msgid "California"
-msgstr ""
+msgstr "Kalifornien"
 
 #. settings-schema.json->region_usa->options
 msgid "Colorado"
-msgstr ""
+msgstr "Colorado"
 
 #. settings-schema.json->region_usa->options
 msgid "Connecticut"
-msgstr ""
+msgstr "Connecticut"
 
 #. settings-schema.json->region_usa->options
 msgid "Delaware"
-msgstr ""
+msgstr "Delaware"
 
 #. settings-schema.json->region_usa->options
 msgid "District of Columbia"
-msgstr ""
+msgstr "Washington, D.C."
 
 #. settings-schema.json->region_usa->options
 msgid "Florida"
-msgstr ""
+msgstr "Florida"
 
 #. settings-schema.json->region_usa->options
 msgid "Georgia"
-msgstr ""
+msgstr "Georgia"
 
 #. settings-schema.json->region_usa->options
 msgid "Hawaii"
-msgstr ""
+msgstr "Hawaii"
 
 #. settings-schema.json->region_usa->options
 msgid "Idaho"
-msgstr ""
+msgstr "Idaho"
 
 #. settings-schema.json->region_usa->options
 msgid "Illinois"
-msgstr ""
+msgstr "Illinois"
 
 #. settings-schema.json->region_usa->options
 msgid "Indiana"
-msgstr ""
+msgstr "Indiana"
 
 #. settings-schema.json->region_usa->options
 msgid "Iowa"
-msgstr ""
+msgstr "Iowa"
 
 #. settings-schema.json->region_usa->options
 msgid "Kansas"
-msgstr ""
+msgstr "Kansas"
 
 #. settings-schema.json->region_usa->options
 msgid "Kentucky"
-msgstr ""
+msgstr "Kentucky"
 
 #. settings-schema.json->region_usa->options
 msgid "Louisiana"
-msgstr ""
+msgstr "Louisiana"
 
 #. settings-schema.json->region_usa->options
 msgid "Maine"
-msgstr ""
+msgstr "Maine"
 
 #. settings-schema.json->region_usa->options
 msgid "Maryland"
-msgstr ""
+msgstr "Maryland"
 
 #. settings-schema.json->region_usa->options
 msgid "Massachusetts"
-msgstr ""
+msgstr "Massachusetts"
 
 #. settings-schema.json->region_usa->options
 msgid "Michigan"
-msgstr ""
+msgstr "Michigan"
 
 #. settings-schema.json->region_usa->options
 msgid "Minnesota"
-msgstr ""
+msgstr "Minnesota"
 
 #. settings-schema.json->region_usa->options
 msgid "Mississippi"
-msgstr ""
+msgstr "Mississippi"
 
 #. settings-schema.json->region_usa->options
 msgid "Missouri"
-msgstr ""
+msgstr "Missouri"
 
 #. settings-schema.json->region_usa->options
 msgid "Montana"
-msgstr ""
+msgstr "Montana"
 
 #. settings-schema.json->region_usa->options
 msgid "Nebraska"
-msgstr ""
+msgstr "Nebraska"
 
 #. settings-schema.json->region_usa->options
 msgid "Nevada"
-msgstr ""
+msgstr "Nevada"
 
 #. settings-schema.json->region_usa->options
 msgid "New Hampshire"
-msgstr ""
+msgstr "New Hampshire"
 
 #. settings-schema.json->region_usa->options
 msgid "New Jersey"
-msgstr ""
+msgstr "New Jersey"
 
 #. settings-schema.json->region_usa->options
 msgid "New Mexico"
-msgstr ""
+msgstr "New Mexico"
 
 #. settings-schema.json->region_usa->options
 msgid "New York"
-msgstr ""
+msgstr "New York"
 
 #. settings-schema.json->region_usa->options
 msgid "North Carolina"
-msgstr ""
+msgstr "North Carolina"
 
 #. settings-schema.json->region_usa->options
 msgid "North Dakota"
-msgstr ""
+msgstr "North Dakota"
 
 #. settings-schema.json->region_usa->options
 msgid "Ohio"
-msgstr ""
+msgstr "Ohio"
 
 #. settings-schema.json->region_usa->options
 msgid "Oklahoma"
-msgstr ""
+msgstr "Oklahoma"
 
 #. settings-schema.json->region_usa->options
 msgid "Oregon"
-msgstr ""
+msgstr "Oregon"
 
 #. settings-schema.json->region_usa->options
 msgid "Pennsylvania"
-msgstr ""
+msgstr "Pennsylvania"
 
 #. settings-schema.json->region_usa->options
 msgid "Rhode Island"
-msgstr ""
+msgstr "Rhode Island"
 
 #. settings-schema.json->region_usa->options
 msgid "South Carolina"
-msgstr ""
+msgstr "South Carolina"
 
 #. settings-schema.json->region_usa->options
 msgid "South Dakota"
-msgstr ""
+msgstr "South Dakota"
 
 #. settings-schema.json->region_usa->options
 msgid "Tennessee"
-msgstr ""
+msgstr "Tennessee"
 
 #. settings-schema.json->region_usa->options
 msgid "Texas"
-msgstr ""
+msgstr "Texas"
 
 #. settings-schema.json->region_usa->options
 msgid "Utah"
-msgstr ""
+msgstr "Utah"
 
 #. settings-schema.json->region_usa->options
 msgid "Vermont"
-msgstr ""
+msgstr "Vermont"
 
 #. settings-schema.json->region_usa->options
 msgid "Virginia"
-msgstr ""
+msgstr "Virginia"
 
 #. settings-schema.json->region_usa->options
 msgid "Washington"
-msgstr ""
+msgstr "Washington"
 
 #. settings-schema.json->region_usa->options
 msgid "West Virginia"
-msgstr ""
+msgstr "West Virginia"
 
 #. settings-schema.json->region_usa->options
 msgid "Wisconsin"
-msgstr ""
+msgstr "Wisconsin"
 
 #. settings-schema.json->region_usa->options
 msgid "Wyoming"
-msgstr ""
+msgstr "Wyoming"
+
+#. settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr "Kalender anzeigen"
+
+#. settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr "Tastenkombination(en) festlegen, um den Kalender anzuzeigen."
 
 #. settings-schema.json->worldclocks->columns->title
 msgid "Display name"
@@ -840,11 +929,3 @@ msgstr "Anzeigename"
 #. settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr "Zeitzone"
-
-#. metadata.json->name
-msgid "Calendar with public Holidays"
-msgstr "Kalender mit Feiertagen"
-
-#. metadata.json->description
-msgid "Calendar applet with public holiday data provided by Enrico service"
-msgstr "Kalender-Applet mit Feiertagsinformationen vom Enrico Webservice"

--- a/calendar@ccprog/files/calendar@ccprog/po/fr.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/fr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-31 18:21+0200\n"
+"POT-Creation-Date: 2021-02-27 15:40+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: FabRCT <fab.rct@gmail.com>\n"
 "Language-Team: \n"
@@ -11,21 +11,79 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.6\n"
+"X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: applet.js:65
+msgid "Date and Time Settings"
+msgstr ""
+
+#: settings_widgets.py:95
+msgid "Add new entry"
+msgstr ""
+
+#: settings_widgets.py:99
+msgid "Edit entry"
+msgstr ""
+
+#. settings-schema.json->region_aus->description
+#. settings-schema.json->region_can->description
+#. settings-schema.json->region_deu->description
+#. settings-schema.json->region_nzl->description
+#. settings-schema.json->region_svk->description
+#. settings-schema.json->region_che->description
+#. settings-schema.json->region_gbr->description
+#. settings-schema.json->region_usa->description
+#: settings_widgets.py:122
+msgid "Region"
+msgstr "Région"
+
+#: settings_widgets.py:123
+msgid "City"
+msgstr ""
+
+#. metadata.json->name
+msgid "Calendar with public Holidays"
+msgstr "Calendrier avec jours fériés"
+
+#. metadata.json->description
+msgid "Calendar applet with public holiday data provided by Enrico service"
+msgstr ""
+"Applet de calendrier avec données de jours fériés fournies par le service "
+"Enrico"
+
+#. settings-schema.json->page1->title
+msgid "Calendar"
+msgstr ""
 
 #. settings-schema.json->page2->title
 #. settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Horloges mondiales"
 
+#. settings-schema.json->section1->title
+msgid "Display"
+msgstr ""
+
 #. settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Obtenez les jours fériés pour"
 
+#. settings-schema.json->section3->title
+msgid "Keyboard shortcuts"
+msgstr ""
+
 #. settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Afficher les heures mondiales"
+
+#. settings-schema.json->show-week-numbers->description
+msgid "Show week numbers in calendar"
+msgstr ""
+
+#. settings-schema.json->show-week-numbers->tooltip
+msgid "Check this to show week numbers in the calendar."
+msgstr ""
 
 #. settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
@@ -43,6 +101,31 @@ msgstr "Un jour"
 #. settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Deux jours"
+
+#. settings-schema.json->use-custom-format->description
+msgid "Use a custom date format"
+msgstr ""
+
+#. settings-schema.json->use-custom-format->tooltip
+msgid ""
+"Check this to define a custom format for the date in the calendar applet."
+msgstr ""
+
+#. settings-schema.json->custom-format->description
+msgid "Date format"
+msgstr ""
+
+#. settings-schema.json->custom-format->tooltip
+msgid "Set your custom format here."
+msgstr ""
+
+#. settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr ""
+
+#. settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr ""
 
 #. settings-schema.json->country->description
 msgid "Country"
@@ -241,6 +324,10 @@ msgid "Switzerland"
 msgstr "Suisse"
 
 #. settings-schema.json->country->options
+msgid "Turkey"
+msgstr ""
+
+#. settings-schema.json->country->options
 msgid "Ukraine"
 msgstr "Ukraine"
 
@@ -251,17 +338,6 @@ msgstr "Royaume-Uni"
 #. settings-schema.json->country->options
 msgid "United States of America"
 msgstr "États-Unis d'Amérique"
-
-#. settings-schema.json->region_aus->description
-#. settings-schema.json->region_can->description
-#. settings-schema.json->region_deu->description
-#. settings-schema.json->region_nzl->description
-#. settings-schema.json->region_svk->description
-#. settings-schema.json->region_che->description
-#. settings-schema.json->region_gbr->description
-#. settings-schema.json->region_usa->description
-msgid "Region"
-msgstr "Région"
 
 #. settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
@@ -384,7 +460,7 @@ msgid "Mecklenburg-Vorpommern"
 msgstr "Mecklembourg-Poméranie-Occidentale"
 
 #. settings-schema.json->region_deu->options
-msgid "Nordrhein-Westphalen"
+msgid "Nordrhein-Westfalen"
 msgstr "Rhénanie-du-Nord-Westphalie"
 
 #. settings-schema.json->region_deu->options
@@ -835,6 +911,14 @@ msgstr "Wisconsin"
 msgid "Wyoming"
 msgstr "Wyoming"
 
+#. settings-schema.json->keyOpen->description
+msgid "Show calendar"
+msgstr ""
+
+#. settings-schema.json->keyOpen->tooltip
+msgid "Set keybinding(s) to show the calendar."
+msgstr ""
+
 #. settings-schema.json->worldclocks->columns->title
 msgid "Display name"
 msgstr "Nom affiché"
@@ -842,13 +926,3 @@ msgstr "Nom affiché"
 #. settings-schema.json->worldclocks->columns->title
 msgid "Timezone"
 msgstr "Fuseau horaire"
-
-#. metadata.json->name
-msgid "Calendar with public Holidays"
-msgstr "Calendrier avec jours fériés"
-
-#. metadata.json->description
-msgid "Calendar applet with public holiday data provided by Enrico service"
-msgstr ""
-"Applet de calendrier avec données de jours fériés fournies par le service "
-"Enrico"

--- a/calendar@ccprog/files/calendar@ccprog/po/makepot
+++ b/calendar@ccprog/files/calendar@ccprog/po/makepot
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cd ..
+uuid="calendar@ccprog"
+
+cinnamon-xlet-makepot --potfile po/$uuid.pot .
+
+# We need to set UTF-8 charset in the .pot file,
+# since there are unicode characters in the settings schema file,
+# e.g. German umlauts, which else are shown wrong in .po files. 
+sed -i 's/charset=CHARSET/charset=UTF-8/g' po/$uuid.pot

--- a/calendar@ccprog/files/calendar@ccprog/po/sv.po
+++ b/calendar@ccprog/files/calendar@ccprog/po/sv.po
@@ -7,29 +7,85 @@ msgid ""
 msgstr ""
 "Project-Id-Version: calendar@ccprog\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-31 18:21+0200\n"
-"PO-Revision-Date: 2021-01-05 09:31+0100\n"
+"POT-Creation-Date: 2021-02-27 15:40+0100\n"
+"PO-Revision-Date: 2021-02-27 16:18+0100\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.6\n"
+"X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applet.js:65
+msgid "Date and Time Settings"
+msgstr ""
+
+#: settings_widgets.py:95
+msgid "Add new entry"
+msgstr ""
+
+#: settings_widgets.py:99
+msgid "Edit entry"
+msgstr ""
+
+#. settings-schema.json->region_aus->description
+#. settings-schema.json->region_can->description
+#. settings-schema.json->region_deu->description
+#. settings-schema.json->region_nzl->description
+#. settings-schema.json->region_svk->description
+#. settings-schema.json->region_che->description
+#. settings-schema.json->region_gbr->description
+#. settings-schema.json->region_usa->description
+#: settings_widgets.py:122
+msgid "Region"
+msgstr "Region"
+
+#: settings_widgets.py:123
+msgid "City"
+msgstr ""
+
+#. metadata.json->name
+msgid "Calendar with public Holidays"
+msgstr "Kalender med allmänna helgdagar"
+
+#. metadata.json->description
+msgid "Calendar applet with public holiday data provided by Enrico service"
+msgstr "Kalenderprogram med helgdagsuppgifter från Enrico-tjänsten"
+
+#. settings-schema.json->page1->title
+msgid "Calendar"
+msgstr ""
 
 #. settings-schema.json->page2->title
 #. settings-schema.json->worldclocks->description
 msgid "World Clocks"
 msgstr "Världsklockor"
 
+#. settings-schema.json->section1->title
+msgid "Display"
+msgstr ""
+
 #. settings-schema.json->section2->title
 msgid "Get Public Holidays for"
 msgstr "Hämta allmänna helgdagar för"
 
+#. settings-schema.json->section3->title
+msgid "Keyboard shortcuts"
+msgstr ""
+
 #. settings-schema.json->section4->title
 msgid "Show World Times"
 msgstr "Visa världstider"
+
+#. settings-schema.json->show-week-numbers->description
+msgid "Show week numbers in calendar"
+msgstr ""
+
+#. settings-schema.json->show-week-numbers->tooltip
+msgid "Check this to show week numbers in the calendar."
+msgstr ""
 
 #. settings-schema.json->weekend-length->description
 msgid "Mark as weekend days"
@@ -46,6 +102,30 @@ msgstr "En dag"
 #. settings-schema.json->weekend-length->options
 msgid "Two days"
 msgstr "Två dagar"
+
+#. settings-schema.json->use-custom-format->description
+msgid "Use a custom date format"
+msgstr ""
+
+#. settings-schema.json->use-custom-format->tooltip
+msgid "Check this to define a custom format for the date in the calendar applet."
+msgstr ""
+
+#. settings-schema.json->custom-format->description
+msgid "Date format"
+msgstr ""
+
+#. settings-schema.json->custom-format->tooltip
+msgid "Set your custom format here."
+msgstr ""
+
+#. settings-schema.json->format-button->description
+msgid "Show information on date format syntax"
+msgstr ""
+
+#. settings-schema.json->format-button->tooltip
+msgid "Click this button to know more about the syntax for date formats."
+msgstr ""
 
 #. settings-schema.json->country->description
 msgid "Country"
@@ -244,6 +324,10 @@ msgid "Switzerland"
 msgstr "Schweiz"
 
 #. settings-schema.json->country->options
+msgid "Turkey"
+msgstr ""
+
+#. settings-schema.json->country->options
 msgid "Ukraine"
 msgstr "Ukraina"
 
@@ -254,17 +338,6 @@ msgstr "Storbritannien"
 #. settings-schema.json->country->options
 msgid "United States of America"
 msgstr "Amerikas förenta stater"
-
-#. settings-schema.json->region_aus->description
-#. settings-schema.json->region_can->description
-#. settings-schema.json->region_deu->description
-#. settings-schema.json->region_nzl->description
-#. settings-schema.json->region_svk->description
-#. settings-schema.json->region_che->description
-#. settings-schema.json->region_gbr->description
-#. settings-schema.json->region_usa->description
-msgid "Region"
-msgstr "Region"
 
 #. settings-schema.json->region_aus->options
 msgid "Australian Capital Territory"
@@ -351,7 +424,7 @@ msgid "Yukon"
 msgstr ""
 
 #. settings-schema.json->region_deu->options
-msgid "Baden-WÃ¼rttemberg"
+msgid "Baden-Württemberg"
 msgstr ""
 
 #. settings-schema.json->region_deu->options
@@ -387,7 +460,7 @@ msgid "Mecklenburg-Vorpommern"
 msgstr ""
 
 #. settings-schema.json->region_deu->options
-msgid "Nordrhein-Westphalen"
+msgid "Nordrhein-Westfalen"
 msgstr ""
 
 #. settings-schema.json->region_deu->options
@@ -411,7 +484,7 @@ msgid "Schleswig-Holstein"
 msgstr ""
 
 #. settings-schema.json->region_deu->options
-msgid "ThÃ¼ringen"
+msgid "Thüringen"
 msgstr ""
 
 #. settings-schema.json->region_nzl->options
@@ -483,15 +556,15 @@ msgid "Chatham Islands Territory"
 msgstr ""
 
 #. settings-schema.json->region_svk->options
-msgid "BanskobystrickÃ½ kraj"
+msgid "Banskobystrický kraj"
 msgstr ""
 
 #. settings-schema.json->region_svk->options
-msgid "BratislavskÃ½ kraj"
+msgid "Bratislavský kraj"
 msgstr ""
 
 #. settings-schema.json->region_svk->options
-msgid "KoÅ¡ickÃ½ kraj"
+msgid "Košický kraj"
 msgstr ""
 
 #. settings-schema.json->region_svk->options
@@ -499,19 +572,19 @@ msgid "Nitriansky kraj"
 msgstr ""
 
 #. settings-schema.json->region_svk->options
-msgid "PreÅ¡ovskÃ½ kraj"
+msgid "Prešovský kraj"
 msgstr ""
 
 #. settings-schema.json->region_svk->options
-msgid "TrnavskÃ½ kraj"
+msgid "Trnavský kraj"
 msgstr ""
 
 #. settings-schema.json->region_svk->options
-msgid "TrenÄiansky kraj"
+msgid "Trenčiansky kraj"
 msgstr ""
 
 #. settings-schema.json->region_svk->options
-msgid "Å½ilinskÃ½ kraj"
+msgid "Žilinský kraj"
 msgstr ""
 
 #. settings-schema.json->region_che->options
@@ -563,7 +636,7 @@ msgid "Luzern"
 msgstr ""
 
 #. settings-schema.json->region_che->options
-msgid "NeuchÃ¢tel"
+msgid "Neuchâtel"
 msgstr ""
 
 #. settings-schema.json->region_che->options
@@ -615,7 +688,7 @@ msgid "Zug"
 msgstr ""
 
 #. settings-schema.json->region_che->options
-msgid "ZÃ¼rich"
+msgid "Zürich"
 msgstr ""
 
 #. settings-schema.json->region_gbr->options
@@ -838,14 +911,6 @@ msgstr ""
 msgid "Wyoming"
 msgstr ""
 
-#. settings-schema.json->worldclocks->columns->title
-msgid "Display name"
-msgstr "Visningsnamn"
-
-#. settings-schema.json->worldclocks->columns->title
-msgid "Timezone"
-msgstr "Tidszon"
-
 #. settings-schema.json->keyOpen->description
 msgid "Show calendar"
 msgstr "Visa kalender"
@@ -854,10 +919,10 @@ msgstr "Visa kalender"
 msgid "Set keybinding(s) to show the calendar."
 msgstr "Ange snabbtangent(er) för att visa kalendern."
 
-#. metadata.json->name
-msgid "Calendar with public Holidays"
-msgstr "Kalender med allmänna helgdagar"
+#. settings-schema.json->worldclocks->columns->title
+msgid "Display name"
+msgstr "Visningsnamn"
 
-#. metadata.json->description
-msgid "Calendar applet with public holiday data provided by Enrico service"
-msgstr "Kalenderprogram med helgdagsuppgifter från Enrico-tjänsten"
+#. settings-schema.json->worldclocks->columns->title
+msgid "Timezone"
+msgstr "Tidszon"

--- a/calendar@ccprog/files/calendar@ccprog/settings-schema.json
+++ b/calendar@ccprog/files/calendar@ccprog/settings-schema.json
@@ -224,7 +224,7 @@
             "Hessen": "he",
             "Niedersachsen": "ni",
             "Mecklenburg-Vorpommern": "mv",
-            "Nordrhein-Westphalen": "nw",
+            "Nordrhein-Westfalen": "nw",
             "Rheinland-Pfalz": "rp",
             "Saarland": "sl",
             "Sachsen": "sn",
@@ -391,8 +391,7 @@
         "description": "World Clocks",
         "file": "settings_widgets.py",
         "widget": "ClocksList",
-        "columns": [
-            {
+        "columns": [{
                 "id": "label",
                 "title": "Display name",
                 "type": "string"

--- a/calendar@ccprog/files/calendar@ccprog/settings_widgets.py
+++ b/calendar@ccprog/files/calendar@ccprog/settings_widgets.py
@@ -4,6 +4,11 @@ from JsonSettingsWidgets import JSONSettingsList
 from xapp.SettingsWidgets import ComboBox, Entry
 import pytz
 from gi.repository import Gtk
+import gettext
+from pathlib import Path
+
+# i18n
+gettext.install("calendar@ccprog", str(Path.home()) + "/.local/share/locale")
 
 TZ_NO_REGION = 'Etc'
 
@@ -114,8 +119,8 @@ class ClocksList(JSONSettingsList):
 
         columns = [
             self.settings.get_property('worldclocks', 'columns')[0],
-            {"id": "region", "title": "Region", "options": self.region_list},
-            {"id": "city", "title": "City", "options": self.region_map[data['region']]}
+            {"id": "region", "title": _("Region"), "options": self.region_list},
+            {"id": "city", "title": _("City"), "options": self.region_map[data['region']]}
         ]
 
         widgets = {}


### PR DESCRIPTION
Add makepot to fix unicode characters in .pot file
Update .pot file
Update German translation

Update other l10n files against new .pot:
The other translation files did contain the broken unicode characters as
well. Fix by updating against new .pot file.

@ccprog 