### PR TITLE
Qredshift toString() bugfixes

### DIFF
--- a/qredshift@quintao/files/qredshift@quintao/applet.js
+++ b/qredshift@quintao/files/qredshift@quintao/applet.js
@@ -24,6 +24,7 @@ function _(str) {
 global.DEBUG = true;
 
 const QUtils = require('./js/QUtils.js');
+const {to_string} = require("./js/to-string");
 
 const qLOG = QUtils.qLOG;
 const lerp = QUtils.lerp;
@@ -48,11 +49,11 @@ const S_ICON_ON = "redshift-status-on-symbolic";
 
 
 class QRedshift extends Applet.TextIconApplet {
-    
+
     constructor(metadata, orientation, panel_height, instance_id) {
         super(orientation, panel_height, instance_id);
         this.metadata = metadata;
-        
+
         this.opt = {
             redshift_version: 0,
             enabled: true,
@@ -63,7 +64,7 @@ class QRedshift extends Applet.TextIconApplet {
             iconLabel: false,
             iconLabelAlways: true,
             symbolicIcon: false,
-            
+
             keyToggle: '',
             keyBrightnessUp: '',
             keyBrightnessDown: '',
@@ -71,11 +72,11 @@ class QRedshift extends Applet.TextIconApplet {
             keyTempDown: '',
             keyGammaUp: '',
             keyGammaDown: '',
-            
+
             dayTemp: 6500,
             dayBrightness: 1,
             gammaMix: 1,
-            
+
             enabledNight: false,
             manualNightTime: false,
             nightStart: {
@@ -88,12 +89,12 @@ class QRedshift extends Applet.TextIconApplet {
             },
             nightTemp: 6500,
             nightBrightness: 1,
-            
+
             locationLatitude: '0',
             locationLongitude: '0',
             period: '-'
         };
-        
+
         this.time = {
             nightStart: {
                 h: 0,
@@ -104,7 +105,7 @@ class QRedshift extends Applet.TextIconApplet {
                 m: 0
             },
         }
-        
+
         // Bind Settings
         this.settings = new Settings.AppletSettings(this.opt, metadata.uuid, instance_id);
         this.settings.getDesc = function (key) {
@@ -112,7 +113,7 @@ class QRedshift extends Applet.TextIconApplet {
                 return this.settingsData[key].description;
             return '';
         };
-        
+
         this.settings.bind('enabled', 'enabled', this.onSettChange.bind(this));
         this.settings.bind('autoUpdate', 'autoUpdate', this.onSettChange.bind(this));
         this.settings.bind('autoUpdateInterval', 'autoUpdateInterval', this.onSettChange.bind(this));
@@ -127,23 +128,23 @@ class QRedshift extends Applet.TextIconApplet {
             // this.opt.symbolicIcon = value;
             this.setIcon();
         });
-        
-        
+
+
         this.settings.bind('dayTemp', 'dayTemp', this.onSettChange.bind(this));
         this.settings.bind('dayBrightness', 'dayBrightness', this.onSettChange.bind(this));
         this.settings.bind('gammaMix', 'gammaMix', this.onSettChange.bind(this));
-        
+
         this.settings.bind('enabledNight', 'enabledNight', this.onSettChange.bind(this));
         this.settings.bind('manualNightTime', 'manualNightTime', this.onSettChange.bind(this));
         this.settings.bind('nightTemp', 'nightTemp', this.onSettChange.bind(this));
         this.settings.bind('nightBrightness', 'nightBrightness', this.onSettChange.bind(this));
-        
+
         this.settings.bind('nightTimeStart', 'nightStart', (value) => {
             // For some reason this callback for timechoorser is called on every setting update so this workaround is required.
             if (this.opt.nightStart.h !== this.time.nightStart.h || this.opt.nightStart.m !== this.time.nightStart.m) {
                 this.time.nightStart.h = this.opt.nightStart.h;
                 this.time.nightStart.m = this.opt.nightStart.m;
-                
+
                 // qLOG("NIGHT START", this.opt.nightStart);
                 this.doUpdate();
             }
@@ -153,16 +154,16 @@ class QRedshift extends Applet.TextIconApplet {
             if (this.opt.nightEnd.h !== this.time.nightEnd.h || this.opt.nightEnd.m !== this.time.nightEnd.m) {
                 this.time.nightEnd.h = this.opt.nightEnd.h;
                 this.time.nightEnd.m = this.opt.nightEnd.m;
-                
+
                 // qLOG("NIGHT END", this.opt.nightEnd);
                 this.doUpdate();
             }
         });
-        
-        
+
+
         this.settings.bind('locationLatitude', 'locationLatitude', this.onSettChange.bind(this));
         this.settings.bind('locationLongitude', 'locationLongitude', this.onSettChange.bind(this));
-        
+
         this.settings.bind("keyToggle", "keyToggle", this.onKeyChanged.bind(this));
         this.settings.bind("keyBrightnessUp", "keyBrightnessUp", this.onKeyChanged.bind(this));
         this.settings.bind("keyBrightnessDown", "keyBrightnessDown", this.onKeyChanged.bind(this));
@@ -170,55 +171,55 @@ class QRedshift extends Applet.TextIconApplet {
         this.settings.bind("keyTempDown", "keyTempDown", this.onKeyChanged.bind(this));
         this.settings.bind("keyGammaUp", "keyGammaUp", this.onKeyChanged.bind(this));
         this.settings.bind("keyGammaDown", "keyGammaDown", this.onKeyChanged.bind(this));
-        
-        
+
+
         this.time.nightStart.h = this.opt.nightStart.h;
         this.time.nightStart.m = this.opt.nightStart.m;
         this.time.nightEnd.h = this.opt.nightEnd.h;
         this.time.nightEnd.m = this.opt.nightEnd.m;
-        
-        
-        
+
+
+
         this.setIcon();
         this.set_applet_label("QRedshift Loading...");
-        
+
         this.hide_applet_label(!this.opt.iconLabel);
         if (!this.opt.enabled && !this.opt.iconLabelAlways) this.hideLabel();
-        
-        
+
+
         qLOG("QRedshift", 'Created');
-        
+
         this.maxBrightness = 100;
         this.minBrightness = 10;
         this.maxColor = 9000;
         this.minColor = 1000;
-        
+
         this.colorStep = 50;
-        
-        
+
+
         this.menuManager = new PopupMenu.PopupMenuManager(this);
         this.menu = new Applet.AppletPopupMenu(this, orientation);
         this.menuManager.addMenu(this.menu);
         this.createPopup();
-        
+
         this.appMenu = this.menu;
-        
+
         // Reload BTN
         let reload_btn = new PopupMenu.PopupIconMenuItem(_("Reload Applet"), 'view-refresh-symbolic', QIcon.SYMBOLIC, {hover: true});
         reload_btn.connect('activate', this.reloadApplet.bind(this));
         this._applet_context_menu.addMenuItem(reload_btn);
         // this._applet_context_menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-        
+
         let recompile_btn = new PopupMenu.PopupIconMenuItem(_("Recompile Translations"), 'preferences-desktop-locale-symbolic', QIcon.SYMBOLIC, {hover: true});
         recompile_btn.connect('activate', this.recompileTranslations.bind(this));
         this._applet_context_menu.addMenuItem(recompile_btn);
-        
-        
-        
+
+
+
         this.actor.connect('scroll-event', (actor, event) => {
             // this.labelHidden = !this.labelHidden;
             // this.hide_applet_label(this.labelHidden);
-            
+
             let action = this.opt.labelScrollAction;
             if (action === 'on_off') {
                 let direction = event.get_scroll_direction();
@@ -239,61 +240,61 @@ class QRedshift extends Applet.TextIconApplet {
             } else if (action === 'gamma') {
                 this.gm_Slider._onScrollEvent(actor, event);
             }
-            
+
             // qLOG('Scroll', this.opt.labelScrollAction);
             //
             // let key = event.get_key_symbol();
             //
             // qLOG('Key', key);
-            
+
         });
-        
-        
+
+
         // qLOG("KEY|");
         this.onKeyChanged();
-        
+
         this.running = false;
         this.timeout_info = false;
-        
+
         // --- Async Loading ---
         this.verifyVersion(() => {
             this.menu = this._applet_context_menu;
-            
+
             this.timeout_info = Mainloop.timeout_add_seconds(1, () => {
                 qLOG('Redshift required!');
                 this.setIcon();
                 this.set_applet_label(_("REDSHIFT NOT INSTALLED!"));
                 this.set_applet_tooltip(_("Requires Redshift: sudo apt-get install redshift"));
             }, null);
-            
+
         }, (success) => {
             Mainloop.source_remove(this.timeout_info)
             // Set Menu
             this.menu = this.appMenu;
-            
+
             // Disable Redshift
             this.disableRedshiftService();
-            
+
             // Load Informations
             this.setAdjustmentMethods(false);
             this.setLocation(false);
-            
+
             this.doUpdate();
-            
+
         });
-        
+
     }
-    
+
     check_period() {
         let date = new Date();
         let d = new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes(), 0);
-        
+
         let date_s = new Date(d.getFullYear(), d.getMonth(), d.getDate(), this.time.nightStart.h, this.time.nightStart.m, 0);
         let date_e = new Date(d.getFullYear(), d.getMonth(), d.getDate(), this.time.nightEnd.h, this.time.nightEnd.m, 0);
-        
+
         let night = false;
         let percent = 1;
-        
+
         if (date_s <= date_e) {
             night = d >= date_s && d <= date_e;
         } else if (date_s > date_e && d >= date_s) {
@@ -306,13 +307,13 @@ class QRedshift extends Applet.TextIconApplet {
         } else if (d.getTime() == date_e.getTime()) {
             percent = date.getSeconds() / 60;
         }
-        
+
         return {'period': night ? 'night' : 'day', 'is_night': night, 'percent': percent};
     }
-    
+
     setIcon() {
         // qLOG('ICON', this.opt.symbolicIcon);
-        
+
         if (this.opt.symbolicIcon) {
             // this.set_applet_icon_symbolic_path('');
             if (this.opt.enabled)
@@ -327,42 +328,42 @@ class QRedshift extends Applet.TextIconApplet {
                 this.set_applet_icon_symbolic_path(this.metadata.path + ICON_OFF);
         }
     }
-    
-    
+
+
     verifyVersion(before = false, success = false) {
         if (before) before();
-        
+
         try {
             let cmd = "redshift -V";
             Util.spawn_async(GLib.shell_parse_argv(cmd)[1], (out) => {
                 let mts = /redshift\s*(\d+.?\d*)/gi.exec(out.trim());
                 if (mts.length == 2) this.opt.redshift_version = parseFloat(mts[1]);
-                
+
                 // qLOG('DEBUG', this.opt.redshift_version);
                 if (success) success(true);
             });
         } catch (e) {}
-        
-        
+
+
     }
-    
+
     disableRedshiftService() {
         Util.spawn_async(GLib.shell_parse_argv("systemctl is-enabled --user redshift")[1], (out) => {
-            if (out.toString().trim() === 'enabled') {
+            if (to_string(out).trim() === 'enabled') {
                 Util.spawnCommandLine('systemctl mask --user redshift');
                 qLOG('QRedshift', 'Disabling Service');
             }
         });
-        
+
         Util.spawn_async(GLib.shell_parse_argv("systemctl is-active --user redshift")[1], (out) => {
-            if (out.toString().trim() === 'active') {
+            if (to_string(out).trim() === 'active') {
                 Util.spawnCommandLine('systemctl stop --user redshift');
                 qLOG('QRedshift', 'Stopping Service');
             }
         });
-        
+
     }
-    
+
     checkLocalConfig() {
         try {
             let home = GLib.get_home_dir();
@@ -372,13 +373,13 @@ class QRedshift extends Applet.TextIconApplet {
             return true;
         }
     }
-    
+
     setAdjustmentMethods(force = false) {
         let methods = this.settings.getOptions('adjustmentMethod');
         if (!methods.needload && !force) return;
-        
+
         const regex = new RegExp(/^\s+(\w+)$/gm);
-        
+
         let cmd = "redshift -m list";
         Util.spawn_async(GLib.shell_parse_argv(cmd)[1], (out) => {
             let mts = out.match(regex).map(s => s.trim());
@@ -386,113 +387,113 @@ class QRedshift extends Applet.TextIconApplet {
             mts.forEach(value => { opts[value] = value;});
             this.settings.setOptions('adjustmentMethod', opts);
         });
-        
+
     }
-    
+
     setLocation(force = true) {
         let remoteEnable = this.settings.getValue('locationRemote');
-        
+
         if (this.opt.locationLatitude != "0" && this.opt.locationLongitude != "0" && !force && !remoteEnable) return;
-        
+
         Util.spawn_async(['curl', 'https://geolocation-db.com/json/'], (out) => {
             let {city, state, country_name, latitude, longitude} = JSON.parse(out);
             let info = `${city}, ${state}, ${country_name}`;
             this.opt.locationLatitude = `${latitude}`;
             this.opt.locationLongitude = `${longitude}`;
         });
-        
+
     }
-    
+
     doUpdate() {
         this.redShiftUpdate();
-        
+
         if (this.timeout) {
             Mainloop.source_remove(this.timeout);
             this.timeout = undefined;
         }
-        
+
         if (this.opt.enabled && this.opt.autoUpdate && this.opt.enabledNight) {
             this.timeout = Mainloop.timeout_add_seconds(this.opt.autoUpdateInterval, this.doUpdate.bind(this), null);
             // qLOG('auto update', this.opt.autoUpdateInterval);
         }
     }
-    
-    
+
+
     onKeyChanged() {
         // Main.keybindingManager.addHotKey("must-be-unique-id", this.keybinding, Lang.bind(this, this.on_hotkey_triggered));
         // qLOG("KEY Changed", this.opt.keyToggle + "", typeof this.opt.keyToggle);
         // qLOG(this.opt.keyToggle + "");
-        
+
         Main.keybindingManager.addHotKey("keyBrightnessUp", this.opt.keyBrightnessUp, (event) => {
             this.db_Slider._setValueEmit(this.db_Slider.value + this.db_Slider.STEP);
             this.nb_Slider._setValueEmit(this.nb_Slider.value + this.nb_Slider.STEP);
         });
-        
+
         Main.keybindingManager.addHotKey("keyBrightnessDown", this.opt.keyBrightnessDown, (event) => {
             this.db_Slider._setValueEmit(this.db_Slider.value - this.db_Slider.STEP);
             this.nb_Slider._setValueEmit(this.nb_Slider.value - this.nb_Slider.STEP);
         });
-        
+
         Main.keybindingManager.addHotKey("keyTempUp", this.opt.keyTempUp, (event) => {
             this.dc_Slider._setValueEmit(this.dc_Slider.value + this.dc_Slider.STEP);
             this.nc_Slider._setValueEmit(this.nc_Slider.value + this.nc_Slider.STEP);
         });
-        
+
         Main.keybindingManager.addHotKey("keyTempDown", this.opt.keyTempDown, (event) => {
             this.dc_Slider._setValueEmit(this.dc_Slider.value - this.dc_Slider.STEP);
             this.nc_Slider._setValueEmit(this.nc_Slider.value - this.nc_Slider.STEP);
         });
-        
+
         Main.keybindingManager.addHotKey("keyGammaUp", this.opt.keyGammaUp, (event) => {
             this.gm_Slider._setValueEmit(this.gm_Slider.value + this.gm_Slider.STEP);
         });
-        
+
         Main.keybindingManager.addHotKey("keyGammaDown", this.opt.keyGammaDown, (event) => {
             this.gm_Slider._setValueEmit(this.gm_Slider.value - this.gm_Slider.STEP);
         });
-        
+
         Main.keybindingManager.addHotKey("keyToggle", this.opt.keyToggle, (event) => {
             this.opt.enabled = !this.opt.enabled;
             this.enabledDay.setToggleState(this.opt.enabled);
             this.doUpdate();
         });
-        
-        
+
+
     }
-    
-    
+
+
     onSettChange() {
         // qLOG('SETTINGS CHANGED', arguments);
-        
+
         this.enabledAuto.setToggleState(this.opt.autoUpdate);
-        
+
         // Day Enabled
         this.enabledDay.setToggleState(this.opt.enabled);
-        
+
         // Day Temp
         this.dc_Slider.setValue(this.opt.dayTemp);
-        
+
         // Day Bright
         this.db_Slider.setValue(this.opt.dayBrightness);
-        
+
         // Gamma mix
         this.gm_Slider.setValue(this.opt.gammaMix);
-        
+
         // Night Enabled
         this.enabledNight.setToggleState(this.opt.enabledNight);
-        
+
         // Night Temp
         this.nc_Slider.setValue(this.opt.nightTemp);
-        
+
         // Night Bright
         this.nb_Slider.setValue(this.opt.nightBrightness);
-        
+
         this.doUpdate();
     }
-    
-    
+
+
     createPopup() {
-        
+
         this.headerIcon = new QPopupHeader({
             label: this.metadata.name,
             sub_label: this.metadata.version + "",
@@ -500,11 +501,11 @@ class QRedshift extends Applet.TextIconApplet {
         });
         this.menu.addMenuItem(this.headerIcon);
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-        
-        
+
+
         if (this.checkLocalConfig()) {
             qLOG('QRedshift', '~/.config/redshift.conf should be removed');
-            
+
             let info = new QPopupHeader({
                 label: "~/.config/redshift.conf",
                 sub_label: _("may conflict with this applet, it is highly recommended removing it."),
@@ -512,25 +513,25 @@ class QRedshift extends Applet.TextIconApplet {
                 iconSize: 16
             })
             this.menu.addMenuItem(info);
-            
-            
+
+
             this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-            
+
         }
-        
-        
-        
-        
-        
+
+
+
+
+
         // region -- DAY Settings --
-        
+
         this.enabledDay = new QPopupSwitch({
             label: _("Enabled"),
             active: this.opt.enabled
         });
         this.enabledDay.connect('toggled', this.dayEnabledChange.bind(this));
         this.menu.addMenuItem(this.enabledDay);
-        
+
         // day color
         this.dc_Slider = new QPopupSlider({
             label: _("Temp:"), unit: 'K',
@@ -541,7 +542,7 @@ class QRedshift extends Applet.TextIconApplet {
             actor._setValueEmit('6500');
         });
         this.menu.addMenuItem(this.dc_Slider);
-        
+
         // day bright
         this.db_Slider = new QPopupSlider({
             label: _("Bright:"), unit: '%',
@@ -553,7 +554,7 @@ class QRedshift extends Applet.TextIconApplet {
         });
         this.menu.addMenuItem(this.db_Slider);
         // endregion
-        
+
         // gamma
         this.gm_Slider = new QPopupSlider({
             label: _("Gamma:"), unit: '',
@@ -565,18 +566,18 @@ class QRedshift extends Applet.TextIconApplet {
         });
         this.menu.addMenuItem(this.gm_Slider);
         // endregion
-        
+
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-        
+
         // region -- Night Settings --
-        
+
         this.enabledNight = new QPopupSwitch({
             label: _("Night Enabled"),
             active: this.opt.enabledNight
         });
         this.enabledNight.connect('toggled', this.nightEnabledChange.bind(this));
         this.menu.addMenuItem(this.enabledNight);
-        
+
         // night color
         this.nc_Slider = new QPopupSlider({
             label: _("Temp:"), unit: 'K',
@@ -587,7 +588,7 @@ class QRedshift extends Applet.TextIconApplet {
             actor._setValueEmit('6500');
         });
         this.menu.addMenuItem(this.nc_Slider);
-        
+
         // night bright
         this.nb_Slider = new QPopupSlider({
             label: _("Bright:"), unit: '%',
@@ -599,14 +600,14 @@ class QRedshift extends Applet.TextIconApplet {
         });
         this.menu.addMenuItem(this.nb_Slider);
         // endregion
-        
-        
+
+
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-        
+
         // region -- Bottom Bar --
         this.bottomBar = new QPopupIconBar();
         this.menu.addMenuItem(this.bottomBar);
-        
+
         // config button
         let configBtn = new QIcon({
             style_class: 'popup-menu-item',
@@ -621,7 +622,7 @@ class QRedshift extends Applet.TextIconApplet {
             this.menu.close();
         });
         this.bottomBar.addOnRight(configBtn);
-        
+
         // auto update
         this.enabledAuto = new QPopupSwitch({
             label: this.settings.getDesc('autoUpdate'),
@@ -630,7 +631,7 @@ class QRedshift extends Applet.TextIconApplet {
         this.enabledAuto.actor.add_style_class_name('q-icon');
         this.enabledAuto.connect('toggled', this.autoUpdateChange.bind(this));
         // this.bottomBar.addOnLeft(this.enabledAuto);
-        
+
         // show label
         this.enabledLabel = new QPopupSwitch({
             label: _("Show Label"),
@@ -643,55 +644,55 @@ class QRedshift extends Applet.TextIconApplet {
             if (!this.opt.enabled && !this.opt.iconLabelAlways) this.hideLabel();
         });
         // this._applet_context_menu.addMenuItem(this.enabledLabel);
-        
+
         this.bottomBar.addOnLeft(this.enabledLabel);
         // endregion
     }
 
 //region -- ON Slider Changes --
-    
+
     autoUpdateChange(switcher, value) {
         this.opt.autoUpdate = value;
         this.doUpdate();
     }
-    
+
     dayEnabledChange(switcher, value) {
         // qLOG('Day Change', value);
         this.opt.enabled = value;
         this.doUpdate();
     }
-    
+
     dayColorChange(slider, value) {
         // qLOG('Day Color Change', value);
         this.opt.dayTemp = value;
         this.doUpdate();
     }
-    
+
     dayBrightChange(slider, value) {
         // qLOG('Day Bright Change', value);
         this.opt.dayBrightness = value;
         this.doUpdate();
     }
-    
+
     gammaMixChange(slider, value) {
         // qLOG('Gamma Change', value);
         this.opt.gammaMix = value;
         this.doUpdate();
     }
-    
-    
+
+
     nightEnabledChange(switcher, value) {
         // qLOG('Night Change', value);
         this.opt.enabledNight = value;
         this.doUpdate();
     }
-    
+
     nightColorChange(slider, value) {
         // qLOG('Night Color Change', value);
         this.opt.nightTemp = value;
         this.doUpdate();
     }
-    
+
     nightBrightChange(slider, value) {
         // qLOG('Night Bright Changee', value);
         this.opt.nightBrightness = value;
@@ -699,17 +700,17 @@ class QRedshift extends Applet.TextIconApplet {
     }
 
 //endregion
-    
-    
+
+
     on_applet_added_to_panel() {
         qLOG('QRedshift', 'ADDED TO PANEL');
     }
-    
-    
+
+
     on_applet_clicked(event) {
         this.menu.toggle();
     }
-    
+
     on_applet_removed_from_panel() {
         qLOG('QRedshift', 'REMOVED FROM PANEL');
         this.settings.finalize();
@@ -724,13 +725,13 @@ class QRedshift extends Applet.TextIconApplet {
             Mainloop.source_remove(this.timeout);
             this.timeout = undefined;
         }
-        
+
         Util.killall('redshift');
         Util.spawnCommandLine(`redshift -x`);
-        
+
     }
-    
-    
+
+
     doCommand(command) {
         // qLOG('QRedshift CMD',  command);
         if (!this.running) {
@@ -750,14 +751,14 @@ class QRedshift extends Applet.TextIconApplet {
         }
         this.setIcon();
     }
-    
+
     doCommandSync(command) {
         // qLOG('QRedshift CMD',  command);
-        
+
         let [success, out] = GLib.spawn_command_line_sync(command);
         if (!success || out == null) return;
-        let resp = out.toString();
-        
+        let resp = to_string(out);
+
         let period = resp.match(/Period:.+/g);
         if (period && period[0]) {
             this.opt.period = period[0].split(':')[1].trim();
@@ -766,7 +767,7 @@ class QRedshift extends Applet.TextIconApplet {
         this.setInfo();
         this.setIcon();
     }
-    
+
     redShiftUpdate() {
         Util.killall('redshift');
         if (this.opt.enabled) {
@@ -774,14 +775,14 @@ class QRedshift extends Applet.TextIconApplet {
             // cmd += `-c ${this.metadata.path + BASE_CONF}  `;
             if (this.opt.redshift_version >= 1.12) cmd += `-P `;
             cmd += `-r -v -o  `;
-            
-            
+
+
             if (this.opt.adjustmentMethod) cmd += `-m ${this.opt.adjustmentMethod} `;
-            
+
             if (this.opt.locationLatitude && this.opt.locationLongitude) {
                 cmd += `-l ${this.opt.locationLatitude}:${this.opt.locationLongitude} `
             }
-            
+
             if (this.opt.enabledNight) {
                 if (this.opt.manualNightTime) {
                     let prd = this.check_period();
@@ -802,46 +803,46 @@ class QRedshift extends Applet.TextIconApplet {
                 cmd += `-t ${this.opt.dayTemp}:${this.opt.dayTemp} `;
                 cmd += `-b ${this.opt.dayBrightness / 100}:${this.opt.dayBrightness / 100} `;
             }
-            
+
             if (this.opt.gammaMix) cmd += `-g ${this.opt.gammaMix} `;
-            
+
             // Util.spawnCommandLine(cmd);
             this.set_applet_icon_symbolic_path(this.metadata.path + ICON_ON);
             this.doCommandSync(cmd);
-            
+
         } else {
             // if(this.opt.period !== '' ){
             Util.spawnCommandLine(`redshift -x`);
             this.set_applet_icon_symbolic_path(this.metadata.path + ICON_OFF);
             this.opt.period = '-';
-            
+
             // }
             this.updateTooltip();
             this.setInfo();
             this.setIcon();
         }
-        
+
     }
-    
+
     setInfo() {
         let period = this.opt.period + "";
-        
+
         if (this.opt.enabled && this.opt.enabledNight && this.opt.manualNightTime) {
             if (this.check_period().is_night) period = _("Night");
             else period = _("Day");
         }
-        
+
         if(this.opt.enabledNight)
             this.headerIcon.setStatus(period + "");
         else
             this.headerIcon.setStatus("-");
     }
-    
+
     updateTooltip() {
         let tooltiptext = `${this.metadata.name}: ${this.opt.enabled ? _("On") : _("Off")}`;
         // let labeltext = `${this.metadata.name}`;
         let labeltext = _("Off");
-        
+
         if (this.opt.enabled) {
             tooltiptext += '\n';
             let period = this.opt.period;
@@ -850,11 +851,11 @@ class QRedshift extends Applet.TextIconApplet {
                 else period = _("Day");
             }
             tooltiptext += `${period}\n\n`;
-            
+
             if (this.opt.enabledNight) {
                 tooltiptext += _("Day Temperature") + ": " + `${this.opt.dayTemp}K\n`;
                 tooltiptext += _("Day Brightness") + ": " + `${this.opt.dayBrightness}%\n`;
-                
+
                 tooltiptext += _("Night Temperature") + ": " + `${this.opt.nightTemp}K\n`;
                 tooltiptext += _("Night Brightness") + ": " + `${this.opt.nightBrightness}%\n`;
             } else {
@@ -862,9 +863,9 @@ class QRedshift extends Applet.TextIconApplet {
                 tooltiptext += _("Brightness") + ": " + `${this.opt.dayBrightness}%\n`;
             }
             tooltiptext += _("Gamma:") + " " + `${this.opt.gammaMix}`;
-            
+
             // Label text
-            
+
         }
         if (this.opt.enabledNight && this.opt.manualNightTime && this.check_period().is_night) {
             labeltext = `${this.opt.nightTemp}k - ${this.opt.nightBrightness}% - `;
@@ -874,33 +875,33 @@ class QRedshift extends Applet.TextIconApplet {
             labeltext = `${this.opt.dayTemp}k - ${this.opt.dayBrightness}% - `;
         }
         labeltext += `${this.opt.gammaMix.toFixed(2)}`;
-        
+
         this.set_applet_tooltip(tooltiptext);
-        
+
         this.set_applet_label(labeltext);
         this.hide_applet_label(!this.opt.iconLabel);
         if (!this.opt.enabled && !this.opt.iconLabelAlways) this.hideLabel();
     }
-    
-    
+
+
     // Cinnamon should be restarted after this.
     recompileTranslations() {
         let cmd = `cinnamon-xlet-makepot -r ${this.metadata.path}`;
         Util.spawnCommandLine(cmd);
-        
+
         cmd = `cinnamon-xlet-makepot -i ${this.metadata.path}`;
         Util.spawnCommandLine(cmd);
     }
-    
+
     reloadApplet() {
         let cmd = `dbus-send --session --dest=org.Cinnamon.LookingGlass --type=method_call /org/Cinnamon/LookingGlass org.Cinnamon.LookingGlass.ReloadExtension string:'${this.metadata.uuid}' string:'APPLET'`;
         Util.spawnCommandLine(cmd);
     }
-    
+
     openSettings() {
         Util.spawnCommandLine("xlet-settings applet " + this._uuid + " " + this.instance_id);
     }
-    
+
 }
 
 

--- a/qredshift@quintao/files/qredshift@quintao/js/QUtils.js
+++ b/qredshift@quintao/files/qredshift@quintao/js/QUtils.js
@@ -21,6 +21,9 @@ const Util = imports.misc.util;
 
 const PopupMenu = imports.ui.popupMenu;
 
+
+const {to_string} = require("./js/to-string");
+
 /** @exports QUtils.lerp */
 function lerp(nvalue, target, t){
     nvalue = (nvalue + (target - nvalue) * t);
@@ -31,9 +34,9 @@ function lerp(nvalue, target, t){
 /** @exports QUtils.qLOG */
 function qLOG(msg, ...data) {
     if (global.DEBUG == false) return;
-    
+
     let str = `\n${msg}: `;
-    
+
     if (data.length > 0) {
         let tmp = [];
         data.forEach(value => {
@@ -44,13 +47,13 @@ function qLOG(msg, ...data) {
     } else {
         str = JSON.stringify(msg, null, 4)
     }
-    
+
     // global.logWarning(str);
-    
+
     global.logWarning(str);
-    
-    
-    
+
+
+
     function formatLogArgument(arg = '', recursion = 0, depth = 4) {
         const GObject = imports.gi.GObject;
         // Make sure falsey values are clearly indicated.
@@ -67,7 +70,7 @@ function qLOG(msg, ...data) {
             try {
                 arg = JSON.stringify(arg);
             } catch (e) {
-                arg = arg.toString();
+                arg = to_string(arg);
             }
             return arg;
         }
@@ -82,7 +85,7 @@ function qLOG(msg, ...data) {
             if (isGObject) {
                 arg = Util.getGObjectPropertyValues(arg);
                 if (Object.keys(arg).length === 0) {
-                    return arg.toString();
+                    return to_string(arg);
                 }
             }
             let array = isArray ? arg : Object.keys(arg);
@@ -100,47 +103,47 @@ function qLOG(msg, ...data) {
             arg = string + space + brackets[1];
             // Functions, numbers, etc.
         } else if (typeof arg === 'function') {
-            let array = arg.toString().split('\n');
+            let array = to_string(arg).split('\n');
             for (let i = 0; i < array.length; i++) {
                 if (i === 0) continue;
                 array[i] = space + array[i];
             }
             arg = array.join('\n');
         } else if (typeof arg !== 'string' || isGObject) {
-            arg = arg.toString();
+            arg = to_string(arg);
         }
         return arg;
     }
-    
-    
+
+
 }
 
 
 /** @exports QUtils.QIcon */
 class QIcon {
     static get FULLCOLOR() { return St.IconType.FULLCOLOR;}
-    
+
     static get SYMBOLIC() { return St.IconType.SYMBOLIC;}
-    
+
     constructor({
         style_class = null, icon_name = null, icon_path = null, icon_size = 32, icon_type = null,
         reactive = false, activate = false, hover = true, can_focus = true, focusOnHover = true
     } = {}) {
-        
-        
+
+
         this._stIcon = new St.Icon({
             style_class, icon_name, icon_type, icon_size,
             reactive, hover, can_focus, track_hover: true
         });
-        
+
         this.active = false;
         this.focusOnHover = focusOnHover;
-        
-        
+
+
         if (icon_path != null) this.iconPath = icon_path;
-        
-        
-        
+
+
+
         if (activate) {
             this._stIcon.connect('button-release-event', (actor, event) => {
                 let button = event.get_button();
@@ -148,7 +151,7 @@ class QIcon {
                 if (button == 3) this.emit('right-click', event, false);
             });
         }
-        
+
         if (reactive && hover) {
             this._stIcon.connect('notify::hover', (actor) => {
                 this.setActive(actor.hover);
@@ -159,8 +162,8 @@ class QIcon {
             this._stIcon.connect('key-focus-out', (actor) => {this.setActive(false);});
         }
     }
-    
-    
+
+
     set iconPath(icon_path) {
         try {
             let file = Gio.file_new_for_path(icon_path);
@@ -170,33 +173,33 @@ class QIcon {
             global.log(e);
         }
     }
-    
+
     get iconName() { return this._stIcon.get_icon_name(); }
-    
+
     set iconName(name) { this._stIcon.set_icon_name(name); }
-    
+
     get iconSize() { return this._stIcon.get_icon_size(); }
-    
+
     set iconSize(size) { this._stIcon.set_icon_size(size); }
-    
+
     /** @returns {Gio.Icon} */
     get stIcon() { return this._stIcon; }
-    
+
     /** @returns {Gio.Icon} */
     get actor() { return this._stIcon; }
-    
-    
+
+
     /** @param {QIcon.FULLCOLOR|QIcon.SYMBOLIC}  type */
     setIconType(type) {
         this._stIcon.set_icon_type(type);
     }
-    
+
     set_style(style) { this._stIcon.set_style(style);}
-    
+
     add_style_class_name(class_name) {this._stIcon.add_style_class_name(class_name);}
-    
+
     // Events
-    
+
     setActive(active) {
         if (active != this.active) {
             this.active = active;
@@ -205,7 +208,7 @@ class QIcon {
             this.emit('active-changed', active);
         }
     }
-    
+
     activate(event, keepMenu) {
         this.emit('activate', event, keepMenu);
     }
@@ -224,7 +227,7 @@ class QPopupItem extends PopupMenu.PopupBaseMenuItem {
         replace_class = false
     } = {}) {
         super({reactive, activate, sensitive, hover, focusOnHover, style_class});
-        
+
         if (style_class && replace_class) this.actor.style_class = style_class;
     }
 }
@@ -234,45 +237,45 @@ class QPopupItem extends PopupMenu.PopupBaseMenuItem {
 class QPopupHeader extends QPopupItem {
     constructor({label = '', sub_label = '', status = '', iconPath, iconName = 'quintao',  iconSize = 32}) {
         super({reactive: false});
-        
+
         if(iconPath){
             this._icon = new QIcon({icon_size: iconSize, icon_path: iconPath});
         } else {
             this._icon = new QIcon({icon_size: iconSize, icon_name: iconName});
         }
-        
+
         this.addActor(this._icon.stIcon, {span: 0, expand: false});
-        
+
         this._label = new St.Label({text: label});
         this.addActor(this._label, {span: 0, expand: false});
         this._label.add_style_class_name('q-text-bigger');
         this._label.add_style_class_name('q-text-bold');
-        
+
         this._sub_label = new St.Label({text: sub_label});
         this._sub_label.add_style_class_name('q-text-smaller');
         this.addActor(this._sub_label, {span: 0, expand: false});
         // this._sub_label.add_style_class_name('q-text-bold');
-        
-        
+
+
         this._statusText = new St.Label({text: status});
         this._statusText.add_style_class_name('q-text-smaller');
         this.addActor(this._statusText, {span: -1, expand: false, align: St.Align.END});
         // this._statusText.set_style('font-size:90%;');
-        
+
     }
-    
+
     setLabel(text = '') {
         this._label.set_text(text);
     }
-    
+
     setStatus(text = '') {
         this._statusText.set_text(text);
     }
-    
+
     setIconSize(size) {
         this._icon.iconSize = size
     }
-    
+
 }
 
 
@@ -280,37 +283,37 @@ class QPopupHeader extends QPopupItem {
 class QPopupIconBar extends QPopupItem {
     constructor() {
         super({reactive: false, activate: false, hover: false, style_class: 'q-icon-bar'});
-        
-        
+
+
         this.contentLeft = new QPopupItem({
             style_class: 'q-icon-bar-holder',
             replace_class: true,
             reactive: false, activate: false, hover: false
         });
         this.addActor(this.contentLeft.actor, {span: 0, expand: false});
-        
-        
+
+
         this.contentRight = new QPopupItem({
             style_class: 'q-icon-bar-holder',
             replace_class: true,
             reactive: false, activate: false, hover: false
         });
         this.addActor(this.contentRight.actor, {span: -1, expand: false, align: St.Align.END});
-        
-        
+
+
         // this.teste('system-run-system');
         // this.teste('quintao');
         // this.teste('quintao');
-        
+
         // this.addIconLeft('quintao');
-        
+
     }
-    
+
     addOnLeft(item) {
         this.contentLeft.addActor(item.actor,
             {span: 0, expand: false});
     }
-    
+
     addOnRight(item) {
         this.contentRight.addActor(item.actor,
             {span: 0, expand: false});
@@ -322,21 +325,21 @@ class QPopupIconBar extends QPopupItem {
 class QPopupSlider extends QPopupItem {
     constructor({label = '', unit = '', value = 0, min = 0, max = 1, step = 0.1} = {}) {
         super({reactive: true});
-        
+
         this._dragging = false;
         this._mark_position = 0;
-        
+
         this.MIN = min;
         this.MAX = max;
         this.STEP = step;
         this.unit = unit;
-        
+
         if (isNaN(value)) throw TypeError('The bar level value must be a number');
         this._value = Math.max(Math.min(value, this.MAX), this.MIN);
-        
+
         this.label = new St.Label({text: label, styleClass: 'qpopup-slider-label'});
         if (label) this.addActor(this.label, {span: 0, expand: false});
-        
+
         this.slider = new St.DrawingArea({
             styleClass: 'qpopup-slider',
             can_focus: true,
@@ -350,83 +353,83 @@ class QPopupSlider extends QPopupItem {
         this.actor.connect('button-press-event', this._onButtonPress.bind(this));
         this.actor.connect('scroll-event', this._onScrollEvent.bind(this));
         this.actor.connect('key-press-event', this._onKeyPressEvent.bind(this));
-        
-        
+
+
         this.infoText = new St.Label({text: this._value + this.unit, styleClass: 'qpopup-slider-info'});
         this.addActor(this.infoText, {span: -1, expand: false, align: St.Align.END});
-        
-        
-        
-        
-        
+
+
+
+
+
     }
-    
+
     setValue(value) {
         if (isNaN(value)) throw TypeError('The slider value must be a number');
         this._value = Math.max(Math.min(value, this.MAX), this.MIN);
         this.infoText.set_text(this._value + this.unit);
         this.slider.queue_repaint();
     }
-    
+
     _setValueEmit(value) {
         if (!Number.isInteger(this.STEP)) value = value.toFixed(2);
-        
+
         this._value = Math.max(Math.min(value, this.MAX), this.MIN);
-        
+
         this.infoText.set_text(this._value + this.unit);
         this.slider.queue_repaint();
         this.emit('value-changed', this._value);
     }
-    
+
     _onButtonPress(actor, event) {
         let button = event.get_button();
-        
+
         if (button == 1) {
             this._startDragging(actor, event);
         } else if (button == 3) {
             this.emit('right-click');
         }
     }
-    
+
     _sliderRepaint(area) {
         let cr = area.get_context();
         let themeNode = area.get_theme_node();
         let [width, height] = area.get_surface_size();
-        
+
         let handleRadius = themeNode.get_length('-slider-handle-radius');
-        
+
         let sliderWidth = width - 2 * handleRadius;
         let sliderHeight = themeNode.get_length('-slider-height');
-        
+
         let sliderBorderWidth = themeNode.get_length('-slider-border-width');
         let sliderBorderRadius = Math.min(width, sliderHeight) / 2;
-        
+
         let sliderBorderColor = themeNode.get_color('-slider-border-color');
         // let sliderColor = themeNode.get_color('-slider-background-color');
-        
-        
+
+
         let sliderActiveBorderColor = themeNode.get_color('-slider-active-border-color');
         // let sliderActiveColor = themeNode.get_color('-slider-active-background-color');
-        
+
         let startColor = themeNode.get_color('-gradient-start');
         let endColor = themeNode.get_color('-gradient-end');
-        
+
         let fgColor = themeNode.get_foreground_color();
         let sliderColor = fgColor.copy();
         let sliderActiveColor = fgColor.copy();
         sliderColor.alpha *= 0.2;
         sliderActiveColor.alpha *= 0.4;
-        
+
         const TAU = Math.PI * 2;
-        
+
         let handleX = handleRadius + (width - 2 * handleRadius) * this._value / this.MAX;
-        
-        
+
+
         let pat = new Cairo.LinearGradient(0.0, 0.0, width * 1.2, 0);
         pat.addColorStopRGBA(0, startColor.red / 255, startColor.green / 255, startColor.blue / 255, 1);
         pat.addColorStopRGBA(1, endColor.red / 255, endColor.green / 255, endColor.blue / 255, endColor.alpha / 255);
-        
-        
+
+
         cr.arc(sliderBorderRadius + sliderBorderWidth, height / 2, sliderBorderRadius, TAU * 1 / 4, TAU * 3 / 4);
         cr.lineTo(handleX, (height - sliderHeight) / 2);
         cr.lineTo(handleX, (height + sliderHeight) / 2);
@@ -434,32 +437,32 @@ class QPopupSlider extends QPopupItem {
         // cr.setSourceRGBA(1, 0.6, 0, 0.5);
         if (this.unit == 'K') cr.setSource(pat);
         else Clutter.cairo_set_source_color(cr, sliderActiveColor);
-        
+
         cr.fillPreserve();
         Clutter.cairo_set_source_color(cr, sliderActiveBorderColor);
         cr.setLineWidth(sliderBorderWidth);
         cr.stroke();
-        
+
         cr.arc(width - sliderBorderRadius - sliderBorderWidth, height / 2, sliderBorderRadius, TAU * 3 / 4, TAU * 1 / 4);
         cr.lineTo(handleX, (height + sliderHeight) / 2);
         cr.lineTo(handleX, (height - sliderHeight) / 2);
         cr.lineTo(width - sliderBorderRadius - sliderBorderWidth, (height - sliderHeight) / 2);
         if (this.unit == 'K') cr.setSource(pat);
         else Clutter.cairo_set_source_color(cr, sliderColor);
-        
+
         cr.fillPreserve();
         Clutter.cairo_set_source_color(cr, sliderBorderColor);
         cr.setLineWidth(sliderBorderWidth);
         cr.stroke();
-        
+
         let handleY = height / 2;
-        
+
         let color = themeNode.get_foreground_color();
         Clutter.cairo_set_source_color(cr, color);
         cr.arc(handleX, handleY, handleRadius, 0, 2 * Math.PI);
         cr.fill();
-        
-        
+
+
         // Draw a mark to indicate a certain value
         if (this._mark_position > 0) {
             let markWidth = 2;
@@ -469,90 +472,90 @@ class QPopupSlider extends QPopupItem {
             cr.rectangle(xMark, yMark, markWidth, markHeight);
             cr.fill();
         }
-        
+
         cr.$dispose();
     }
-    
+
     _startDragging(actor, event) {
         if (this._dragging) // don't allow two drags at the same time
             return;
-        
+
         this.emit('drag-begin');
         this._dragging = true;
-        
-        
+
+
         // FIXME: we should only grab the specific device that originated
         // the event, but for some weird reason events are still delivered
         // outside the slider if using clutter_grab_pointer_for_device
         Clutter.grab_pointer(this.slider);
         this._signals.connect(this.slider, 'button-release-event', this._endDragging.bind(this));
         this._signals.connect(this.slider, 'motion-event', this._motionEvent.bind(this));
-        
+
         let absX, absY;
         [absX, absY] = event.get_coords();
         this._moveHandle(absX, absY);
     }
-    
+
     _endDragging() {
         if (this._dragging) {
             this._signals.disconnect('button-release-event', this.slider);
             this._signals.disconnect('motion-event', this.slider);
-            
+
             Clutter.ungrab_pointer();
             this._dragging = false;
-            
+
             this.emit('drag-end');
         }
         return true;
     }
-    
+
     _motionEvent(actor, event) {
         let absX, absY;
         [absX, absY] = event.get_coords();
         this._moveHandle(absX, absY);
         return true;
     }
-    
+
     _moveHandle(absX, absY) {
         let relX, relY, sliderX, sliderY;
         [sliderX, sliderY] = this.slider.get_transformed_position();
         relX = absX - sliderX;
         relY = absY - sliderY;
-        
+
         let width = this.slider.width;
         let handleRadius = this.slider.get_theme_node().get_length('-slider-handle-radius');
-        
+
         let newvalue;
         if (relX < handleRadius) newvalue = 0;
         else if (relX > width - handleRadius) newvalue = 1;
         else newvalue = (relX - handleRadius) / (width - 2 * handleRadius);
-        
-        
+
+
         newvalue *= this.MAX;
         if (Number.isInteger(this.STEP)) newvalue = Math.round(newvalue);
-        
+
         this._setValueEmit(newvalue);
     }
-    
-    
+
+
     _onScrollEvent(actor, event) {
         let direction = event.get_scroll_direction();
-        
+
         let newvalue = this._value;
         if (direction == Clutter.ScrollDirection.DOWN) {
             newvalue -= this.STEP;
         } else if (direction == Clutter.ScrollDirection.UP) {
             newvalue += this.STEP;
         }
-        
+
         // qLOG('LOG', this._signals);
-        
+
         this._setValueEmit(newvalue);
     }
-    
+
     _onKeyPressEvent(actor, event) {
         let key = event.get_key_symbol();
-        
+
         if (key == Clutter.KEY_Right || key == Clutter.KEY_Left) {
             let delta = key == Clutter.KEY_Right ? this.STEP : -this.STEP;
             this._setValueEmit(this._value + delta);
@@ -561,38 +564,38 @@ class QPopupSlider extends QPopupItem {
         }
         return false;
     }
-    
-    
+
+
     get value() { return this._value; }
-    
+
     set value(value) { this.setValue(value); }
-    
+
 }
 
 /** @exports QUtils.QPopupSwitch */
 class QPopupSwitch extends QPopupItem {
-    
+
     constructor({label = '', active = false, reactive = true} = {}) {
         super({reactive: reactive, activate: true});
-        
+
         this.label = new St.Label({text: label});
         this.label.add_style_class_name('q-text-medium');
         this._statusLabel = new St.Label({text: '', style_class: 'popup-inactive-menu-item'});
-        
+
         this._switch = new PopupMenu.Switch(active);
-        
+
         this.addActor(this.label, {span: 0, expand: false});
         this.addActor(this._statusLabel, {span: 0, expand: false});
-        
+
         this._statusBin = new St.Bin();
         this.addActor(this._statusBin, {span: -1, expand: false, align: St.Align.END});
         this._statusBin.child = this._switch.actor;
-        
-        
+
+
         // this._statusLabel.set_style('background: blue;');
         // this.actor.set_style('cursor: pointer;');
     }
-    
+
     setStatus(text) {
         if (text != null) {
             this._statusLabel.set_text(text);
@@ -600,24 +603,24 @@ class QPopupSwitch extends QPopupItem {
             this._statusLabel.set_text('');
         }
     }
-    
+
     activate(event) {
         if (this._switch.actor.mapped) {
             this.toggle();
         }
-        
+
         this.emit('activate', event, true);
     }
-    
+
     toggle() {
         this._switch.toggle();
         this.emit('toggled', this._switch.state);
     }
-    
+
     get state() {
         return this._switch.state;
     }
-    
+
     setToggleState(state) {
         this._switch.setToggleState(state);
     }

--- a/qredshift@quintao/files/qredshift@quintao/js/to-string.js
+++ b/qredshift@quintao/files/qredshift@quintao/js/to-string.js
@@ -1,0 +1,10 @@
+const Gio = imports.gi.Gio;
+const ByteArray = imports.byteArray;
+
+const to_string = function(data) {
+  if (ByteArray.hasOwnProperty("toString")) {
+    return ""+ByteArray.toString(data);
+  } else {
+    return ""+data;
+  }
+}


### PR DESCRIPTION
Hi,

This PR removes this message from '.xsession-errors':
```
(cinnamon:1596): Cjs-WARNING **: 03:08:26.885: Some code called array.toString() on a Uint8Array instance. Previously this would have interpreted the bytes of the array as a string, but that is nonstandard. In the future this will return the bytes as comma-separated digits. For the time being, the old behavior has been preserved, but please fix your code anyway to explicitly call ByteArray.toString(array). (Note that array.toString() may have been called implicitly.)

ByteArray.toString(array) is *not* backward compatible with previous (< 4.8) versions of Cinnamon. You will have add versioning support to your applet if it does not already have it, so that compatibility can be maintained for users on older Cinnamon versions.

See:
https://projects.linuxmint.com/reference/git/cinnamon-tutorials/xlet-versioning.html

0 doCommandSync() ["/usr/share/cinnamon/js/misc/fileUtils.js line 211 > Function":761:23]
1 redShiftUpdate() ["/usr/share/cinnamon/js/misc/fileUtils.js line 211 > Function":812:17]
2 doUpdate() ["/usr/share/cinnamon/js/misc/fileUtils.js line 211 > Function":409:13]
3 QRedshift/<() ["/usr/share/cinnamon/js/misc/fileUtils.js line 211 > Function":283:17]
4 verifyVersion/<() ["/usr/share/cinnamon/js/misc/fileUtils.js line 211 > Function":344:36]
5 PushSubprocessResult() ["/usr/share/cinnamon/js/ui/cinnamonDBus.js":420:53]
6 _handleMethodCall() ["resource:///org/gnome/gjs/modules/core/overrides/Gio.js":327:37]
7 _wrapJSObject/<() ["resource:///org/gnome/gjs/modules/core/overrides/Gio.js":404:33]
```

Regards.
Claudiux

Applet: qredshift@quintao
Author: @raphaelquintao 