### PR TITLE
[octopussy@centurix] Use URL from settings instead of default

### DIFF
--- a/octopussy@centurix/files/octopussy@centurix/applet.js
+++ b/octopussy@centurix/files/octopussy@centurix/applet.js
@@ -400,11 +400,11 @@ OctoPussy.prototype = {
 	},
 
 	openCamera: function() {
-		Main.Util.spawnCommandLine(this.video_cmd.replace("%s", OCTOPRINT_URL + "webcam/?action=stream"));
+		Main.Util.spawnCommandLine(this.video_cmd.replace("%s", this.octoprint_url + "webcam/?action=stream"));
 	},
 
 	openOctoPrint: function() {
-		Main.Util.spawnCommandLine("xdg-open " + OCTOPRINT_URL);
+		Main.Util.spawnCommandLine("xdg-open " + this.octoprint_url);
 	},
 
 	openConfiguration: function() {


### PR DESCRIPTION
When opening the webcam stream or the octoprint page it will use the hardcoded url "octopi.local" even if a different url is set. This PR fixes it.
@Centurix 