### PR TITLE
[radio@driglu4it] fix volume-slider not showing zero

### DIFF
--- a/radio@driglu4it/files/radio@driglu4it/4.6/radio-applet.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/radio-applet.js
@@ -4210,8 +4210,14 @@ function createAppletContainer(args) {
     const panel = panelManager.panels.find(panel => (panel === null || panel === void 0 ? void 0 : panel.panelId) === appletDefinition.panelId);
     const applet = new Applet(__meta.orientation, panel.height, __meta.instanceId);
     let appletReloaded = false;
-    applet.on_applet_clicked = onClick;
-    applet.on_applet_middle_clicked = onMiddleClick;
+    applet.on_applet_clicked = () => {
+        onClick();
+        return true;
+    };
+    applet.on_applet_middle_clicked = () => {
+        onMiddleClick();
+        return true;
+    };
     applet.setAllowedLayout(AllowedLayout.BOTH);
     applet.on_applet_reloaded = function () {
         appletReloaded = true;
@@ -4996,7 +5002,6 @@ function createVolumeSlider() {
     const slider = createSlider({
         onValueChanged: (newValue) => setVolume(newValue * 100)
     });
-    // @ts-ignore
     const tooltip = new Tooltip(slider.actor, null);
     const icon = new VolumeSlider_Icon({
         icon_type: VolumeSlider_IconType.SYMBOLIC,
@@ -5031,7 +5036,7 @@ function createVolumeSlider() {
     }
     const setRefreshVolumeSlider = () => {
         const volume = getVolume();
-        if (volume) {
+        if (volume != null) {
             tooltip.set_text(`Volume: ${volume.toString()} %`);
             slider.setValue(volume / 100, true);
             icon.set_icon_name(getVolumeIcon({ volume }));

--- a/radio@driglu4it/package.json
+++ b/radio@driglu4it/package.json
@@ -12,7 +12,7 @@
   "author": "Jonathan Heard",
   "license": "MIT",
   "devDependencies": {
-    "@ci-types/cjs": "^1.0.16",
+    "@ci-types/cjs": "^1.0.17",
     "@types/jest": "^27.0.1",
     "@types/lodash": "^4.14.170",
     "@types/lodash-es": "^4.17.5",

--- a/radio@driglu4it/src/lib/AppletContainer.ts
+++ b/radio@driglu4it/src/lib/AppletContainer.ts
@@ -35,8 +35,16 @@ export function createAppletContainer(args: Arguments) {
 
     let appletReloaded = false;
 
-    applet.on_applet_clicked = onClick
-    applet.on_applet_middle_clicked = onMiddleClick
+    applet.on_applet_clicked = () => {
+        onClick()
+        return true
+    }
+    
+    applet.on_applet_middle_clicked = () => {
+        onMiddleClick()
+        return true
+    }
+
     applet.setAllowedLayout(AllowedLayout.BOTH)
 
     applet.on_applet_reloaded = function () {

--- a/radio@driglu4it/src/ui/VolumeSlider.ts
+++ b/radio@driglu4it/src/ui/VolumeSlider.ts
@@ -28,7 +28,6 @@ export function createVolumeSlider() {
         onValueChanged: (newValue) => setVolume(newValue * 100)
     })
 
-    // @ts-ignore
     const tooltip = new Tooltip(slider.actor, null)
 
     const icon = new Icon({
@@ -76,7 +75,7 @@ export function createVolumeSlider() {
     const setRefreshVolumeSlider = () => {
         const volume = getVolume()
 
-        if (volume) {
+        if (volume != null) {
             tooltip.set_text(`Volume: ${volume.toString()} %`)
             slider.setValue(volume / 100, true)
             icon.set_icon_name(getVolumeIcon({ volume }))


### PR DESCRIPTION
Just another (and hopefully the last) fix for the last major update. Currently the volume slider is never showing 0 which is of course wrong (it is always a pain in javascript that 0 is "falsy"). 