### PR TITLE
[Cinnamenu@json] Fix search delay bug

### DIFF
--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/applet.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/applet.js
@@ -54,7 +54,7 @@ class CinnamenuApplet extends TextIconApplet {
         this.signals = new SignalManager(null);
         this.appSystem = Cinnamon.AppSystem.get_default();
         const searchFilesMenuItem = new PopupIconMenuItem(_('Find files...'), 'system-search',
-                                                                            St.IconType.SYMBOLIC, false);
+                                                                        St.IconType.SYMBOLIC, false);
         this._applet_context_menu.addMenuItem(searchFilesMenuItem);
         searchFilesMenuItem.connect('activate', () => {
                             Util.spawnCommandLine(__meta.path + '/search.py ' + GLib.get_home_dir()); });
@@ -65,11 +65,11 @@ class CinnamenuApplet extends TextIconApplet {
                                                 () => this.settings.customMenuWidth,
                                                 () => this.settings.customMenuHeight);
         this.signals.connect(this.privacy_settings, 'changed::' + REMEMBER_RECENT_KEY, () => {
-                                this.recentsEnabled = this.privacy_settings.get_boolean(REMEMBER_RECENT_KEY);
-                                this.categoriesView.update();
-                                if (this.currentCategory === 'recents' && !this.recentsEnabled) {
-                                    this.currentCategory = 'all';
-                                } });
+                        this.recentsEnabled = this.privacy_settings.get_boolean(REMEMBER_RECENT_KEY);
+                        this.categoriesView.update();
+                        if (this.currentCategory === 'recents' && !this.recentsEnabled) {
+                            this.currentCategory = 'all';
+                        } });
         this.signals.connect(Main.themeManager, 'theme-set', () => {this._updateIconAndLabel();
                                                                     setTimeout(() => this._refresh()); });
         this.iconTheme = Gtk.IconTheme.get_default();
@@ -77,13 +77,13 @@ class CinnamenuApplet extends TextIconApplet {
         this.signals.connect(this.appSystem, 'installed-changed', () => {   this.apps.installedChanged();
                                                                             this._refresh(); });
         this.signals.connect(this.appFavorites, 'changed', () => {
-                                if (this.appsView) {// Check if the menu has been rendered at least once
-                                    this.sidebar.populate();
-                                    this.updateMenuSize();
-                                    if (this.currentCategory === 'favorite_apps' && !this.searchActive) {
-                                        this.setActiveCategory(this.currentCategory);
-                                    }
-                                } });
+                        if (this.appsView) {// Check if the menu has been rendered at least once
+                            this.sidebar.populate();
+                            this.updateMenuSize();
+                            if (this.currentCategory === 'favorite_apps' && !this.searchActive) {
+                                this.setActiveCategory(this.currentCategory);
+                            }
+                        } });
         this.signals.connect(this.menu, 'open-state-changed', (...args) => this._onOpenStateToggled(...args));
         //this.signals.connect(global, 'scale-changed', () => this._refresh() );
         this.apps = new Apps(this);
@@ -1140,7 +1140,7 @@ class CinnamenuApplet extends TextIconApplet {
                         }
 
                         //Enter subdirectories
-                        if (isDirectory && depth < 4 && !next.get_is_hidden() && filesSearched < 10000) {
+                        if (isDirectory && depth < 4 && !next.get_is_hidden() && recursionCount < 50) {
                             recursionCount++;
                             setTimeout(() => searchDir(filePath, pattern, depth + 1, thisSearchId));
                         }

--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/buttons.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/buttons.js
@@ -19,6 +19,15 @@ const {_, wordWrap, getThumbnail_gicon, showTooltip, hideTooltipIfVisible} = req
 const {MODABLE, MODED} = require('./emoji');
 const PlacementTOOLTIP = 1, PlacementUNDER = 2, PlacementNONE = 3;
 
+function lightenOrDarkenColor(col) { //lighten a dark color or darken a light color
+    const isLightTheme = (col.red + col.green + col.blue) > 364;
+    const amt = isLightTheme ? -15 : 15;
+    col.red += amt;
+    col.green += amt;
+    col.blue += amt;
+    return col;
+}
+
 class CategoryButton {
     constructor(appThis, category_id, category_name, icon_name, gicon) {
         this.appThis = appThis;
@@ -706,13 +715,6 @@ class AppButton {
         const toRgbaString = (col) => {
                 const decPlaces2 = (n) => Math.round(n * 100) / 100;
                 return `rgba(${col.red},${col.green},${col.blue},${decPlaces2(col.alpha / 255)})`; };
-        const lightenOrDarkenColor = (col) => { //lighten dark color or darken light color
-                    const isLightTheme = (col.red + col.green + col.blue) > 364;
-                    const amt = isLightTheme ? -15 : 15;
-                    col.red += amt;
-                    col.green += amt;
-                    col.blue += amt;
-                    return col; };
         //const opaqueify = (col) => { //make color 1/3 more opaque
         //            col.alpha = Math.floor((col.alpha + col.alpha + 255) / 3);
         //            return col; };

--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/settings-schema.json
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/settings-schema.json
@@ -265,9 +265,9 @@
     },
     "search-home-folder":{
         "type":"checkbox",
-        "default":true,
+        "default":false,
         "description":"Search home folder",
-        "tooltip":"When searching, also search home folder for files"
+        "tooltip":"When searching, also search home folder for files (Note: Recommended only if you have an SSD, otherwise this may slow down the search function)"
     },
     "show-hidden-files":{
         "type":"checkbox",

--- a/Cinnamenu@json/files/Cinnamenu@json/metadata.json
+++ b/Cinnamenu@json/files/Cinnamenu@json/metadata.json
@@ -3,7 +3,7 @@
     "name": "Cinnamenu",
     "description": "A flexible menu providing formatting options, web bookmarks, search provider support and fuzzy searching.",
     "max-instances": 2,
-    "version": "4.13.11",
+    "version": "4.13.12",
     "multiversion": true,
     "website": "https://github.com/linuxmint/cinnamon-spices-applets",
     "cinnamon-version": [


### PR DESCRIPTION
Limit file search folder recursion to 50 in order to avoid delays when searching home folder. This means that "search home folder" option will not find all files that match a search string when there are a large number of folders in the home directory.

fixes: #3742
and
fixes: #3759