### PR TITLE
applet.js: Remove the idle callback when updating the graphs.

### DIFF
--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/applet.js
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/applet.js
@@ -326,7 +326,8 @@ GraphicalHWMonitorApplet.prototype = {
     },
 
     update: function() {
-        Mainloop.idle_add_full(Mainloop.PRIORITY_LOW, () => this._update());
+        this._update();
+
         return this.shouldUpdate;
     },
 


### PR DESCRIPTION
This was added as part of this commit:
https://github.com/linuxmint/cinnamon-spices-applets/commit/0195a9d776d22b7cf4c6269a3edc7dcc6188179a

There is a danger to this, which manifests randomly and crashes cinnamon.  Scenario:

- Applet is in a timed loop (Mainloop.timeout_add_seconds)
- Each time the callback for this loop is called, the true update
  is setup on an idle callback. Note: idle callbacks are never
  guaranteed to run within any particular timeframe.
- The idle callback is made, and the graphs update.

When the system is not too busy, this is fine. But when there is a lot
of activity with the cpu, disk i/o, etc... those idle callbacks can
be delayed, and will end up accumulating until finally they all run
immediately one after the other.

The cpu provider uses libgtop to get cpu stats - this ends up reading
/proc/stat (one after the other) - if it's unable to read the file
(it may be locked) then cinnamon crashes.

Remove the idle callback, and just update on the original timer. I
think there's always danger here since it's a race condition, but
much less of one than the current situataion.


sorry for the wordiness..