### PR TITLE
screen-inhibit@mtwebster: Don't check for cinnamon-control-center when launching screensaver settings

### DIFF
--- a/screen-inhibit@mtwebster/files/screen-inhibit@mtwebster/applet.js
+++ b/screen-inhibit@mtwebster/files/screen-inhibit@mtwebster/applet.js
@@ -127,9 +127,7 @@ MyApplet.prototype = {
     },
 
     _screen_menu: function() {
-        if (GLib.find_program_in_path("cinnamon-control-center")) {
-            Util.spawn(['cinnamon-settings', 'screensaver']);
-        }
+        Util.spawn(['cinnamon-settings', 'screensaver']);
     },
 
     on_applet_clicked: function(event) {


### PR DESCRIPTION
Screensaver settings is a python module now.