### PR TITLE
ddcci-multi-monitor@tim-we update 1.1.0

### DIFF
--- a/ddcci-multi-monitor@tim-we/files/ddcci-multi-monitor@tim-we/metadata.json
+++ b/ddcci-multi-monitor@tim-we/files/ddcci-multi-monitor@tim-we/metadata.json
@@ -1,7 +1,7 @@
 {
     "uuid": "ddcci-multi-monitor@tim-we",
     "name": "DDC/CI Multi-Monitor",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Adjust monitor brightness via DDC/CI",
     "author": "tim-we",
     "hide-configuration": true,


### PR DESCRIPTION
- display error messages if `ddcutil` is not installed
- display `InfoOSD` modal when running `ddcutil detect` (so the user knows the applet is doing something)