### PR TITLE
ipindicator@matus.benko: Use ip command to retrive list of interfaces.

### DIFF
--- a/ipindicator@matus.benko@gmail.com/files/ipindicator@matus.benko@gmail.com/applet.js
+++ b/ipindicator@matus.benko@gmail.com/files/ipindicator@matus.benko@gmail.com/applet.js
@@ -429,10 +429,6 @@ IpIndicatorApplet.prototype = {
         Debugger.log("Executing " + this._getNetworkInterfacesPath, 2);
         let output = GLib.spawn_command_line_sync(this._getNetworkInterfacesPath);
         let interfaces = output[1].toString().split("\n");
-        //remove Iface column header
-        interfaces.splice(0, 1);
-        //remove last empty element
-        interfaces.splice(-1, 1);
         return interfaces;
     },
 

--- a/ipindicator@matus.benko@gmail.com/files/ipindicator@matus.benko@gmail.com/getNetworkInterfaces.sh
+++ b/ipindicator@matus.benko@gmail.com/files/ipindicator@matus.benko@gmail.com/getNetworkInterfaces.sh
@@ -1,1 +1,1 @@
-ifconfig -s | awk '{ print $1 }'
+ip -br link | awk '{ print $1 }'


### PR DESCRIPTION
The legacy tool ifconfig is not installed by default in many distributions and has been replaced by "ip".
Use that tool to get the list of network interfaces.