### PR TITLE
ddcci-multi-monitor@tim-we - Make sure code is es2017 compliant

### DIFF
--- a/ddcci-multi-monitor@tim-we/files/ddcci-multi-monitor@tim-we/applet.js
+++ b/ddcci-multi-monitor@tim-we/files/ddcci-multi-monitor@tim-we/applet.js
@@ -106,11 +106,10 @@ class Monitor {
 }
 
 class DDCMultiMonitor extends Applet.IconApplet {
-    detecting = false;
 
     constructor(metadata, orientation, panelHeight, instance_id) {
         super(orientation, panelHeight, instance_id);
-
+        this.detecting = false;
         this.set_applet_icon_symbolic_name("display-brightness");
         this.set_applet_tooltip("Adjust monitor brightness via DDC/CI");
 


### PR DESCRIPTION
App can't be run on older versions on CJS.

This fix makes sure it is compatible from ES2017+ (cjs version 52 and up)

@tim-we 