### PR TITLE
IP Indicator: fix #3800 Home icon not displayed 

### DIFF
--- a/ipindicator@matus.benko@gmail.com/files/ipindicator@matus.benko@gmail.com/applet.js
+++ b/ipindicator@matus.benko@gmail.com/files/ipindicator@matus.benko@gmail.com/applet.js
@@ -38,33 +38,33 @@ const IpGateway = {
             url: "https://api.ipify.org?format=json",
             parse: function (jsonResponse) {
                 let response = JSON.parse(jsonResponse);
-                return response.ip;
+                return response.ip.trim();
             }
         });
         this._services.push({
             url: "https://bot.whatismyipaddress.com/",
             parse: function (response) {
-                return response;
+                return response.trim();
             }
         });
         this._services.push({
             url: "https://myexternalip.com/json",
             parse: function (jsonResponse) {
                 let response = JSON.parse(jsonResponse);
-                return response.ip;
+                return response.ip.trim();
             }
         });
         this._services.push({
             url: "https://icanhazip.com",
             parse: function (response) {
-                return response;
+                return response.trim();
             }
         });
         this._services.push({
             url: "https://ipinfo.io/json",
             parse: function (jsonResponse) {
                 let response = JSON.parse(jsonResponse);
-                return response.ip;
+                return response.ip.trim();
             }
         });
 
@@ -75,13 +75,14 @@ const IpGateway = {
             parse: function (jsonResponse) {
                 let response = JSON.parse(jsonResponse);
                 return {
-                    ip: response.query,
-                    isp: response.isp,
-                    country: response.country,
-                    countryCode: response.countryCode
+                    ip: response.query.trim(),
+                    isp: response.isp.trim(),
+                    country: response.country.trim(),
+                    countryCode: response.countryCode.toLowerCase().trim()
                 };
             }
         });
+
     },
 
     getOnlyIp: function (callback) {
@@ -278,34 +279,34 @@ IpIndicatorApplet.prototype = {
 
     _prepareIspsSettings: function () {
         this.homeIsp = {
-            name: this.homeIspName,
+            name: this.homeIspName.trim(),
             icon: this.homeIspIcon,
-            nickname: this.homeIspNickname
+            nickname: this.homeIspNickname.trim()
         };
         this.other1_isp = {
-            name: this.other1IspName,
+            name: this.other1IspName.trim(),
             icon: this.other1IspIcon,
-            nickname: this.other1IspNickname
+            nickname: this.other1IspNickname.trim()
         };
         this.other2_isp = {
-            name: this.other2IspName,
+            name: this.other2IspName.trim(),
             icon: this.other2IspIcon,
-            nickname: this.other2IspNickname
+            nickname: this.other2IspNickname.trim()
         };
         this.other3_isp = {
-            name: this.other3IspName,
+            name: this.other3IspName.trim(),
             icon: this.other3IspIcon,
-            nickname: this.other3IspNickname
+            nickname: this.other3IspNickname.trim()
         };
         this.other4_isp = {
-            name: this.other4IspName,
+            name: this.other4IspName.trim(),
             icon: this.other4IspIcon,
-            nickname: this.other4IspNickname
+            nickname: this.other4IspNickname.trim()
         };
         this.other5_isp = {
-            name: this.other5IspName,
+            name: this.other5IspName.trim(),
             icon: this.other5IspIcon,
-            nickname: this.other5IspNickname
+            nickname: this.other5IspNickname.trim()
         };
         this.ispsSettings = [this.homeIsp, this.other1_isp, this.other2_isp,
             this.other3_isp, this.other4_isp, this.other5_isp
@@ -327,7 +328,6 @@ IpIndicatorApplet.prototype = {
 
     _updateInfo: function (ip, isp, country, countryCode) {
         Debugger.log("Updating info");
-        countryCode = countryCode.toLowerCase();
         Debugger.log("ip = " + ip, 2);
         Debugger.log("isp = " + isp, 2);
         Debugger.log("country = " + country, 2);

--- a/ipindicator@matus.benko@gmail.com/files/ipindicator@matus.benko@gmail.com/applet.js
+++ b/ipindicator@matus.benko@gmail.com/files/ipindicator@matus.benko@gmail.com/applet.js
@@ -344,7 +344,7 @@ IpIndicatorApplet.prototype = {
         Debugger.log("Searching for ISP settings", 2);
         for (let i = 0; i < this.ispsSettings.length; i++) {
             const ispSetting = this.ispsSettings[i];
-            if (isp === ispSetting.name) {
+            if (ispSetting.name != "" && isp.toLowerCase().includes(ispSetting.name.toLowerCase())) {
                 Debugger.log("ISP setting found: " + ispSetting.name, 2);
                 if (ispSetting.icon) {
                     iconName = ispSetting.icon;

--- a/ipindicator@matus.benko@gmail.com/files/ipindicator@matus.benko@gmail.com/applet.js
+++ b/ipindicator@matus.benko@gmail.com/files/ipindicator@matus.benko@gmail.com/applet.js
@@ -353,7 +353,6 @@ IpIndicatorApplet.prototype = {
                 }
                 Debugger.log("iconName: " + iconName, 2);
                 if (ispSetting.nickname) {
-                    tooltip = ispSetting.nickname;
                     ispName = ispSetting.nickname;
                     Debugger.log("nickname: " + ispSetting.nickname, 2);
                 }


### PR DESCRIPTION
Suggested improvements to fix #3800.

Delete line 356, which breaks the code. Its function is superfluous anyway.

Add trim() to all input strings at input.

Change code to enable partial ISP name match to make it far more robust.

@PrimaMateria, @PRSoftware

