### PR TITLE
[radio@driglu4it] Fix Problems when moving applet

### DIFF
--- a/radio@driglu4it/files/radio@driglu4it/4.6/applet.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/applet.js
@@ -31,7 +31,6 @@ const { getAppletDefinition } = imports.ui.appletManager;
 const { panelManager } = imports.ui.main;
 const { IconType, BoxLayout } = imports.gi.St;
 function main(metadata, orientation, panelHeight, instanceId) {
-    global.log('this line is executed');
     let lastVolume;
     let mpvHandler;
     const appletDefinition = getAppletDefinition({
@@ -53,7 +52,8 @@ function main(metadata, orientation, panelHeight, instanceId) {
         onClick: handleAppletClicked,
         onScroll: handleScroll,
         onMiddleClick: () => mpvHandler === null || mpvHandler === void 0 ? void 0 : mpvHandler.togglePlayPause(),
-        onAppletRemovedFromPanel: handleAppletRemovedFromPanel,
+        onAppletMoved: () => mpvHandler === null || mpvHandler === void 0 ? void 0 : mpvHandler.deactivateAllListener(),
+        onAppletRemoved: handleAppletRemoved,
         onRightClick: () => popupMenu === null || popupMenu === void 0 ? void 0 : popupMenu.close()
     });
     const appletTooltip = AppletTooltip_1.createAppletTooltip({
@@ -139,8 +139,9 @@ function main(metadata, orientation, panelHeight, instanceId) {
             GenericNotification_1.notify({ text: notificationText });
         }
     }
-    function handleAppletRemovedFromPanel() {
-        mpvHandler.deactivateAllListener();
+    function handleAppletRemoved() {
+        mpvHandler === null || mpvHandler === void 0 ? void 0 : mpvHandler.deactivateAllListener();
+        mpvHandler === null || mpvHandler === void 0 ? void 0 : mpvHandler.stop();
     }
     function handleScroll(scrollDirection) {
         const volumeChange = scrollDirection === ScrollDirection.UP ? consts_1.VOLUME_DELTA : -consts_1.VOLUME_DELTA;

--- a/radio@driglu4it/files/radio@driglu4it/4.6/applet.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/applet.js
@@ -31,6 +31,7 @@ const { getAppletDefinition } = imports.ui.appletManager;
 const { panelManager } = imports.ui.main;
 const { IconType, BoxLayout } = imports.gi.St;
 function main(metadata, orientation, panelHeight, instanceId) {
+    global.log('this line is executed');
     let lastVolume;
     let mpvHandler;
     const appletDefinition = getAppletDefinition({
@@ -52,7 +53,7 @@ function main(metadata, orientation, panelHeight, instanceId) {
         onClick: handleAppletClicked,
         onScroll: handleScroll,
         onMiddleClick: () => mpvHandler === null || mpvHandler === void 0 ? void 0 : mpvHandler.togglePlayPause(),
-        onAppletRemovedFromPanel: () => mpvHandler === null || mpvHandler === void 0 ? void 0 : mpvHandler.stop(),
+        onAppletRemovedFromPanel: handleAppletRemovedFromPanel,
         onRightClick: () => popupMenu === null || popupMenu === void 0 ? void 0 : popupMenu.close()
     });
     const appletTooltip = AppletTooltip_1.createAppletTooltip({
@@ -137,6 +138,9 @@ function main(metadata, orientation, panelHeight, instanceId) {
             const notificationText = "Couldn't start the applet. Make sure mpv is installed and the mpv mpris plugin saved in the configs folder.";
             GenericNotification_1.notify({ text: notificationText });
         }
+    }
+    function handleAppletRemovedFromPanel() {
+        mpvHandler.deactivateAllListener();
     }
     function handleScroll(scrollDirection) {
         const volumeChange = scrollDirection === ScrollDirection.UP ? consts_1.VOLUME_DELTA : -consts_1.VOLUME_DELTA;

--- a/radio@driglu4it/files/radio@driglu4it/4.6/applet.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/applet.js
@@ -33,6 +33,7 @@ const { IconType, BoxLayout } = imports.gi.St;
 function main(metadata, orientation, panelHeight, instanceId) {
     let lastVolume;
     let mpvHandler;
+    let installationInProgress = false;
     const appletDefinition = getAppletDefinition({
         applet_id: instanceId,
     });
@@ -130,13 +131,19 @@ function main(metadata, orientation, panelHeight, instanceId) {
         onUrlChanged: handleUrlChanged
     });
     async function handleAppletClicked() {
+        if (installationInProgress)
+            return;
         try {
+            installationInProgress = true;
             await CheckInstallation_1.installMpvWithMpris();
             popupMenu.toggle();
         }
         catch (error) {
             const notificationText = "Couldn't start the applet. Make sure mpv is installed and the mpv mpris plugin saved in the configs folder.";
             GenericNotification_1.notify({ text: notificationText });
+        }
+        finally {
+            installationInProgress = false;
         }
     }
     function handleAppletRemoved() {

--- a/radio@driglu4it/files/radio@driglu4it/4.6/lib/PopupMenu.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/lib/PopupMenu.js
@@ -25,7 +25,6 @@ function createPopupMenu(args) {
     launcher.connect('queue-relayout', () => {
         if (!box.visible)
             return;
-        global.log('queue-relayout called');
         setTimeout(() => {
             setLayout();
         }, 0);
@@ -110,9 +109,6 @@ function createPopupMenu(args) {
         const appletClicked = launcher.contains(clickedActor);
         (!binClicked && !appletClicked) && close();
     }
-    box.connect('destroy', () => {
-        global.log('this has been called');
-    });
     box.toggle = toggle;
     box.close = close;
     return box;

--- a/radio@driglu4it/files/radio@driglu4it/4.6/lib/PopupMenu.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/lib/PopupMenu.js
@@ -25,11 +25,7 @@ function createPopupMenu(args) {
     launcher.connect('queue-relayout', () => {
         if (!box.visible)
             return;
-        setTimeout(() => {
-            setLayout();
-        }, 0);
-    });
-    bin.connect('queue-relayout', () => {
+        global.log('queue-relayout called');
         setTimeout(() => {
             setLayout();
         }, 0);
@@ -114,6 +110,9 @@ function createPopupMenu(args) {
         const appletClicked = launcher.contains(clickedActor);
         (!binClicked && !appletClicked) && close();
     }
+    box.connect('destroy', () => {
+        global.log('this has been called');
+    });
     box.toggle = toggle;
     box.close = close;
     return box;

--- a/radio@driglu4it/files/radio@driglu4it/4.6/mpv/MpvHandler.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/mpv/MpvHandler.js
@@ -260,7 +260,7 @@ function createMpvHandler(args) {
         getCurrentTitle,
         setPosition,
         deactivateAllListener,
-        dbus,
+        dbus
     };
 }
 exports.createMpvHandler = createMpvHandler;

--- a/radio@driglu4it/files/radio@driglu4it/4.6/settings-schema.json
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/settings-schema.json
@@ -102,6 +102,11 @@
 				"name": "Austrian Rock Radio",
 				"url": "http://live.antenne.at/arr",
 				"inc": true
+			},
+			{
+				"name": "Deep House",
+				"url": "http://yp.shoutcast.com/sbin/tunein-station.pls?id=499023",
+				"inc": true
 			}
 		]
 	},

--- a/radio@driglu4it/files/radio@driglu4it/4.6/ui/Applet/Applet.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/ui/Applet/Applet.js
@@ -5,15 +5,22 @@ const { Applet, AllowedLayout } = imports.ui.applet;
 const { Bin } = imports.gi.St;
 const { EventType } = imports.gi.Clutter;
 function createApplet(args) {
-    const { orientation, panelHeight, instanceId, icon, label, onClick, onScroll, onMiddleClick, onAppletRemovedFromPanel, onRightClick } = args;
+    const { orientation, panelHeight, instanceId, icon, label, onClick, onScroll, onMiddleClick, onAppletMoved, onAppletRemoved, onRightClick } = args;
     const applet = new Applet(orientation, panelHeight, instanceId);
+    let appletReloaded = false;
     [icon, label].forEach(widget => {
         applet.actor.add_child(widget);
     });
     applet.on_applet_clicked = onClick;
     applet.on_applet_middle_clicked = onMiddleClick;
-    applet.on_applet_removed_from_panel = onAppletRemovedFromPanel;
     applet.setAllowedLayout(AllowedLayout.BOTH);
+    applet.on_applet_reloaded = function () {
+        appletReloaded = true;
+    };
+    applet.on_applet_removed_from_panel = function () {
+        appletReloaded ? onAppletMoved() : onAppletRemoved();
+        appletReloaded = false;
+    };
     applet.actor.connect('event', (actor, event) => {
         if (event.type() !== EventType.BUTTON_PRESS)
             return;

--- a/radio@driglu4it/files/radio@driglu4it/4.6/ui/Applet/AppletLabel.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/ui/Applet/AppletLabel.js
@@ -17,7 +17,6 @@ function createAppletLabel() {
     let visible;
     let text;
     function setText(newValue) {
-        global.log('setText called');
         text = newValue;
         if (!visible)
             return;

--- a/radio@driglu4it/files/radio@driglu4it/4.6/ui/Applet/AppletLabel.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/ui/Applet/AppletLabel.js
@@ -17,6 +17,7 @@ function createAppletLabel() {
     let visible;
     let text;
     function setText(newValue) {
+        global.log('setText called');
         text = newValue;
         if (!visible)
             return;

--- a/radio@driglu4it/src/applet.ts
+++ b/radio@driglu4it/src/applet.ts
@@ -75,9 +75,8 @@ function main(
 		onClick: handleAppletClicked,
 		onScroll: handleScroll,
 		onMiddleClick: () => mpvHandler?.togglePlayPause(),
-		// onAppletRemovedFromPanel: () => mpvHandler?.stop(),
-		onAppletRemovedFromPanel: handleAppletRemovedFromPanel,
-
+		onAppletMoved: () => mpvHandler?.deactivateAllListener(),
+		onAppletRemoved: handleAppletRemoved,
 		onRightClick: () => popupMenu?.close()
 	})
 
@@ -185,8 +184,9 @@ function main(
 		}
 	}
 
-	function handleAppletRemovedFromPanel() {
-		mpvHandler.deactivateAllListener()
+	function handleAppletRemoved() {
+		mpvHandler?.deactivateAllListener()
+		mpvHandler?.stop()
 	}
 
 

--- a/radio@driglu4it/src/applet.ts
+++ b/radio@driglu4it/src/applet.ts
@@ -45,9 +45,9 @@ function main(
 
 	// this is a workaround for now. Optimally the lastVolume should be saved persistently each time the volume is changed but this lead to significant performance issue on scrolling at the moment. However this shouldn't be the case as it is no problem to log the volume each time the volume changes (so it is a problem in the config implementation). As a workaround the volume is only saved persistently when the radio stops but the volume obviously can't be received anymore from dbus when the player has been already stopped ... 
 	let lastVolume: number
-
 	let mpvHandler: ReturnType<typeof createMpvHandler>
 
+	let installationInProgress = false
 
 	const appletDefinition = getAppletDefinition({
 		applet_id: instanceId,
@@ -175,12 +175,18 @@ function main(
 	// CALLBACKS
 
 	async function handleAppletClicked() {
+
+		if (installationInProgress) return
+
 		try {
+			installationInProgress = true
 			await installMpvWithMpris()
 			popupMenu.toggle()
 		} catch (error) {
 			const notificationText = "Couldn't start the applet. Make sure mpv is installed and the mpv mpris plugin saved in the configs folder."
 			notify({ text: notificationText })
+		} finally {
+			installationInProgress = false
 		}
 	}
 

--- a/radio@driglu4it/src/applet.ts
+++ b/radio@driglu4it/src/applet.ts
@@ -75,7 +75,9 @@ function main(
 		onClick: handleAppletClicked,
 		onScroll: handleScroll,
 		onMiddleClick: () => mpvHandler?.togglePlayPause(),
-		onAppletRemovedFromPanel: () => mpvHandler?.stop(),
+		// onAppletRemovedFromPanel: () => mpvHandler?.stop(),
+		onAppletRemovedFromPanel: handleAppletRemovedFromPanel,
+
 		onRightClick: () => popupMenu?.close()
 	})
 
@@ -182,6 +184,11 @@ function main(
 			notify({ text: notificationText })
 		}
 	}
+
+	function handleAppletRemovedFromPanel() {
+		mpvHandler.deactivateAllListener()
+	}
+
 
 	function handleScroll(scrollDirection: imports.gi.Clutter.ScrollDirection) {
 		const volumeChange =

--- a/radio@driglu4it/src/lib/PopupMenu.ts
+++ b/radio@driglu4it/src/lib/PopupMenu.ts
@@ -43,7 +43,6 @@ export function createPopupMenu(args: Arguments) {
         visible: false
     })
 
-
     uiGroup.add_child(bin)
 
     box.connect('key-press-event', (actor, event) => {
@@ -53,12 +52,7 @@ export function createPopupMenu(args: Arguments) {
     launcher.connect('queue-relayout', () => {
         if (!box.visible) return
 
-        setTimeout(() => {
-            setLayout()
-        }, 0);
-    })
 
-    bin.connect('queue-relayout', () => {
         setTimeout(() => {
             setLayout()
         }, 0);
@@ -138,8 +132,6 @@ export function createPopupMenu(args: Arguments) {
 
         return [xLeft, yTop];
     }
-
-
 
     function toggle() {
         box.visible ? close() : open()

--- a/radio@driglu4it/src/ui/Applet/Applet.ts
+++ b/radio@driglu4it/src/ui/Applet/Applet.ts
@@ -11,8 +11,9 @@ interface Arguments {
     onClick: () => void,
     onScroll: (scrollDirection: imports.gi.Clutter.ScrollDirection) => void,
     onMiddleClick: () => void,
-    onAppletRemovedFromPanel: () => void,
-    onRightClick: () => void
+    onRightClick: () => void,
+    onAppletMoved: () => void,
+    onAppletRemoved: () => void
 }
 
 export function createApplet(args: Arguments) {
@@ -26,11 +27,14 @@ export function createApplet(args: Arguments) {
         onClick,
         onScroll,
         onMiddleClick,
-        onAppletRemovedFromPanel,
+        onAppletMoved,
+        onAppletRemoved,
         onRightClick
     } = args
 
     const applet = new Applet(orientation, panelHeight, instanceId);
+
+    let appletReloaded = false;
 
     [icon, label].forEach(widget => {
         applet.actor.add_child(widget)
@@ -38,8 +42,16 @@ export function createApplet(args: Arguments) {
 
     applet.on_applet_clicked = onClick
     applet.on_applet_middle_clicked = onMiddleClick
-    applet.on_applet_removed_from_panel = onAppletRemovedFromPanel
     applet.setAllowedLayout(AllowedLayout.BOTH)
+
+    applet.on_applet_reloaded = function () {
+        appletReloaded = true
+    }
+
+    applet.on_applet_removed_from_panel = function () {
+        appletReloaded ? onAppletMoved() : onAppletRemoved()
+        appletReloaded = false
+    }
 
     applet.actor.connect('event', (actor, event) => {
         if (event.type() !== EventType.BUTTON_PRESS) return


### PR DESCRIPTION
- In the past the mpv listeners haven't been deactivated when the applet has been moved or permanently removed from the panel which lead to the problem that the applet has been tried to access destroyed widgets which even could lead to cinnamon crashing. This has been fixed  
- add another default station
- prevent opening multiple installation windows when clicking on the applet while an installation is already in progress
