### PR TITLE
calendar@simonwiles.net: require gtk 3.0 for settings window

### DIFF
--- a/calendar@simonwiles.net/files/calendar@simonwiles.net/world_clock_calendar_settings.py
+++ b/calendar@simonwiles.net/files/calendar@simonwiles.net/world_clock_calendar_settings.py
@@ -16,6 +16,9 @@ import io
 import os
 import subprocess
 
+import gi
+gi.require_version('Gtk', '3.0')
+
 from gi.repository import Gtk, GLib  # pylint: disable-msg=E0611
 
 # prefer simplejson if available (it's faster), and fallback to json


### PR DESCRIPTION
Require Gtk 3.0 for world clocks setting window.
If Gtk 4.0 is installed, it is automatically picked as the highest
version and the settings window fails to open due to different API in
Gtk major versions.

Fixes #4118