### PR TITLE
darkMode@linuxedo.com: Add option to change wallpaper with mode change

### DIFF
--- a/darkMode@linuxedo.com/README.md
+++ b/darkMode@linuxedo.com/README.md
@@ -1,14 +1,15 @@
 # Dark Mode
 
 Changing themes to switch between light mode and dark mode doesn't have to be a tedious task. Once you have configured
-the applet with your default light mode and dark mode themes, you can switch between the modes with a single click.
+the applet with your default light mode and dark mode themes & wallpaper, you can switch between the modes with a single click.
 
 For more details and feature requests: [Dark Mode in Cinnamon Desktop Environment](https://www.linuxedo.com/2021/10/dark-mode-in-cinnamon-desktop.html)
 
 License: [GPL-v3](https://github.com/linuxedo/cinnamon-dark-mode-applet/blob/main/LICENSE)
 
 ## Changelog
-
+* Nov 21, 2021
+  - Change the desktop background.
 * Oct 28, 2021
   - Automatic mode switch based on time.
 * Oct 21, 2021

--- a/darkMode@linuxedo.com/files/darkMode@linuxedo.com/metadata.json
+++ b/darkMode@linuxedo.com/files/darkMode@linuxedo.com/metadata.json
@@ -1,6 +1,6 @@
 {
     "uuid": "darkMode@linuxedo.com", 
-    "max-instances": "-1",
+    "max-instances": "1",
     "description": "Easily switch between dark mode and light mode with one click.", 
     "name": "Dark Mode"
 }

--- a/darkMode@linuxedo.com/files/darkMode@linuxedo.com/po/darkMode@linuxedo.com.pot
+++ b/darkMode@linuxedo.com/files/darkMode@linuxedo.com/po/darkMode@linuxedo.com.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-28 06:50-0400\n"
+"POT-Creation-Date: 2021-11-21 17:15-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 
 #. metadata.json->name
 #. settings-schema.json->page_dark_mode->title
-#: applet.js:75 applet.js:157
+#: applet.js:75 applet.js:177
 msgid "Dark Mode"
 msgstr ""
 
@@ -69,6 +69,21 @@ msgstr ""
 #. settings-schema.json->light_icon_theme->description
 #. settings-schema.json->dark_icon_theme->description
 msgid "Icon theme"
+msgstr ""
+
+#. settings-schema.json->enable_light_background_switch->description
+#. settings-schema.json->enable_dark_background_switch->description
+msgid "Change desktop background"
+msgstr ""
+
+#. settings-schema.json->light_background_dir->description
+#. settings-schema.json->dark_background_dir->description
+msgid "Desktop background location"
+msgstr ""
+
+#. settings-schema.json->light_background_dir->tooltip
+#. settings-schema.json->dark_background_dir->tooltip
+msgid "A picture from this folder will be randomly chosen."
 msgstr ""
 
 #. settings-schema.json->postpone_auto_mode_until->description

--- a/darkMode@linuxedo.com/files/darkMode@linuxedo.com/settings-schema.json
+++ b/darkMode@linuxedo.com/files/darkMode@linuxedo.com/settings-schema.json
@@ -44,7 +44,9 @@
                 "light_win_border_theme",
                 "light_gtk_theme",
                 "light_cinnamon_theme",
-                "light_icon_theme"
+                "light_icon_theme",
+                "enable_light_background_switch",
+                "light_background_dir"
             ]
         },
         "section_dark_mode": {
@@ -54,7 +56,9 @@
                 "dark_win_border_theme",
                 "dark_gtk_theme",
                 "dark_cinnamon_theme",
-                "dark_icon_theme"
+                "dark_icon_theme",
+                "enable_dark_background_switch",
+                "dark_background_dir"
             ]
         }
     },
@@ -135,6 +139,34 @@
         "default": "none",
         "options": {},
         "description": "Icon theme"
+    },
+    "enable_light_background_switch": {
+        "type": "switch",
+        "description": "Change desktop background",
+        "default": false
+    },
+    "light_background_dir": {
+        "type": "filechooser",
+        "default": "",
+        "allow-none" : true,
+        "select-dir" : true,
+        "dependency": "enable_light_background_switch=true",
+        "description": "Desktop background location",
+        "tooltip": "A picture from this folder will be randomly chosen."
+    },
+    "enable_dark_background_switch": {
+        "type": "switch",
+        "description": "Change desktop background",
+        "default": false
+    },
+    "dark_background_dir": {
+        "type": "filechooser",
+        "default": "",
+        "allow-none" : true,
+        "select-dir" : true,
+        "dependency": "enable_dark_background_switch=true",
+        "description": "Desktop background location",
+        "tooltip": "A picture from this folder will be randomly chosen."
     },
     "postpone_auto_mode_until": {
         "type":        "generic",


### PR DESCRIPTION
A new option is added to change the wallpaper based on the light and dark modes from a given folder. If there are multiple images in the folder, a picture will be selected randomly. Currently supporting only .jpg, .jpeg, and .png files.