### PR TITLE
[radio@driglu4it] bugfix

### DIFF
--- a/.typescript-declarations/cinnamon/globals.d.ts
+++ b/.typescript-declarations/cinnamon/globals.d.ts
@@ -7,6 +7,7 @@ declare function clearTimeout(timouetId: number): void;
 
 declare class global {
     static log(...any: Array<any>): void;
+    static logWarning(...any: Array<any>): void;
     static logError(...text: Array<string>): void;
     static create_app_launch_context(): imports.gi.Gio.AppLaunchContext;
     /** Main Cinnamon settings */

--- a/radio@driglu4it/files/radio@driglu4it/4.6/Config.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/Config.js
@@ -20,7 +20,11 @@ const createConfig = (args) => {
     appletSettings.bind('music-download-dir-select', 'musicDownloadDir', () => handleMusicDirChanged());
     function getInitialVolume() {
         const { keepVolume, lastVolume, customInitVolume } = settingsObject;
-        const initialVolume = keepVolume ? lastVolume : customInitVolume;
+        let initialVolume = keepVolume ? lastVolume : customInitVolume;
+        if (initialVolume == null) {
+            global.logWarning('initial Volume was null or undefined. Applying 50 as a fallback solution to prevent radio stop working');
+            initialVolume = 50;
+        }
         return initialVolume;
     }
     function handleMusicDirChanged() {

--- a/radio@driglu4it/files/radio@driglu4it/4.6/lib/PopupMenu.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/lib/PopupMenu.js
@@ -16,6 +16,7 @@ function createPopupMenu(args) {
     const bin = new Bin({
         style_class: 'menu',
         child: box,
+        visible: false
     });
     uiGroup.add_child(bin);
     box.connect('key-press-event', (actor, event) => {
@@ -89,6 +90,7 @@ function createPopupMenu(args) {
     }
     function open() {
         setLayout();
+        bin.show();
         box.show();
         launcher.add_style_pseudo_class('checked');
         pushModal(box);
@@ -98,6 +100,7 @@ function createPopupMenu(args) {
     function close() {
         if (!box.visible)
             return;
+        bin.hide();
         box.hide();
         launcher.remove_style_pseudo_class('checked');
         popModal(box);

--- a/radio@driglu4it/files/radio@driglu4it/4.6/lib/PopupSubMenu.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/lib/PopupSubMenu.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.createSubMenu = void 0;
-const ActivWidget_1 = require("lib//ActivWidget");
+const ActivWidget_1 = require("lib/ActivWidget");
 const { BoxLayout, Label, Icon, ScrollView } = imports.gi.St;
 const { ActorAlign, Point } = imports.gi.Clutter;
 const { PolicyType } = imports.gi.Gtk;

--- a/radio@driglu4it/src/Config.ts
+++ b/radio@driglu4it/src/Config.ts
@@ -78,7 +78,14 @@ export const createConfig = (args: Arguments) => {
             customInitVolume
         } = settingsObject
 
-        const initialVolume = keepVolume ? lastVolume : customInitVolume
+        let initialVolume = keepVolume ? lastVolume : customInitVolume
+
+        if (initialVolume == null){
+            global.logWarning('initial Volume was null or undefined. Applying 50 as a fallback solution to prevent radio stop working')
+            initialVolume = 50
+        }
+
+
         return initialVolume
     }
 

--- a/radio@driglu4it/src/lib/PopupMenu.ts
+++ b/radio@driglu4it/src/lib/PopupMenu.ts
@@ -40,6 +40,7 @@ export function createPopupMenu(args: Arguments) {
     const bin = new Bin({
         style_class: 'menu',
         child: box,
+        visible: false
     })
 
 
@@ -148,7 +149,7 @@ export function createPopupMenu(args: Arguments) {
     function open() {
 
         setLayout()
-
+        bin.show()
         box.show()
 
         launcher.add_style_pseudo_class('checked')
@@ -164,6 +165,7 @@ export function createPopupMenu(args: Arguments) {
 
         if (!box.visible) return
 
+        bin.hide()
         box.hide()
         launcher.remove_style_pseudo_class('checked')
         popModal(box)


### PR DESCRIPTION
Fix for bugs reported on last commit: https://github.com/linuxmint/cinnamon-spices-applets/pull/3820#issuecomment-866357893. Thanks to @fredcw 

- In some unknown situation, it happens that the last volume is saved as null or undefined, which prevent radio from starting after restarting cinnamon. Added a fallback value of 50 as a workaround for this situation to prevent radio from stop working. 
- Fixing grey line on the screen when closing the popup menu on some themes 