### PR TITLE
ShellTools@abgoyal: Fixes error that causes applet not to load.

### DIFF
--- a/ShellTools@abgoyal/files/ShellTools@abgoyal/applet.js
+++ b/ShellTools@abgoyal/files/ShellTools@abgoyal/applet.js
@@ -100,7 +100,7 @@ MyApplet.prototype = {
             this._contentSection = new PopupMenu.PopupMenuSection();
             this.menu.addMenuItem(this._contentSection);
 
-            tools = eval(Cinnamon.get_file_contents_utf8_sync(f));
+            let tools = eval(Cinnamon.get_file_contents_utf8_sync(f));
 
             for (let i = 0; i < tools.length; i++) {
                 let tool = tools[i];


### PR DESCRIPTION
A variable not being initialized stopped the applet from loading.

@brownsr @NikoKrause 