### PR TITLE
feat(azan@fahri.nurul.id): add settings option to choose between 12 hour and 24 hour time

### DIFF
--- a/azan@fahri.nurul.id/files/azan@fahri.nurul.id/applet.js
+++ b/azan@fahri.nurul.id/files/azan@fahri.nurul.id/applet.js
@@ -208,6 +208,15 @@ AzanApplet.prototype = {
 
         this._settingsProvider.bindProperty(
             Settings.BindingDirection.IN,
+            "time_format",
+            "_opt_timeFormat",
+            function() {
+                this._updateLabel();
+            }
+        );
+		
+        this._settingsProvider.bindProperty(
+            Settings.BindingDirection.IN,
             "juristic",
             "_opt_juristic",
             function() {
@@ -249,7 +258,7 @@ AzanApplet.prototype = {
 
         let currentSeconds = this._calculateSecondsFromDate(currentDate);
 
-        let timesStr = this._prayTimes.getTimes(currentDate, myLocation, myTimezone, 'auto', '24h');
+        let timesStr = this._prayTimes.getTimes(currentDate, myLocation, myTimezone, 'auto', this._opt_timeFormat);
         let timesFloat = this._prayTimes.getTimes(currentDate, myLocation, myTimezone, 'auto', 'Float');
 
         let nearestPrayerId;

--- a/azan@fahri.nurul.id/files/azan@fahri.nurul.id/metadata.json
+++ b/azan@fahri.nurul.id/files/azan@fahri.nurul.id/metadata.json
@@ -3,5 +3,5 @@
 	"name": "Azan",
     "description": "Azan is an Islamic prayer times application", 
     "max-instances": "-1",
-    "version": "0.2"
+    "version": "0.3"
 }

--- a/azan@fahri.nurul.id/files/azan@fahri.nurul.id/settings-schema.json
+++ b/azan@fahri.nurul.id/files/azan@fahri.nurul.id/settings-schema.json
@@ -76,6 +76,15 @@
             "GMT +13:00": "13"
         }
     },
+	"time_format": {
+		"type": "combobox",
+		"default": "24h",
+		"description": "Time format",
+		"options": {
+			"24h": "24h",
+			"12h": "12h"
+		}
+	},
     "head_juristic": {
         "type": "header",
         "description": "Juristic Settings"


### PR DESCRIPTION
This update will allow the user to choose the format for prayer times in the widget. The PrayTimes library already has this feature; this update lets the user adjust it.