### PR TITLE
uiscaler default 100% settings are actual default for Mint 20.2 + 20.3

### DIFF
--- a/uiscaler@joka42/files/uiscaler@joka42/uiscaler
+++ b/uiscaler@joka42/files/uiscaler@joka42/uiscaler
@@ -5,15 +5,15 @@
 
 scaling_100 () {
 	dconf write /org/cinnamon/desktop/interface/text-scaling-factor 1.0
-	dconf write /org/cinnamon/panels-height "['1:32']"
-	dconf write /org/cinnamon/panel-zone-icon-sizes "'[{\"panelId\":1, \"left\":24, \"center\":0, \"right\":16}]'"
+	dconf write /org/cinnamon/panels-height "['1:40']"
+	dconf write /org/cinnamon/panel-zone-icon-sizes "'[{\"panelId\":1, \"left\":0, \"center\":0, \"right\":24}]'"
 	dconf write /org/cinnamon/panel-zone-symbolic-icon-sizes "'[{\"panelId\":1, \"left\":18, \"center\":0, \"right\":16}]'"
 }
 
 scaling_125 () {
 	dconf write /org/cinnamon/desktop/interface/text-scaling-factor 1.25
-	dconf write /org/cinnamon/panels-height "['1:48']"
-	dconf write /org/cinnamon/panel-zone-icon-sizes "'[{\"panelId\":1, \"left\":34, \"center\":0, \"right\":22}]'"
+	dconf write /org/cinnamon/panels-height "['1:50']"
+	dconf write /org/cinnamon/panel-zone-icon-sizes "'[{\"panelId\":1, \"left\":35, \"center\":0, \"right\":22}]'"
     dconf write /org/cinnamon/panel-zone-symbolic-icon-sizes "'[{\"panelId\":1, \"left\":26, \"center\":0, \"right\":22}]'"
 }
 
@@ -25,6 +25,7 @@ case $1 in
         exit
     ;;
     "125")
+        scaling_100
         scaling_125
         exit
     ;;

--- a/uiscaler@joka42/files/uiscaler@joka42/uiscaler
+++ b/uiscaler@joka42/files/uiscaler@joka42/uiscaler
@@ -13,7 +13,7 @@ scaling_100 () {
 scaling_125 () {
 	dconf write /org/cinnamon/desktop/interface/text-scaling-factor 1.25
 	dconf write /org/cinnamon/panels-height "['1:50']"
-	dconf write /org/cinnamon/panel-zone-icon-sizes "'[{\"panelId\":1, \"left\":35, \"center\":0, \"right\":22}]'"
+	dconf write /org/cinnamon/panel-zone-icon-sizes "'[{\"panelId\":1, \"left\":34, \"center\":0, \"right\":22}]'"
     dconf write /org/cinnamon/panel-zone-symbolic-icon-sizes "'[{\"panelId\":1, \"left\":26, \"center\":0, \"right\":22}]'"
 }
 


### PR DESCRIPTION
Fixed Issues:
* Scaling 200% and then 125% resulted in 225% increase which is now fixed
* Default panel height at 100% was not the cinnamon default, which is now fixed