### PR TITLE
MessagingMenuV3@blub: Update Application Support, added support for unsupported and updated applications

### DIFF
--- a/MessagingMenuV3@blub/files/MessagingMenuV3@blub/applet.js
+++ b/MessagingMenuV3@blub/files/MessagingMenuV3@blub/applet.js
@@ -21,10 +21,10 @@ function _(str) {
 /* global values */
 let icon_path = "/usr/share/cinnamon/theme/";
 
-let compatible_Apps = ["skype", "skypeforlinux", "pidgin", "empathy", "xchat", "kmess", "gajim", "emesene", "qutim", "amsn", "openfetion", "gwibber", "qwit", "turpial", "birdie", "pino", "slack", "fbmessenger", "fbmessengerdesktop", "telegramdesktop", "whatsdesk", "whatsie"];
-let compatible_Emails = ["evolution", "postler", "geary", "thunderbird", "KMail2", "claws-mail"];
-let compose_Commands = ["evolution mailto:", "postler mailto:", "geary mailto:", "thunderbird -compose", "kmail -compose", "claws-mail --compose"];
-let contact_Commands = ["evolution -c contacts", null, null, "thunderbird -addressbook", null, null];
+let compatible_Apps = ["caprine", "discord", "skype", "skypeforlinux", "teams", "pidgin", "empathy", "xchat", "kmess", "gajim", "emesene", "qutim", "amsn", "openfetion", "gwibber", "qwit", "turpial", "birdie", "pino", "slack", "fbmessenger", "fbmessengerdesktop", "telegramdesktop", "whatsdesk", "whatsie", "Zoom", "org.gnome.Contacts"];
+let compatible_Emails = ["evolution", "org.gnome.Evolution", "postler", "geary", "org.gnome.Geary", "thunderbird", "KMail2", "claws-mail"];
+let compose_Commands = ["evolution mailto:", "evolution mailto:", "postler mailto:", "geary mailto:", "geary mailto:", "thunderbird -compose", "kmail -compose", "claws-mail --compose"];
+let contact_Commands = ["evolution -c contacts", "evolution -c contacts", null, null, null, "thunderbird -addressbook", null, null];
 
 const ICON_SIZE = 22;
 


### PR DESCRIPTION
Current version of Messaging Menu V3 is missing support for newer messaging applications, and older applications that used to be supported no longer show up in the menu (specifically Geary and Evolution). I've kept in the older geary and evolution ID's as well as the newer org.gnome.* versions in case this is used on older systems that might still support the older applications.