### PR TITLE
changes for backward compatibility

### DIFF
--- a/app-launcher@mchilli/files/app-launcher@mchilli/applet.js
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/applet.js
@@ -248,9 +248,13 @@ class MyApplet extends Applet.TextIconApplet {
         source.notify(notification);
     }
 
+    _replaceAll(string, search, replace) {
+        return string.split(search).join(replace);
+    }
+
     run(name, icon, cmd) {
         if (this.notificationEnabled) {
-            let text = this.notificationText.replaceAll('%s', name);
+            let text = this._replaceAll(this.notificationText, '%s', name);
             this.showNotification(APPNAME, text, icon);
         }
         Util.spawnCommandLine(cmd);

--- a/app-launcher@mchilli/files/app-launcher@mchilli/settings-schema.json
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/settings-schema.json
@@ -123,7 +123,7 @@
     "use-symbolic-icons": {
         "type": "switch",
         "description": "Use Symbolic Application Icons",
-        "default": true,
+        "default": false,
         "tooltip": "Use Symbolic Application Icons, where it's possible",
         "dependency": "visible-app-icons"
     },


### PR DESCRIPTION
Don't use symbolic-icons by default and use a local "replaceAll" function, for compatibility with cinnamon < 4.8