### PR TITLE
Update Typescript declarations with changes in npm package

### DIFF
--- a/.typescript-declarations/Atk-1.0.d.ts
+++ b/.typescript-declarations/Atk-1.0.d.ts
@@ -124,20 +124,14 @@ declare namespace imports.gi.Atk {
 		 */
 		connect(signal: "link-activated", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::end_index", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::number_of_anchors", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::selected_link", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::start_index", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::end-index", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::number-of-anchors", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::selected-link", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::start-index", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type HyperlinkInitOptionsMixin = GObject.ObjectInitOptions & ActionInitOptions & 
-	Pick<IHyperlink,
-		"end_index" |
-		"number_of_anchors" |
-		"selected_link" |
-		"start_index">;
-
+	type HyperlinkInitOptionsMixin = GObject.ObjectInitOptions & ActionInitOptions
 	export interface HyperlinkInitOptions extends HyperlinkInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -643,21 +637,21 @@ declare namespace imports.gi.Atk {
 		 */
 		connect(signal: "visible-data-changed", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::accessible_component_layer", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accessible_component_mdi_zorder", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accessible_description", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accessible_hypertext_nlinks", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accessible_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accessible_parent", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accessible_role", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accessible_table_caption", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accessible_table_caption_object", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accessible_table_column_description", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accessible_table_column_header", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accessible_table_row_description", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accessible_table_row_header", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accessible_table_summary", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accessible_value", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-component-layer", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-component-mdi-zorder", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-description", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-hypertext-nlinks", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-parent", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-role", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-table-caption", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-table-caption-object", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-table-column-description", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-table-column-header", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-table-row-description", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-table-row-header", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-table-summary", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-value", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::description", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::accessible_parent", callback: (owner: this, ...args: any) => void): number;
@@ -669,10 +663,7 @@ declare namespace imports.gi.Atk {
 
 	type ObjectInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IObject,
-		"accessible_component_layer" |
-		"accessible_component_mdi_zorder" |
 		"accessible_description" |
-		"accessible_hypertext_nlinks" |
 		"accessible_name" |
 		"accessible_parent" |
 		"accessible_role" |
@@ -683,13 +674,7 @@ declare namespace imports.gi.Atk {
 		"accessible_table_row_description" |
 		"accessible_table_row_header" |
 		"accessible_table_summary" |
-		"accessible_value" |
-		"description" |
-		"name" |
-		"accessible_parent" |
-		"role" |
-		"relation_set" |
-		"layer">;
+		"accessible_value">;
 
 	export interface ObjectInitOptions extends ObjectInitOptionsMixin {}
 
@@ -865,11 +850,7 @@ declare namespace imports.gi.Atk {
 
 	}
 
-	type RegistryInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IRegistry,
-		"factory_type_registry" |
-		"factory_singleton_cache">;
-
+	type RegistryInitOptionsMixin = GObject.ObjectInitOptions
 	export interface RegistryInitOptions extends RegistryInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -921,7 +902,7 @@ declare namespace imports.gi.Atk {
 		 * @returns TRUE if the removal is successful.
 		 */
 		remove_target(target: Object): boolean;
-		connect(signal: "notify::relation_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::relation-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::target", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::target", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::relationship", callback: (owner: this, ...args: any) => void): number;
@@ -931,9 +912,7 @@ declare namespace imports.gi.Atk {
 	type RelationInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IRelation,
 		"relation_type" |
-		"target" |
-		"target" |
-		"relationship">;
+		"target">;
 
 	export interface RelationInitOptions extends RelationInitOptionsMixin {}
 
@@ -1036,10 +1015,7 @@ declare namespace imports.gi.Atk {
 
 	}
 
-	type RelationSetInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IRelationSet,
-		"relations">;
-
+	type RelationSetInitOptionsMixin = GObject.ObjectInitOptions
 	export interface RelationSetInitOptions extends RelationSetInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,

--- a/.typescript-declarations/CMenu-3.0.d.ts
+++ b/.typescript-declarations/CMenu-3.0.d.ts
@@ -264,8 +264,8 @@ declare namespace imports.gi.CMenu {
 		connect(signal: "changed", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::flags", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::menu_basename", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::menu_path", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::menu-basename", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::menu-path", callback: (owner: this, ...args: any) => void): number;
 
 	}
 

--- a/.typescript-declarations/Caribou-1.0.d.ts
+++ b/.typescript-declarations/Caribou-1.0.d.ts
@@ -102,9 +102,9 @@ declare namespace imports.gi.Caribou {
 		connect(signal: "group-added", callback: (owner: this, name: string) => void): number;
 		connect(signal: "group-removed", callback: (owner: this, name: string) => void): number;
 
-		connect(signal: "notify::active_group", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::keyboard_type", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::keyboard_file", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::active-group", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::keyboard-type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::keyboard-file", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -164,7 +164,7 @@ declare namespace imports.gi.Caribou {
 		get_levels(): [ string[], number ];
 		get_level(level_name: string): Caribou.LevelModel;
 		get_active_level(): string;
-		connect(signal: "notify::active_level", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::active-level", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::group", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::variant", callback: (owner: this, ...args: any) => void): number;
 
@@ -172,9 +172,7 @@ declare namespace imports.gi.Caribou {
 
 	type GroupModelInitOptionsMixin = GObject.ObjectInitOptions & Caribou.IKeyboardObjectInitOptions & 
 	Pick<IGroupModel,
-		"active_level" |
-		"group" |
-		"variant">;
+		"active_level">;
 
 	export interface GroupModelInitOptions extends GroupModelInitOptionsMixin {}
 
@@ -286,8 +284,8 @@ declare namespace imports.gi.Caribou {
 		connect(signal: "notify::width", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::toggle", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::repeatable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_modifier", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_subkeys", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-modifier", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-subkeys", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::keyval", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::text", callback: (owner: this, ...args: any) => void): number;
@@ -307,8 +305,7 @@ declare namespace imports.gi.Caribou {
 		"name" |
 		"keyval" |
 		"text" |
-		"label" |
-		"modifier_state">;
+		"label">;
 
 	export interface KeyModelInitOptions extends KeyModelInitOptionsMixin {}
 
@@ -382,16 +379,16 @@ declare namespace imports.gi.Caribou {
 		set_autorestart(value: boolean): void;
 		get_inverse_scanning(): boolean;
 		set_inverse_scanning(value: boolean): void;
-		connect(signal: "notify::bind_settings", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scan_grouping", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scan_enabled", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::step_time", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::switch_device", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::keyboard_key", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::mouse_button", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scan_cycles", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::bind-settings", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scan-grouping", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scan-enabled", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::step-time", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::switch-device", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::keyboard-key", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::mouse-button", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scan-cycles", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::autorestart", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::inverse_scanning", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::inverse-scanning", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -489,8 +486,8 @@ declare namespace imports.gi.Caribou {
 		set_scan_stepping(value: boolean): void;
 		get_scan_selected(): boolean;
 		set_scan_selected(value: boolean): void;
-		connect(signal: "notify::scan_stepping", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scan_selected", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scan-stepping", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scan-selected", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -530,7 +527,7 @@ declare namespace imports.gi.Caribou {
 		connect(signal: "step-item-changed", callback: (owner: this, step_item: Caribou.IScannableItem | null) => void): number;
 		connect(signal: "scan-cleared", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::scan_grouping", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scan-grouping", callback: (owner: this, ...args: any) => void): number;
 
 	}
 

--- a/.typescript-declarations/Cinnamon-0.1.d.ts
+++ b/.typescript-declarations/Cinnamon-0.1.d.ts
@@ -120,10 +120,7 @@ declare namespace imports.gi.Cinnamon {
 
 	}
 
-	type AppInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IApp,
-		"state">;
-
+	type AppInitOptionsMixin = GObject.ObjectInitOptions
 	export interface AppInitOptions extends AppInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -552,51 +549,33 @@ declare namespace imports.gi.Cinnamon {
 		connect(signal: "xdnd-leave", callback: (owner: this) => void): number;
 		connect(signal: "xdnd-position-changed", callback: (owner: this, object: number, p0: number) => void): number;
 
-		connect(signal: "notify::background_actor", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::bottom_window_group", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::background-actor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::bottom-window-group", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::datadir", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::display", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::focus_manager", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gdk_screen", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::focus-manager", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gdk-screen", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::imagedir", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::overlay_group", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::overlay-group", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::screen", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::screen_height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::screen_width", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::session_running", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::screen-height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::screen-width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::session-running", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::settings", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::stage", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::stage_input_mode", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::top_window_group", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ui_scale", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::stage-input-mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::top-window-group", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ui-scale", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::userdatadir", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::window_group", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::window_manager", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::window-group", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::window-manager", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type GlobalInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IGlobal,
-		"background_actor" |
-		"bottom_window_group" |
-		"datadir" |
-		"display" |
-		"focus_manager" |
-		"gdk_screen" |
-		"imagedir" |
-		"overlay_group" |
-		"screen" |
-		"screen_height" |
-		"screen_width" |
 		"session_running" |
-		"settings" |
-		"stage" |
-		"stage_input_mode" |
-		"top_window_group" |
-		"ui_scale" |
-		"userdatadir" |
-		"window_group" |
-		"window_manager">;
+		"stage_input_mode">;
 
 	export interface GlobalInitOptions extends GlobalInitOptionsMixin {}
 
@@ -1021,16 +1000,11 @@ declare namespace imports.gi.Cinnamon {
 		click(event: Clutter.Event): void;
 		connect(signal: "notify::pid", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::title", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::wm_class", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::wm-class", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type TrayIconInitOptionsMixin = GtkEmbedInitOptions & Atk.ImplementorIfaceInitOptions & Clutter.AnimatableInitOptions & Clutter.ContainerInitOptions & Clutter.ScriptableInitOptions & 
-	Pick<ITrayIcon,
-		"pid" |
-		"title" |
-		"wm_class">;
-
+	type TrayIconInitOptionsMixin = GtkEmbedInitOptions & Atk.ImplementorIfaceInitOptions & Clutter.AnimatableInitOptions & Clutter.ContainerInitOptions & Clutter.ScriptableInitOptions
 	export interface TrayIconInitOptions extends TrayIconInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1056,7 +1030,7 @@ declare namespace imports.gi.Cinnamon {
 		connect(signal: "tray-icon-added", callback: (owner: this, object: Clutter.Actor) => void): number;
 		connect(signal: "tray-icon-removed", callback: (owner: this, object: Clutter.Actor) => void): number;
 
-		connect(signal: "notify::bg_color", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::bg-color", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1184,14 +1158,11 @@ declare namespace imports.gi.Cinnamon {
 		connect(signal: "startup-sequence-changed", callback: (owner: this, object: StartupSequence) => void): number;
 		connect(signal: "window-app-changed", callback: (owner: this, object: Meta.Window) => void): number;
 
-		connect(signal: "notify::focus_app", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::focus-app", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type WindowTrackerInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IWindowTracker,
-		"focus_app">;
-
+	type WindowTrackerInitOptionsMixin = GObject.ObjectInitOptions
 	export interface WindowTrackerInitOptions extends WindowTrackerInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,

--- a/.typescript-declarations/CinnamonDesktop-3.0.d.ts
+++ b/.typescript-declarations/CinnamonDesktop-3.0.d.ts
@@ -175,8 +175,7 @@ declare namespace imports.gi.CinnamonDesktop {
 	type BGCrossfadeInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IBGCrossfade,
 		"height" |
-		"width" |
-		"parent_object">;
+		"width">;
 
 	export interface BGCrossfadeInitOptions extends BGCrossfadeInitOptionsMixin {}
 
@@ -570,7 +569,7 @@ declare namespace imports.gi.CinnamonDesktop {
 		 */
 		connect(signal: "output-disconnected", callback: (owner: this, output: any | null) => void): number;
 
-		connect(signal: "notify::gdk_screen", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gdk-screen", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -654,16 +653,14 @@ declare namespace imports.gi.CinnamonDesktop {
 		 */
 		set_format_string(format_string: string | null): boolean;
 		connect(signal: "notify::clock", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::format_string", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::format-string", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::parent_object", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type WallClockInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IWallClock,
-		"clock" |
-		"format_string" |
-		"parent_object">;
+		"format_string">;
 
 	export interface WallClockInitOptions extends WallClockInitOptionsMixin {}
 
@@ -779,10 +776,7 @@ declare namespace imports.gi.CinnamonDesktop {
 
 	}
 
-	type XkbInfoInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IXkbInfo,
-		"parent_object">;
-
+	type XkbInfoInitOptionsMixin = GObject.ObjectInitOptions
 	export interface XkbInfoInitOptions extends XkbInfoInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,

--- a/.typescript-declarations/Clutter-1.0.d.ts
+++ b/.typescript-declarations/Clutter-1.0.d.ts
@@ -4129,117 +4129,108 @@ declare namespace imports.gi.Clutter {
 		connect(signal: "unrealize", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::allocation", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::anchor_gravity", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::anchor_x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::anchor_y", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::background_color", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::background_color_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::child_transform", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::child_transform_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::anchor-gravity", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::anchor-x", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::anchor-y", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::background-color", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::background-color-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::child-transform", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::child-transform-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::clip", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::clip_rect", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::clip_to_allocation", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::clip-rect", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::clip-to-allocation", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::content", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::content_box", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::content_gravity", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::content_repeat", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::content-box", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::content-gravity", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::content-repeat", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::depth", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::first_child", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::fixed_position_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::fixed_x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::fixed_y", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_clip", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_pointer", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::first-child", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::fixed-position-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::fixed-x", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::fixed-y", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-clip", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-pointer", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::last_child", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::layout_manager", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::magnification_filter", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::last-child", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::layout-manager", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::magnification-filter", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::mapped", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::margin_bottom", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::margin_left", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::margin_right", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::margin_top", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::min_height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::min_height_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::min_width", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::min_width_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::minification_filter", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::margin-bottom", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::margin-left", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::margin-right", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::margin-top", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::min-height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::min-height-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::min-width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::min-width-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::minification-filter", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::natural_height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::natural_height_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::natural_width", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::natural_width_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::offscreen_redirect", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::natural-height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::natural-height-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::natural-width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::natural-width-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::offscreen-redirect", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::opacity", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pivot_point", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pivot_point_z", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pivot-point", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pivot-point-z", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::position", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::reactive", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::realized", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::request_mode", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::rotation_angle_x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::rotation_angle_y", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::rotation_angle_z", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::rotation_center_x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::rotation_center_y", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::rotation_center_z", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::rotation_center_z_gravity", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scale_center_x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scale_center_y", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scale_gravity", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scale_x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scale_y", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scale_z", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_on_set_parent", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::request-mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::rotation-angle-x", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::rotation-angle-y", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::rotation-angle-z", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::rotation-center-x", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::rotation-center-y", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::rotation-center-z", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::rotation-center-z-gravity", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scale-center-x", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scale-center-y", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scale-gravity", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scale-x", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scale-y", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scale-z", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-on-set-parent", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::text_direction", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::text-direction", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::transform", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::transform_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::translation_x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::translation_y", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::translation_z", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::transform-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::translation-x", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::translation-y", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::translation-z", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::visible", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::width", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::x_align", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::x_expand", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::x-align", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::x-expand", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::y", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::y_align", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::y_expand", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::z_position", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::y-align", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::y-expand", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::z-position", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::flags", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type ActorInitOptionsMixin = GObject.InitiallyUnownedInitOptions & Atk.ImplementorIfaceInitOptions & AnimatableInitOptions & ContainerInitOptions & ScriptableInitOptions & 
 	Pick<IActor,
-		"allocation" |
 		"anchor_gravity" |
 		"anchor_x" |
 		"anchor_y" |
 		"background_color" |
-		"background_color_set" |
 		"child_transform" |
-		"child_transform_set" |
 		"clip" |
 		"clip_rect" |
 		"clip_to_allocation" |
 		"content" |
-		"content_box" |
 		"content_gravity" |
 		"content_repeat" |
 		"depth" |
-		"first_child" |
 		"fixed_position_set" |
 		"fixed_x" |
 		"fixed_y" |
-		"has_clip" |
-		"has_pointer" |
 		"height" |
-		"last_child" |
 		"layout_manager" |
 		"magnification_filter" |
-		"mapped" |
 		"margin_bottom" |
 		"margin_left" |
 		"margin_right" |
@@ -4260,7 +4251,6 @@ declare namespace imports.gi.Clutter {
 		"pivot_point_z" |
 		"position" |
 		"reactive" |
-		"realized" |
 		"request_mode" |
 		"rotation_angle_x" |
 		"rotation_angle_y" |
@@ -4279,7 +4269,6 @@ declare namespace imports.gi.Clutter {
 		"size" |
 		"text_direction" |
 		"transform" |
-		"transform_set" |
 		"translation_x" |
 		"translation_y" |
 		"translation_z" |
@@ -4291,8 +4280,7 @@ declare namespace imports.gi.Clutter {
 		"y" |
 		"y_align" |
 		"y_expand" |
-		"z_position" |
-		"flags">;
+		"z_position">;
 
 	export interface ActorInitOptions extends ActorInitOptionsMixin {}
 
@@ -4372,7 +4360,6 @@ declare namespace imports.gi.Clutter {
 
 	type ActorMetaInitOptionsMixin = GObject.InitiallyUnownedInitOptions & 
 	Pick<IActorMeta,
-		"actor" |
 		"enabled" |
 		"name">;
 
@@ -4458,7 +4445,7 @@ declare namespace imports.gi.Clutter {
 		 * @param source a {@link Actor}, or %NULL to unset the source
 		 */
 		set_source(source: Actor | null): void;
-		connect(signal: "notify::align_axis", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::align-axis", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::factor", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::source", callback: (owner: this, ...args: any) => void): number;
 
@@ -4603,7 +4590,6 @@ declare namespace imports.gi.Clutter {
 
 	type AlphaInitOptionsMixin = GObject.InitiallyUnownedInitOptions & ScriptableInitOptions & 
 	Pick<IAlpha,
-		"alpha" |
 		"mode" |
 		"timeline">;
 
@@ -5577,8 +5563,8 @@ declare namespace imports.gi.Clutter {
 		 * @param depth_end final value of the depth
 		 */
 		set_bounds(depth_start: number, depth_end: number): void;
-		connect(signal: "notify::depth_end", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::depth_start", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::depth-end", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::depth-start", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -5751,11 +5737,11 @@ declare namespace imports.gi.Clutter {
 		 * @param width width of the ellipse
 		 */
 		set_width(width: number): void;
-		connect(signal: "notify::angle_end", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::angle_start", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::angle_tilt_x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::angle_tilt_y", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::angle_tilt_z", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::angle-end", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::angle-start", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::angle-tilt-x", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::angle-tilt-y", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::angle-tilt-z", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::center", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::direction", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::height", callback: (owner: this, ...args: any) => void): number;
@@ -5841,8 +5827,8 @@ declare namespace imports.gi.Clutter {
 		 * @param opacity_end maximum level of opacity
 		 */
 		set_bounds(opacity_start: number, opacity_end: number): void;
-		connect(signal: "notify::opacity_end", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::opacity_start", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::opacity-end", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::opacity-start", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -6064,12 +6050,12 @@ declare namespace imports.gi.Clutter {
 		 * @param direction the rotation direction
 		 */
 		set_direction(direction: RotateDirection): void;
-		connect(signal: "notify::angle_end", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::angle_start", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::angle-end", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::angle-start", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::axis", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::center_x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::center_y", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::center_z", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::center-x", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::center-y", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::center-z", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::direction", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -6162,10 +6148,10 @@ declare namespace imports.gi.Clutter {
 		 * @param y_scale_end final scale factor on the Y axis
 		 */
 		set_bounds(x_scale_start: number, y_scale_start: number, x_scale_end: number, y_scale_end: number): void;
-		connect(signal: "notify::x_scale_end", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::x_scale_start", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::y_scale_end", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::y_scale_start", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::x-scale-end", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::x-scale-start", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::y-scale-end", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::y-scale-start", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -6280,8 +6266,8 @@ declare namespace imports.gi.Clutter {
 		 *   inside #container
 		 */
 		set_alignment(child: Actor | null, x_align: BinAlignment, y_align: BinAlignment): void;
-		connect(signal: "notify::x_align", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::y_align", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::x-align", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::y-align", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -6792,7 +6778,7 @@ declare namespace imports.gi.Clutter {
 		 */
 		set_layout_manager(manager: LayoutManager): void;
 		connect(signal: "notify::color", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::color_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::color-set", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -7100,13 +7086,13 @@ declare namespace imports.gi.Clutter {
 		 * @param vertical %TRUE if the layout should be vertical
 		 */
 		set_vertical(vertical: boolean): void;
-		connect(signal: "notify::easing_duration", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::easing_mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::easing-duration", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::easing-mode", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::homogeneous", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::orientation", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pack_start", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pack-start", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::spacing", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_animations", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-animations", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::vertical", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -7443,9 +7429,9 @@ declare namespace imports.gi.Clutter {
 		 */
 		connect(signal: "draw", callback: (owner: this, cr: cairo.Context) => boolean): number;
 
-		connect(signal: "notify::auto_resize", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::surface_height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::surface_width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::auto-resize", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::surface-height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::surface-width", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -7576,8 +7562,8 @@ declare namespace imports.gi.Clutter {
 		connect(signal: "draw", callback: (owner: this, cr: cairo.Context, width: number, height: number) => boolean): number;
 
 		connect(signal: "notify::height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scale_factor", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scale_factor_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scale-factor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scale-factor-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::width", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -7586,7 +7572,6 @@ declare namespace imports.gi.Clutter {
 	Pick<ICanvas,
 		"height" |
 		"scale_factor" |
-		"scale_factor_set" |
 		"width">;
 
 	export interface CanvasInitOptions extends CanvasInitOptionsMixin {}
@@ -7658,9 +7643,7 @@ declare namespace imports.gi.Clutter {
 	type ChildMetaInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IChildMeta,
 		"actor" |
-		"container" |
-		"container" |
-		"actor">;
+		"container">;
 
 	export interface ChildMetaInitOptions extends ChildMetaInitOptionsMixin {}
 
@@ -7806,18 +7789,16 @@ declare namespace imports.gi.Clutter {
 		connect(signal: "long-press", callback: (owner: this, actor: Actor, state: LongPressState) => boolean): number;
 
 		connect(signal: "notify::held", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::long_press_duration", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::long_press_threshold", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::long-press-duration", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::long-press-threshold", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::pressed", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type ClickActionInitOptionsMixin = ActionInitOptions & 
 	Pick<IClickAction,
-		"held" |
 		"long_press_duration" |
-		"long_press_threshold" |
-		"pressed">;
+		"long_press_threshold">;
 
 	export interface ClickActionInitOptions extends ClickActionInitOptionsMixin {}
 
@@ -8092,9 +8073,9 @@ declare namespace imports.gi.Clutter {
 		 * @param y_tiles number of vertical tiles
 		 */
 		set_n_tiles(x_tiles: number, y_tiles: number): void;
-		connect(signal: "notify::back_material", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::x_tiles", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::y_tiles", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::back-material", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::x-tiles", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::y-tiles", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -8507,19 +8488,18 @@ declare namespace imports.gi.Clutter {
 		 */
 		connect(signal: "drag-progress", callback: (owner: this, actor: Actor, delta_x: number, delta_y: number) => boolean): number;
 
-		connect(signal: "notify::drag_area", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::drag_area_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::drag_axis", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::drag_handle", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::x_drag_threshold", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::y_drag_threshold", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::drag-area", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::drag-area-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::drag-axis", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::drag-handle", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::x-drag-threshold", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::y-drag-threshold", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type DragActionInitOptionsMixin = ActionInitOptions & 
 	Pick<IDragAction,
 		"drag_area" |
-		"drag_area_set" |
 		"drag_axis" |
 		"drag_handle" |
 		"x_drag_threshold" |
@@ -8877,15 +8857,15 @@ declare namespace imports.gi.Clutter {
 		 * @param snap_to_grid %TRUE if #layout should place its children on a grid
 		 */
 		set_snap_to_grid(snap_to_grid: boolean): void;
-		connect(signal: "notify::column_spacing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::column-spacing", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::homogeneous", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_column_width", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_row_height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::min_column_width", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::min_row_height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-column-width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-row-height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::min-column-width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::min-row-height", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::orientation", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::row_spacing", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::snap_to_grid", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::row-spacing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::snap-to-grid", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -9152,10 +9132,10 @@ declare namespace imports.gi.Clutter {
 		 */
 		connect(signal: "gesture-progress", callback: (owner: this, actor: Actor) => boolean): number;
 
-		connect(signal: "notify::n_touch_points", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::threshold_trigger_distance_x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::threshold_trigger_distance_y", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::threshold_trigger_edge", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::n-touch-points", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::threshold-trigger-distance-x", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::threshold-trigger-distance-y", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::threshold-trigger-edge", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -9337,11 +9317,11 @@ declare namespace imports.gi.Clutter {
 		 * @param spacing the spacing between rows of the layout, in pixels
 		 */
 		set_row_spacing(spacing: number): void;
-		connect(signal: "notify::column_homogeneous", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::column_spacing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::column-homogeneous", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::column-spacing", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::orientation", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::row_homogeneous", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::row_spacing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::row-homogeneous", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::row-spacing", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -9883,16 +9863,16 @@ declare namespace imports.gi.Clutter {
 		 */
 		update_from_event(event: Event, update_stage: boolean): void;
 		connect(signal: "notify::backend", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::device_manager", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::device_mode", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::device_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::device-manager", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::device-mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::device-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::enabled", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_cursor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-cursor", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::id", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::n_axes", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::n-axes", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::product_id", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::vendor_id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::product-id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::vendor-id", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -9905,7 +9885,6 @@ declare namespace imports.gi.Clutter {
 		"enabled" |
 		"has_cursor" |
 		"id" |
-		"n_axes" |
 		"name" |
 		"product_id" |
 		"vendor_id">;
@@ -10082,7 +10061,7 @@ declare namespace imports.gi.Clutter {
 		validate(pspec: GObject.ParamSpec): boolean;
 		connect(signal: "notify::final", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::initial", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::value_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::value-type", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -10525,7 +10504,6 @@ declare namespace imports.gi.Clutter {
 
 	type LayoutMetaInitOptionsMixin = ChildMetaInitOptions & 
 	Pick<ILayoutMeta,
-		"manager" |
 		"manager">;
 
 	export interface LayoutMetaInitOptions extends LayoutMetaInitOptionsMixin {}
@@ -10971,14 +10949,11 @@ declare namespace imports.gi.Clutter {
 		 */
 		connect(signal: "sort-changed", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::filter_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::filter-set", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type ModelInitOptionsMixin = GObject.ObjectInitOptions & ScriptableInitOptions & 
-	Pick<IModel,
-		"filter_set">;
-
+	type ModelInitOptionsMixin = GObject.ObjectInitOptions & ScriptableInitOptions
 	export interface ModelInitOptions extends ModelInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -11592,10 +11567,10 @@ declare namespace imports.gi.Clutter {
 		 */
 		connect(signal: "pan-stopped", callback: (owner: this, actor: Actor) => void): number;
 
-		connect(signal: "notify::acceleration_factor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::acceleration-factor", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::deceleration", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::interpolate", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pan_axis", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pan-axis", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -11641,10 +11616,7 @@ declare namespace imports.gi.Clutter {
 
 	}
 
-	type ParamSpecColorInitOptionsMixin = GObject.ParamSpecInitOptions & 
-	Pick<IParamSpecColor,
-		"default_value">;
-
+	type ParamSpecColorInitOptionsMixin = GObject.ParamSpecInitOptions
 	export interface ParamSpecColorInitOptions extends ParamSpecColorInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -11685,12 +11657,7 @@ declare namespace imports.gi.Clutter {
 
 	}
 
-	type ParamSpecFixedInitOptionsMixin = GObject.ParamSpecInitOptions & 
-	Pick<IParamSpecFixed,
-		"minimum" |
-		"maximum" |
-		"default_value">;
-
+	type ParamSpecFixedInitOptionsMixin = GObject.ParamSpecInitOptions
 	export interface ParamSpecFixedInitOptions extends ParamSpecFixedInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -11922,8 +11889,7 @@ declare namespace imports.gi.Clutter {
 
 	type PathInitOptionsMixin = GObject.InitiallyUnownedInitOptions & 
 	Pick<IPath,
-		"description" |
-		"length">;
+		"description">;
 
 	export interface PathInitOptions extends PathInitOptionsMixin {}
 
@@ -12092,7 +12058,7 @@ declare namespace imports.gi.Clutter {
 		 * @param property_name a property name
 		 */
 		set_property_name(property_name: string | null): void;
-		connect(signal: "notify::property_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::property-name", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -12200,10 +12166,10 @@ declare namespace imports.gi.Clutter {
 		 * @param color a {@link Color}
 		 */
 		set_color(color: Color): void;
-		connect(signal: "notify::border_color", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::border_width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::border-color", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::border-width", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::color", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_border", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-border", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -12672,15 +12638,13 @@ declare namespace imports.gi.Clutter {
 		 */
 		unmerge_objects(merge_id: number): void;
 		connect(signal: "notify::filename", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::filename_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::translation_domain", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::filename-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::translation-domain", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type ScriptInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IScript,
-		"filename" |
-		"filename_set" |
 		"translation_domain">;
 
 	export interface ScriptInitOptions extends ScriptInitOptionsMixin {}
@@ -12744,7 +12708,7 @@ declare namespace imports.gi.Clutter {
 		 * @param mode a {@link ScrollMode}
 		 */
 		set_scroll_mode(mode: ScrollMode): void;
-		connect(signal: "notify::scroll_mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scroll-mode", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -12848,18 +12812,18 @@ declare namespace imports.gi.Clutter {
 		password_hint_time: number;
 		window_scaling_factor: number;
 
-		connect(signal: "notify::dnd_drag_threshold", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::double_click_distance", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::double_click_time", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::font_antialias", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::font_dpi", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::font_hint_style", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::font_hinting", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::font_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::font_subpixel_order", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::long_press_duration", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::password_hint_time", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::window_scaling_factor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::dnd-drag-threshold", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::double-click-distance", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::double-click-time", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-antialias", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-dpi", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-hint-style", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-hinting", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-subpixel-order", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::long-press-duration", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::password-hint-time", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::window-scaling-factor", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -13065,14 +13029,13 @@ declare namespace imports.gi.Clutter {
 		set_vertex_source(data: string, length: number): void;
 		connect(signal: "notify::compiled", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::enabled", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::fragment_source", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::vertex_source", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::fragment-source", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::vertex-source", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type ShaderInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IShader,
-		"compiled" |
 		"enabled" |
 		"fragment_source" |
 		"vertex_source">;
@@ -13354,10 +13317,10 @@ declare namespace imports.gi.Clutter {
 		 * @param source a {@link Actor}, or %NULL to unset the source
 		 */
 		set_source(source: Actor | null): void;
-		connect(signal: "notify::from_edge", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::from-edge", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::offset", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::source", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::to_edge", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::to-edge", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -13955,19 +13918,19 @@ declare namespace imports.gi.Clutter {
 		 */
 		connect(signal: "unfullscreen", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::accept_focus", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accept-focus", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::color", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cursor_visible", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cursor-visible", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::fog", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::fullscreen_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::key_focus", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::no_clear_hint", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::fullscreen-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::key-focus", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::no-clear-hint", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::offscreen", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::perspective", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::title", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_alpha", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_fog", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::user_resizable", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-alpha", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-fog", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::user-resizable", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -13977,7 +13940,6 @@ declare namespace imports.gi.Clutter {
 		"color" |
 		"cursor_visible" |
 		"fog" |
-		"fullscreen_set" |
 		"key_focus" |
 		"no_clear_hint" |
 		"offscreen" |
@@ -14106,14 +14068,11 @@ declare namespace imports.gi.Clutter {
 		 */
 		connect(signal: "stage-removed", callback: (owner: this, stage: Stage) => void): number;
 
-		connect(signal: "notify::default_stage", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::default-stage", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type StageManagerInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IStageManager,
-		"default_stage">;
-
+	type StageManagerInitOptionsMixin = GObject.ObjectInitOptions
 	export interface StageManagerInitOptions extends StageManagerInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -14821,11 +14780,11 @@ declare namespace imports.gi.Clutter {
 		 * @param animate %TRUE if the #layout should use animations
 		 */
 		set_use_animations(animate: boolean): void;
-		connect(signal: "notify::column_spacing", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::easing_duration", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::easing_mode", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::row_spacing", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_animations", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::column-spacing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::easing-duration", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::easing-mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::row-spacing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-animations", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -15695,31 +15654,31 @@ declare namespace imports.gi.Clutter {
 		connect(signal: "notify::attributes", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::buffer", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::color", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cursor_color", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cursor_color_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cursor_position", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cursor_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cursor_visible", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cursor-color", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cursor-color-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cursor-position", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cursor-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cursor-visible", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::editable", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::ellipsize", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::font_description", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::font_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-description", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::justify", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::line_alignment", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::line_wrap", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::line_wrap_mode", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_length", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::password_char", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::line-alignment", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::line-wrap", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::line-wrap-mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-length", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::password-char", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::position", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::selectable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::selected_text_color", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::selected_text_color_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::selection_bound", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::selection_color", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::selection_color_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::single_line_mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::selected-text-color", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::selected-text-color-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::selection-bound", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::selection-color", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::selection-color-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::single-line-mode", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::text", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_markup", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-markup", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -15730,7 +15689,6 @@ declare namespace imports.gi.Clutter {
 		"buffer" |
 		"color" |
 		"cursor_color" |
-		"cursor_color_set" |
 		"cursor_position" |
 		"cursor_size" |
 		"cursor_visible" |
@@ -15747,10 +15705,8 @@ declare namespace imports.gi.Clutter {
 		"position" |
 		"selectable" |
 		"selected_text_color" |
-		"selected_text_color_set" |
 		"selection_bound" |
 		"selection_color" |
-		"selection_color_set" |
 		"single_line_mode" |
 		"text" |
 		"use_markup">;
@@ -15945,16 +15901,14 @@ declare namespace imports.gi.Clutter {
 		connect(signal: "inserted-text", callback: (owner: this, position: number, chars: string, n_chars: number) => void): number;
 
 		connect(signal: "notify::length", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_length", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-length", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::text", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type TextBufferInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<ITextBuffer,
-		"length" |
-		"max_length" |
-		"text">;
+		"max_length">;
 
 	export interface TextBufferInitOptions extends TextBufferInitOptionsMixin {}
 
@@ -16428,18 +16382,18 @@ declare namespace imports.gi.Clutter {
 		 */
 		connect(signal: "size-change", callback: (owner: this, width: number, height: number) => void): number;
 
-		connect(signal: "notify::cogl_material", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cogl_texture", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::disable_slicing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cogl-material", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cogl-texture", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::disable-slicing", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::filename", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::filter_quality", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::keep_aspect_ratio", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pick_with_alpha", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixel_format", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::repeat_x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::repeat_y", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::sync_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tile_waste", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::filter-quality", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::keep-aspect-ratio", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pick-with-alpha", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixel-format", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::repeat-x", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::repeat-y", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::sync-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tile-waste", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -16452,11 +16406,9 @@ declare namespace imports.gi.Clutter {
 		"filter_quality" |
 		"keep_aspect_ratio" |
 		"pick_with_alpha" |
-		"pixel_format" |
 		"repeat_x" |
 		"repeat_y" |
-		"sync_size" |
-		"tile_waste">;
+		"sync_size">;
 
 	export interface TextureInitOptions extends TextureInitOptionsMixin {}
 
@@ -17107,13 +17059,13 @@ declare namespace imports.gi.Clutter {
 		 */
 		connect(signal: "stopped", callback: (owner: this, is_finished: boolean) => void): number;
 
-		connect(signal: "notify::auto_reverse", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::auto-reverse", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::delay", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::direction", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::duration", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::loop", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::progress_mode", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::repeat_count", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::progress-mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::repeat-count", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -17292,7 +17244,7 @@ declare namespace imports.gi.Clutter {
 		set_to_value(value: GObject.Value): void;
 		connect(signal: "notify::animatable", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::interval", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::remove_on_complete", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::remove-on-complete", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -17424,7 +17376,7 @@ declare namespace imports.gi.Clutter {
 		 */
 		connect(signal: "zoom", callback: (owner: this, actor: Actor, focal_point: Point, factor: number) => boolean): number;
 
-		connect(signal: "notify::zoom_axis", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::zoom-axis", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -20238,23 +20190,20 @@ declare namespace imports.gi.Clutter {
 		 */
 		connect(signal: "error", callback: (owner: this, error: GLib.Error) => void): number;
 
-		connect(signal: "notify::audio_volume", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::buffer_fill", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::can_seek", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::audio-volume", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::buffer-fill", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::can-seek", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::duration", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::playing", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::progress", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::subtitle_font_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::subtitle_uri", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::subtitle-font-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::subtitle-uri", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::uri", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type MediaInitOptionsMixin = Pick<IMedia,
 		"audio_volume" |
-		"buffer_fill" |
-		"can_seek" |
-		"duration" |
 		"playing" |
 		"progress" |
 		"subtitle_font_name" |

--- a/.typescript-declarations/ClutterX11-1.0.d.ts
+++ b/.typescript-declarations/ClutterX11-1.0.d.ts
@@ -94,35 +94,27 @@ declare namespace imports.gi.ClutterX11 {
 		 */
 		connect(signal: "update-area", callback: (owner: this, x: number, y: number, width: number, height: number) => void): number;
 
-		connect(signal: "notify::automatic_updates", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::automatic-updates", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::destroyed", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::pixmap", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixmap_depth", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixmap_height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixmap_width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixmap-depth", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixmap-height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixmap-width", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::window", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::window_mapped", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::window_override_redirect", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::window_redirect_automatic", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::window_x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::window_y", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::window-mapped", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::window-override-redirect", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::window-redirect-automatic", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::window-x", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::window-y", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type TexturePixmapInitOptionsMixin = Clutter.TextureInitOptions & Atk.ImplementorIfaceInitOptions & Clutter.AnimatableInitOptions & Clutter.ContainerInitOptions & Clutter.ScriptableInitOptions & 
 	Pick<ITexturePixmap,
 		"automatic_updates" |
-		"destroyed" |
 		"pixmap" |
-		"pixmap_depth" |
-		"pixmap_height" |
-		"pixmap_width" |
 		"window" |
-		"window_mapped" |
-		"window_override_redirect" |
-		"window_redirect_automatic" |
-		"window_x" |
-		"window_y">;
+		"window_redirect_automatic">;
 
 	export interface TexturePixmapInitOptions extends TexturePixmapInitOptionsMixin {}
 

--- a/.typescript-declarations/Cvc-1.0.d.ts
+++ b/.typescript-declarations/Cvc-1.0.d.ts
@@ -61,19 +61,18 @@ declare namespace imports.gi.Cvc {
 		set_ports(ports: GLib.List): boolean;
 		set_profile(profile: string): boolean;
 		set_profiles(profiles: GLib.List): boolean;
-		connect(signal: "notify::human_profile", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::human-profile", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::id", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::index", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pa_context", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pa-context", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::profile", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type MixerCardInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IMixerCard,
-		"human_profile" |
 		"icon_name" |
 		"id" |
 		"index" |
@@ -346,23 +345,23 @@ declare namespace imports.gi.Cvc {
 		connect(signal: "monitor-suspend", callback: (owner: this) => void): number;
 		connect(signal: "monitor-update", callback: (owner: this, object: number) => void): number;
 
-		connect(signal: "notify::application_id", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::can_decibel", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::card_index", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::channel_map", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::application-id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::can-decibel", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::card-index", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::channel-map", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::decibel", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::description", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::form_factor", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::form-factor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::id", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::index", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_event_stream", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_muted", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_virtual", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-event-stream", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-muted", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-virtual", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pa_context", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pa-context", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::port", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::sysfs_path", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::sysfs-path", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::volume", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -457,11 +456,11 @@ declare namespace imports.gi.Cvc {
 		should_profiles_be_hidden(): boolean;
 		connect(signal: "notify::card", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::description", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::origin", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::port_available", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::port_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::stream_id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::port-available", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::port-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::stream-id", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::type", callback: (owner: this, ...args: any) => void): number;
 
 	}

--- a/.typescript-declarations/GObject-2.0.d.ts
+++ b/.typescript-declarations/GObject-2.0.d.ts
@@ -121,9 +121,9 @@ declare namespace imports.gi.GObject {
 		unbind(): void;
 		connect(signal: "notify::flags", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::source", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::source_property", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::source-property", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::target", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::target_property", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::target-property", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1303,12 +1303,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecInitOptionsMixin = Pick<IParamSpec,
-		"name" |
-		"flags" |
-		"value_type" |
-		"owner_type">;
-
+	type ParamSpecInitOptionsMixin  = {};
 	export interface ParamSpecInitOptions extends ParamSpecInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1382,10 +1377,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecBooleanInitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecBoolean,
-		"default_value">;
-
+	type ParamSpecBooleanInitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecBooleanInitOptions extends ParamSpecBooleanInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1449,12 +1441,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecCharInitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecChar,
-		"minimum" |
-		"maximum" |
-		"default_value">;
-
+	type ParamSpecCharInitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecCharInitOptions extends ParamSpecCharInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1500,13 +1487,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecDoubleInitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecDouble,
-		"minimum" |
-		"maximum" |
-		"default_value" |
-		"epsilon">;
-
+	type ParamSpecDoubleInitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecDoubleInitOptions extends ParamSpecDoubleInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1541,11 +1522,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecEnumInitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecEnum,
-		"enum_class" |
-		"default_value">;
-
+	type ParamSpecEnumInitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecEnumInitOptions extends ParamSpecEnumInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1581,11 +1558,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecFlagsInitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecFlags,
-		"flags_class" |
-		"default_value">;
-
+	type ParamSpecFlagsInitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecFlagsInitOptions extends ParamSpecFlagsInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1632,13 +1605,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecFloatInitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecFloat,
-		"minimum" |
-		"maximum" |
-		"default_value" |
-		"epsilon">;
-
+	type ParamSpecFloatInitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecFloatInitOptions extends ParamSpecFloatInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1668,10 +1635,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecGTypeInitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecGType,
-		"is_a_type">;
-
+	type ParamSpecGTypeInitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecGTypeInitOptions extends ParamSpecGTypeInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1711,12 +1675,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecIntInitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecInt,
-		"minimum" |
-		"maximum" |
-		"default_value">;
-
+	type ParamSpecIntInitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecIntInitOptions extends ParamSpecIntInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1756,12 +1715,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecInt64InitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecInt64,
-		"minimum" |
-		"maximum" |
-		"default_value">;
-
+	type ParamSpecInt64InitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecInt64InitOptions extends ParamSpecInt64InitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1801,12 +1755,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecLongInitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecLong,
-		"minimum" |
-		"maximum" |
-		"default_value">;
-
+	type ParamSpecLongInitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecLongInitOptions extends ParamSpecLongInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1968,15 +1917,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecStringInitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecString,
-		"default_value" |
-		"cset_first" |
-		"cset_nth" |
-		"substitutor" |
-		"null_fold_if_empty" |
-		"ensure_non_null">;
-
+	type ParamSpecStringInitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecStringInitOptions extends ParamSpecStringInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -2017,12 +1958,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecUCharInitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecUChar,
-		"minimum" |
-		"maximum" |
-		"default_value">;
-
+	type ParamSpecUCharInitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecUCharInitOptions extends ParamSpecUCharInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -2062,12 +1998,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecUIntInitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecUInt,
-		"minimum" |
-		"maximum" |
-		"default_value">;
-
+	type ParamSpecUIntInitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecUIntInitOptions extends ParamSpecUIntInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -2107,12 +2038,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecUInt64InitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecUInt64,
-		"minimum" |
-		"maximum" |
-		"default_value">;
-
+	type ParamSpecUInt64InitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecUInt64InitOptions extends ParamSpecUInt64InitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -2152,12 +2078,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecULongInitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecULong,
-		"minimum" |
-		"maximum" |
-		"default_value">;
-
+	type ParamSpecULongInitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecULongInitOptions extends ParamSpecULongInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -2187,10 +2108,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecUnicharInitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecUnichar,
-		"default_value">;
-
+	type ParamSpecUnicharInitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecUnicharInitOptions extends ParamSpecUnicharInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -2225,11 +2143,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecValueArrayInitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecValueArray,
-		"element_spec" |
-		"fixed_n_elements">;
-
+	type ParamSpecValueArrayInitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecValueArrayInitOptions extends ParamSpecValueArrayInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -2264,11 +2178,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type ParamSpecVariantInitOptionsMixin = ParamSpecInitOptions & 
-	Pick<IParamSpecVariant,
-		"type" |
-		"default_value">;
-
+	type ParamSpecVariantInitOptionsMixin = ParamSpecInitOptions
 	export interface ParamSpecVariantInitOptions extends ParamSpecVariantInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -2406,13 +2316,7 @@ declare namespace imports.gi.GObject {
 
 	}
 
-	type TypeModuleInitOptionsMixin = ObjectInitOptions & TypePluginInitOptions & 
-	Pick<ITypeModule,
-		"use_count" |
-		"type_infos" |
-		"interface_infos" |
-		"name">;
-
+	type TypeModuleInitOptionsMixin = ObjectInitOptions & TypePluginInitOptions
 	export interface TypeModuleInitOptions extends TypeModuleInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,

--- a/.typescript-declarations/Gdk-3.0.d.ts
+++ b/.typescript-declarations/Gdk-3.0.d.ts
@@ -179,7 +179,7 @@ declare namespace imports.gi.Gdk {
 		 * if no references remain.
 		 */
 		unref(): void;
-		connect(signal: "notify::cursor_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cursor-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::display", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -768,39 +768,35 @@ declare namespace imports.gi.Gdk {
 		 */
 		connect(signal: "tool-changed", callback: (owner: this, tool: DeviceTool) => void): number;
 
-		connect(signal: "notify::associated_device", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::associated-device", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::axes", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::device_manager", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::device-manager", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::display", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_cursor", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::input_mode", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::input_source", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::n_axes", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-cursor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::input-mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::input-source", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::n-axes", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::num_touches", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::product_id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::num-touches", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::product-id", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::seat", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::tool", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::type", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::vendor_id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::vendor-id", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type DeviceInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IDevice,
-		"associated_device" |
-		"axes" |
 		"device_manager" |
 		"display" |
 		"has_cursor" |
 		"input_mode" |
 		"input_source" |
-		"n_axes" |
 		"name" |
 		"num_touches" |
 		"product_id" |
 		"seat" |
-		"tool" |
 		"type" |
 		"vendor_id">;
 
@@ -1105,9 +1101,9 @@ declare namespace imports.gi.Gdk {
 		 */
 		get_tool_type(): DeviceToolType;
 		connect(signal: "notify::axes", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::hardware_id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::hardware-id", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::serial", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tool_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tool-type", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1694,7 +1690,7 @@ declare namespace imports.gi.Gdk {
 		 */
 		connect(signal: "display-opened", callback: (owner: this, display: Display) => void): number;
 
-		connect(signal: "notify::default_display", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::default-display", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -2385,7 +2381,7 @@ declare namespace imports.gi.Gdk {
 		 */
 		set_use_es(use_es: number): void;
 		connect(signal: "notify::display", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::shared_context", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::shared-context", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::window", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -2838,29 +2834,20 @@ declare namespace imports.gi.Gdk {
 
 		connect(signal: "notify::display", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::geometry", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::height_mm", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::height-mm", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::manufacturer", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::model", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::refresh_rate", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scale_factor", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::subpixel_layout", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::width_mm", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::refresh-rate", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scale-factor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::subpixel-layout", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::width-mm", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::workarea", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type MonitorInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IMonitor,
-		"display" |
-		"geometry" |
-		"height_mm" |
-		"manufacturer" |
-		"model" |
-		"refresh_rate" |
-		"scale_factor" |
-		"subpixel_layout" |
-		"width_mm" |
-		"workarea">;
+		"display">;
 
 	export interface MonitorInitOptions extends MonitorInitOptionsMixin {}
 
@@ -3267,7 +3254,7 @@ declare namespace imports.gi.Gdk {
 		 */
 		connect(signal: "size-changed", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::font_options", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-options", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::resolution", callback: (owner: this, ...args: any) => void): number;
 
 	}

--- a/.typescript-declarations/GdkPixbuf-2.0.d.ts
+++ b/.typescript-declarations/GdkPixbuf-2.0.d.ts
@@ -692,12 +692,12 @@ declare namespace imports.gi.GdkPixbuf {
 		 * Removes a reference from a pixbuf.
 		 */
 		unref(): void;
-		connect(signal: "notify::bits_per_sample", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::bits-per-sample", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::colorspace", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_alpha", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-alpha", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::n_channels", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixel_bytes", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::n-channels", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixel-bytes", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::pixels", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::rowstride", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::width", callback: (owner: this, ...args: any) => void): number;

--- a/.typescript-declarations/Gio-2.0.d.ts
+++ b/.typescript-declarations/Gio-2.0.d.ts
@@ -907,13 +907,13 @@ declare namespace imports.gi.Gio {
 		 */
 		connect(signal: "startup", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::application_id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::application-id", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::flags", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::inactivity_timeout", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_busy", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_registered", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_remote", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::resource_base_path", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::inactivity-timeout", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-busy", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-registered", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-remote", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::resource-base-path", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -922,9 +922,6 @@ declare namespace imports.gi.Gio {
 		"application_id" |
 		"flags" |
 		"inactivity_timeout" |
-		"is_busy" |
-		"is_registered" |
-		"is_remote" |
 		"resource_base_path">;
 
 	export interface ApplicationInitOptions extends ApplicationInitOptionsMixin {}
@@ -1307,14 +1304,11 @@ declare namespace imports.gi.Gio {
 		 * @param exit_status the exit status
 		 */
 		set_exit_status(exit_status: number): void;
-		connect(signal: "notify::is_remote", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-remote", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type ApplicationCommandLineInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IApplicationCommandLine,
-		"is_remote">;
-
+	type ApplicationCommandLineInitOptionsMixin = GObject.ObjectInitOptions
 	export interface ApplicationCommandLineInitOptions extends ApplicationCommandLineInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1594,7 +1588,7 @@ declare namespace imports.gi.Gio {
 		 * @param size a #gsize
 		 */
 		set_buffer_size(size: number): void;
-		connect(signal: "notify::buffer_size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::buffer-size", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1676,8 +1670,8 @@ declare namespace imports.gi.Gio {
 		 * @param size a #gsize.
 		 */
 		set_buffer_size(size: number): void;
-		connect(signal: "notify::auto_grow", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::buffer_size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::auto-grow", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::buffer-size", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -2073,9 +2067,9 @@ declare namespace imports.gi.Gio {
 		 * @param use_fallback %TRUE to use fallbacks
 		 */
 		set_use_fallback(use_fallback: boolean): void;
-		connect(signal: "notify::from_charset", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::to_charset", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_fallback", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::from-charset", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::to-charset", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-fallback", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -3450,23 +3444,20 @@ declare namespace imports.gi.Gio {
 
 		connect(signal: "notify::capabilities", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::closed", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::exit_on_close", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::exit-on-close", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::flags", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::guid", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::stream", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::unique_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::unique-name", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type DBusConnectionInitOptionsMixin = GObject.ObjectInitOptions & AsyncInitableInitOptions & InitableInitOptions & 
 	Pick<IDBusConnection,
-		"capabilities" |
-		"closed" |
 		"exit_on_close" |
 		"flags" |
 		"guid" |
-		"stream" |
-		"unique_name">;
+		"stream">;
 
 	export interface DBusConnectionInitOptions extends DBusConnectionInitOptionsMixin {}
 
@@ -3807,7 +3798,7 @@ declare namespace imports.gi.Gio {
 		 */
 		connect(signal: "g-authorize-method", callback: (owner: this, invocation: DBusMethodInvocation) => boolean): number;
 
-		connect(signal: "notify::g_flags", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::g-flags", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -4199,10 +4190,7 @@ declare namespace imports.gi.Gio {
 
 	}
 
-	type DBusMessageInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IDBusMessage,
-		"locked">;
-
+	type DBusMessageInitOptionsMixin = GObject.ObjectInitOptions
 	export interface DBusMessageInitOptions extends DBusMessageInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -4616,12 +4604,12 @@ declare namespace imports.gi.Gio {
 
 		connect(signal: "notify::connection", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::flags", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::get_proxy_type_destroy_notify", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::get_proxy_type_func", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::get_proxy_type_user_data", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::get-proxy-type-destroy-notify", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::get-proxy-type-func", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::get-proxy-type-user-data", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::name_owner", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::object_path", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::name-owner", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::object-path", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -4633,7 +4621,6 @@ declare namespace imports.gi.Gio {
 		"get_proxy_type_func" |
 		"get_proxy_type_user_data" |
 		"name" |
-		"name_owner" |
 		"object_path">;
 
 	export interface DBusObjectManagerClientInitOptions extends DBusObjectManagerClientInitOptionsMixin {}
@@ -4886,7 +4873,7 @@ declare namespace imports.gi.Gio {
 		 */
 		unexport(object_path: string): boolean;
 		connect(signal: "notify::connection", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::object_path", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::object-path", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -4962,8 +4949,8 @@ declare namespace imports.gi.Gio {
 		 *   object is owned by #proxy.
 		 */
 		get_connection(): DBusConnection;
-		connect(signal: "notify::g_connection", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::g_object_path", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::g-connection", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::g-object-path", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -5062,7 +5049,7 @@ declare namespace imports.gi.Gio {
 		 */
 		connect(signal: "authorize-method", callback: (owner: this, _interface: DBusInterfaceSkeleton, invocation: DBusMethodInvocation) => boolean): number;
 
-		connect(signal: "notify::g_object_path", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::g-object-path", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -5478,14 +5465,14 @@ declare namespace imports.gi.Gio {
 		 */
 		connect(signal: "g-signal", callback: (owner: this, sender_name: string | null, signal_name: string, parameters: GLib.Variant) => void): number;
 
-		connect(signal: "notify::g_connection", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::g_default_timeout", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::g_flags", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::g_interface_info", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::g_interface_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::g_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::g_name_owner", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::g_object_path", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::g-connection", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::g-default-timeout", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::g-flags", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::g-interface-info", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::g-interface-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::g-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::g-name-owner", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::g-object-path", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -5497,7 +5484,6 @@ declare namespace imports.gi.Gio {
 		"g_interface_info" |
 		"g_interface_name" |
 		"g_name" |
-		"g_name_owner" |
 		"g_object_path">;
 
 	export interface DBusProxyInitOptions extends DBusProxyInitOptionsMixin {}
@@ -5773,8 +5759,8 @@ declare namespace imports.gi.Gio {
 
 		connect(signal: "notify::active", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::address", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::authentication_observer", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::client_address", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::authentication-observer", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::client-address", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::flags", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::guid", callback: (owner: this, ...args: any) => void): number;
 
@@ -5782,10 +5768,8 @@ declare namespace imports.gi.Gio {
 
 	type DBusServerInitOptionsMixin = GObject.ObjectInitOptions & InitableInitOptions & 
 	Pick<IDBusServer,
-		"active" |
 		"address" |
 		"authentication_observer" |
-		"client_address" |
 		"flags" |
 		"guid">;
 
@@ -6188,8 +6172,8 @@ declare namespace imports.gi.Gio {
 		 * @param type the type of new line return as #GDataStreamNewlineType.
 		 */
 		set_newline_type(type: DataStreamNewlineType): void;
-		connect(signal: "notify::byte_order", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::newline_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::byte-order", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::newline-type", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -6296,7 +6280,7 @@ declare namespace imports.gi.Gio {
 		 * @param order a %GDataStreamByteOrder.
 		 */
 		set_byte_order(order: DataStreamByteOrder): void;
-		connect(signal: "notify::byte_order", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::byte-order", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -7793,13 +7777,12 @@ declare namespace imports.gi.Gio {
 		connect(signal: "changed", callback: (owner: this, file: File, other_file: File | null, event_type: FileMonitorEvent) => void): number;
 
 		connect(signal: "notify::cancelled", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::rate_limit", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::rate-limit", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type FileMonitorInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IFileMonitor,
-		"cancelled" |
 		"rate_limit">;
 
 	export interface FileMonitorInitOptions extends FileMonitorInitOptionsMixin {}
@@ -8001,8 +7984,8 @@ declare namespace imports.gi.Gio {
 		 * @param close_base %TRUE to close the base stream.
 		 */
 		set_close_base_stream(close_base: boolean): void;
-		connect(signal: "notify::base_stream", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::close_base_stream", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::base-stream", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::close-base-stream", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::base_stream", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -8010,8 +7993,7 @@ declare namespace imports.gi.Gio {
 	type FilterInputStreamInitOptionsMixin = InputStreamInitOptions & 
 	Pick<IFilterInputStream,
 		"base_stream" |
-		"close_base_stream" |
-		"base_stream">;
+		"close_base_stream">;
 
 	export interface FilterInputStreamInitOptions extends FilterInputStreamInitOptionsMixin {}
 
@@ -8055,8 +8037,8 @@ declare namespace imports.gi.Gio {
 		 * @param close_base %TRUE to close the base stream.
 		 */
 		set_close_base_stream(close_base: boolean): void;
-		connect(signal: "notify::base_stream", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::close_base_stream", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::base-stream", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::close-base-stream", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::base_stream", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -8064,8 +8046,7 @@ declare namespace imports.gi.Gio {
 	type FilterOutputStreamInitOptionsMixin = OutputStreamInitOptions & 
 	Pick<IFilterOutputStream,
 		"base_stream" |
-		"close_base_stream" |
-		"base_stream">;
+		"close_base_stream">;
 
 	export interface FilterOutputStreamInitOptions extends FilterOutputStreamInitOptionsMixin {}
 
@@ -8305,17 +8286,12 @@ declare namespace imports.gi.Gio {
 		 */
 		splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null): void;
 		connect(signal: "notify::closed", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::input_stream", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::output_stream", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::input-stream", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::output-stream", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type IOStreamInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IIOStream,
-		"closed" |
-		"input_stream" |
-		"output_stream">;
-
+	type IOStreamInitOptionsMixin = GObject.ObjectInitOptions
 	export interface IOStreamInitOptions extends IOStreamInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -8526,33 +8502,23 @@ declare namespace imports.gi.Gio {
 		to_string(): string;
 		connect(signal: "notify::bytes", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::family", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_any", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_link_local", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_loopback", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_mc_global", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_mc_link_local", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_mc_node_local", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_mc_org_local", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_mc_site_local", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_multicast", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_site_local", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-any", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-link-local", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-loopback", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-mc-global", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-mc-link-local", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-mc-node-local", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-mc-org-local", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-mc-site-local", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-multicast", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-site-local", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type InetAddressInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IInetAddress,
 		"bytes" |
-		"family" |
-		"is_any" |
-		"is_link_local" |
-		"is_loopback" |
-		"is_mc_global" |
-		"is_mc_link_local" |
-		"is_mc_node_local" |
-		"is_mc_org_local" |
-		"is_mc_site_local" |
-		"is_multicast" |
-		"is_site_local">;
+		"family">;
 
 	export interface InetAddressInitOptions extends InetAddressInitOptionsMixin {}
 
@@ -8663,7 +8629,6 @@ declare namespace imports.gi.Gio {
 	type InetAddressMaskInitOptionsMixin = GObject.ObjectInitOptions & InitableInitOptions & 
 	Pick<IInetAddressMask,
 		"address" |
-		"family" |
 		"length">;
 
 	export interface InetAddressMaskInitOptions extends InetAddressMaskInitOptionsMixin {}
@@ -8740,7 +8705,7 @@ declare namespace imports.gi.Gio {
 		connect(signal: "notify::address", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::flowinfo", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::port", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scope_id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scope-id", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -9254,7 +9219,7 @@ declare namespace imports.gi.Gio {
 		 * @param n_additions the number of items to add
 		 */
 		splice(position: number, n_removals: number, additions: GObject.Object[], n_additions: number): void;
-		connect(signal: "notify::item_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::item-type", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -9423,9 +9388,9 @@ declare namespace imports.gi.Gio {
 		 */
 		steal_data(): any | null;
 		connect(signal: "notify::data", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::data_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::destroy_function", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::realloc_function", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::data-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::destroy-function", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::realloc-function", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::size", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -9433,7 +9398,6 @@ declare namespace imports.gi.Gio {
 	type MemoryOutputStreamInitOptionsMixin = OutputStreamInitOptions & PollableOutputStreamInitOptions & SeekableInitOptions & 
 	Pick<IMemoryOutputStream,
 		"data" |
-		"data_size" |
 		"destroy_function" |
 		"realloc_function" |
 		"size">;
@@ -10721,10 +10685,10 @@ declare namespace imports.gi.Gio {
 		connect(signal: "notify::anonymous", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::choice", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::domain", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_tcrypt_hidden_volume", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_tcrypt_system_volume", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-tcrypt-hidden-volume", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-tcrypt-system-volume", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::password", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::password_save", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::password-save", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::pim", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::username", callback: (owner: this, ...args: any) => void): number;
 
@@ -11948,17 +11912,12 @@ declare namespace imports.gi.Gio {
 		 */
 		release_finish(result: AsyncResult): boolean;
 		connect(signal: "notify::allowed", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::can_acquire", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::can_release", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::can-acquire", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::can-release", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type PermissionInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IPermission,
-		"allowed" |
-		"can_acquire" |
-		"can_release">;
-
+	type PermissionInitOptionsMixin = GObject.ObjectInitOptions
 	export interface PermissionInitOptions extends PermissionInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -12026,22 +11985,18 @@ declare namespace imports.gi.Gio {
 		readonly state_type: GLib.VariantType;
 
 		connect(signal: "notify::enabled", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::invert_boolean", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::invert-boolean", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::parameter_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::parameter-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::state", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::state_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::state-type", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type PropertyActionInitOptionsMixin = GObject.ObjectInitOptions & ActionInitOptions & 
 	Pick<IPropertyAction,
-		"enabled" |
 		"invert_boolean" |
-		"name" |
-		"parameter_type" |
-		"state" |
-		"state_type">;
+		"name">;
 
 	export interface PropertyActionInitOptions extends PropertyActionInitOptionsMixin {}
 
@@ -12184,9 +12139,9 @@ declare namespace imports.gi.Gio {
 		 * @returns the #proxy's username
 		 */
 		get_username(): string | null;
-		connect(signal: "notify::destination_hostname", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::destination_port", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::destination_protocol", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::destination-hostname", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::destination-port", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::destination-protocol", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::password", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::protocol", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::uri", callback: (owner: this, ...args: any) => void): number;
@@ -12256,8 +12211,8 @@ declare namespace imports.gi.Gio {
 		uri: string;
 
 		connect(signal: "notify::connectable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::default_port", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::proxy_resolver", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::default-port", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::proxy-resolver", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::uri", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -13346,20 +13301,18 @@ declare namespace imports.gi.Gio {
 		connect(signal: "writable-changed", callback: (owner: this, key: string) => void): number;
 
 		connect(signal: "notify::backend", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::delay_apply", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_unapplied", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::delay-apply", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-unapplied", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::path", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::schema", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::schema_id", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::settings_schema", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::schema-id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::settings-schema", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type SettingsInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<ISettings,
 		"backend" |
-		"delay_apply" |
-		"has_unapplied" |
 		"path" |
 		"schema" |
 		"schema_id" |
@@ -14117,9 +14070,9 @@ declare namespace imports.gi.Gio {
 
 		connect(signal: "notify::enabled", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::parameter_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::parameter-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::state", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::state_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::state-type", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -14128,8 +14081,7 @@ declare namespace imports.gi.Gio {
 		"enabled" |
 		"name" |
 		"parameter_type" |
-		"state" |
-		"state_type">;
+		"state">;
 
 	export interface SimpleActionInitOptions extends SimpleActionInitOptionsMixin {}
 
@@ -14705,8 +14657,8 @@ declare namespace imports.gi.Gio {
 		input_stream: InputStream;
 		output_stream: OutputStream;
 
-		connect(signal: "notify::input_stream", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::output_stream", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::input-stream", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::output-stream", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -14865,8 +14817,8 @@ declare namespace imports.gi.Gio {
 		 * @param proxy the proxy to use for #uri_scheme
 		 */
 		set_uri_proxy(uri_scheme: string, proxy: string): void;
-		connect(signal: "notify::default_proxy", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ignore_hosts", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::default-proxy", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ignore-hosts", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -15937,12 +15889,12 @@ declare namespace imports.gi.Gio {
 		connect(signal: "notify::family", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::fd", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::keepalive", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::listen_backlog", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::local_address", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::multicast_loopback", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::multicast_ttl", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::listen-backlog", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::local-address", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::multicast-loopback", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::multicast-ttl", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::protocol", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::remote_address", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::remote-address", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::timeout", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::ttl", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::type", callback: (owner: this, ...args: any) => void): number;
@@ -15957,11 +15909,9 @@ declare namespace imports.gi.Gio {
 		"fd" |
 		"keepalive" |
 		"listen_backlog" |
-		"local_address" |
 		"multicast_loopback" |
 		"multicast_ttl" |
 		"protocol" |
-		"remote_address" |
 		"timeout" |
 		"ttl" |
 		"type">;
@@ -16108,10 +16058,7 @@ declare namespace imports.gi.Gio {
 
 	}
 
-	type SocketAddressInitOptionsMixin = GObject.ObjectInitOptions & SocketConnectableInitOptions & 
-	Pick<ISocketAddress,
-		"family">;
-
+	type SocketAddressInitOptionsMixin = GObject.ObjectInitOptions & SocketConnectableInitOptions
 	export interface SocketAddressInitOptions extends SocketAddressInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -16667,14 +16614,14 @@ declare namespace imports.gi.Gio {
 		 */
 		connect(signal: "event", callback: (owner: this, event: SocketClientEvent, connectable: SocketConnectable, connection: IOStream | null) => void): number;
 
-		connect(signal: "notify::enable_proxy", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-proxy", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::family", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::local_address", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::local-address", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::protocol", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::proxy_resolver", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::proxy-resolver", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::timeout", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::tls", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tls_validation_flags", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tls-validation-flags", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::type", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -17126,7 +17073,7 @@ declare namespace imports.gi.Gio {
 		 */
 		connect(signal: "event", callback: (owner: this, event: SocketListenerEvent, socket: Socket) => void): number;
 
-		connect(signal: "notify::listen_backlog", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::listen-backlog", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -18336,10 +18283,7 @@ declare namespace imports.gi.Gio {
 
 	}
 
-	type TaskInitOptionsMixin = GObject.ObjectInitOptions & AsyncResultInitOptions & 
-	Pick<ITask,
-		"completed">;
-
+	type TaskInitOptionsMixin = GObject.ObjectInitOptions & AsyncResultInitOptions
 	export interface TaskInitOptions extends TaskInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -18947,7 +18891,7 @@ declare namespace imports.gi.Gio {
 		 * @param graceful_disconnect Whether to do graceful disconnects or not
 		 */
 		set_graceful_disconnect(graceful_disconnect: boolean): void;
-		connect(signal: "notify::graceful_disconnect", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::graceful-disconnect", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -18982,7 +18926,7 @@ declare namespace imports.gi.Gio {
 		 * @returns #conn's base #GIOStream
 		 */
 		get_base_io_stream(): IOStream;
-		connect(signal: "notify::base_io_stream", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::base-io-stream", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -19229,7 +19173,7 @@ declare namespace imports.gi.Gio {
 		 */
 		prepend_name(iconname: string): void;
 		connect(signal: "notify::names", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_default_fallbacks", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-default-fallbacks", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -19316,7 +19260,7 @@ declare namespace imports.gi.Gio {
 		 */
 		connect(signal: "run", callback: (owner: this, connection: SocketConnection, source_object: GObject.Object | null) => boolean): number;
 
-		connect(signal: "notify::max_threads", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-threads", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -19563,18 +19507,18 @@ declare namespace imports.gi.Gio {
 		 */
 		verify(identity: SocketConnectable | null, trusted_ca: TlsCertificate | null): TlsCertificateFlags;
 		connect(signal: "notify::certificate", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::certificate_pem", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::dns_names", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ip_addresses", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::certificate-pem", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::dns-names", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ip-addresses", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::issuer", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::issuer_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::not_valid_after", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::not_valid_before", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pkcs11_uri", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::private_key", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::private_key_pem", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::private_key_pkcs11_uri", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::subject_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::issuer-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::not-valid-after", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::not-valid-before", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pkcs11-uri", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::private-key", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::private-key-pem", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::private-key-pkcs11-uri", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::subject-name", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -19582,17 +19526,11 @@ declare namespace imports.gi.Gio {
 	Pick<ITlsCertificate,
 		"certificate" |
 		"certificate_pem" |
-		"dns_names" |
-		"ip_addresses" |
 		"issuer" |
-		"issuer_name" |
-		"not_valid_after" |
-		"not_valid_before" |
 		"pkcs11_uri" |
 		"private_key" |
 		"private_key_pem" |
-		"private_key_pkcs11_uri" |
-		"subject_name">;
+		"private_key_pkcs11_uri">;
 
 	export interface TlsCertificateInitOptions extends TlsCertificateInitOptionsMixin {}
 
@@ -20143,19 +20081,19 @@ declare namespace imports.gi.Gio {
 		 */
 		connect(signal: "accept-certificate", callback: (owner: this, peer_cert: TlsCertificate, errors: TlsCertificateFlags) => boolean): number;
 
-		connect(signal: "notify::advertised_protocols", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::base_io_stream", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::advertised-protocols", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::base-io-stream", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::certificate", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ciphersuite_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ciphersuite-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::database", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::interaction", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::negotiated_protocol", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::peer_certificate", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::peer_certificate_errors", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::protocol_version", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::rehandshake_mode", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::require_close_notify", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_system_certdb", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::negotiated-protocol", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::peer-certificate", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::peer-certificate-errors", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::protocol-version", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::rehandshake-mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::require-close-notify", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-system-certdb", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -20164,13 +20102,8 @@ declare namespace imports.gi.Gio {
 		"advertised_protocols" |
 		"base_io_stream" |
 		"certificate" |
-		"ciphersuite_name" |
 		"database" |
 		"interaction" |
-		"negotiated_protocol" |
-		"peer_certificate" |
-		"peer_certificate_errors" |
-		"protocol_version" |
 		"rehandshake_mode" |
 		"require_close_notify" |
 		"use_system_certdb">;
@@ -21168,7 +21101,7 @@ declare namespace imports.gi.Gio {
 		 *     array, or %NULL
 		 */
 		steal_fds(): [ number[], number | null ];
-		connect(signal: "notify::fd_list", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::fd-list", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -21245,7 +21178,7 @@ declare namespace imports.gi.Gio {
 		 * @param close_fd %TRUE to close the file descriptor when done
 		 */
 		set_close_fd(close_fd: boolean): void;
-		connect(signal: "notify::close_fd", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::close-fd", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::fd", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -21399,7 +21332,7 @@ declare namespace imports.gi.Gio {
 		 * @param close_fd %TRUE to close the file descriptor when done
 		 */
 		set_close_fd(close_fd: boolean): void;
-		connect(signal: "notify::close_fd", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::close-fd", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::fd", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -21490,9 +21423,9 @@ declare namespace imports.gi.Gio {
 		 */
 		get_path_len(): number;
 		connect(signal: "notify::abstract", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::address_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::address-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::path", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::path_as_array", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::path-as-array", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -21985,7 +21918,7 @@ declare namespace imports.gi.Gio {
 		 * @param file_info a #GFileInfo
 		 */
 		set_file_info(file_info: FileInfo | null): void;
-		connect(signal: "notify::file_info", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::file-info", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::format", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::level", callback: (owner: this, ...args: any) => void): number;
 
@@ -22042,14 +21975,13 @@ declare namespace imports.gi.Gio {
 		 * @returns a #GFileInfo, or %NULL
 		 */
 		get_file_info(): FileInfo | null;
-		connect(signal: "notify::file_info", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::file-info", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::format", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type ZlibDecompressorInitOptionsMixin = GObject.ObjectInitOptions & ConverterInitOptions & 
 	Pick<IZlibDecompressor,
-		"file_info" |
 		"format">;
 
 	export interface ZlibDecompressorInitOptions extends ZlibDecompressorInitOptionsMixin {}
@@ -24840,19 +24772,13 @@ declare namespace imports.gi.Gio {
 		get_state_type(): GLib.VariantType | null;
 		connect(signal: "notify::enabled", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::parameter_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::parameter-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::state", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::state_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::state-type", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type ActionInitOptionsMixin = Pick<IAction,
-		"enabled" |
-		"name" |
-		"parameter_type" |
-		"state" |
-		"state_type">;
-
+	type ActionInitOptionsMixin  = {};
 	export interface ActionInitOptions extends ActionInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -27242,14 +27168,13 @@ declare namespace imports.gi.Gio {
 		 * @param flags the #GTlsCertificateFlags to use
 		 */
 		set_validation_flags(flags: TlsCertificateFlags): void;
-		connect(signal: "notify::accepted_cas", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::server_identity", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::validation_flags", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accepted-cas", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::server-identity", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::validation-flags", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type DtlsClientConnectionInitOptionsMixin = Pick<IDtlsClientConnection,
-		"accepted_cas" |
 		"server_identity" |
 		"validation_flags">;
 
@@ -27746,18 +27671,18 @@ declare namespace imports.gi.Gio {
 		 */
 		connect(signal: "accept-certificate", callback: (owner: this, peer_cert: TlsCertificate, errors: TlsCertificateFlags) => boolean): number;
 
-		connect(signal: "notify::advertised_protocols", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::base_socket", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::advertised-protocols", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::base-socket", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::certificate", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ciphersuite_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ciphersuite-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::database", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::interaction", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::negotiated_protocol", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::peer_certificate", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::peer_certificate_errors", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::protocol_version", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::rehandshake_mode", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::require_close_notify", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::negotiated-protocol", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::peer-certificate", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::peer-certificate-errors", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::protocol-version", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::rehandshake-mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::require-close-notify", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -27765,13 +27690,8 @@ declare namespace imports.gi.Gio {
 		"advertised_protocols" |
 		"base_socket" |
 		"certificate" |
-		"ciphersuite_name" |
 		"database" |
 		"interaction" |
-		"negotiated_protocol" |
-		"peer_certificate" |
-		"peer_certificate_errors" |
-		"protocol_version" |
 		"rehandshake_mode" |
 		"require_close_notify">;
 
@@ -27822,7 +27742,7 @@ declare namespace imports.gi.Gio {
 		 */
 		authentication_mode: TlsAuthenticationMode;
 
-		connect(signal: "notify::authentication_mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::authentication-mode", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -31234,16 +31154,12 @@ declare namespace imports.gi.Gio {
 		connect(signal: "network-changed", callback: (owner: this, network_available: boolean) => void): number;
 
 		connect(signal: "notify::connectivity", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::network_available", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::network_metered", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::network-available", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::network-metered", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type NetworkMonitorInitOptionsMixin = Pick<INetworkMonitor,
-		"connectivity" |
-		"network_available" |
-		"network_metered">;
-
+	type NetworkMonitorInitOptionsMixin  = {};
 	export interface NetworkMonitorInitOptions extends NetworkMonitorInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -31498,13 +31414,11 @@ declare namespace imports.gi.Gio {
 		 * @returns Whether the system is in “Power Saver” mode.
 		 */
 		get_power_saver_enabled(): boolean;
-		connect(signal: "notify::power_saver_enabled", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::power-saver-enabled", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type PowerProfileMonitorInitOptionsMixin = Pick<IPowerProfileMonitor,
-		"power_saver_enabled">;
-
+	type PowerProfileMonitorInitOptionsMixin  = {};
 	export interface PowerProfileMonitorInitOptions extends PowerProfileMonitorInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -32228,15 +32142,14 @@ declare namespace imports.gi.Gio {
 		 * @param flags the #GTlsCertificateFlags to use
 		 */
 		set_validation_flags(flags: TlsCertificateFlags): void;
-		connect(signal: "notify::accepted_cas", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::server_identity", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_ssl3", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::validation_flags", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accepted-cas", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::server-identity", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-ssl3", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::validation-flags", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type TlsClientConnectionInitOptionsMixin = Pick<ITlsClientConnection,
-		"accepted_cas" |
 		"server_identity" |
 		"use_ssl3" |
 		"validation_flags">;
@@ -32334,7 +32247,7 @@ declare namespace imports.gi.Gio {
 		 */
 		authentication_mode: TlsAuthenticationMode;
 
-		connect(signal: "notify::authentication_mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::authentication-mode", callback: (owner: this, ...args: any) => void): number;
 
 	}
 

--- a/.typescript-declarations/Gst-1.0.d.ts
+++ b/.typescript-declarations/Gst-1.0.d.ts
@@ -78,18 +78,7 @@ declare namespace imports.gi.Gst {
 
 	}
 
-	type AllocatorInitOptionsMixin = ObjectInitOptions & 
-	Pick<IAllocator,
-		"object" |
-		"mem_type" |
-		"mem_map" |
-		"mem_unmap" |
-		"mem_copy" |
-		"mem_share" |
-		"mem_is_span" |
-		"mem_map_full" |
-		"mem_unmap_full">;
-
+	type AllocatorInitOptionsMixin = ObjectInitOptions
 	export interface AllocatorInitOptions extends AllocatorInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -464,8 +453,8 @@ declare namespace imports.gi.Gst {
 		 */
 		connect(signal: "element-removed", callback: (owner: this, element: Element) => void): number;
 
-		connect(signal: "notify::async_handling", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::message_forward", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::async-handling", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::message-forward", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::element", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::numchildren", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::children", callback: (owner: this, ...args: any) => void): number;
@@ -483,18 +472,7 @@ declare namespace imports.gi.Gst {
 	type BinInitOptionsMixin = ElementInitOptions & ChildProxyInitOptions & 
 	Pick<IBin,
 		"async_handling" |
-		"message_forward" |
-		"element" |
-		"numchildren" |
-		"children" |
-		"children_cookie" |
-		"child_bus" |
-		"messages" |
-		"polling" |
-		"state_dirty" |
-		"clock_dirty" |
-		"provided_clock" |
-		"clock_provider">;
+		"message_forward">;
 
 	export interface BinInitOptions extends BinInitOptionsMixin {}
 
@@ -740,11 +718,7 @@ declare namespace imports.gi.Gst {
 
 	}
 
-	type BufferPoolInitOptionsMixin = ObjectInitOptions & 
-	Pick<IBufferPool,
-		"object" |
-		"flushing">;
-
+	type BufferPoolInitOptionsMixin = ObjectInitOptions
 	export interface BufferPoolInitOptions extends BufferPoolInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1264,10 +1238,7 @@ declare namespace imports.gi.Gst {
 
 	}
 
-	type BusInitOptionsMixin = ObjectInitOptions & 
-	Pick<IBus,
-		"object">;
-
+	type BusInitOptionsMixin = ObjectInitOptions
 	export interface BusInitOptions extends BusInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1651,8 +1622,8 @@ declare namespace imports.gi.Gst {
 		connect(signal: "synced", callback: (owner: this, synced: boolean) => void): number;
 
 		connect(signal: "notify::timeout", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::window_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::window_threshold", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::window-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::window-threshold", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::object", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -1661,8 +1632,7 @@ declare namespace imports.gi.Gst {
 	Pick<IClock,
 		"timeout" |
 		"window_size" |
-		"window_threshold" |
-		"object">;
+		"window_threshold">;
 
 	export interface ClockInitOptions extends ClockInitOptionsMixin {}
 
@@ -1947,9 +1917,7 @@ declare namespace imports.gi.Gst {
 	type ControlBindingInitOptionsMixin = ObjectInitOptions & 
 	Pick<IControlBinding,
 		"name" |
-		"object" |
-		"name" |
-		"pspec">;
+		"object">;
 
 	export interface ControlBindingInitOptions extends ControlBindingInitOptionsMixin {}
 
@@ -2005,11 +1973,7 @@ declare namespace imports.gi.Gst {
 
 	}
 
-	type ControlSourceInitOptionsMixin = ObjectInitOptions & 
-	Pick<IControlSource,
-		"get_value" |
-		"get_value_array">;
-
+	type ControlSourceInitOptionsMixin = ObjectInitOptions
 	export interface ControlSourceInitOptions extends ControlSourceInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -2108,8 +2072,8 @@ declare namespace imports.gi.Gst {
 		connect(signal: "removed", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::caps", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::device_class", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::display_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::device-class", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::display-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::properties", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -2216,7 +2180,7 @@ declare namespace imports.gi.Gst {
 		 * Stops monitoring the devices.
 		 */
 		stop(): void;
-		connect(signal: "notify::show_all", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-all", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -2426,10 +2390,7 @@ declare namespace imports.gi.Gst {
 
 	}
 
-	type DeviceProviderInitOptionsMixin = ObjectInitOptions & 
-	Pick<IDeviceProvider,
-		"devices">;
-
+	type DeviceProviderInitOptionsMixin = ObjectInitOptions
 	export interface DeviceProviderInitOptions extends DeviceProviderInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -3585,30 +3546,7 @@ declare namespace imports.gi.Gst {
 
 	}
 
-	type ElementInitOptionsMixin = ObjectInitOptions & 
-	Pick<IElement,
-		"object" |
-		"state_lock" |
-		"state_cond" |
-		"state_cookie" |
-		"target_state" |
-		"current_state" |
-		"next_state" |
-		"pending_state" |
-		"last_return" |
-		"bus" |
-		"clock" |
-		"base_time" |
-		"start_time" |
-		"numpads" |
-		"pads" |
-		"numsrcpads" |
-		"srcpads" |
-		"numsinkpads" |
-		"sinkpads" |
-		"pads_cookie" |
-		"contexts">;
-
+	type ElementInitOptionsMixin = ObjectInitOptions
 	export interface ElementInitOptions extends ElementInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -4015,10 +3953,7 @@ declare namespace imports.gi.Gst {
 
 	}
 
-	type GhostPadInitOptionsMixin = ProxyPadInitOptions & 
-	Pick<IGhostPad,
-		"pad">;
-
+	type GhostPadInitOptionsMixin = ProxyPadInitOptions
 	export interface GhostPadInitOptions extends GhostPadInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -4456,11 +4391,7 @@ declare namespace imports.gi.Gst {
 
 	type ObjectInitOptionsMixin = GObject.InitiallyUnownedInitOptions & 
 	Pick<IObject,
-		"name" |
-		"object" |
-		"lock" |
-		"name" |
-		"flags">;
+		"name">;
 
 	export interface ObjectInitOptions extends ObjectInitOptionsMixin {}
 
@@ -5575,14 +5506,9 @@ declare namespace imports.gi.Gst {
 
 	type PadInitOptionsMixin = ObjectInitOptions & 
 	Pick<IPad,
-		"caps" |
 		"direction" |
 		"offset" |
-		"template" |
-		"object" |
-		"element_private" |
-		"padtemplate" |
-		"direction">;
+		"template">;
 
 	export interface PadInitOptions extends PadInitOptionsMixin {}
 
@@ -5764,7 +5690,7 @@ declare namespace imports.gi.Gst {
 		connect(signal: "notify::caps", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::direction", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::gtype", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::name_template", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::name-template", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::presence", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::object", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name_template", callback: (owner: this, ...args: any) => void): number;
@@ -5780,12 +5706,7 @@ declare namespace imports.gi.Gst {
 		"direction" |
 		"gtype" |
 		"name_template" |
-		"presence" |
-		"object" |
-		"name_template" |
-		"direction" |
-		"presence" |
-		"caps">;
+		"presence">;
 
 	export interface PadTemplateInitOptions extends PadTemplateInitOptionsMixin {}
 
@@ -6103,7 +6024,7 @@ declare namespace imports.gi.Gst {
 		 * @param clock the clock to use
 		 */
 		use_clock(clock: Clock | null): void;
-		connect(signal: "notify::auto_flush_bus", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::auto-flush-bus", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::delay", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::latency", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::bin", callback: (owner: this, ...args: any) => void): number;
@@ -6117,11 +6038,7 @@ declare namespace imports.gi.Gst {
 	Pick<IPipeline,
 		"auto_flush_bus" |
 		"delay" |
-		"latency" |
-		"bin" |
-		"fixed_clock" |
-		"stream_time" |
-		"delay">;
+		"latency">;
 
 	export interface PipelineInitOptions extends PipelineInitOptionsMixin {}
 
@@ -6567,10 +6484,7 @@ declare namespace imports.gi.Gst {
 
 	}
 
-	type ProxyPadInitOptionsMixin = PadInitOptions & 
-	Pick<IProxyPad,
-		"pad">;
-
+	type ProxyPadInitOptionsMixin = PadInitOptions
 	export interface ProxyPadInitOptions extends ProxyPadInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -6806,10 +6720,7 @@ declare namespace imports.gi.Gst {
 
 	}
 
-	type RegistryInitOptionsMixin = ObjectInitOptions & 
-	Pick<IRegistry,
-		"object">;
-
+	type RegistryInitOptionsMixin = ObjectInitOptions
 	export interface RegistryInitOptions extends RegistryInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -6981,9 +6892,9 @@ declare namespace imports.gi.Gst {
 		 */
 		set_tags(tags: TagList | null): void;
 		connect(signal: "notify::caps", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::stream_flags", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::stream_id", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::stream_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::stream-flags", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::stream-id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::stream-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::tags", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::stream_id", callback: (owner: this, ...args: any) => void): number;
 
@@ -6995,8 +6906,7 @@ declare namespace imports.gi.Gst {
 		"stream_flags" |
 		"stream_id" |
 		"stream_type" |
-		"tags" |
-		"stream_id">;
+		"tags">;
 
 	export interface StreamInitOptions extends StreamInitOptionsMixin {}
 
@@ -7067,7 +6977,7 @@ declare namespace imports.gi.Gst {
 		get_upstream_id(): string | null;
 		connect(signal: "stream-notify", callback: (owner: this, object: Stream, p0: GObject.ParamSpec) => void): number;
 
-		connect(signal: "notify::upstream_id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::upstream-id", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -7119,15 +7029,14 @@ declare namespace imports.gi.Gst {
 		clock_type: ClockType;
 		readonly clock: Clock;
 
-		connect(signal: "notify::clock_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::clock-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::clock", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type SystemClockInitOptionsMixin = ClockInitOptions & 
 	Pick<ISystemClock,
-		"clock_type" |
-		"clock">;
+		"clock_type">;
 
 	export interface SystemClockInitOptions extends SystemClockInitOptionsMixin {}
 
@@ -7330,17 +7239,7 @@ declare namespace imports.gi.Gst {
 
 	}
 
-	type TaskInitOptionsMixin = ObjectInitOptions & 
-	Pick<ITask,
-		"object" |
-		"state" |
-		"cond" |
-		"lock" |
-		"func" |
-		"user_data" |
-		"notify" |
-		"running">;
-
+	type TaskInitOptionsMixin = ObjectInitOptions
 	export interface TaskInitOptions extends TaskInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -7459,10 +7358,7 @@ declare namespace imports.gi.Gst {
 
 	}
 
-	type TaskPoolInitOptionsMixin = ObjectInitOptions & 
-	Pick<ITaskPool,
-		"object">;
-
+	type TaskPoolInitOptionsMixin = ObjectInitOptions
 	export interface TaskPoolInitOptions extends TaskPoolInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,

--- a/.typescript-declarations/Gtk-3.0.d.ts
+++ b/.typescript-declarations/Gtk-3.0.d.ts
@@ -330,15 +330,15 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "notify::copyright", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::documenters", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::license", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::license_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::license-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::logo", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::logo_icon_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::program_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::translator_credits", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::logo-icon-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::program-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::translator-credits", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::version", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::website", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::website_label", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::wrap_license", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::website-label", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::wrap-license", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -571,16 +571,12 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "accel-changed", callback: (owner: this, keyval: number, modifier: Gdk.ModifierType, accel_closure: GObject.Closure) => void): number;
 
-		connect(signal: "notify::is_locked", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::modifier_mask", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-locked", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::modifier-mask", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type AccelGroupInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IAccelGroup,
-		"is_locked" |
-		"modifier_mask">;
-
+	type AccelGroupInitOptionsMixin = GObject.ObjectInitOptions
 	export interface AccelGroupInitOptions extends AccelGroupInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -686,8 +682,8 @@ declare namespace imports.gi.Gtk {
 		 * @param accel_widget the widget to be monitored, or %NULL
 		 */
 		set_accel_widget(accel_widget: Widget | null): void;
-		connect(signal: "notify::accel_closure", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accel_widget", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accel-closure", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accel-widget", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::label", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -695,8 +691,7 @@ declare namespace imports.gi.Gtk {
 	type AccelLabelInitOptionsMixin = LabelInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
 	Pick<IAccelLabel,
 		"accel_closure" |
-		"accel_widget" |
-		"label">;
+		"accel_widget">;
 
 	export interface AccelLabelInitOptions extends AccelLabelInitOptionsMixin {}
 
@@ -1672,22 +1667,22 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "activate", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::action_group", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::always_show_image", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::action-group", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::always-show-image", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::gicon", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::hide_if_empty", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_important", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::hide-if-empty", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-important", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::label", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::sensitive", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::short_label", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::stock_id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::short-label", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::stock-id", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::tooltip", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::visible", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::visible_horizontal", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::visible_overflown", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::visible_vertical", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::visible-horizontal", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::visible-overflown", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::visible-vertical", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::object", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -1709,8 +1704,7 @@ declare namespace imports.gi.Gtk {
 		"visible" |
 		"visible_horizontal" |
 		"visible_overflown" |
-		"visible_vertical" |
-		"object">;
+		"visible_vertical">;
 
 	export interface ActionInitOptions extends ActionInitOptionsMixin {}
 
@@ -2113,7 +2107,7 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "pre-activate", callback: (owner: this, action: Action) => void): number;
 
-		connect(signal: "notify::accel_group", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accel-group", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::sensitive", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::visible", callback: (owner: this, ...args: any) => void): number;
@@ -2404,9 +2398,9 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "value-changed", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::lower", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::page_increment", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::page_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::step_increment", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::page-increment", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::page-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::step-increment", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::upper", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::value", callback: (owner: this, ...args: any) => void): number;
 
@@ -2574,10 +2568,10 @@ declare namespace imports.gi.Gtk {
 		 * @param padding_right the padding at the right of the widget.
 		 */
 		set_padding(padding_top: number, padding_bottom: number, padding_left: number, padding_right: number): void;
-		connect(signal: "notify::bottom_padding", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::left_padding", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::right_padding", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::top_padding", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::bottom-padding", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::left-padding", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::right-padding", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::top-padding", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::xalign", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::xscale", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::yalign", callback: (owner: this, ...args: any) => void): number;
@@ -2595,8 +2589,7 @@ declare namespace imports.gi.Gtk {
 		"xalign" |
 		"xscale" |
 		"yalign" |
-		"yscale" |
-		"bin">;
+		"yscale">;
 
 	export interface AlignmentInitOptions extends AlignmentInitOptionsMixin {}
 
@@ -2746,8 +2739,8 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "custom-item-activated", callback: (owner: this, item_name: string) => void): number;
 
 		connect(signal: "notify::heading", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_default_item", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_dialog_item", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-default-item", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-dialog-item", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -3039,12 +3032,12 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "populate-popup", callback: (owner: this, menu: Menu, application: Gio.AppInfo) => void): number;
 
-		connect(signal: "notify::default_text", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_all", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_default", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_fallback", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_other", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_recommended", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::default-text", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-all", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-default", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-fallback", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-other", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-recommended", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -3461,21 +3454,19 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "window-removed", callback: (owner: this, window: Window) => void): number;
 
-		connect(signal: "notify::active_window", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::app_menu", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::active-window", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::app-menu", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::menubar", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::register_session", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::screensaver_active", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::register-session", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::screensaver-active", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type ApplicationInitOptionsMixin = Gio.ApplicationInitOptions & Gio.ActionGroupInitOptions & Gio.ActionMapInitOptions & 
 	Pick<IApplication,
-		"active_window" |
 		"app_menu" |
 		"menubar" |
-		"register_session" |
-		"screensaver_active">;
+		"register_session">;
 
 	export interface ApplicationInitOptions extends ApplicationInitOptionsMixin {}
 
@@ -3646,7 +3637,7 @@ declare namespace imports.gi.Gtk {
 		 * @param show_menubar whether to show a menubar when needed
 		 */
 		set_show_menubar(show_menubar: boolean): void;
-		connect(signal: "notify::show_menubar", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-menubar", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -3794,8 +3785,8 @@ declare namespace imports.gi.Gtk {
 		 * @param shadow_type a valid {@link ShadowType}.
 		 */
 		set(arrow_type: ArrowType, shadow_type: ShadowType): void;
-		connect(signal: "notify::arrow_type", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::shadow_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::arrow-type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::shadow-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::misc", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -3803,8 +3794,7 @@ declare namespace imports.gi.Gtk {
 	type ArrowInitOptionsMixin = MiscInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
 	Pick<IArrow,
 		"arrow_type" |
-		"shadow_type" |
-		"misc">;
+		"shadow_type">;
 
 	export interface ArrowInitOptions extends ArrowInitOptionsMixin {}
 
@@ -3894,7 +3884,7 @@ declare namespace imports.gi.Gtk {
 		 *  ratio is taken from the requistion of the child.
 		 */
 		set(xalign: number, yalign: number, ratio: number, obey_child: boolean): void;
-		connect(signal: "notify::obey_child", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::obey-child", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::ratio", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::xalign", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::yalign", callback: (owner: this, ...args: any) => void): number;
@@ -3907,8 +3897,7 @@ declare namespace imports.gi.Gtk {
 		"obey_child" |
 		"ratio" |
 		"xalign" |
-		"yalign" |
-		"frame">;
+		"yalign">;
 
 	export interface AspectFrameInitOptions extends AspectFrameInitOptionsMixin {}
 
@@ -4246,7 +4235,7 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "prepare", callback: (owner: this, page: Widget) => void): number;
 
-		connect(signal: "notify::use_header_bar", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-header-bar", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -4319,10 +4308,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type BinInitOptionsMixin = ContainerInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
-	Pick<IBin,
-		"container">;
-
+	type BinInitOptionsMixin = ContainerInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions
 	export interface BinInitOptions extends BinInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -4508,7 +4494,7 @@ declare namespace imports.gi.Gtk {
 		 * @param spacing the number of pixels to put between children
 		 */
 		set_spacing(spacing: number): void;
-		connect(signal: "notify::baseline_position", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::baseline-position", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::homogeneous", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::spacing", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::container", callback: (owner: this, ...args: any) => void): number;
@@ -4519,8 +4505,7 @@ declare namespace imports.gi.Gtk {
 	Pick<IBox,
 		"baseline_position" |
 		"homogeneous" |
-		"spacing" |
-		"container">;
+		"spacing">;
 
 	export interface BoxInitOptions extends BoxInitOptionsMixin {}
 
@@ -4881,7 +4866,7 @@ declare namespace imports.gi.Gtk {
 		 * the #GValue to store the result in
 		 */
 		value_from_string_type(type: GObject.Type, string: string): [ boolean, GObject.Value ];
-		connect(signal: "notify::translation_domain", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::translation-domain", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -5422,13 +5407,13 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "released", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::always_show_image", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::always-show-image", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::image", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::image_position", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::image-position", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::label", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::relief", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_stock", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_underline", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-stock", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-underline", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::xalign", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::yalign", callback: (owner: this, ...args: any) => void): number;
 
@@ -5612,15 +5597,14 @@ declare namespace imports.gi.Gtk {
 		 * @param layout_style the new layout style
 		 */
 		set_layout(layout_style: ButtonBoxStyle): void;
-		connect(signal: "notify::layout_style", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::layout-style", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::box", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type ButtonBoxInitOptionsMixin = BoxInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
 	Pick<IButtonBox,
-		"layout_style" |
-		"box">;
+		"layout_style">;
 
 	export interface ButtonBoxInitOptions extends ButtonBoxInitOptionsMixin {}
 
@@ -5855,14 +5839,14 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "prev-year", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::day", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::detail_height_rows", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::detail_width_chars", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::detail-height-rows", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::detail-width-chars", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::month", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::no_month_change", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_day_names", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_details", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_heading", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_week_numbers", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::no-month-change", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-day-names", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-details", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-heading", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-week-numbers", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::year", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::widget", callback: (owner: this, ...args: any) => void): number;
 
@@ -5879,8 +5863,7 @@ declare namespace imports.gi.Gtk {
 		"show_details" |
 		"show_heading" |
 		"show_week_numbers" |
-		"year" |
-		"widget">;
+		"year">;
 
 	export interface CalendarInitOptions extends CalendarInitOptionsMixin {}
 
@@ -6464,16 +6447,14 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "remove-editable", callback: (owner: this, renderer: CellRenderer, editable: CellEditable) => void): number;
 
-		connect(signal: "notify::edit_widget", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::edited_cell", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::focus_cell", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::edit-widget", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::edited-cell", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::focus-cell", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type CellAreaInitOptionsMixin = GObject.InitiallyUnownedInitOptions & BuildableInitOptions & CellLayoutInitOptions & 
 	Pick<ICellArea,
-		"edit_widget" |
-		"edited_cell" |
 		"focus_cell">;
 
 	export interface CellAreaInitOptions extends CellAreaInitOptionsMixin {}
@@ -7073,20 +7054,16 @@ declare namespace imports.gi.Gtk {
 		 */
 		reset(): void;
 		connect(signal: "notify::area", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::minimum_height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::minimum_width", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::natural_height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::natural_width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::minimum-height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::minimum-width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::natural-height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::natural-width", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type CellAreaContextInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<ICellAreaContext,
-		"area" |
-		"minimum_height" |
-		"minimum_width" |
-		"natural_height" |
-		"natural_width">;
+		"area">;
 
 	export interface CellAreaContextInitOptions extends CellAreaContextInitOptionsMixin {}
 
@@ -7405,13 +7382,13 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "editing-started", callback: (owner: this, editable: CellEditable, path: string) => void): number;
 
-		connect(signal: "notify::cell_background_gdk", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cell_background_rgba", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cell_background_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cell-background-gdk", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cell-background-rgba", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cell-background-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::editing", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_expanded", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_expander", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-expanded", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-expander", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::mode", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::sensitive", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::visible", callback: (owner: this, ...args: any) => void): number;
@@ -7428,7 +7405,6 @@ declare namespace imports.gi.Gtk {
 		"cell_background_gdk" |
 		"cell_background_rgba" |
 		"cell_background_set" |
-		"editing" |
 		"height" |
 		"is_expanded" |
 		"is_expander" |
@@ -7541,9 +7517,9 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "accel-edited", callback: (owner: this, path_string: string, accel_key: number, accel_mods: Gdk.ModifierType, hardware_keycode: number) => void): number;
 
-		connect(signal: "notify::accel_key", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accel_mode", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accel_mods", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accel-key", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accel-mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accel-mods", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::keycode", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -7631,9 +7607,9 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "changed", callback: (owner: this, path_string: string, new_iter: TreeIter) => void): number;
 
-		connect(signal: "notify::has_entry", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-entry", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::model", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::text_column", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::text-column", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -7716,15 +7692,15 @@ declare namespace imports.gi.Gtk {
 		stock_size: number;
 		surface: cairo.Surface;
 
-		connect(signal: "notify::follow_state", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::follow-state", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::gicon", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::pixbuf", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixbuf_expander_closed", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixbuf_expander_open", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::stock_detail", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::stock_id", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::stock_size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixbuf-expander-closed", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixbuf-expander-open", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::stock-detail", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::stock-id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::stock-size", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::surface", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -7826,8 +7802,8 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "notify::inverted", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::pulse", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::text", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::text_xalign", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::text_yalign", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::text-xalign", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::text-yalign", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::value", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -7884,7 +7860,7 @@ declare namespace imports.gi.Gtk {
 		digits: number;
 
 		connect(signal: "notify::adjustment", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::climb_rate", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::climb-rate", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::digits", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -8126,51 +8102,51 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "edited", callback: (owner: this, path: string, new_text: string) => void): number;
 
-		connect(signal: "notify::align_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::align-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::alignment", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::attributes", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::background_gdk", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::background_rgba", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::background_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::background-gdk", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::background-rgba", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::background-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::editable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::editable_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::editable-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::ellipsize", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ellipsize_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ellipsize-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::family", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::family_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::family-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::font", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::font_desc", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::foreground_gdk", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::foreground_rgba", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::foreground_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-desc", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::foreground-gdk", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::foreground-rgba", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::foreground-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::language", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::language_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_width_chars", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::placeholder_text", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::language-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-width-chars", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::placeholder-text", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::rise", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::rise_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::rise-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::scale", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scale_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::single_paragraph_mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scale-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::single-paragraph-mode", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::size_points", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::size_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::size-points", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::size-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::stretch", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::stretch_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::stretch-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::strikethrough", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::strikethrough_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::strikethrough-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::style", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::style_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::style-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::text", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::underline", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::underline_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::underline-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::variant", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::variant_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::variant-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::weight", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::weight_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::width_chars", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::wrap_mode", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::wrap_width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::weight-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::width-chars", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::wrap-mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::wrap-width", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -8320,7 +8296,7 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "notify::activatable", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::active", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::inconsistent", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::indicator_size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::indicator-size", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::radio", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -8515,13 +8491,13 @@ declare namespace imports.gi.Gtk {
 		 * @param model a {@link TreeModel}
 		 */
 		set_model(model: TreeModel | null): void;
-		connect(signal: "notify::background_gdk", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::background_rgba", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::background_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cell_area", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cell_area_context", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::draw_sensitive", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::fit_model", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::background-gdk", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::background-rgba", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::background-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cell-area", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cell-area-context", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::draw-sensitive", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::fit-model", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::model", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -8619,10 +8595,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type CheckButtonInitOptionsMixin = ToggleButtonInitOptions & Atk.ImplementorIfaceInitOptions & ActionableInitOptions & ActivatableInitOptions & BuildableInitOptions & 
-	Pick<ICheckButton,
-		"toggle_button">;
-
+	type CheckButtonInitOptionsMixin = ToggleButtonInitOptions & Atk.ImplementorIfaceInitOptions & ActionableInitOptions & ActivatableInitOptions & BuildableInitOptions
 	export interface CheckButtonInitOptions extends CheckButtonInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -8749,7 +8722,7 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "toggled", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::active", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::draw_as_radio", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::draw-as-radio", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::inconsistent", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::menu_item", callback: (owner: this, ...args: any) => void): number;
 
@@ -8759,8 +8732,7 @@ declare namespace imports.gi.Gtk {
 	Pick<ICheckMenuItem,
 		"active" |
 		"draw_as_radio" |
-		"inconsistent" |
-		"menu_item">;
+		"inconsistent">;
 
 	export interface CheckMenuItemInitOptions extends CheckMenuItemInitOptionsMixin {}
 
@@ -9436,9 +9408,9 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "notify::alpha", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::color", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::rgba", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_editor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-editor", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::title", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_alpha", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-alpha", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::button", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -9450,8 +9422,7 @@ declare namespace imports.gi.Gtk {
 		"rgba" |
 		"show_editor" |
 		"title" |
-		"use_alpha" |
-		"button">;
+		"use_alpha">;
 
 	export interface ColorButtonInitOptions extends ColorButtonInitOptionsMixin {}
 
@@ -9508,7 +9479,7 @@ declare namespace imports.gi.Gtk {
 	interface IColorChooserDialog {
 		show_editor: boolean;
 
-		connect(signal: "notify::show_editor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-editor", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -9551,7 +9522,7 @@ declare namespace imports.gi.Gtk {
 		 */
 		show_editor: boolean;
 
-		connect(signal: "notify::show_editor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-editor", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -9749,11 +9720,11 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "color-changed", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::current_alpha", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::current_color", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::current_rgba", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_opacity_control", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_palette", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::current-alpha", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::current-color", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::current-rgba", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-opacity-control", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-palette", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -9826,20 +9797,14 @@ declare namespace imports.gi.Gtk {
 		 * @returns the embedded {@link ColorSelection}
 		 */
 		get_color_selection(): Widget;
-		connect(signal: "notify::cancel_button", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::color_selection", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::help_button", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ok_button", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cancel-button", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::color-selection", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::help-button", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ok-button", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type ColorSelectionDialogInitOptionsMixin = DialogInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
-	Pick<IColorSelectionDialog,
-		"cancel_button" |
-		"color_selection" |
-		"help_button" |
-		"ok_button">;
-
+	type ColorSelectionDialogInitOptionsMixin = DialogInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions
 	export interface ColorSelectionDialogInitOptions extends ColorSelectionDialogInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -10319,21 +10284,21 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "popup", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::active", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::active_id", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::add_tearoffs", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::button_sensitivity", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cell_area", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::column_span_column", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::entry_text_column", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_entry", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_frame", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::id_column", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::active-id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::add-tearoffs", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::button-sensitivity", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cell-area", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::column-span-column", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::entry-text-column", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-entry", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-frame", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::id-column", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::model", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::popup_fixed_width", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::popup_shown", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::row_span_column", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tearoff_title", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::wrap_width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::popup-fixed-width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::popup-shown", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::row-span-column", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tearoff-title", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::wrap-width", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -10351,7 +10316,6 @@ declare namespace imports.gi.Gtk {
 		"id_column" |
 		"model" |
 		"popup_fixed_width" |
-		"popup_shown" |
 		"row_span_column" |
 		"tearoff_title" |
 		"wrap_width">;
@@ -10998,8 +10962,8 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "remove", callback: (owner: this, object: Widget) => void): number;
 		connect(signal: "set-focus-child", callback: (owner: this, object: Widget) => void): number;
 
-		connect(signal: "notify::border_width", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::resize_mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::border-width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::resize-mode", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::widget", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -11007,8 +10971,7 @@ declare namespace imports.gi.Gtk {
 	type ContainerInitOptionsMixin = WidgetInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
 	Pick<IContainer,
 		"border_width" |
-		"resize_mode" |
-		"widget">;
+		"resize_mode">;
 
 	export interface ContainerInitOptions extends ContainerInitOptionsMixin {}
 
@@ -11659,15 +11622,14 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "response", callback: (owner: this, response_id: number) => void): number;
 
-		connect(signal: "notify::use_header_bar", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-header-bar", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::window", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type DialogInitOptionsMixin = WindowInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
 	Pick<IDialog,
-		"use_header_bar" |
-		"window">;
+		"use_header_bar">;
 
 	export interface DialogInitOptions extends DialogInitOptionsMixin {}
 
@@ -11860,10 +11822,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type DrawingAreaInitOptionsMixin = WidgetInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
-	Pick<IDrawingArea,
-		"widget">;
-
+	type DrawingAreaInitOptionsMixin = WidgetInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions
 	export interface DrawingAreaInitOptions extends DrawingAreaInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -13108,56 +13067,56 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "toggle-overwrite", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::activates_default", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::activates-default", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::attributes", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::buffer", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::caps_lock_warning", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::caps-lock-warning", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::completion", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cursor_position", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cursor-position", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::editable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_emoji_completion", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_frame", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::im_module", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::inner_border", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::input_hints", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::input_purpose", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::invisible_char", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::invisible_char_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_length", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_width_chars", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::overwrite_mode", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::placeholder_text", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::populate_all", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::primary_icon_activatable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::primary_icon_gicon", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::primary_icon_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::primary_icon_pixbuf", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::primary_icon_sensitive", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::primary_icon_stock", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::primary_icon_storage_type", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::primary_icon_tooltip_markup", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::primary_icon_tooltip_text", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::progress_fraction", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::progress_pulse_step", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scroll_offset", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::secondary_icon_activatable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::secondary_icon_gicon", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::secondary_icon_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::secondary_icon_pixbuf", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::secondary_icon_sensitive", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::secondary_icon_stock", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::secondary_icon_storage_type", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::secondary_icon_tooltip_markup", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::secondary_icon_tooltip_text", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::selection_bound", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::shadow_type", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_emoji_icon", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-emoji-completion", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-frame", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::im-module", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::inner-border", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::input-hints", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::input-purpose", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::invisible-char", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::invisible-char-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-length", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-width-chars", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::overwrite-mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::placeholder-text", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::populate-all", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::primary-icon-activatable", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::primary-icon-gicon", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::primary-icon-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::primary-icon-pixbuf", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::primary-icon-sensitive", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::primary-icon-stock", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::primary-icon-storage-type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::primary-icon-tooltip-markup", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::primary-icon-tooltip-text", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::progress-fraction", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::progress-pulse-step", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scroll-offset", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::secondary-icon-activatable", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::secondary-icon-gicon", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::secondary-icon-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::secondary-icon-pixbuf", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::secondary-icon-sensitive", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::secondary-icon-stock", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::secondary-icon-storage-type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::secondary-icon-tooltip-markup", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::secondary-icon-tooltip-text", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::selection-bound", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::shadow-type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-emoji-icon", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::tabs", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::text", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::text_length", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::truncate_multiline", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::text-length", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::truncate-multiline", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::visibility", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::width_chars", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::width-chars", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::xalign", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -13169,7 +13128,6 @@ declare namespace imports.gi.Gtk {
 		"buffer" |
 		"caps_lock_warning" |
 		"completion" |
-		"cursor_position" |
 		"editable" |
 		"enable_emoji_completion" |
 		"has_frame" |
@@ -13190,27 +13148,22 @@ declare namespace imports.gi.Gtk {
 		"primary_icon_pixbuf" |
 		"primary_icon_sensitive" |
 		"primary_icon_stock" |
-		"primary_icon_storage_type" |
 		"primary_icon_tooltip_markup" |
 		"primary_icon_tooltip_text" |
 		"progress_fraction" |
 		"progress_pulse_step" |
-		"scroll_offset" |
 		"secondary_icon_activatable" |
 		"secondary_icon_gicon" |
 		"secondary_icon_name" |
 		"secondary_icon_pixbuf" |
 		"secondary_icon_sensitive" |
 		"secondary_icon_stock" |
-		"secondary_icon_storage_type" |
 		"secondary_icon_tooltip_markup" |
 		"secondary_icon_tooltip_text" |
-		"selection_bound" |
 		"shadow_type" |
 		"show_emoji_icon" |
 		"tabs" |
 		"text" |
-		"text_length" |
 		"truncate_multiline" |
 		"visibility" |
 		"width_chars" |
@@ -13468,14 +13421,13 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "inserted-text", callback: (owner: this, position: number, chars: string, n_chars: number) => void): number;
 
 		connect(signal: "notify::length", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_length", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-length", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::text", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type EntryBufferInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IEntryBuffer,
-		"length" |
 		"max_length" |
 		"text">;
 
@@ -13811,15 +13763,15 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "no-matches", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::cell_area", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::inline_completion", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::inline_selection", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::minimum_key_length", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cell-area", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::inline-completion", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::inline-selection", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::minimum-key-length", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::model", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::popup_completion", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::popup_set_width", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::popup_single_match", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::text_column", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::popup-completion", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::popup-set-width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::popup-single-match", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::text-column", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -13993,8 +13945,8 @@ declare namespace imports.gi.Gtk {
 		 * @param visible_window %TRUE to make the event box have a visible window
 		 */
 		set_visible_window(visible_window: boolean): void;
-		connect(signal: "notify::above_child", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::visible_window", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::above-child", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::visible-window", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::bin", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -14002,8 +13954,7 @@ declare namespace imports.gi.Gtk {
 	type EventBoxInitOptionsMixin = BinInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
 	Pick<IEventBox,
 		"above_child" |
-		"visible_window" |
-		"bin">;
+		"visible_window">;
 
 	export interface EventBoxInitOptions extends EventBoxInitOptionsMixin {}
 
@@ -14073,7 +14024,7 @@ declare namespace imports.gi.Gtk {
 		 * @param phase a propagation phase
 		 */
 		set_propagation_phase(phase: PropagationPhase): void;
-		connect(signal: "notify::propagation_phase", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::propagation-phase", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::widget", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -14519,12 +14470,12 @@ declare namespace imports.gi.Gtk {
 
 		connect(signal: "notify::expanded", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::label", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::label_fill", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::label_widget", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::resize_toplevel", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::label-fill", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::label-widget", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::resize-toplevel", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::spacing", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_markup", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_underline", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-markup", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-underline", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::bin", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -14538,8 +14489,7 @@ declare namespace imports.gi.Gtk {
 		"resize_toplevel" |
 		"spacing" |
 		"use_markup" |
-		"use_underline" |
-		"bin">;
+		"use_underline">;
 
 	export interface ExpanderInitOptions extends ExpanderInitOptionsMixin {}
 
@@ -14745,7 +14695,7 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "file-set", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::title", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::width_chars", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::width-chars", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -15061,8 +15011,8 @@ declare namespace imports.gi.Gtk {
 		 * @param cancel_label custom label or %NULL for the default
 		 */
 		set_cancel_label(cancel_label: string | null): void;
-		connect(signal: "notify::accept_label", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cancel_label", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accept-label", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cancel-label", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -15450,15 +15400,14 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "up-folder", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::search_mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::search-mode", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::subtitle", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type FileChooserWidgetInitOptionsMixin = BoxInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & FileChooserInitOptions & OrientableInitOptions & 
 	Pick<IFileChooserWidget,
-		"search_mode" |
-		"subtitle">;
+		"search_mode">;
 
 	export interface FileChooserWidgetInitOptions extends FileChooserWidgetInitOptionsMixin {}
 
@@ -15690,10 +15639,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type FixedInitOptionsMixin = ContainerInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
-	Pick<IFixed,
-		"container">;
-
+	type FixedInitOptionsMixin = ContainerInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions
 	export interface FixedInitOptions extends FixedInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -16155,13 +16101,13 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "unselect-all", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::activate_on_single_click", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::column_spacing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::activate-on-single-click", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::column-spacing", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::homogeneous", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_children_per_line", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::min_children_per_line", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::row_spacing", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::selection_mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-children-per-line", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::min-children-per-line", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::row-spacing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::selection-mode", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::container", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -16174,8 +16120,7 @@ declare namespace imports.gi.Gtk {
 		"max_children_per_line" |
 		"min_children_per_line" |
 		"row_spacing" |
-		"selection_mode" |
-		"container">;
+		"selection_mode">;
 
 	export interface FlowBoxInitOptions extends FlowBoxInitOptionsMixin {}
 
@@ -16481,12 +16426,12 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "font-set", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::font_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_style", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-style", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::title", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_font", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-font", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-size", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::button", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -16498,8 +16443,7 @@ declare namespace imports.gi.Gtk {
 		"show_style" |
 		"title" |
 		"use_font" |
-		"use_size" |
-		"button">;
+		"use_size">;
 
 	export interface FontButtonInitOptions extends FontButtonInitOptionsMixin {}
 
@@ -16586,14 +16530,11 @@ declare namespace imports.gi.Gtk {
 		 */
 		readonly tweak_action: Gio.Action;
 
-		connect(signal: "notify::tweak_action", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tweak-action", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type FontChooserWidgetInitOptionsMixin = BoxInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & FontChooserInitOptions & OrientableInitOptions & 
-	Pick<IFontChooserWidget,
-		"tweak_action">;
-
+	type FontChooserWidgetInitOptionsMixin = BoxInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & FontChooserInitOptions & OrientableInitOptions
 	export interface FontChooserWidgetInitOptions extends FontChooserWidgetInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -16761,8 +16702,8 @@ declare namespace imports.gi.Gtk {
 		 * @param text the text to display in the preview area
 		 */
 		set_preview_text(text: string): void;
-		connect(signal: "notify::font_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::preview_text", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::preview-text", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -16968,10 +16909,10 @@ declare namespace imports.gi.Gtk {
 		 */
 		set_shadow_type(type: ShadowType): void;
 		connect(signal: "notify::label", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::label_widget", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::label_xalign", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::label_yalign", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::shadow_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::label-widget", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::label-xalign", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::label-yalign", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::shadow-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::bin", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -16982,8 +16923,7 @@ declare namespace imports.gi.Gtk {
 		"label_widget" |
 		"label_xalign" |
 		"label_yalign" |
-		"shadow_type" |
-		"bin">;
+		"shadow_type">;
 
 	export interface FrameInitOptions extends FrameInitOptionsMixin {}
 
@@ -17309,19 +17249,18 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "resize", callback: (owner: this, width: number, height: number) => void): number;
 
-		connect(signal: "notify::auto_render", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::auto-render", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::context", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_alpha", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_depth_buffer", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_stencil_buffer", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_es", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-alpha", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-depth-buffer", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-stencil-buffer", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-es", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type GLAreaInitOptionsMixin = WidgetInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
 	Pick<IGLArea,
 		"auto_render" |
-		"context" |
 		"has_alpha" |
 		"has_depth_buffer" |
 		"has_stencil_buffer" |
@@ -17735,7 +17674,7 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "update", callback: (owner: this, sequence: Gdk.EventSequence | null) => void): number;
 
-		connect(signal: "notify::n_points", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::n-points", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::window", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -17968,7 +17907,7 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "pressed", callback: (owner: this, x: number, y: number) => void): number;
 
-		connect(signal: "notify::delay_factor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::delay-factor", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -18301,7 +18240,7 @@ declare namespace imports.gi.Gtk {
 		set_touch_only(touch_only: boolean): void;
 		connect(signal: "notify::button", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::exclusive", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::touch_only", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::touch-only", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -18683,11 +18622,11 @@ declare namespace imports.gi.Gtk {
 		 * @param spacing the amount of space to insert between rows
 		 */
 		set_row_spacing(spacing: number): void;
-		connect(signal: "notify::baseline_row", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::column_homogeneous", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::column_spacing", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::row_homogeneous", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::row_spacing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::baseline-row", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::column-homogeneous", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::column-spacing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::row-homogeneous", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::row-spacing", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -18745,10 +18684,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type HBoxInitOptionsMixin = BoxInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
-	Pick<IHBox,
-		"box">;
-
+	type HBoxInitOptionsMixin = BoxInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions
 	export interface HBoxInitOptions extends HBoxInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -18803,10 +18739,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type HButtonBoxInitOptionsMixin = ButtonBoxInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
-	Pick<IHButtonBox,
-		"button_box">;
-
+	type HButtonBoxInitOptionsMixin = ButtonBoxInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions
 	export interface HButtonBoxInitOptions extends HButtonBoxInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -18838,10 +18771,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type HPanedInitOptionsMixin = PanedInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
-	Pick<IHPaned,
-		"paned">;
-
+	type HPanedInitOptionsMixin = PanedInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions
 	export interface HPanedInitOptions extends HPanedInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -18975,10 +18905,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type HScaleInitOptionsMixin = ScaleInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
-	Pick<IHScale,
-		"scale">;
-
+	type HScaleInitOptionsMixin = ScaleInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions
 	export interface HScaleInitOptions extends HScaleInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -19039,10 +18966,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type HScrollbarInitOptionsMixin = ScrollbarInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
-	Pick<IHScrollbar,
-		"scrollbar">;
-
+	type HScrollbarInitOptionsMixin = ScrollbarInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions
 	export interface HScrollbarInitOptions extends HScrollbarInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -19085,10 +19009,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type HSeparatorInitOptionsMixin = SeparatorInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
-	Pick<IHSeparator,
-		"separator">;
-
+	type HSeparatorInitOptionsMixin = SeparatorInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions
 	export interface HSeparatorInitOptions extends HSeparatorInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -19235,23 +19156,21 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "child-detached", callback: (owner: this, widget: Widget) => void): number;
 
-		connect(signal: "notify::child_detached", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::handle_position", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::shadow_type", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::snap_edge", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::snap_edge_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::child-detached", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::handle-position", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::shadow-type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::snap-edge", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::snap-edge-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::bin", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type HandleBoxInitOptionsMixin = BinInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
 	Pick<IHandleBox,
-		"child_detached" |
 		"handle_position" |
 		"shadow_type" |
 		"snap_edge" |
-		"snap_edge_set" |
-		"bin">;
+		"snap_edge_set">;
 
 	export interface HandleBoxInitOptions extends HandleBoxInitOptionsMixin {}
 
@@ -19454,11 +19373,11 @@ declare namespace imports.gi.Gtk {
 		 * @param title a title, or %NULL
 		 */
 		set_title(title: string | null): void;
-		connect(signal: "notify::custom_title", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::decoration_layout", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::decoration_layout_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_subtitle", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_close_button", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::custom-title", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::decoration-layout", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::decoration-layout-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-subtitle", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-close-button", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::spacing", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::subtitle", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::title", callback: (owner: this, ...args: any) => void): number;
@@ -19475,8 +19394,7 @@ declare namespace imports.gi.Gtk {
 		"show_close_button" |
 		"spacing" |
 		"subtitle" |
-		"title" |
-		"container">;
+		"title">;
 
 	export interface HeaderBarInitOptions extends HeaderBarInitOptionsMixin {}
 
@@ -19741,8 +19659,8 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "retrieve-surrounding", callback: (owner: this) => boolean): number;
 
-		connect(signal: "notify::input_hints", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::input_purpose", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::input-hints", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::input-purpose", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -19861,10 +19779,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type IMContextSimpleInitOptionsMixin = IMContextInitOptions & 
-	Pick<IIMContextSimple,
-		"object">;
-
+	type IMContextSimpleInitOptionsMixin = IMContextInitOptions
 	export interface IMContextSimpleInitOptions extends IMContextSimpleInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -19936,10 +19851,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type IMMulticontextInitOptionsMixin = IMContextInitOptions & 
-	Pick<IIMMulticontext,
-		"object">;
-
+	type IMMulticontextInitOptionsMixin = IMContextInitOptions
 	export interface IMMulticontextInitOptions extends IMMulticontextInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -21675,23 +21587,23 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "unselect-all", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::activate_on_single_click", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cell_area", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::column_spacing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::activate-on-single-click", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cell-area", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::column-spacing", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::columns", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::item_orientation", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::item_padding", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::item_width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::item-orientation", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::item-padding", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::item-width", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::margin", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::markup_column", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::markup-column", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::model", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixbuf_column", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixbuf-column", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::reorderable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::row_spacing", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::selection_mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::row-spacing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::selection-mode", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::spacing", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::text_column", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tooltip_column", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::text-column", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tooltip-column", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -21988,17 +21900,17 @@ declare namespace imports.gi.Gtk {
 		set_pixel_size(pixel_size: number): void;
 		connect(signal: "notify::file", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::gicon", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-size", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::pixbuf", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixbuf_animation", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixel_size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixbuf-animation", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixel-size", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::resource", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::stock", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::storage_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::storage-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::surface", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_fallback", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-fallback", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::misc", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -22015,10 +21927,8 @@ declare namespace imports.gi.Gtk {
 		"pixel_size" |
 		"resource" |
 		"stock" |
-		"storage_type" |
 		"surface" |
-		"use_fallback" |
-		"misc">;
+		"use_fallback">;
 
 	export interface ImageInitOptions extends ImageInitOptionsMixin {}
 
@@ -22383,9 +22293,9 @@ declare namespace imports.gi.Gtk {
 		 * @param use_stock %TRUE if the menuitem should use a stock item
 		 */
 		set_use_stock(use_stock: boolean): void;
-		connect(signal: "notify::always_show_image", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::always-show-image", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::image", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_stock", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-stock", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::menu_item", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -22394,8 +22304,7 @@ declare namespace imports.gi.Gtk {
 	Pick<IImageMenuItem,
 		"always_show_image" |
 		"image" |
-		"use_stock" |
-		"menu_item">;
+		"use_stock">;
 
 	export interface ImageMenuItemInitOptions extends ImageMenuItemInitOptionsMixin {}
 
@@ -22658,9 +22567,9 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "response", callback: (owner: this, response_id: number) => void): number;
 
-		connect(signal: "notify::message_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::message-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::revealed", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_close_button", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-close-button", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -22795,8 +22704,7 @@ declare namespace imports.gi.Gtk {
 
 	type InvisibleInitOptionsMixin = WidgetInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
 	Pick<IInvisible,
-		"screen" |
-		"widget">;
+		"screen">;
 
 	export interface InvisibleInitOptions extends InvisibleInitOptionsMixin {}
 
@@ -23424,23 +23332,23 @@ declare namespace imports.gi.Gtk {
 
 		connect(signal: "notify::angle", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::attributes", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cursor_position", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cursor-position", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::ellipsize", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::justify", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::label", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::lines", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_width_chars", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::mnemonic_keyval", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::mnemonic_widget", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-width-chars", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::mnemonic-keyval", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::mnemonic-widget", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::selectable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::selection_bound", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::single_line_mode", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::track_visited_links", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_markup", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_underline", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::width_chars", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::selection-bound", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::single-line-mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::track-visited-links", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-markup", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-underline", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::width-chars", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::wrap", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::wrap_mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::wrap-mode", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::xalign", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::yalign", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::misc", callback: (owner: this, ...args: any) => void): number;
@@ -23451,16 +23359,13 @@ declare namespace imports.gi.Gtk {
 	Pick<ILabel,
 		"angle" |
 		"attributes" |
-		"cursor_position" |
 		"ellipsize" |
 		"justify" |
 		"label" |
 		"lines" |
 		"max_width_chars" |
-		"mnemonic_keyval" |
 		"mnemonic_widget" |
 		"selectable" |
-		"selection_bound" |
 		"single_line_mode" |
 		"track_visited_links" |
 		"use_markup" |
@@ -23469,8 +23374,7 @@ declare namespace imports.gi.Gtk {
 		"wrap" |
 		"wrap_mode" |
 		"xalign" |
-		"yalign" |
-		"misc">;
+		"yalign">;
 
 	export interface LabelInitOptions extends LabelInitOptionsMixin {}
 
@@ -23811,8 +23715,7 @@ declare namespace imports.gi.Gtk {
 	type LayoutInitOptionsMixin = ContainerInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & ScrollableInitOptions & 
 	Pick<ILayout,
 		"height" |
-		"width" |
-		"container">;
+		"width">;
 
 	export interface LayoutInitOptions extends LayoutInitOptionsMixin {}
 
@@ -23987,8 +23890,8 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "offset-changed", callback: (owner: this, name: string) => void): number;
 
 		connect(signal: "notify::inverted", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_value", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::min_value", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-value", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::min-value", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::mode", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::value", callback: (owner: this, ...args: any) => void): number;
 
@@ -24584,8 +24487,8 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "unselect-all", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::activate_on_single_click", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::selection_mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::activate-on-single-click", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::selection-mode", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -25203,11 +25106,11 @@ declare namespace imports.gi.Gtk {
 		 */
 		set_permission(permission: Gio.Permission | null): void;
 		connect(signal: "notify::permission", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::text_lock", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::text_unlock", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tooltip_lock", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tooltip_not_authorized", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tooltip_unlock", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::text-lock", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::text-unlock", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tooltip-lock", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tooltip-not-authorized", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tooltip-unlock", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -25765,18 +25668,18 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "popped-up", callback: (owner: this, flipped_rect: any | null, final_rect: any | null, flipped_x: boolean, flipped_y: boolean) => void): number;
 
-		connect(signal: "notify::accel_group", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accel_path", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accel-group", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accel-path", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::active", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::anchor_hints", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::attach_widget", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::menu_type_hint", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::anchor-hints", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::attach-widget", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::menu-type-hint", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::monitor", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::rect_anchor_dx", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::rect_anchor_dy", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::reserve_toggle_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tearoff_state", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tearoff_title", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::rect-anchor-dx", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::rect-anchor-dy", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::reserve-toggle-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tearoff-state", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tearoff-title", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::menu_shell", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -25794,8 +25697,7 @@ declare namespace imports.gi.Gtk {
 		"rect_anchor_dy" |
 		"reserve_toggle_size" |
 		"tearoff_state" |
-		"tearoff_title" |
-		"menu_shell">;
+		"tearoff_title">;
 
 	export interface MenuInitOptions extends MenuInitOptionsMixin {}
 
@@ -25968,8 +25870,8 @@ declare namespace imports.gi.Gtk {
 		 * @param pack_dir a new {@link PackDirection}
 		 */
 		set_pack_direction(pack_dir: PackDirection): void;
-		connect(signal: "notify::child_pack_direction", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pack_direction", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::child-pack-direction", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pack-direction", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::menu_shell", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -25977,8 +25879,7 @@ declare namespace imports.gi.Gtk {
 	type MenuBarInitOptionsMixin = MenuShellInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
 	Pick<IMenuBar,
 		"child_pack_direction" |
-		"pack_direction" |
-		"menu_shell">;
+		"pack_direction">;
 
 	export interface MenuBarInitOptions extends MenuBarInitOptionsMixin {}
 
@@ -26155,12 +26056,12 @@ declare namespace imports.gi.Gtk {
 		 * @param use_popover %TRUE to construct a popover from the menu model
 		 */
 		set_use_popover(use_popover: boolean): void;
-		connect(signal: "notify::align_widget", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::align-widget", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::direction", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::menu_model", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::menu-model", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::popover", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::popup", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_popover", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-popover", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -26483,11 +26384,11 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "toggle-size-allocate", callback: (owner: this, object: number) => void): number;
 		connect(signal: "toggle-size-request", callback: (owner: this, object: any | null) => void): number;
 
-		connect(signal: "notify::accel_path", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accel-path", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::label", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::right_justified", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::right-justified", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::submenu", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_underline", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-underline", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::bin", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -26498,8 +26399,7 @@ declare namespace imports.gi.Gtk {
 		"label" |
 		"right_justified" |
 		"submenu" |
-		"use_underline" |
-		"bin">;
+		"use_underline">;
 
 	export interface MenuItemInitOptions extends MenuItemInitOptionsMixin {}
 
@@ -26857,15 +26757,14 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "selection-done", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::take_focus", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::take-focus", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::container", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type MenuShellInitOptionsMixin = ContainerInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
 	Pick<IMenuShell,
-		"take_focus" |
-		"container">;
+		"take_focus">;
 
 	export interface MenuShellInitOptions extends MenuShellInitOptionsMixin {}
 
@@ -27143,19 +27042,18 @@ declare namespace imports.gi.Gtk {
 		 */
 		set_markup(str: string): void;
 		connect(signal: "notify::image", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::message_area", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::message_type", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::secondary_text", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::secondary_use_markup", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::message-area", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::message-type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::secondary-text", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::secondary-use-markup", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::text", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_markup", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-markup", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type MessageDialogInitOptionsMixin = DialogInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
 	Pick<IMessageDialog,
 		"image" |
-		"message_area" |
 		"message_type" |
 		"secondary_text" |
 		"secondary_use_markup" |
@@ -27375,8 +27273,7 @@ declare namespace imports.gi.Gtk {
 		"xalign" |
 		"xpad" |
 		"yalign" |
-		"ypad" |
-		"widget">;
+		"ypad">;
 
 	export interface MiscInitOptions extends MiscInitOptionsMixin {}
 
@@ -27466,10 +27363,10 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "notify::icon", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::iconic", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::inverted", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::menu_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::menu-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::role", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::text", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_markup", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-markup", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -27638,14 +27535,13 @@ declare namespace imports.gi.Gtk {
 		 * @param screen a #GdkScreen
 		 */
 		set_screen(screen: Gdk.Screen): void;
-		connect(signal: "notify::is_showing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-showing", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::screen", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type MountOperationInitOptionsMixin = Gio.MountOperationInitOptions & 
 	Pick<IMountOperation,
-		"is_showing" |
 		"screen">;
 
 	export interface MountOperationInitOptions extends MountOperationInitOptionsMixin {}
@@ -27820,7 +27716,7 @@ declare namespace imports.gi.Gtk {
 
 		connect(signal: "notify::modal", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::title", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::transient_for", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::transient-for", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::visible", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -28345,13 +28241,13 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "switch-page", callback: (owner: this, page: Widget, page_num: number) => void): number;
 
-		connect(signal: "notify::enable_popup", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::group_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-popup", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::group-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::page", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::scrollable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_border", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_tabs", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tab_pos", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-border", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-tabs", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tab-pos", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -28609,11 +28505,11 @@ declare namespace imports.gi.Gtk {
 		 * @param style a {@link StyleContext}
 		 */
 		set_style_context(style: StyleContext): void;
-		connect(signal: "notify::background_icon", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::background_icon_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::background-icon", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::background-icon-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::count", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::label", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::style_context", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::style-context", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -28691,10 +28587,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type OffscreenWindowInitOptionsMixin = WindowInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
-	Pick<IOffscreenWindow,
-		"parent_object">;
-
+	type OffscreenWindowInitOptionsMixin = WindowInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions
 	export interface OffscreenWindowInitOptions extends OffscreenWindowInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -28883,7 +28776,7 @@ declare namespace imports.gi.Gtk {
 		 * @param n_entries the number of elements in #entries
 		 */
 		set_action_entries(entries: PadActionEntry[], n_entries: number): void;
-		connect(signal: "notify::action_group", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::action-group", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::pad", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -29400,23 +29293,20 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "toggle-handle-focus", callback: (owner: this) => boolean): number;
 
-		connect(signal: "notify::max_position", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::min_position", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-position", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::min-position", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::position", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::position_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::wide_handle", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::position-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::wide-handle", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::container", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type PanedInitOptionsMixin = ContainerInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
 	Pick<IPaned,
-		"max_position" |
-		"min_position" |
 		"position" |
 		"position_set" |
-		"wide_handle" |
-		"container">;
+		"wide_handle">;
 
 	export interface PanedInitOptions extends PanedInitOptionsMixin {}
 
@@ -29972,17 +29862,17 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "unmount", callback: (owner: this, mount_operation: Gio.MountOperation) => void): number;
 
-		connect(signal: "notify::local_only", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::local-only", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::location", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::open_flags", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::populate_all", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_connect_to_server", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_desktop", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_enter_location", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_other_locations", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_recent", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_starred_location", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_trash", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::open-flags", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::populate-all", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-connect-to-server", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-desktop", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-enter-location", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-other-locations", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-recent", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-starred-location", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-trash", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -30113,17 +30003,12 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "embedded", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::embedded", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::socket_window", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::socket-window", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::window", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type PlugInitOptionsMixin = WindowInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
-	Pick<IPlug,
-		"embedded" |
-		"socket_window" |
-		"window">;
-
+	type PlugInitOptionsMixin = WindowInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions
 	export interface PlugInitOptions extends PlugInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -30392,12 +30277,12 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "closed", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::constrain_to", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::constrain-to", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::modal", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pointing_to", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pointing-to", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::position", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::relative_to", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::transitions_enabled", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::relative-to", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::transitions-enabled", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -30547,7 +30432,7 @@ declare namespace imports.gi.Gtk {
 		 * @param name the name of the menu to switch to
 		 */
 		open_submenu(name: string): void;
-		connect(signal: "notify::visible_submenu", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::visible-submenu", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -31495,24 +31380,24 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "update-custom-widget", callback: (owner: this, widget: Widget, setup: PageSetup, settings: PrintSettings) => void): number;
 
-		connect(signal: "notify::allow_async", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::current_page", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::custom_tab_label", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::default_page_setup", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::embed_page_setup", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::export_filename", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_selection", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::job_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::n_pages", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::n_pages_to_print", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::print_settings", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_progress", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::allow-async", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::current-page", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::custom-tab-label", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::default-page-setup", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::embed-page-setup", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::export-filename", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-selection", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::job-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::n-pages", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::n-pages-to-print", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::print-settings", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-progress", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::status", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::status_string", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::support_selection", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::track_print_status", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::status-string", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::support-selection", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::track-print-status", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::unit", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_full_page", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-full-page", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -31527,11 +31412,8 @@ declare namespace imports.gi.Gtk {
 		"has_selection" |
 		"job_name" |
 		"n_pages" |
-		"n_pages_to_print" |
 		"print_settings" |
 		"show_progress" |
-		"status" |
-		"status_string" |
 		"support_selection" |
 		"track_print_status" |
 		"unit" |
@@ -32240,8 +32122,8 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "notify::ellipsize", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::fraction", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::inverted", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pulse_step", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_text", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pulse-step", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-text", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::text", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -32426,7 +32308,7 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "changed", callback: (owner: this, current: RadioAction) => void): number;
 
-		connect(signal: "notify::current_value", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::current-value", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::value", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -32533,10 +32415,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type RadioButtonInitOptionsMixin = CheckButtonInitOptions & Atk.ImplementorIfaceInitOptions & ActionableInitOptions & ActivatableInitOptions & BuildableInitOptions & 
-	Pick<IRadioButton,
-		"check_button">;
-
+	type RadioButtonInitOptionsMixin = CheckButtonInitOptions & Atk.ImplementorIfaceInitOptions & ActionableInitOptions & ActivatableInitOptions & BuildableInitOptions
 	export interface RadioButtonInitOptions extends RadioButtonInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -32762,10 +32641,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type RadioMenuItemInitOptionsMixin = CheckMenuItemInitOptions & Atk.ImplementorIfaceInitOptions & ActionableInitOptions & ActivatableInitOptions & BuildableInitOptions & 
-	Pick<IRadioMenuItem,
-		"check_menu_item">;
-
+	type RadioMenuItemInitOptionsMixin = CheckMenuItemInitOptions & Atk.ImplementorIfaceInitOptions & ActionableInitOptions & ActivatableInitOptions & BuildableInitOptions
 	export interface RadioMenuItemInitOptions extends RadioMenuItemInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -33275,13 +33151,13 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "value-changed", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::adjustment", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::fill_level", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::fill-level", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::inverted", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::lower_stepper_sensitivity", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::restrict_to_fill_level", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::round_digits", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_fill_level", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::upper_stepper_sensitivity", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::lower-stepper-sensitivity", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::restrict-to-fill-level", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::round-digits", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-fill-level", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::upper-stepper-sensitivity", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::widget", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -33295,8 +33171,7 @@ declare namespace imports.gi.Gtk {
 		"restrict_to_fill_level" |
 		"round_digits" |
 		"show_fill_level" |
-		"upper_stepper_sensitivity" |
-		"widget">;
+		"upper_stepper_sensitivity">;
 
 	export interface RangeInitOptions extends RangeInitOptionsMixin {}
 
@@ -33408,19 +33283,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type RcStyleInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IRcStyle,
-		"name" |
-		"bg_pixmap_name" |
-		"font_desc" |
-		"color_flags" |
-		"fg" |
-		"bg" |
-		"text" |
-		"base" |
-		"xthickness" |
-		"ythickness">;
-
+	type RcStyleInitOptionsMixin = GObject.ObjectInitOptions
 	export interface RcStyleInitOptions extends RcStyleInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -33470,7 +33333,7 @@ declare namespace imports.gi.Gtk {
 		 * @param show_numbers %TRUE if the shown items should be numbered
 		 */
 		set_show_numbers(show_numbers: boolean): void;
-		connect(signal: "notify::show_numbers", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-numbers", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -33636,7 +33499,7 @@ declare namespace imports.gi.Gtk {
 		 * @param show_numbers whether to show numbers
 		 */
 		set_show_numbers(show_numbers: boolean): void;
-		connect(signal: "notify::show_numbers", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-numbers", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -34048,8 +33911,7 @@ declare namespace imports.gi.Gtk {
 
 	type RecentManagerInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IRecentManager,
-		"filename" |
-		"size">;
+		"filename">;
 
 	export interface RecentManagerInitOptions extends RecentManagerInitOptionsMixin {}
 
@@ -34229,16 +34091,15 @@ declare namespace imports.gi.Gtk {
 		 * @param transition the new transition type
 		 */
 		set_transition_type(transition: RevealerTransitionType): void;
-		connect(signal: "notify::child_revealed", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::reveal_child", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::transition_duration", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::transition_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::child-revealed", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::reveal-child", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::transition-duration", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::transition-type", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type RevealerInitOptionsMixin = BinInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
 	Pick<IRevealer,
-		"child_revealed" |
 		"reveal_child" |
 		"transition_duration" |
 		"transition_type">;
@@ -34414,9 +34275,9 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "format-value", callback: (owner: this, value: number) => string): number;
 
 		connect(signal: "notify::digits", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::draw_value", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_origin", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::value_pos", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::draw-value", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-origin", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::value-pos", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::range", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -34426,8 +34287,7 @@ declare namespace imports.gi.Gtk {
 		"digits" |
 		"draw_value" |
 		"has_origin" |
-		"value_pos" |
-		"range">;
+		"value_pos">;
 
 	export interface ScaleInitOptions extends ScaleInitOptionsMixin {}
 
@@ -34757,10 +34617,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type ScrollbarInitOptionsMixin = RangeInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
-	Pick<IScrollbar,
-		"range">;
-
+	type ScrollbarInitOptionsMixin = RangeInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions
 	export interface ScrollbarInitOptions extends ScrollbarInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -35212,20 +35069,20 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "scroll-child", callback: (owner: this, scroll: ScrollType, horizontal: boolean) => boolean): number;
 
 		connect(signal: "notify::hadjustment", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::hscrollbar_policy", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::kinetic_scrolling", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_content_height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_content_width", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::min_content_height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::min_content_width", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::overlay_scrolling", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::propagate_natural_height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::propagate_natural_width", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::shadow_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::hscrollbar-policy", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::kinetic-scrolling", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-content-height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-content-width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::min-content-height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::min-content-width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::overlay-scrolling", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::propagate-natural-height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::propagate-natural-width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::shadow-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::vadjustment", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::vscrollbar_policy", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::window_placement", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::window_placement_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::vscrollbar-policy", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::window-placement", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::window-placement-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::container", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -35246,8 +35103,7 @@ declare namespace imports.gi.Gtk {
 		"vadjustment" |
 		"vscrollbar_policy" |
 		"window_placement" |
-		"window_placement_set" |
-		"container">;
+		"window_placement_set">;
 
 	export interface ScrolledWindowInitOptions extends ScrolledWindowInitOptionsMixin {}
 
@@ -35456,8 +35312,8 @@ declare namespace imports.gi.Gtk {
 		 * @param visible whether the close button will be shown or not
 		 */
 		set_show_close_button(visible: boolean): void;
-		connect(signal: "notify::search_mode_enabled", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_close_button", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::search-mode-enabled", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-close-button", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -35649,10 +35505,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type SeparatorInitOptionsMixin = WidgetInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
-	Pick<ISeparator,
-		"widget">;
-
+	type SeparatorInitOptionsMixin = WidgetInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions
 	export interface SeparatorInitOptions extends SeparatorInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -35693,10 +35546,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type SeparatorMenuItemInitOptionsMixin = MenuItemInitOptions & Atk.ImplementorIfaceInitOptions & ActionableInitOptions & ActivatableInitOptions & BuildableInitOptions & 
-	Pick<ISeparatorMenuItem,
-		"menu_item">;
-
+	type SeparatorMenuItemInitOptionsMixin = MenuItemInitOptions & Atk.ImplementorIfaceInitOptions & ActionableInitOptions & ActivatableInitOptions & BuildableInitOptions
 	export interface SeparatorMenuItemInitOptions extends SeparatorMenuItemInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -36314,97 +36164,96 @@ declare namespace imports.gi.Gtk {
 		set_long_property(name: string, v_long: number, origin: string): void;
 		set_property_value(name: string, svalue: SettingsValue): void;
 		set_string_property(name: string, v_string: string, origin: string): void;
-		connect(signal: "notify::color_hash", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_alternative_button_order", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_alternative_sort_arrows", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_application_prefer_dark_theme", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_auto_mnemonics", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_button_images", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_can_change_accels", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_color_palette", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_color_scheme", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_cursor_aspect_ratio", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_cursor_blink", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_cursor_blink_time", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_cursor_blink_timeout", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_cursor_theme_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_cursor_theme_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_decoration_layout", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_dialogs_use_header", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_dnd_drag_threshold", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_double_click_distance", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_double_click_time", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_enable_accels", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_enable_animations", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_enable_event_sounds", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_enable_input_feedback_sounds", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_enable_mnemonics", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_enable_primary_paste", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_enable_tooltips", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_entry_password_hint_timeout", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_entry_select_on_focus", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_error_bell", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_fallback_icon_theme", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_file_chooser_backend", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_font_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_fontconfig_timestamp", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_icon_sizes", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_icon_theme_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_im_module", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_im_preedit_style", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_im_status_style", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_key_theme_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_keynav_cursor_only", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_keynav_use_caret", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_keynav_wrap_around", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_label_select_on_focus", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_long_press_time", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_menu_bar_accel", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_menu_bar_popup_delay", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_menu_images", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_menu_popdown_delay", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_menu_popup_delay", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_modules", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_overlay_scrolling", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_primary_button_warps_slider", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_print_backends", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_print_preview_command", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_recent_files_enabled", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_recent_files_limit", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_recent_files_max_age", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_scrolled_window_placement", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_shell_shows_app_menu", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_shell_shows_desktop", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_shell_shows_menubar", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_show_input_method_menu", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_show_unicode_menu", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_sound_theme_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_split_cursor", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_theme_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_timeout_expand", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_timeout_initial", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_timeout_repeat", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_titlebar_double_click", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_titlebar_middle_click", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_titlebar_right_click", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_toolbar_icon_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_toolbar_style", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_tooltip_browse_mode_timeout", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_tooltip_browse_timeout", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_tooltip_timeout", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_touchscreen_mode", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_visible_focus", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_xft_antialias", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_xft_dpi", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_xft_hinting", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_xft_hintstyle", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_xft_rgba", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::color-hash", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-alternative-button-order", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-alternative-sort-arrows", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-application-prefer-dark-theme", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-auto-mnemonics", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-button-images", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-can-change-accels", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-color-palette", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-color-scheme", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-cursor-aspect-ratio", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-cursor-blink", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-cursor-blink-time", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-cursor-blink-timeout", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-cursor-theme-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-cursor-theme-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-decoration-layout", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-dialogs-use-header", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-dnd-drag-threshold", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-double-click-distance", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-double-click-time", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-enable-accels", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-enable-animations", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-enable-event-sounds", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-enable-input-feedback-sounds", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-enable-mnemonics", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-enable-primary-paste", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-enable-tooltips", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-entry-password-hint-timeout", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-entry-select-on-focus", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-error-bell", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-fallback-icon-theme", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-file-chooser-backend", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-font-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-fontconfig-timestamp", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-icon-sizes", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-icon-theme-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-im-module", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-im-preedit-style", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-im-status-style", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-key-theme-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-keynav-cursor-only", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-keynav-use-caret", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-keynav-wrap-around", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-label-select-on-focus", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-long-press-time", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-menu-bar-accel", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-menu-bar-popup-delay", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-menu-images", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-menu-popdown-delay", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-menu-popup-delay", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-modules", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-overlay-scrolling", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-primary-button-warps-slider", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-print-backends", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-print-preview-command", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-recent-files-enabled", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-recent-files-limit", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-recent-files-max-age", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-scrolled-window-placement", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-shell-shows-app-menu", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-shell-shows-desktop", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-shell-shows-menubar", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-show-input-method-menu", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-show-unicode-menu", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-sound-theme-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-split-cursor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-theme-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-timeout-expand", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-timeout-initial", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-timeout-repeat", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-titlebar-double-click", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-titlebar-middle-click", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-titlebar-right-click", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-toolbar-icon-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-toolbar-style", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-tooltip-browse-mode-timeout", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-tooltip-browse-timeout", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-tooltip-timeout", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-touchscreen-mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-visible-focus", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-xft-antialias", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-xft-dpi", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-xft-hinting", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-xft-hintstyle", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-xft-rgba", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type SettingsInitOptionsMixin = GObject.ObjectInitOptions & StyleProviderInitOptions & 
 	Pick<ISettings,
-		"color_hash" |
 		"gtk_alternative_button_order" |
 		"gtk_alternative_sort_arrows" |
 		"gtk_application_prefer_dark_theme" |
@@ -36591,7 +36440,7 @@ declare namespace imports.gi.Gtk {
 		 */
 		set_disabled_text(disabled_text: string): void;
 		connect(signal: "notify::accelerator", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::disabled_text", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::disabled-text", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -36654,7 +36503,6 @@ declare namespace imports.gi.Gtk {
 
 	type ShortcutsGroupInitOptionsMixin = BoxInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
 	Pick<IShortcutsGroup,
-		"height" |
 		"title" |
 		"view">;
 
@@ -36714,10 +36562,10 @@ declare namespace imports.gi.Gtk {
 
 		connect(signal: "change-current-page", callback: (owner: this, object: number) => boolean): number;
 
-		connect(signal: "notify::max_height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::section_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::section-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::title", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::view_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::view-name", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -36829,13 +36677,13 @@ declare namespace imports.gi.Gtk {
 		title: string;
 
 		connect(signal: "notify::accelerator", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::action_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::action-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::direction", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::icon", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::shortcut_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::shortcut-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::subtitle", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::subtitle_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::subtitle-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::title", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -36919,8 +36767,8 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "search", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::section_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::view_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::section-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::view-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::window", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -36928,8 +36776,7 @@ declare namespace imports.gi.Gtk {
 	type ShortcutsWindowInitOptionsMixin = WindowInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
 	Pick<IShortcutsWindow,
 		"section_name" |
-		"view_name" |
-		"window">;
+		"view_name">;
 
 	export interface ShortcutsWindowInitOptions extends ShortcutsWindowInitOptionsMixin {}
 
@@ -37070,7 +36917,7 @@ declare namespace imports.gi.Gtk {
 		 * @param mode the mode to set for the size group.
 		 */
 		set_mode(mode: SizeGroupMode): void;
-		connect(signal: "notify::ignore_hidden", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ignore-hidden", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::mode", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -37232,10 +37079,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type SocketInitOptionsMixin = ContainerInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & 
-	Pick<ISocket,
-		"container">;
-
+	type SocketInitOptionsMixin = ContainerInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions
 	export interface SocketInitOptions extends SocketInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -37568,11 +37412,11 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "wrapped", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::adjustment", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::climb_rate", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::climb-rate", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::digits", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::numeric", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::snap_to_ticks", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::update_policy", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::snap-to-ticks", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::update-policy", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::value", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::wrap", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::entry", callback: (owner: this, ...args: any) => void): number;
@@ -37588,8 +37432,7 @@ declare namespace imports.gi.Gtk {
 		"snap_to_ticks" |
 		"update_policy" |
 		"value" |
-		"wrap" |
-		"entry">;
+		"wrap">;
 
 	export interface SpinButtonInitOptions extends SpinButtonInitOptionsMixin {}
 
@@ -38025,13 +37868,13 @@ declare namespace imports.gi.Gtk {
 		set_visible_child_name(name: string): void;
 		connect(signal: "notify::hhomogeneous", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::homogeneous", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::interpolate_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::transition_duration", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::transition_running", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::transition_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::interpolate-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::transition-duration", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::transition-running", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::transition-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::vhomogeneous", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::visible_child", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::visible_child_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::visible-child", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::visible-child-name", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -38041,7 +37884,6 @@ declare namespace imports.gi.Gtk {
 		"homogeneous" |
 		"interpolate_size" |
 		"transition_duration" |
-		"transition_running" |
 		"transition_type" |
 		"vhomogeneous" |
 		"visible_child" |
@@ -38191,7 +38033,7 @@ declare namespace imports.gi.Gtk {
 		 * @param stack a {@link Stack}
 		 */
 		set_stack(stack: Stack | null): void;
-		connect(signal: "notify::icon_size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-size", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::stack", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::widget", callback: (owner: this, ...args: any) => void): number;
 
@@ -38200,8 +38042,7 @@ declare namespace imports.gi.Gtk {
 	type StackSwitcherInitOptionsMixin = BoxInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
 	Pick<IStackSwitcher,
 		"icon_size" |
-		"stack" |
-		"widget">;
+		"stack">;
 
 	export interface StackSwitcherInitOptions extends StackSwitcherInitOptionsMixin {}
 
@@ -38825,33 +38666,29 @@ declare namespace imports.gi.Gtk {
 
 		connect(signal: "notify::embedded", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::gicon", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_tooltip", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-tooltip", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::orientation", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::pixbuf", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::screen", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::size", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::stock", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::storage_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::storage-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::title", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tooltip_markup", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tooltip_text", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tooltip-markup", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tooltip-text", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::visible", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type StatusIconInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IStatusIcon,
-		"embedded" |
 		"gicon" |
 		"has_tooltip" |
 		"icon_name" |
-		"orientation" |
 		"pixbuf" |
 		"screen" |
-		"size" |
 		"stock" |
-		"storage_type" |
 		"title" |
 		"tooltip_markup" |
 		"tooltip_text" |
@@ -39068,10 +38905,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type StatusbarInitOptionsMixin = BoxInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
-	Pick<IStatusbar,
-		"parent_widget">;
-
+	type StatusbarInitOptionsMixin = BoxInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions
 	export interface StatusbarInitOptions extends StatusbarInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -39375,21 +39209,7 @@ declare namespace imports.gi.Gtk {
 
 	type StyleInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IStyle,
-		"context" |
-		"fg" |
-		"bg" |
-		"light" |
-		"dark" |
-		"mid" |
-		"text" |
-		"base" |
-		"text_aa" |
-		"black" |
-		"white" |
-		"font_desc" |
-		"xthickness" |
-		"ythickness" |
-		"background">;
+		"context">;
 
 	export interface StyleInitOptions extends StyleInitOptionsMixin {}
 
@@ -40045,7 +39865,7 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "changed", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::direction", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::paint_clock", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::paint-clock", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::screen", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::parent_object", callback: (owner: this, ...args: any) => void): number;
 
@@ -40055,8 +39875,7 @@ declare namespace imports.gi.Gtk {
 	Pick<IStyleContext,
 		"direction" |
 		"paint_clock" |
-		"screen" |
-		"parent_object">;
+		"screen">;
 
 	export interface StyleContextInitOptions extends StyleContextInitOptionsMixin {}
 
@@ -40677,11 +40496,11 @@ declare namespace imports.gi.Gtk {
 		 * @param spacing the number of pixels of space to place between every row in the table.
 		 */
 		set_row_spacings(spacing: number): void;
-		connect(signal: "notify::column_spacing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::column-spacing", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::homogeneous", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::n_columns", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::n_rows", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::row_spacing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::n-columns", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::n-rows", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::row-spacing", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::container", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -40692,8 +40511,7 @@ declare namespace imports.gi.Gtk {
 		"homogeneous" |
 		"n_columns" |
 		"n_rows" |
-		"row_spacing" |
-		"container">;
+		"row_spacing">;
 
 	export interface TableInitOptions extends TableInitOptionsMixin {}
 
@@ -40760,10 +40578,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type TearoffMenuItemInitOptionsMixin = MenuItemInitOptions & Atk.ImplementorIfaceInitOptions & ActionableInitOptions & ActivatableInitOptions & BuildableInitOptions & 
-	Pick<ITearoffMenuItem,
-		"menu_item">;
-
+	type TearoffMenuItemInitOptionsMixin = MenuItemInitOptions & Atk.ImplementorIfaceInitOptions & ActionableInitOptions & ActivatableInitOptions & BuildableInitOptions
 	export interface TearoffMenuItemInitOptions extends TearoffMenuItemInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -41845,21 +41660,17 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "remove-tag", callback: (owner: this, tag: TextTag, start: TextIter, end: TextIter) => void): number;
 
-		connect(signal: "notify::copy_target_list", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cursor_position", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_selection", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::paste_target_list", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tag_table", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::copy-target-list", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cursor-position", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-selection", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::paste-target-list", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tag-table", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::text", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type TextBufferInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<ITextBuffer,
-		"copy_target_list" |
-		"cursor_position" |
-		"has_selection" |
-		"paste_target_list" |
 		"tag_table" |
 		"text">;
 
@@ -42010,7 +41821,7 @@ declare namespace imports.gi.Gtk {
 		 * @param setting visibility of mark
 		 */
 		set_visible(setting: boolean): void;
-		connect(signal: "notify::left_gravity", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::left-gravity", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -42292,77 +42103,77 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "event", callback: (owner: this, object: GObject.Object, event: Gdk.Event, iter: TextIter) => boolean): number;
 
-		connect(signal: "notify::accumulative_margin", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::background_full_height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::background_full_height_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::background_gdk", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::background_rgba", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::background_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accumulative-margin", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::background-full-height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::background-full-height-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::background-gdk", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::background-rgba", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::background-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::direction", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::editable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::editable_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::editable-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::fallback", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::fallback_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::fallback-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::family", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::family_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::family-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::font", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::font_desc", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::font_features", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::font_features_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::foreground_gdk", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::foreground_rgba", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::foreground_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-desc", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-features", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-features-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::foreground-gdk", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::foreground-rgba", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::foreground-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::indent", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::indent_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::indent-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::invisible", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::invisible_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::invisible-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::justification", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::justification_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::justification-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::language", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::language_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::left_margin", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::left_margin_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::letter_spacing", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::letter_spacing_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::language-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::left-margin", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::left-margin-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::letter-spacing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::letter-spacing-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::paragraph_background_gdk", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::paragraph_background_rgba", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::paragraph_background_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixels_above_lines", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixels_above_lines_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixels_below_lines", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixels_below_lines_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixels_inside_wrap", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixels_inside_wrap_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::right_margin", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::right_margin_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::paragraph-background-gdk", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::paragraph-background-rgba", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::paragraph-background-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixels-above-lines", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixels-above-lines-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixels-below-lines", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixels-below-lines-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixels-inside-wrap", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixels-inside-wrap-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::right-margin", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::right-margin-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::rise", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::rise_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::rise-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::scale", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scale_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scale-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::size_points", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::size_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::size-points", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::size-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::stretch", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::stretch_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::stretch-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::strikethrough", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::strikethrough_rgba", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::strikethrough_rgba_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::strikethrough_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::strikethrough-rgba", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::strikethrough-rgba-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::strikethrough-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::style", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::style_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::style-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::tabs", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tabs_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tabs-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::underline", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::underline_rgba", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::underline_rgba_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::underline_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::underline-rgba", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::underline-rgba-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::underline-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::variant", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::variant_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::variant-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::weight", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::weight_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::wrap_mode", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::wrap_mode_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::weight-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::wrap-mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::wrap-mode-set", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -43587,27 +43398,27 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "toggle-overwrite", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::accepts_tab", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::bottom_margin", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accepts-tab", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::bottom-margin", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::buffer", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cursor_visible", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cursor-visible", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::editable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::im_module", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::im-module", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::indent", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::input_hints", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::input_purpose", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::input-hints", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::input-purpose", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::justification", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::left_margin", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::left-margin", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::monospace", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::overwrite", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixels_above_lines", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixels_below_lines", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pixels_inside_wrap", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::populate_all", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::right_margin", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixels-above-lines", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixels-below-lines", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pixels-inside-wrap", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::populate-all", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::right-margin", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::tabs", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::top_margin", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::wrap_mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::top-margin", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::wrap-mode", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -43900,8 +43711,7 @@ declare namespace imports.gi.Gtk {
 
 	type ThemingEngineInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IThemingEngine,
-		"name" |
-		"parent_object">;
+		"name">;
 
 	export interface ThemingEngineInitOptions extends ThemingEngineInitOptionsMixin {}
 
@@ -44023,7 +43833,7 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "toggled", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::active", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::draw_as_radio", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::draw-as-radio", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -44140,7 +43950,7 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "toggled", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::active", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::draw_indicator", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::draw-indicator", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::inconsistent", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -44475,12 +44285,12 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "clicked", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::icon_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_widget", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-widget", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::label", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::label_widget", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::stock_id", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_underline", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::label-widget", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::stock-id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-underline", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -44822,9 +44632,9 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "toolbar-reconfigured", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::is_important", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::visible_horizontal", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::visible_vertical", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-important", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::visible-horizontal", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::visible-vertical", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -44971,9 +44781,9 @@ declare namespace imports.gi.Gtk {
 		set_label_widget(label_widget: Widget): void;
 		connect(signal: "notify::collapsed", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::ellipsize", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::header_relief", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::header-relief", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::label", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::label_widget", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::label-widget", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -45168,9 +44978,9 @@ declare namespace imports.gi.Gtk {
 		 * so that user preferences will be used to determine the toolbar style.
 		 */
 		unset_style(): void;
-		connect(signal: "notify::icon_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_size_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::toolbar_style", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-size-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::toolbar-style", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -45467,10 +45277,10 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "style-changed", callback: (owner: this, style: ToolbarStyle) => void): number;
 
-		connect(signal: "notify::icon_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_size_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_arrow", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::toolbar_style", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-size-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-arrow", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::toolbar-style", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::container", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -45480,8 +45290,7 @@ declare namespace imports.gi.Gtk {
 		"icon_size" |
 		"icon_size_set" |
 		"show_arrow" |
-		"toolbar_style" |
-		"container">;
+		"toolbar_style">;
 
 	export interface ToolbarInitOptions extends ToolbarInitOptionsMixin {}
 
@@ -45811,8 +45620,8 @@ declare namespace imports.gi.Gtk {
 		 * @param destroy Destroy notifier of #data, or %NULL
 		 */
 		set_visible_func(func: TreeModelFilterVisibleFunc, data: any | null, destroy: GLib.DestroyNotify | null): void;
-		connect(signal: "notify::child_model", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::virtual_root", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::child-model", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::virtual-root", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -47698,24 +47507,24 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "toggle-cursor-row", callback: (owner: this) => boolean): number;
 		connect(signal: "unselect-all", callback: (owner: this) => boolean): number;
 
-		connect(signal: "notify::activate_on_single_click", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_grid_lines", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_search", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_tree_lines", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::expander_column", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::fixed_height_mode", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::headers_clickable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::headers_visible", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::hover_expand", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::hover_selection", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::level_indentation", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::activate-on-single-click", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-grid-lines", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-search", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-tree-lines", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::expander-column", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::fixed-height-mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::headers-clickable", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::headers-visible", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::hover-expand", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::hover-selection", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::level-indentation", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::model", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::reorderable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::rubber_banding", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::rules_hint", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::search_column", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_expanders", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tooltip_column", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::rubber-banding", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::rules-hint", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::search-column", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-expanders", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tooltip-column", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -48254,24 +48063,24 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "clicked", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::alignment", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cell_area", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cell-area", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::clickable", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::expand", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::fixed_width", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_width", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::min_width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::fixed-width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::min-width", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::reorderable", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::resizable", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::sizing", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::sort_column_id", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::sort_indicator", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::sort_order", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::sort-column-id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::sort-indicator", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::sort-order", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::spacing", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::title", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::visible", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::widget", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::width", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::x_offset", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::x-offset", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -48293,9 +48102,7 @@ declare namespace imports.gi.Gtk {
 		"spacing" |
 		"title" |
 		"visible" |
-		"widget" |
-		"width" |
-		"x_offset">;
+		"widget">;
 
 	export interface TreeViewColumnInitOptions extends TreeViewColumnInitOptionsMixin {}
 
@@ -48625,15 +48432,14 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "pre-activate", callback: (owner: this, action: Action) => void): number;
 
-		connect(signal: "notify::add_tearoffs", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::add-tearoffs", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::ui", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type UIManagerInitOptionsMixin = GObject.ObjectInitOptions & BuildableInitOptions & 
 	Pick<IUIManager,
-		"add_tearoffs" |
-		"ui">;
+		"add_tearoffs">;
 
 	export interface UIManagerInitOptions extends UIManagerInitOptionsMixin {}
 
@@ -48890,10 +48696,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type VBoxInitOptionsMixin = BoxInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
-	Pick<IVBox,
-		"box">;
-
+	type VBoxInitOptionsMixin = BoxInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions
 	export interface VBoxInitOptions extends VBoxInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -48955,10 +48758,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type VButtonBoxInitOptionsMixin = ButtonBoxInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
-	Pick<IVButtonBox,
-		"button_box">;
-
+	type VButtonBoxInitOptionsMixin = ButtonBoxInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions
 	export interface VButtonBoxInitOptions extends VButtonBoxInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -48990,10 +48790,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type VPanedInitOptionsMixin = PanedInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
-	Pick<IVPaned,
-		"paned">;
-
+	type VPanedInitOptionsMixin = PanedInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions
 	export interface VPanedInitOptions extends VPanedInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -49033,10 +48830,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type VScaleInitOptionsMixin = ScaleInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
-	Pick<IVScale,
-		"scale">;
-
+	type VScaleInitOptionsMixin = ScaleInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions
 	export interface VScaleInitOptions extends VScaleInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -49096,10 +48890,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type VScrollbarInitOptionsMixin = ScrollbarInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
-	Pick<IVScrollbar,
-		"scrollbar">;
-
+	type VScrollbarInitOptionsMixin = ScrollbarInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions
 	export interface VScrollbarInitOptions extends VScrollbarInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -49142,10 +48933,7 @@ declare namespace imports.gi.Gtk {
 
 	}
 
-	type VSeparatorInitOptionsMixin = SeparatorInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions & 
-	Pick<IVSeparator,
-		"separator">;
-
+	type VSeparatorInitOptionsMixin = SeparatorInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & OrientableInitOptions
 	export interface VSeparatorInitOptions extends VSeparatorInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -49233,15 +49021,14 @@ declare namespace imports.gi.Gtk {
 		 * @param adjustment a {@link Adjustment}.
 		 */
 		set_vadjustment(adjustment: Adjustment | null): void;
-		connect(signal: "notify::shadow_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::shadow-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::bin", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type ViewportInitOptionsMixin = BinInitOptions & Atk.ImplementorIfaceInitOptions & BuildableInitOptions & ScrollableInitOptions & 
 	Pick<IViewport,
-		"shadow_type" |
-		"bin">;
+		"shadow_type">;
 
 	export interface ViewportInitOptions extends ViewportInitOptionsMixin {}
 
@@ -49297,7 +49084,7 @@ declare namespace imports.gi.Gtk {
 		 */
 		use_symbolic: boolean;
 
-		connect(signal: "notify::use_symbolic", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-symbolic", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -53719,43 +53506,43 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "window-state-event", callback: (owner: this, event: Gdk.EventWindowState) => boolean): number;
 
-		connect(signal: "notify::app_paintable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::can_default", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::can_focus", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::composite_child", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::double_buffered", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::app-paintable", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::can-default", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::can-focus", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::composite-child", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::double-buffered", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::events", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::expand", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::focus_on_click", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::focus-on-click", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::halign", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_default", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_focus", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_tooltip", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::height_request", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-default", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-focus", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-tooltip", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::height-request", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::hexpand", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::hexpand_set", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_focus", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::hexpand-set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-focus", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::margin", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::margin_bottom", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::margin_end", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::margin_left", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::margin_right", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::margin_start", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::margin_top", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::margin-bottom", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::margin-end", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::margin-left", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::margin-right", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::margin-start", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::margin-top", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::no_show_all", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::no-show-all", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::opacity", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::receives_default", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scale_factor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::receives-default", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scale-factor", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::sensitive", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::style", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tooltip_markup", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tooltip_text", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tooltip-markup", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tooltip-text", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::valign", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::vexpand", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::vexpand_set", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::vexpand-set", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::visible", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::width_request", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::width-request", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::window", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -53765,7 +53552,6 @@ declare namespace imports.gi.Gtk {
 		"app_paintable" |
 		"can_default" |
 		"can_focus" |
-		"composite_child" |
 		"double_buffered" |
 		"events" |
 		"expand" |
@@ -53789,7 +53575,6 @@ declare namespace imports.gi.Gtk {
 		"no_show_all" |
 		"opacity" |
 		"receives_default" |
-		"scale_factor" |
 		"sensitive" |
 		"style" |
 		"tooltip_markup" |
@@ -53798,8 +53583,7 @@ declare namespace imports.gi.Gtk {
 		"vexpand" |
 		"vexpand_set" |
 		"visible" |
-		"width_request" |
-		"window">;
+		"width_request">;
 
 	export interface WidgetInitOptions extends WidgetInitOptionsMixin {}
 
@@ -55789,38 +55573,38 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "set-focus", callback: (owner: this, widget: Widget | null) => void): number;
 
-		connect(signal: "notify::accept_focus", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accept-focus", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::application", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::attached_to", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::attached-to", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::decorated", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::default_height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::default_width", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::default-height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::default-width", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::deletable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::destroy_with_parent", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::focus_on_map", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::focus_visible", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::destroy-with-parent", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::focus-on-map", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::focus-visible", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::gravity", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_resize_grip", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::has_toplevel_focus", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::hide_titlebar_when_maximized", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-resize-grip", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::has-toplevel-focus", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::hide-titlebar-when-maximized", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::icon", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_active", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_maximized", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::mnemonics_visible", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-active", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-maximized", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::mnemonics-visible", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::modal", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::resizable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::resize_grip_visible", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::resize-grip-visible", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::role", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::screen", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::skip_pager_hint", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::skip_taskbar_hint", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::skip-pager-hint", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::skip-taskbar-hint", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::title", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::transient_for", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::transient-for", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::type", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::type_hint", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::urgency_hint", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::window_position", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::type-hint", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::urgency-hint", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::window-position", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::bin", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -55839,16 +55623,12 @@ declare namespace imports.gi.Gtk {
 		"focus_visible" |
 		"gravity" |
 		"has_resize_grip" |
-		"has_toplevel_focus" |
 		"hide_titlebar_when_maximized" |
 		"icon" |
 		"icon_name" |
-		"is_active" |
-		"is_maximized" |
 		"mnemonics_visible" |
 		"modal" |
 		"resizable" |
-		"resize_grip_visible" |
 		"role" |
 		"screen" |
 		"skip_pager_hint" |
@@ -55858,8 +55638,7 @@ declare namespace imports.gi.Gtk {
 		"type" |
 		"type_hint" |
 		"urgency_hint" |
-		"window_position" |
-		"bin">;
+		"window_position">;
 
 	export interface WindowInitOptions extends WindowInitOptionsMixin {}
 
@@ -60499,8 +60278,8 @@ declare namespace imports.gi.Gtk {
 		 * @param detailed_action_name the detailed action name
 		 */
 		set_detailed_action_name(detailed_action_name: string): void;
-		connect(signal: "notify::action_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::action_target", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::action-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::action-target", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -60620,8 +60399,8 @@ declare namespace imports.gi.Gtk {
 		 * @param action the related {@link Action} or %NULL
 		 */
 		sync_action_properties(action: Action | null): void;
-		connect(signal: "notify::related_action", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_action_appearance", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::related-action", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-action-appearance", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -60906,7 +60685,7 @@ declare namespace imports.gi.Gtk {
 		 * Reloads the list of applications.
 		 */
 		refresh(): void;
-		connect(signal: "notify::content_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::content-type", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -61175,7 +60954,7 @@ declare namespace imports.gi.Gtk {
 		 */
 		connect(signal: "remove-widget", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::editing_canceled", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::editing-canceled", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -61502,7 +61281,7 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "color-activated", callback: (owner: this, color: Gdk.RGBA) => void): number;
 
 		connect(signal: "notify::rgba", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_alpha", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-alpha", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -62592,16 +62371,16 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "update-preview", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::action", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::create_folders", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::do_overwrite_confirmation", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::extra_widget", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::create-folders", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::do-overwrite-confirmation", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::extra-widget", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::filter", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::local_only", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::preview_widget", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::preview_widget_active", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::select_multiple", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_hidden", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_preview_label", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::local-only", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::preview-widget", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::preview-widget-active", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::select-multiple", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-hidden", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-preview-label", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -62965,19 +62744,18 @@ declare namespace imports.gi.Gtk {
 		connect(signal: "font-activated", callback: (owner: this, fontname: string) => void): number;
 
 		connect(signal: "notify::font", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::font_desc", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::font_features", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-desc", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-features", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::language", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::level", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::preview_text", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_preview_entry", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::preview-text", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-preview-entry", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type FontChooserInitOptionsMixin = Pick<IFontChooser,
 		"font" |
 		"font_desc" |
-		"font_features" |
 		"language" |
 		"level" |
 		"preview_text" |
@@ -63410,13 +63188,13 @@ declare namespace imports.gi.Gtk {
 
 		connect(signal: "notify::filter", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::limit", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::local_only", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::select_multiple", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_icons", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_not_found", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_private", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::show_tips", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::sort_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::local-only", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::select-multiple", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-icons", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-not-found", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-private", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::show-tips", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::sort-type", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -63534,9 +63312,9 @@ declare namespace imports.gi.Gtk {
 		 */
 		set_vscroll_policy(policy: ScrollablePolicy): void;
 		connect(signal: "notify::hadjustment", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::hscroll_policy", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::hscroll-policy", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::vadjustment", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::vscroll_policy", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::vscroll-policy", callback: (owner: this, ...args: any) => void): number;
 
 	}
 

--- a/.typescript-declarations/Meta-3.0.d.ts
+++ b/.typescript-declarations/Meta-3.0.d.ts
@@ -10,7 +10,7 @@ declare namespace imports.gi.Meta {
 		 */
 		dim_factor: number;
 
-		connect(signal: "notify::dim_factor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::dim-factor", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -267,14 +267,11 @@ declare namespace imports.gi.Meta {
 		connect(signal: "zoom-scroll-in", callback: (owner: this) => void): number;
 		connect(signal: "zoom-scroll-out", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::focus_window", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::focus-window", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type DisplayInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IDisplay,
-		"focus_window">;
-
+	type DisplayInitOptionsMixin = GObject.ObjectInitOptions
 	export interface DisplayInitOptions extends DisplayInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -342,14 +339,13 @@ declare namespace imports.gi.Meta {
 		switch_workspace_completed(): void;
 		tile_completed(actor: WindowActor): void;
 		unmaximize_completed(actor: WindowActor): void;
-		connect(signal: "notify::debug_mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::debug-mode", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::screen", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type PluginInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IPlugin,
-		"debug_mode" |
 		"screen">;
 
 	export interface PluginInitOptions extends PluginInitOptionsMixin {}
@@ -489,16 +485,12 @@ declare namespace imports.gi.Meta {
 		connect(signal: "workspace-removed", callback: (owner: this, object: number) => void): number;
 		connect(signal: "workspace-switched", callback: (owner: this, object: number, p0: number, p1: MotionDirection) => void): number;
 
-		connect(signal: "notify::keyboard_grabbed", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::n_workspaces", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::keyboard-grabbed", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::n-workspaces", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type ScreenInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IScreen,
-		"keyboard_grabbed" |
-		"n_workspaces">;
-
+	type ScreenInitOptionsMixin = GObject.ObjectInitOptions
 	export interface ScreenInitOptions extends ScreenInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -754,7 +746,7 @@ declare namespace imports.gi.Meta {
 		 * Gets the compositor's wrapper object for #window.
 		 * @returns the wrapper object.
 		 */
-		get_compositor_private(): GObject.Object;
+		get_compositor_private(): WindowActor;
 		get_description(): string;
 		get_display(): Display;
 		get_frame(): Frame;
@@ -1075,59 +1067,33 @@ declare namespace imports.gi.Meta {
 		connect(signal: "workspace-changed", callback: (owner: this, object: number) => void): number;
 
 		connect(signal: "notify::above", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::appears_focused", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::appears-focused", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::decorated", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::demands_attention", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::demands-attention", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::fullscreen", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_app_menu_object_path", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_application_id", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_application_object_path", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_menubar_object_path", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_unique_bus_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::gtk_window_object_path", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::maximized_horizontally", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::maximized_vertically", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-app-menu-object-path", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-application-id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-application-object-path", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-menubar-object-path", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-unique-bus-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::gtk-window-object-path", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::maximized-horizontally", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::maximized-vertically", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::minimized", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::muffin_hints", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::muffin-hints", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::progress", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::progress_pulse", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::progress-pulse", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::resizeable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tile_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tile-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::title", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::urgent", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::user_time", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::window_type", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::wm_class", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::user-time", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::window-type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::wm-class", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type WindowInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IWindow,
-		"above" |
-		"appears_focused" |
-		"decorated" |
-		"demands_attention" |
-		"fullscreen" |
-		"gtk_app_menu_object_path" |
-		"gtk_application_id" |
-		"gtk_application_object_path" |
-		"gtk_menubar_object_path" |
-		"gtk_unique_bus_name" |
-		"gtk_window_object_path" |
-		"maximized_horizontally" |
-		"maximized_vertically" |
-		"minimized" |
-		"muffin_hints" |
-		"progress" |
-		"progress_pulse" |
-		"resizeable" |
-		"tile_type" |
-		"title" |
-		"urgent" |
-		"user_time" |
-		"window_type" |
-		"wm_class">;
-
+	type WindowInitOptionsMixin = GObject.ObjectInitOptions
 	export interface WindowInitOptions extends WindowInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1180,11 +1146,11 @@ declare namespace imports.gi.Meta {
 		connect(signal: "position-changed", callback: (owner: this) => void): number;
 		connect(signal: "size-changed", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::meta_screen", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::meta_window", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::no_shadow", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::shadow_class", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::x_window", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::meta-screen", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::meta-window", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::no-shadow", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::shadow-class", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::x-window", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1271,14 +1237,11 @@ declare namespace imports.gi.Meta {
 		connect(signal: "window-added", callback: (owner: this, object: Window) => void): number;
 		connect(signal: "window-removed", callback: (owner: this, object: Window) => void): number;
 
-		connect(signal: "notify::n_windows", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::n-windows", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type WorkspaceInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IWorkspace,
-		"n_windows">;
-
+	type WorkspaceInitOptionsMixin = GObject.ObjectInitOptions
 	export interface WorkspaceInitOptions extends WorkspaceInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,

--- a/.typescript-declarations/Pango-1.0.d.ts
+++ b/.typescript-declarations/Pango-1.0.d.ts
@@ -1834,10 +1834,7 @@ declare namespace imports.gi.Pango {
 
 	}
 
-	type RendererInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IRenderer,
-		"matrix">;
-
+	type RendererInitOptionsMixin = GObject.ObjectInitOptions
 	export interface RendererInitOptions extends RendererInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,

--- a/.typescript-declarations/Soup-2.4.d.ts
+++ b/.typescript-declarations/Soup-2.4.d.ts
@@ -169,7 +169,6 @@ declare namespace imports.gi.Soup {
 	Pick<IAddress,
 		"family" |
 		"name" |
-		"physical" |
 		"port" |
 		"protocol" |
 		"sockaddr">;
@@ -323,10 +322,10 @@ declare namespace imports.gi.Soup {
 		 */
 		update(msg: Message, auth_header: string): boolean;
 		connect(signal: "notify::host", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_authenticated", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_for_proxy", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-authenticated", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-for-proxy", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::realm", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scheme_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scheme-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::realm", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -334,10 +333,7 @@ declare namespace imports.gi.Soup {
 	type AuthInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IAuth,
 		"host" |
-		"is_authenticated" |
 		"is_for_proxy" |
-		"realm" |
-		"scheme_name" |
 		"realm">;
 
 	export interface AuthInitOptions extends AuthInitOptionsMixin {}
@@ -555,9 +551,9 @@ declare namespace imports.gi.Soup {
 		set_generic_auth_callback(auth_callback: AuthDomainGenericAuthCallback, auth_data: any | null, dnotify: GLib.DestroyNotify): void;
 		try_generic_auth_callback(msg: Message, username: string): boolean;
 		connect(signal: "notify::filter", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::filter_data", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::generic_auth_callback", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::generic_auth_data", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::filter-data", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::generic-auth-callback", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::generic-auth-data", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::proxy", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::realm", callback: (owner: this, ...args: any) => void): number;
 
@@ -612,8 +608,8 @@ declare namespace imports.gi.Soup {
 		 * is destroyed
 		 */
 		set_auth_callback(callback: AuthDomainBasicAuthCallback, dnotify: GLib.DestroyNotify): void;
-		connect(signal: "notify::auth_callback", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::auth_data", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::auth-callback", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::auth-data", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -671,8 +667,8 @@ declare namespace imports.gi.Soup {
 		 * is destroyed
 		 */
 		set_auth_callback(callback: AuthDomainDigestAuthCallback, dnotify: GLib.DestroyNotify): void;
-		connect(signal: "notify::auth_callback", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::auth_data", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::auth-callback", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::auth-data", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -871,8 +867,8 @@ declare namespace imports.gi.Soup {
 		 * @param max_size the maximum size of the cache, in bytes
 		 */
 		set_max_size(max_size: number): void;
-		connect(signal: "notify::cache_dir", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cache_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cache-dir", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cache-type", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1152,8 +1148,8 @@ declare namespace imports.gi.Soup {
 		 */
 		connect(signal: "changed", callback: (owner: this, old_cookie: Cookie, new_cookie: Cookie) => void): number;
 
-		connect(signal: "notify::accept_policy", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::read_only", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accept-policy", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::read-only", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1479,7 +1475,7 @@ declare namespace imports.gi.Soup {
 		 */
 		set_response_filter(response_filter: LoggerFilter, filter_data: any | null, destroy: GLib.DestroyNotify): void;
 		connect(signal: "notify::level", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_body_size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-body-size", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -2086,24 +2082,24 @@ declare namespace imports.gi.Soup {
 		 */
 		connect(signal: "wrote-informational", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::first_party", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::first-party", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::flags", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::http_version", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_top_level_navigation", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::http-version", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-top-level-navigation", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::method", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::priority", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::reason_phrase", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::request_body", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::request_body_data", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::request_headers", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::response_body", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::response_body_data", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::response_headers", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::server_side", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::site_for_cookies", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::status_code", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tls_certificate", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tls_errors", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::reason-phrase", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::request-body", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::request-body-data", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::request-headers", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::response-body", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::response-body-data", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::response-headers", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::server-side", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::site-for-cookies", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::status-code", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tls-certificate", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tls-errors", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::uri", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::method", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::status_code", callback: (owner: this, ...args: any) => void): number;
@@ -2124,25 +2120,12 @@ declare namespace imports.gi.Soup {
 		"method" |
 		"priority" |
 		"reason_phrase" |
-		"request_body" |
-		"request_body_data" |
-		"request_headers" |
-		"response_body" |
-		"response_body_data" |
-		"response_headers" |
 		"server_side" |
 		"site_for_cookies" |
 		"status_code" |
 		"tls_certificate" |
 		"tls_errors" |
-		"uri" |
-		"method" |
-		"status_code" |
-		"reason_phrase" |
-		"request_body" |
-		"request_headers" |
-		"response_body" |
-		"response_headers">;
+		"uri">;
 
 	export interface MessageInitOptions extends MessageInitOptionsMixin {}
 
@@ -3134,16 +3117,16 @@ declare namespace imports.gi.Soup {
 		 */
 		connect(signal: "request-started", callback: (owner: this, message: Message, client: ClientContext) => void): number;
 
-		connect(signal: "notify::async_context", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::http_aliases", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::https_aliases", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::async-context", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::http-aliases", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::https-aliases", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::interface", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::port", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::raw_paths", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::server_header", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ssl_cert_file", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ssl_key_file", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tls_certificate", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::raw-paths", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::server-header", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ssl-cert-file", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ssl-key-file", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tls-certificate", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -4019,29 +4002,29 @@ declare namespace imports.gi.Soup {
 		 */
 		connect(signal: "tunneling", callback: (owner: this, connection: GObject.Object) => void): number;
 
-		connect(signal: "notify::accept_language", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accept_language_auto", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::add_feature", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::add_feature_by_type", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::async_context", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::http_aliases", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::https_aliases", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::idle_timeout", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::local_address", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_conns", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_conns_per_host", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::proxy_resolver", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::proxy_uri", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::remove_feature_by_type", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ssl_ca_file", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ssl_strict", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ssl_use_system_ca_file", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accept-language", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accept-language-auto", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::add-feature", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::add-feature-by-type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::async-context", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::http-aliases", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::https-aliases", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::idle-timeout", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::local-address", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-conns", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-conns-per-host", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::proxy-resolver", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::proxy-uri", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::remove-feature-by-type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ssl-ca-file", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ssl-strict", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ssl-use-system-ca-file", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::timeout", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tls_database", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tls_interaction", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_ntlm", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_thread_context", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::user_agent", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tls-database", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tls-interaction", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-ntlm", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-thread-context", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::user-agent", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -4445,21 +4428,21 @@ declare namespace imports.gi.Soup {
 		 */
 		connect(signal: "writable", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::async_context", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::async-context", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::fd", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ipv6_only", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_server", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::local_address", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::non_blocking", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::remote_address", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ssl_creds", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ssl_fallback", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ssl_strict", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ipv6-only", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-server", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::local-address", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::non-blocking", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::remote-address", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ssl-creds", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ssl-fallback", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ssl-strict", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::timeout", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tls_certificate", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::tls_errors", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::trusted_certificate", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_thread_context", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tls-certificate", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tls-errors", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::trusted-certificate", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-thread-context", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -4468,7 +4451,6 @@ declare namespace imports.gi.Soup {
 		"async_context" |
 		"fd" |
 		"ipv6_only" |
-		"is_server" |
 		"local_address" |
 		"non_blocking" |
 		"remote_address" |
@@ -4476,9 +4458,6 @@ declare namespace imports.gi.Soup {
 		"ssl_fallback" |
 		"ssl_strict" |
 		"timeout" |
-		"tls_certificate" |
-		"tls_errors" |
-		"trusted_certificate" |
 		"use_thread_context">;
 
 	export interface SocketInitOptions extends SocketInitOptionsMixin {}
@@ -4739,11 +4718,11 @@ declare namespace imports.gi.Soup {
 		 */
 		connect(signal: "pong", callback: (owner: this, message: GLib.Bytes) => void): number;
 
-		connect(signal: "notify::connection_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::connection-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::extensions", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::io_stream", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::keepalive_interval", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::max_incoming_payload_size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::io-stream", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::keepalive-interval", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-incoming-payload-size", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::origin", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::protocol", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::state", callback: (owner: this, ...args: any) => void): number;
@@ -4760,7 +4739,6 @@ declare namespace imports.gi.Soup {
 		"max_incoming_payload_size" |
 		"origin" |
 		"protocol" |
-		"state" |
 		"uri">;
 
 	export interface WebsocketConnectionInitOptions extends WebsocketConnectionInitOptionsMixin {}

--- a/.typescript-declarations/St-1.0.d.ts
+++ b/.typescript-declarations/St-1.0.d.ts
@@ -40,9 +40,9 @@ declare namespace imports.gi.St {
 		connect(signal: "changed", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::lower", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::page_increment", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::page_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::step_increment", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::page-increment", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::page-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::step-increment", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::upper", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::value", callback: (owner: this, ...args: any) => void): number;
 
@@ -146,36 +146,7 @@ declare namespace imports.gi.St {
 
 	type BackgroundEffectInitOptionsMixin = Clutter.OffscreenEffectInitOptions & 
 	Pick<IBackgroundEffect,
-		"bumpmap" |
-		"actor" |
-		"bg_texture" |
-		"bg_sub_texture" |
-		"bg_bumpmap" |
-		"bumpmap_location" |
-		"pixel_step_uniform0" |
-		"pixel_step_uniform1" |
-		"pixel_step_uniform2" |
-		"BumpTex_uniform" |
-		"bump_step_uniform" |
-		"bg_posx_i" |
-		"bg_posy_i" |
-		"bg_width_i" |
-		"bg_height_i" |
-		"fg_width_i" |
-		"fg_height_i" |
-		"bumptex_width_i" |
-		"bumptex_height_i" |
-		"posx_old" |
-		"posy_old" |
-		"width_old" |
-		"height_old" |
-		"pipeline0" |
-		"pipeline1" |
-		"pipeline2" |
-		"pipeline3" |
-		"pipeline4" |
-		"old_time" |
-		"opacity">;
+		"bumpmap">;
 
 	export interface BackgroundEffectInitOptions extends BackgroundEffectInitOptionsMixin {}
 
@@ -256,10 +227,10 @@ declare namespace imports.gi.St {
 		 */
 		set_fill(x_fill: boolean, y_fill: boolean): void;
 		connect(signal: "notify::child", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::x_align", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::x_fill", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::y_align", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::y_fill", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::x-align", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::x-fill", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::y-align", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::y-fill", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -364,7 +335,7 @@ declare namespace imports.gi.St {
 		 * @param vertical %TRUE if the layout should be vertical
 		 */
 		set_vertical(vertical: boolean): void;
-		connect(signal: "notify::pack_start", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pack-start", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::vertical", callback: (owner: this, ...args: any) => void): number;
 
 	}
@@ -407,10 +378,10 @@ declare namespace imports.gi.St {
 		y_fill: boolean;
 
 		connect(signal: "notify::expand", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::x_align", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::x_fill", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::y_align", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::y_fill", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::x-align", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::x-fill", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::y-align", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::y-fill", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -515,11 +486,11 @@ declare namespace imports.gi.St {
 		 */
 		connect(signal: "clicked", callback: (owner: this, clicked_button: number) => void): number;
 
-		connect(signal: "notify::button_mask", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::button-mask", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::checked", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::label", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::pressed", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::toggle_mode", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::toggle-mode", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -528,7 +499,6 @@ declare namespace imports.gi.St {
 		"button_mask" |
 		"checked" |
 		"label" |
-		"pressed" |
 		"toggle_mode">;
 
 	export interface ButtonInitOptions extends ButtonInitOptionsMixin {}
@@ -722,15 +692,14 @@ declare namespace imports.gi.St {
 		 */
 		connect(signal: "secondary-icon-clicked", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::clutter_text", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::hint_text", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::clutter-text", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::hint-text", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::text", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type EntryInitOptionsMixin = WidgetInitOptions & Atk.ImplementorIfaceInitOptions & Clutter.AnimatableInitOptions & Clutter.ContainerInitOptions & Clutter.ScriptableInitOptions & 
 	Pick<IEntry,
-		"clutter_text" |
 		"hint_text" |
 		"text">;
 
@@ -904,9 +873,9 @@ declare namespace imports.gi.St {
 		 */
 		set_icon_type(icon_type: IconType): void;
 		connect(signal: "notify::gicon", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::icon_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-type", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -961,14 +930,13 @@ declare namespace imports.gi.St {
 		 * @param text text to set the label to
 		 */
 		set_text(text: string): void;
-		connect(signal: "notify::clutter_text", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::clutter-text", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::text", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type LabelInitOptionsMixin = WidgetInitOptions & Atk.ImplementorIfaceInitOptions & Clutter.AnimatableInitOptions & Clutter.ContainerInitOptions & Clutter.ScriptableInitOptions & 
 	Pick<ILabel,
-		"clutter_text" |
 		"text">;
 
 	export interface LabelInitOptions extends LabelInitOptionsMixin {}
@@ -1018,14 +986,14 @@ declare namespace imports.gi.St {
 		connect(signal: "repaint", callback: (owner: this) => void): number;
 
 		connect(signal: "notify::debug", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::llc_x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::llc_y", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::lrc_x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::lrc_y", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ulc_x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::ulc_y", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::urc_x", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::urc_y", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::llc-x", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::llc-y", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::lrc-x", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::lrc-y", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ulc-x", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::ulc-y", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::urc-x", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::urc-y", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1134,14 +1102,14 @@ declare namespace imports.gi.St {
 		 */
 		set_policy(hscroll: Gtk.PolicyType, vscroll: Gtk.PolicyType): void;
 		set_row_size(row_size: number): void;
-		connect(signal: "notify::enable_auto_scrolling", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_mouse_scrolling", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-auto-scrolling", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-mouse-scrolling", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::hscroll", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::hscrollbar_policy", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::hscrollbar_visible", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::hscrollbar-policy", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::hscrollbar-visible", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::vscroll", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::vscrollbar_policy", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::vscrollbar_visible", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::vscrollbar-policy", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::vscrollbar-visible", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1149,12 +1117,8 @@ declare namespace imports.gi.St {
 	Pick<IScrollView,
 		"enable_auto_scrolling" |
 		"enable_mouse_scrolling" |
-		"hscroll" |
 		"hscrollbar_policy" |
-		"hscrollbar_visible" |
-		"vscroll" |
-		"vscrollbar_policy" |
-		"vscrollbar_visible">;
+		"vscrollbar_policy">;
 
 	export interface ScrollViewInitOptions extends ScrollViewInitOptionsMixin {}
 
@@ -1180,7 +1144,7 @@ declare namespace imports.gi.St {
 	interface IScrollViewFade {
 		fade_offset: number;
 
-		connect(signal: "notify::fade_offset", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::fade-offset", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1208,14 +1172,11 @@ declare namespace imports.gi.St {
 	interface ISettings {
 		readonly font_name: string;
 
-		connect(signal: "notify::font_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::font-name", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type SettingsInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<ISettings,
-		"font_name">;
-
+	type SettingsInitOptionsMixin = GObject.ObjectInitOptions
 	export interface SettingsInitOptions extends SettingsInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1367,17 +1328,15 @@ declare namespace imports.gi.St {
 		 * @returns the number of rows
 		 */
 		get_row_count(): number;
-		connect(signal: "notify::column_count", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::column-count", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::homogeneous", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::row_count", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::row-count", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type TableInitOptionsMixin = WidgetInitOptions & Atk.ImplementorIfaceInitOptions & Clutter.AnimatableInitOptions & Clutter.ContainerInitOptions & Clutter.ScriptableInitOptions & 
 	Pick<ITable,
-		"column_count" |
-		"homogeneous" |
-		"row_count">;
+		"homogeneous">;
 
 	export interface TableInitOptions extends TableInitOptionsMixin {}
 
@@ -1417,17 +1376,17 @@ declare namespace imports.gi.St {
 		y_expand: boolean;
 		y_fill: boolean;
 
-		connect(signal: "notify::allocate_hidden", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::allocate-hidden", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::col", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::col_span", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::col-span", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::row", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::row_span", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::x_align", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::x_expand", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::x_fill", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::y_align", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::y_expand", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::y_fill", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::row-span", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::x-align", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::x-expand", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::x-fill", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::y-align", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::y-expand", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::y-fill", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1639,10 +1598,10 @@ declare namespace imports.gi.St {
 		unload_stylesheet(path: string): void;
 		connect(signal: "custom-stylesheets-changed", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::application_stylesheet", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::default_stylesheet", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::fallback_stylesheet", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::theme_stylesheet", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::application-stylesheet", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::default-stylesheet", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::fallback-stylesheet", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::theme-stylesheet", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1717,7 +1676,7 @@ declare namespace imports.gi.St {
 		set_theme(theme: Theme): void;
 		connect(signal: "changed", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::scale_factor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scale-factor", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -2597,17 +2556,17 @@ declare namespace imports.gi.St {
 		 */
 		connect(signal: "style-changed", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::accessible_name", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::accessible_role", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::can_focus", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::accessible-role", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::can-focus", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::hover", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::important", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::label_actor", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pseudo_class", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::label-actor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pseudo-class", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::style", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::style_class", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::style-class", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::theme", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::track_hover", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::track-hover", callback: (owner: this, ...args: any) => void): number;
 
 	}
 

--- a/.typescript-declarations/WebKit2-4.0.d.ts
+++ b/.typescript-declarations/WebKit2-4.0.d.ts
@@ -965,19 +965,16 @@ declare namespace imports.gi.WebKit2 {
 		 */
 		connect(signal: "received-data", callback: (owner: this, data_length: number) => void): number;
 
-		connect(signal: "notify::allow_overwrite", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::allow-overwrite", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::destination", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::estimated_progress", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::estimated-progress", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::response", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type DownloadInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IDownload,
-		"allow_overwrite" |
-		"destination" |
-		"estimated_progress" |
-		"response">;
+		"allow_overwrite">;
 
 	export interface DownloadInitOptions extends DownloadInitOptionsMixin {}
 
@@ -1035,14 +1032,11 @@ declare namespace imports.gi.WebKit2 {
 		 * @returns %TRUE if undo is currently available
 		 */
 		is_undo_available(): boolean;
-		connect(signal: "notify::typing_attributes", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::typing-attributes", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type EditorStateInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IEditorState,
-		"typing_attributes">;
-
+	type EditorStateInitOptionsMixin = GObject.ObjectInitOptions
 	export interface EditorStateInitOptions extends EditorStateInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1228,19 +1222,13 @@ declare namespace imports.gi.WebKit2 {
 		 */
 		select_files(files: string[]): void;
 		connect(signal: "notify::filter", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::mime_types", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::select_multiple", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::selected_files", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::mime-types", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::select-multiple", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::selected-files", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type FileChooserRequestInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IFileChooserRequest,
-		"filter" |
-		"mime_types" |
-		"select_multiple" |
-		"selected_files">;
-
+	type FileChooserRequestInitOptionsMixin = GObject.ObjectInitOptions
 	export interface FileChooserRequestInitOptions extends FileChooserRequestInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1402,18 +1390,15 @@ declare namespace imports.gi.WebKit2 {
 		 */
 		connect(signal: "found-text", callback: (owner: this, match_count: number) => void): number;
 
-		connect(signal: "notify::max_match_count", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::max-match-count", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::options", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::text", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::web_view", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::web-view", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
 	type FindControllerInitOptionsMixin = GObject.ObjectInitOptions & 
 	Pick<IFindController,
-		"max_match_count" |
-		"options" |
-		"text" |
 		"web_view">;
 
 	export interface FindControllerInitOptions extends FindControllerInitOptionsMixin {}
@@ -1535,14 +1520,11 @@ declare namespace imports.gi.WebKit2 {
 		 */
 		connect(signal: "stop", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::enable_high_accuracy", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-high-accuracy", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type GeolocationManagerInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IGeolocationManager,
-		"enable_high_accuracy">;
-
+	type GeolocationManagerInitOptionsMixin = GObject.ObjectInitOptions
 	export interface GeolocationManagerInitOptions extends GeolocationManagerInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -1691,11 +1673,11 @@ declare namespace imports.gi.WebKit2 {
 		 */
 		get_media_uri(): string;
 		connect(signal: "notify::context", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::image_uri", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::link_label", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::link_title", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::link_uri", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::media_uri", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::image-uri", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::link-label", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::link-title", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::link-uri", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::media-uri", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -1848,8 +1830,8 @@ declare namespace imports.gi.WebKit2 {
 		 */
 		connect(signal: "preedit-started", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::input_hints", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::input_purpose", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::input-hints", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::input-purpose", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -2013,24 +1995,16 @@ declare namespace imports.gi.WebKit2 {
 		 * @returns The URI request that is associated with this navigation
 		 */
 		get_request(): URIRequest;
-		connect(signal: "notify::frame_name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::frame-name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::modifiers", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::mouse_button", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::navigation_action", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::navigation_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::mouse-button", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::navigation-action", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::navigation-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::request", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type NavigationPolicyDecisionInitOptionsMixin = PolicyDecisionInitOptions & 
-	Pick<INavigationPolicyDecision,
-		"frame_name" |
-		"modifiers" |
-		"mouse_button" |
-		"navigation_action" |
-		"navigation_type" |
-		"request">;
-
+	type NavigationPolicyDecisionInitOptionsMixin = PolicyDecisionInitOptions
 	export interface NavigationPolicyDecisionInitOptions extends NavigationPolicyDecisionInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -2122,13 +2096,7 @@ declare namespace imports.gi.WebKit2 {
 
 	}
 
-	type NotificationInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<INotification,
-		"body" |
-		"id" |
-		"tag" |
-		"title">;
-
+	type NotificationInitOptionsMixin = GObject.ObjectInitOptions
 	export interface NotificationInitOptions extends NotificationInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -2515,9 +2483,9 @@ declare namespace imports.gi.WebKit2 {
 		 */
 		connect(signal: "finished", callback: (owner: this) => void): number;
 
-		connect(signal: "notify::page_setup", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::print_settings", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::web_view", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::page-setup", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::print-settings", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::web-view", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -2586,11 +2554,7 @@ declare namespace imports.gi.WebKit2 {
 
 	}
 
-	type ResponsePolicyDecisionInitOptionsMixin = PolicyDecisionInitOptions & 
-	Pick<IResponsePolicyDecision,
-		"request" |
-		"response">;
-
+	type ResponsePolicyDecisionInitOptionsMixin = PolicyDecisionInitOptions
 	export interface ResponsePolicyDecisionInitOptions extends ResponsePolicyDecisionInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -3682,65 +3646,65 @@ declare namespace imports.gi.WebKit2 {
 		 * @param zoom_text_only Value to be set
 		 */
 		set_zoom_text_only(zoom_text_only: boolean): void;
-		connect(signal: "notify::allow_file_access_from_file_urls", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::allow_modal_dialogs", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::allow_top_navigation_to_data_urls", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::allow_universal_access_from_file_urls", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::auto_load_images", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::cursive_font_family", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::default_charset", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::default_font_family", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::default_font_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::default_monospace_font_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::draw_compositing_indicators", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_accelerated_2d_canvas", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_back_forward_navigation_gestures", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_caret_browsing", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_developer_extras", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_dns_prefetching", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_encrypted_media", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_frame_flattening", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_fullscreen", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_html5_database", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_html5_local_storage", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_hyperlink_auditing", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_java", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_javascript", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_javascript_markup", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_media", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_media_capabilities", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_media_stream", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_mediasource", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_mock_capture_devices", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_offline_web_application_cache", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_page_cache", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_plugins", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_private_browsing", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_resizable_text_areas", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_site_specific_quirks", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_smooth_scrolling", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_spatial_navigation", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_tabs_to_links", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_webaudio", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_webgl", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_write_console_messages_to_stdout", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::enable_xss_auditor", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::fantasy_font_family", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::hardware_acceleration_policy", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::javascript_can_access_clipboard", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::javascript_can_open_windows_automatically", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::load_icons_ignoring_image_load_setting", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::media_content_types_requiring_hardware_support", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::media_playback_allows_inline", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::media_playback_requires_user_gesture", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::minimum_font_size", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::monospace_font_family", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::pictograph_font_family", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::print_backgrounds", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::sans_serif_font_family", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::serif_font_family", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::user_agent", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::zoom_text_only", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::allow-file-access-from-file-urls", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::allow-modal-dialogs", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::allow-top-navigation-to-data-urls", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::allow-universal-access-from-file-urls", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::auto-load-images", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::cursive-font-family", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::default-charset", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::default-font-family", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::default-font-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::default-monospace-font-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::draw-compositing-indicators", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-accelerated-2d-canvas", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-back-forward-navigation-gestures", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-caret-browsing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-developer-extras", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-dns-prefetching", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-encrypted-media", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-frame-flattening", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-fullscreen", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-html5-database", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-html5-local-storage", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-hyperlink-auditing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-java", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-javascript", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-javascript-markup", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-media", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-media-capabilities", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-media-stream", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-mediasource", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-mock-capture-devices", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-offline-web-application-cache", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-page-cache", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-plugins", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-private-browsing", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-resizable-text-areas", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-site-specific-quirks", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-smooth-scrolling", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-spatial-navigation", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-tabs-to-links", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-webaudio", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-webgl", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-write-console-messages-to-stdout", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::enable-xss-auditor", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::fantasy-font-family", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::hardware-acceleration-policy", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::javascript-can-access-clipboard", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::javascript-can-open-windows-automatically", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::load-icons-ignoring-image-load-setting", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::media-content-types-requiring-hardware-support", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::media-playback-allows-inline", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::media-playback-requires-user-gesture", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::minimum-font-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::monospace-font-family", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::pictograph-font-family", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::print-backgrounds", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::sans-serif-font-family", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::serif-font-family", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::user-agent", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::zoom-text-only", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -3962,24 +3926,16 @@ declare namespace imports.gi.WebKit2 {
 		 */
 		get_suggested_filename(): string;
 		get_uri(): string;
-		connect(signal: "notify::content_length", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::http_headers", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::mime_type", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::status_code", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::suggested_filename", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::content-length", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::http-headers", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::mime-type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::status-code", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::suggested-filename", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::uri", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type URIResponseInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IURIResponse,
-		"content_length" |
-		"http_headers" |
-		"mime_type" |
-		"status_code" |
-		"suggested_filename" |
-		"uri">;
-
+	type URIResponseInitOptionsMixin = GObject.ObjectInitOptions
 	export interface URIResponseInitOptions extends URIResponseInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -4351,16 +4307,12 @@ declare namespace imports.gi.WebKit2 {
 		readonly is_for_audio_device: boolean;
 		readonly is_for_video_device: boolean;
 
-		connect(signal: "notify::is_for_audio_device", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_for_video_device", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-for-audio-device", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-for-video-device", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type UserMediaPermissionRequestInitOptionsMixin = GObject.ObjectInitOptions & PermissionRequestInitOptions & 
-	Pick<IUserMediaPermissionRequest,
-		"is_for_audio_device" |
-		"is_for_video_device">;
-
+	type UserMediaPermissionRequestInitOptionsMixin = GObject.ObjectInitOptions & PermissionRequestInitOptions
 	export interface UserMediaPermissionRequestInitOptions extends UserMediaPermissionRequestInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -4414,7 +4366,7 @@ declare namespace imports.gi.WebKit2 {
 		 * @param reply a #WebKitUserMessage to send as reply
 		 */
 		send_reply(reply: UserMessage): void;
-		connect(signal: "notify::fd_list", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::fd-list", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::parameters", callback: (owner: this, ...args: any) => void): number;
 
@@ -4968,10 +4920,10 @@ declare namespace imports.gi.WebKit2 {
 		 */
 		connect(signal: "user-message-received", callback: (owner: this, message: UserMessage) => boolean): number;
 
-		connect(signal: "notify::local_storage_directory", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::process_swap_on_cross_site_navigation_enabled", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::use_system_appearance_for_scrollbars", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::website_data_manager", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::local-storage-directory", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::process-swap-on-cross-site-navigation-enabled", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::use-system-appearance-for-scrollbars", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::website-data-manager", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -5181,18 +5133,13 @@ declare namespace imports.gi.WebKit2 {
 		 */
 		connect(signal: "open-window", callback: (owner: this) => boolean): number;
 
-		connect(signal: "notify::attached_height", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::can_attach", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::inspected_uri", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::attached-height", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::can-attach", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::inspected-uri", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
-	type WebInspectorInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IWebInspector,
-		"attached_height" |
-		"can_attach" |
-		"inspected_uri">;
-
+	type WebInspectorInitOptionsMixin = GObject.ObjectInitOptions
 	export interface WebInspectorInitOptions extends WebInspectorInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -5343,11 +5290,7 @@ declare namespace imports.gi.WebKit2 {
 
 	}
 
-	type WebResourceInitOptionsMixin = GObject.ObjectInitOptions & 
-	Pick<IWebResource,
-		"response" |
-		"uri">;
-
+	type WebResourceInitOptionsMixin = GObject.ObjectInitOptions
 	export interface WebResourceInitOptions extends WebResourceInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -6808,22 +6751,22 @@ declare namespace imports.gi.WebKit2 {
 		 */
 		connect(signal: "web-process-terminated", callback: (owner: this, reason: WebProcessTerminationReason) => void): number;
 
-		connect(signal: "notify::automation_presentation_type", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::automation-presentation-type", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::editable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::estimated_load_progress", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::estimated-load-progress", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::favicon", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_controlled_by_automation", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_ephemeral", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_loading", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_muted", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_playing_audio", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::page_id", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-controlled-by-automation", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-ephemeral", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-loading", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-muted", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-playing-audio", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::page-id", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::title", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::uri", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::user_content_manager", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::web_context", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::website_policies", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::zoom_level", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::user-content-manager", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::web-context", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::website-policies", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::zoom-level", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -6831,16 +6774,9 @@ declare namespace imports.gi.WebKit2 {
 	Pick<IWebView,
 		"automation_presentation_type" |
 		"editable" |
-		"estimated_load_progress" |
-		"favicon" |
 		"is_controlled_by_automation" |
 		"is_ephemeral" |
-		"is_loading" |
 		"is_muted" |
-		"is_playing_audio" |
-		"page_id" |
-		"title" |
-		"uri" |
 		"user_content_manager" |
 		"web_context" |
 		"website_policies" |
@@ -6918,10 +6854,7 @@ declare namespace imports.gi.WebKit2 {
 
 	}
 
-	type WebViewBaseInitOptionsMixin = Gtk.ContainerInitOptions & Atk.ImplementorIfaceInitOptions & Gtk.BuildableInitOptions & 
-	Pick<IWebViewBase,
-		"parentInstance">;
-
+	type WebViewBaseInitOptionsMixin = Gtk.ContainerInitOptions & Atk.ImplementorIfaceInitOptions & Gtk.BuildableInitOptions
 	export interface WebViewBaseInitOptions extends WebViewBaseInitOptionsMixin {}
 
 	/** This construct is only for enabling class multi-inheritance,
@@ -7219,18 +7152,18 @@ declare namespace imports.gi.WebKit2 {
 		 * @param policy a #WebKitTLSErrorsPolicy
 		 */
 		set_tls_errors_policy(policy: TLSErrorsPolicy): void;
-		connect(signal: "notify::base_cache_directory", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::base_data_directory", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::disk_cache_directory", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::dom_cache_directory", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::hsts_cache_directory", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::indexeddb_directory", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::is_ephemeral", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::itp_directory", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::local_storage_directory", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::offline_application_cache_directory", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::service_worker_registrations_directory", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::websql_directory", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::base-cache-directory", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::base-data-directory", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::disk-cache-directory", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::dom-cache-directory", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::hsts-cache-directory", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::indexeddb-directory", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::is-ephemeral", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::itp-directory", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::local-storage-directory", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::offline-application-cache-directory", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::service-worker-registrations-directory", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::websql-directory", callback: (owner: this, ...args: any) => void): number;
 
 	}
 
@@ -7388,12 +7321,12 @@ declare namespace imports.gi.WebKit2 {
 		get_toolbar_visible(): boolean;
 		connect(signal: "notify::fullscreen", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::geometry", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::locationbar_visible", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::menubar_visible", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::locationbar-visible", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::menubar-visible", callback: (owner: this, ...args: any) => void): number;
 		connect(signal: "notify::resizable", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::scrollbars_visible", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::statusbar_visible", callback: (owner: this, ...args: any) => void): number;
-		connect(signal: "notify::toolbar_visible", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::scrollbars-visible", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::statusbar-visible", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::toolbar-visible", callback: (owner: this, ...args: any) => void): number;
 
 	}
 

--- a/.typescript-declarations/XApp-1.0.d.ts
+++ b/.typescript-declarations/XApp-1.0.d.ts
@@ -1,0 +1,2068 @@
+/** Generated with https://github.com/Gr3q/GIR2TS - If possible do not modify. */
+declare namespace imports.gi.XApp {
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link Favorites} instead.
+	 */
+	interface IFavorites {
+		/**
+		 * Adds a new favorite.  If the uri already exists, this does nothing.
+		 * @param uri The uri the favorite is for
+		 */
+		add(uri: string): void;
+		/**
+		 * Generates a list of favorite GtkActions.
+		 * @param mimetypes The mimetypes to filter for, or NULL to include all favorites.
+		 * @returns a new #GtkActionGroup populated with a list of favorites, or NULL
+		 *             if there are no favorites.
+		 */
+		create_actions(mimetypes: string | null): GLib.List;
+		/**
+		 * Generates a GtkMenu widget populated with favorites. The callback will be called when
+		 * a menu item has been activated, and will include the uri of the respective item.
+		 * @param mimetypes The mimetypes to filter for, or NULL to include all favorites.
+		 * @param callback (closure user_data): The callback to use when a menu item has been selected.
+		 * @param func Destroy function for user_data
+		 * @returns a new #GtkMenu populated with a list of favorites, or NULL
+		 *             if there are no favorites.
+		 */
+		create_menu(mimetypes: string | null, callback: FavoritesItemSelectedCallback, func: GLib.DestroyNotify): Gtk.Widget;
+		/**
+		 * Looks for an XAppFavoriteInfo that corresponds to #display_name.
+		 * @param display_name The display name to lookup info for.
+		 * @returns an XAppFavoriteInfo or NULL if one was not found. This is owned
+		 *          by the favorites manager and should not be freed.
+		 */
+		find_by_display_name(display_name: string): FavoriteInfo;
+		/**
+		 * Looks for an XAppFavoriteInfo that corresponds to #uri.
+		 * @param uri The uri to lookup info for.
+		 * @returns an XAppFavoriteInfo or NULL if one was not found. This is owned
+		 *          by the favorites manager and should not be freed.
+		 */
+		find_by_uri(uri: string): FavoriteInfo;
+		/**
+		 * Gets a list of all favorites.  If mimetype is not %NULL, the list will
+		 * contain only favorites with that mimetype.
+		 * @param mimetypes The mimetypes to filter by for results
+		 * @returns a list of {@link FavoriteInfos}.
+		 *             Free the list with #g_list_free, free elements with #xapp_favorite_info_free.
+		 */
+		get_favorites(mimetypes: string | null): GLib.List;
+		get_n_favorites(): number;
+		/**
+		 * Opens a favorite in its default app.
+		 * @param uri The uri for the favorite to launch
+		 * @param timestamp The timestamp from an event or 0
+		 */
+		launch(uri: string, timestamp: number): void;
+		/**
+		 * Removes a favorite from the list.
+		 * @param uri The uri for the favorite being removed
+		 */
+		remove(uri: string): void;
+		/**
+		 * Removes old_uri and adds new_uri. This is mainly for file managers to use as
+		 * a convenience instead of add/remove, and guarantees the result, without having to
+		 * worry about multiple dbus calls (gsettings).
+		 * @param old_uri the old favorite's uri.
+		 * @param new_uri The new uri.
+		 */
+		rename(old_uri: string, new_uri: string): void;
+		/**
+		 * Notifies when the favorites list has changed.
+		 * @param signal 
+		 * @param callback Callback function
+		 *  - owner: owner of the emitted event 
+		 * 
+		 * @returns Callback ID
+		 */
+		connect(signal: "changed", callback: (owner: this) => void): number;
+
+	}
+
+	type FavoritesInitOptionsMixin = GObject.ObjectInitOptions
+	export interface FavoritesInitOptions extends FavoritesInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link Favorites} instead.
+	 */
+	type FavoritesMixin = IFavorites & GObject.Object;
+
+	interface Favorites extends FavoritesMixin {}
+
+	class Favorites {
+		public constructor(options?: Partial<FavoritesInitOptions>);
+		/**
+		 * Returns the {@link Favorites} instance.
+		 * @returns the XAppFavorites instance for the process. Do not free.
+		 */
+		public static get_default(): Favorites;
+	}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link GtkWindow} instead.
+	 */
+	interface IGtkWindow {
+		/**
+		 * Sets the icon name hint for a window manager (like muffin) to make
+		 * available when applications want to change their icons during runtime
+		 * without having to resort to the internal low-res pixbufs that GdkWindow
+		 * sets on the client side.  This also chains up and calls GtkWindow.set_icon_from_file
+		 * for convenience and compatibility.  Set to %NULL to unset.
+		 * @param file_name The icon path to set, or %NULL to unset.
+		 */
+		set_icon_from_file(file_name: string | null): void;
+		/**
+		 * Sets the icon name hint for a window manager (like muffin) to make
+		 * available when applications want to change their icons during runtime
+		 * without having to resort to the internal low-res pixbufs that GdkWindow
+		 * sets on the client side.  This also chains up and calls GtkWindow.set_icon_name
+		 * for convenience and compatibility.  Set to %NULL to unset.
+		 * @param icon_name The icon name or path to set, or %NULL to unset.
+		 */
+		set_icon_name(icon_name: string | null): void;
+		/**
+		 * Sets the progress hint for a window manager (like muffin) to make
+		 * available when applications want to display the application's progress
+		 * in some operation. The value sent to the WM will be clamped to
+		 * between 0 and 100.
+		 * 
+		 * Note: If a window will stick around after progress is complete, you will
+		 * probaby need to set progress to 0 to remove any progress effects on taskbars
+		 * and window lists.
+		 * 
+		 * Setting progress will also cancel the 'pulsing' flag on the window as
+		 * well, if it has been set.
+		 * @param progress The value to set for progress.
+		 */
+		set_progress(progress: number): void;
+		/**
+		 * Sets the progress pulse hint hint for a window manager (like muffin)
+		 * to make available when applications want to display indeterminate or
+		 * ongoing progress in a task manager.
+		 * 
+		 * Note: If a window will stick around after progress is complete, you will
+		 * probaby need to set progress to 0 to remove any progress effects on taskbars
+		 * and window lists.  This will also remove the pulse state, if it is set.
+		 * 
+		 * Setting an explicit progress value will unset this flag.
+		 * @param pulse Whether to have pulsing set or not.
+		 */
+		set_progress_pulse(pulse: boolean): void;
+	}
+
+	type GtkWindowInitOptionsMixin = Gtk.WindowInitOptions & Atk.ImplementorIfaceInitOptions & Gtk.BuildableInitOptions
+	export interface GtkWindowInitOptions extends GtkWindowInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link GtkWindow} instead.
+	 */
+	type GtkWindowMixin = IGtkWindow & Gtk.Window & Atk.ImplementorIface & Gtk.Buildable;
+
+	interface GtkWindow extends GtkWindowMixin {}
+
+	class GtkWindow {
+		public constructor(options?: Partial<GtkWindowInitOptions>);
+		/**
+		 * Creates a new {@link GtkWindow} of type #type.  See {@link Gtk.Window.new}
+		 * for more details.
+		 * @param type The #GtkWindowType to use
+		 * @returns A new {@link GtkWindow} (transfer: full)
+		 */
+		public static new(type: Gtk.WindowType): Gtk.Widget;
+	}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link IconChooserButton} instead.
+	 */
+	interface IIconChooserButton {
+		/**
+		 * The category selected by default.
+		 */
+		category: string;
+		/**
+		 * The preferred size to use when looking up icons. This only works with icon names.
+		 * Additionally, there is no guarantee that a selected icon name will exist in a
+		 * particular size.
+		 */
+		icon: string;
+		/**
+		 * The size to use when displaying the icon.
+		 */
+		icon_size: Gtk.IconSize;
+		/**
+		 * Gets a reference to the icon chooser dialog for the {@link IconChooserButton}.
+		 * This is useful for setting properties on the dialog.
+		 * @returns the {@link IconChooserDialog}
+		 */
+		get_dialog(): IconChooserDialog;
+		/**
+		 * Gets the icon from the {@link IconChooserButton}.
+		 * @returns a string representing the icon. This may be an icon name or a file path.
+		 */
+		get_icon(): string;
+		/**
+		 * Sets the icon on the {@link IconChooserButton}.
+		 * @param category a string representing the category selected by default.
+		 */
+		set_default_category(category: string | null): void;
+		/**
+		 * Sets the icon on the {@link IconChooserButton}.
+		 * @param icon a string representing the icon to be set. This may be an icon name or a file path.
+		 */
+		set_icon(icon: string | null): void;
+		/**
+		 * Sets the icon size used in the button.
+		 * @param icon_size the size of icon to use in the button, or -1 to use the default value.
+		 */
+		set_icon_size(icon_size: Gtk.IconSize): void;
+		connect(signal: "notify::category", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-size", callback: (owner: this, ...args: any) => void): number;
+
+	}
+
+	type IconChooserButtonInitOptionsMixin = Gtk.ButtonInitOptions & Atk.ImplementorIfaceInitOptions & Gtk.ActionableInitOptions & Gtk.ActivatableInitOptions & Gtk.BuildableInitOptions & 
+	Pick<IIconChooserButton,
+		"category" |
+		"icon" |
+		"icon_size">;
+
+	export interface IconChooserButtonInitOptions extends IconChooserButtonInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link IconChooserButton} instead.
+	 */
+	type IconChooserButtonMixin = IIconChooserButton & Gtk.Button & Atk.ImplementorIface & Gtk.Actionable & Gtk.Activatable & Gtk.Buildable;
+
+	interface IconChooserButton extends IconChooserButtonMixin {}
+
+	class IconChooserButton {
+		public constructor(options?: Partial<IconChooserButtonInitOptions>);
+		/**
+		 * Creates a new {@link IconChooserButton} and sets its icon to #icon.
+		 * @returns a newly created {@link IconChooserButton}
+		 */
+		public static new(): IconChooserButton;
+		/**
+		 * Creates a new {@link IconChooserButton}, and sets the sizes of the button image and the icons in
+		 * the dialog. Note that xapp_icon_chooser_button_new_with_size (NULL, NULL) is the same as calling
+		 * xapp_icon_chooser_button_new ().
+		 * @param icon_size the size of icon to use in the button, or NULL to use the default value.
+		 * @returns a newly created {@link IconChooserButton}
+		 */
+		public static new_with_size(icon_size: Gtk.IconSize): IconChooserButton;
+	}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link IconChooserDialog} instead.
+	 */
+	interface IIconChooserDialog {
+		/**
+		 * Whether to allow paths to be searched and selected or only icon names.
+		 */
+		allow_paths: boolean;
+		/**
+		 * The icon to use by default.
+		 */
+		default_icon: string;
+		/**
+		 * The preferred size to use when looking up icons. This only works with icon names.
+		 * Additionally, there is no guarantee that a selected icon name will exist in a
+		 * particular size.
+		 */
+		icon_size: IconSize;
+		/**
+		 * Allows a button to be added to the #GtkActionBar of the dialog with a custom
+		 * response id.
+		 * @param button a #GtkButton to add
+		 * @param packing the #GtkPackType to specify start or end packing to the action bar
+		 * @param response_id the dialog response id to return when this button is clicked.
+		 */
+		add_button(button: Gtk.Widget, packing: Gtk.PackType, response_id: Gtk.ResponseType): void;
+		/**
+		 * Adds a custom category to the dialog.
+		 * @param name the name of the category as it will be displayed in the category list
+		 * @param icons a list of icon names to add to the new category
+		 */
+		add_custom_category(name: string, icons: GLib.List): void;
+		/**
+		 * Returns the default icon (if set).
+		 * @returns the default icon, or NULL if none is set
+		 */
+		get_default_icon(): string;
+		/**
+		 * Gets the currently selected icon from the dialog. If allow-paths is TRUE, this function may return
+		 * either an icon name or a path depending on what the user selects. Otherwise it will only return an
+		 * icon name.
+		 * @returns the string representation of the currently selected icon or NULL
+		 * if no icon is selected.
+		 */
+		get_icon_string(): string;
+		/**
+		 * Shows the dialog and enters a separate main loop until an icon is chosen or the action is canceled.
+		 * 
+		 * xapp_icon_chooser_dialog_run (), {@link Xapp.icon_chooser_dialog_run_with_icon}, and
+		 * xapp_icon_chooser_dialog_run_with_category () may all be called multiple times. This is useful for
+		 * applications which use this dialog multiple times, as it may improve performance for subsequent
+		 * calls.
+		 * @returns GTK_RESPONSE_OK if the user selected an icon, or GTK_RESPONSE_CANCEL otherwise
+		 */
+		run(): number;
+		/**
+		 * Like xapp_icon_chooser_dialog_run but selects a particular category specified by #category.
+		 * This is used when there is a particular category of icon that is more appropriate than the
+		 * others. If the category does not exist, the first category in the list will be selected. To
+		 * get a list of possible categories, use gtk_icon_theme_list_contexts ().
+		 * 
+		 * xapp_icon_chooser_dialog_run (), {@link Xapp.icon_chooser_dialog_run_with_icon}, and
+		 * xapp_icon_chooser_dialog_run_with_category () may all be called multiple times. This is useful for
+		 * applications which use this dialog multiple times, as it may improve performance for subsequent
+		 * calls.
+		 * @param category
+		 * @returns GTK_RESPONSE_OK if the user selected an icon, or GTK_RESPONSE_CANCEL otherwise
+		 */
+		run_with_category(category: string): number;
+		/**
+		 * Like xapp_icon_chooser_dialog_run but selects the icon specified by #icon. This can be either an
+		 * icon name or a path. Passing an icon string or path that doesn't exist is accepted, but it may show
+		 * multiple results, or none at all. This behavior is useful if, for example, you wish to have the
+		 * user select an image file from a particular directory.
+		 * 
+		 * If the property allow_paths is FALSE, setting a path will yield no results when the dialog is opened.
+		 * 
+		 * xapp_icon_chooser_dialog_run (), {@link Xapp.icon_chooser_dialog_run_with_icon}, and
+		 * xapp_icon_chooser_dialog_run_with_category () may all be called multiple times. This is useful for
+		 * applications which use this dialog multiple times, as it may improve performance for subsequent
+		 * calls.
+		 * @param icon a string representing the icon that should be selected
+		 * @returns GTK_RESPONSE_OK if the user selected an icon, or GTK_RESPONSE_CANCEL otherwise
+		 */
+		run_with_icon(icon: string): number;
+		/**
+		 * Sets the default icon. If #icon is not NULL, a button will be shown that
+		 * will reset the dialog to it's default value.
+		 * @param icon the default icon, or NULL to unset
+		 */
+		set_default_icon(icon: string): void;
+		connect(signal: "close", callback: (owner: this) => void): number;
+		connect(signal: "select", callback: (owner: this) => void): number;
+
+		connect(signal: "notify::allow-paths", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::default-icon", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-size", callback: (owner: this, ...args: any) => void): number;
+
+	}
+
+	type IconChooserDialogInitOptionsMixin = GtkWindowInitOptions & Atk.ImplementorIfaceInitOptions & Gtk.BuildableInitOptions & 
+	Pick<IIconChooserDialog,
+		"allow_paths" |
+		"default_icon" |
+		"icon_size">;
+
+	export interface IconChooserDialogInitOptions extends IconChooserDialogInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link IconChooserDialog} instead.
+	 */
+	type IconChooserDialogMixin = IIconChooserDialog & GtkWindow & Atk.ImplementorIface & Gtk.Buildable;
+
+	interface IconChooserDialog extends IconChooserDialogMixin {}
+
+	class IconChooserDialog {
+		public constructor(options?: Partial<IconChooserDialogInitOptions>);
+		/**
+		 * Creates a new {@link IconChooserDialog}.
+		 * @returns a newly created {@link IconChooserDialog}
+		 */
+		public static new(): IconChooserDialog;
+	}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link KbdLayoutController} instead.
+	 */
+	interface IKbdLayoutController {
+		readonly enabled: boolean;
+		readonly parent_object: GObject.Object;
+		/**
+		 * Returns an array of all full layout names
+		 * @returns array of names
+		 */
+		get_all_names(): string[];
+		/**
+		 * Returns the duplicate id for the current layout
+		 * @returns the id
+		 */
+		get_current_flag_id(): number;
+		/**
+		 * Selects the previous group in the group list.
+		 * @returns 
+		 */
+		get_current_group(): number;
+		/**
+		 * Returns the icon file name (no path or extension) to use for the current layout
+		 * @returns a new string with the icon name.
+		 */
+		get_current_icon_name(): string;
+		/**
+		 * Returns the full name of the current keyboard layout.
+		 * @returns the newly created string or NULL
+		 * if something went wrong.
+		 */
+		get_current_name(): string;
+		/**
+		 * Returns the short group label (and subscript, if any) of the current layout
+		 * @returns a new string or NULL.
+		 */
+		get_current_short_group_label(): string;
+		/**
+		 * Returns the variant label (and subscript, if any) of the current layout
+		 * @returns a new string or NULL.
+		 */
+		get_current_variant_label(): string;
+		/**
+		 * Returns whether or not the layout controller is enabled
+		 * @returns 
+		 */
+		get_enabled(): boolean;
+		get_flag_id_for_group(group: number): number;
+		/**
+		 * Returns the icon file name (no path or extension) to use for the specified layout.
+		 * @param group a group number
+		 * @returns a new string with the icon name.
+		 */
+		get_icon_name_for_group(group: number): string;
+		/**
+		 * Returns the short group label and subscript of the specified layout.
+		 * @param group a group number
+		 * @returns a new string or NULL.
+		 */
+		get_short_group_label_for_group(group: number): string;
+		/**
+		 * Returns the variant label and subscript of the specified layout.
+		 * @param group a group number
+		 * @returns a new string or NULL.
+		 */
+		get_variant_label_for_group(group: number): string;
+		/**
+		 * Selects the next group in the group list.
+		 */
+		next_group(): void;
+		/**
+		 * Selects the previous group in the group list.
+		 */
+		previous_group(): void;
+		/**
+		 * Selects the given group number as active.
+		 * @param group the group number to make active
+		 */
+		set_current_group(group: number): void;
+		connect(signal: "config-changed", callback: (owner: this) => void): number;
+		connect(signal: "layout-changed", callback: (owner: this, object: number) => void): number;
+
+		connect(signal: "notify::enabled", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::parent_object", callback: (owner: this, ...args: any) => void): number;
+
+	}
+
+	type KbdLayoutControllerInitOptionsMixin = GObject.ObjectInitOptions
+	export interface KbdLayoutControllerInitOptions extends KbdLayoutControllerInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link KbdLayoutController} instead.
+	 */
+	type KbdLayoutControllerMixin = IKbdLayoutController & GObject.Object;
+
+	interface KbdLayoutController extends KbdLayoutControllerMixin {}
+
+	class KbdLayoutController {
+		public constructor(options?: Partial<KbdLayoutControllerInitOptions>);
+		/**
+		 * Creates a new XAppKbdLayoutController instance.
+		 * @returns a new {@link KbdLayoutController} instance
+		 */
+		public static new(): KbdLayoutController;
+		/**
+		 * Renders a subscript number in the given work area.  This should
+		 * be called from within a "draw" or "paint" widget/actor function,
+		 * where a valid cairo_t is provided to draw with.
+		 * @param cr a #cairo_t
+		 * @param x the x position of the drawing area
+		 * @param y the y position of the drawing area
+		 * @param width the width of the drawing area
+		 * @param height the height of the drawing area
+		 * @param subscript the number to render
+		 */
+		public static render_cairo_subscript(cr: cairo.Context, x: number, y: number, width: number, height: number, subscript: number): void;
+	}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link MonitorBlanker} instead.
+	 */
+	interface IMonitorBlanker {
+		/**
+		 * Returns whether monitors are currently blanked.
+		 * See {@link Xapp.monitor_blanker_blank_other_monitors}.
+		 * @returns %TRUE if monitors are blanked.
+		 */
+		are_monitors_blanked(): boolean;
+		/**
+		 * Blanks monitors besides the one where the #window is.
+		 * @param window a #GtkWindow
+		 */
+		blank_other_monitors(window: Gtk.Window): void;
+		/**
+		 * Unblanks monitors that were blanked by
+		 * {@link Xapp.monitor_blanker_blank_other_monitors};
+		 */
+		unblank_monitors(): void;
+	}
+
+	type MonitorBlankerInitOptionsMixin = GObject.ObjectInitOptions
+	export interface MonitorBlankerInitOptions extends MonitorBlankerInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link MonitorBlanker} instead.
+	 */
+	type MonitorBlankerMixin = IMonitorBlanker & GObject.Object;
+
+	interface MonitorBlanker extends MonitorBlankerMixin {}
+
+	class MonitorBlanker {
+		public constructor(options?: Partial<MonitorBlankerInitOptions>);
+		/**
+		 * Creates a new {@link MonitorBlanker}.
+		 * @returns a newly created {@link MonitorBlanker}
+		 */
+		public static new(): MonitorBlanker;
+	}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link ObjectManagerClient} instead.
+	 */
+	interface IObjectManagerClient {
+
+	}
+
+	type ObjectManagerClientInitOptionsMixin = Gio.DBusObjectManagerClientInitOptions & Gio.AsyncInitableInitOptions & Gio.DBusObjectManagerInitOptions & Gio.InitableInitOptions
+	export interface ObjectManagerClientInitOptions extends ObjectManagerClientInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link ObjectManagerClient} instead.
+	 */
+	type ObjectManagerClientMixin = IObjectManagerClient & Gio.DBusObjectManagerClient & Gio.AsyncInitable & Gio.DBusObjectManager & Gio.Initable;
+
+	/**
+	 * The {@link ObjectManagerClient} structure contains only private data and should only be accessed using the provided API.
+	 */
+	interface ObjectManagerClient extends ObjectManagerClientMixin {}
+
+	class ObjectManagerClient {
+		public constructor(options?: Partial<ObjectManagerClientInitOptions>);
+		/**
+		 * Finishes an operation started with {@link Xapp.object_manager_client_new}.
+		 * @param res The #GAsyncResult obtained from the #GAsyncReadyCallback passed to {@link Xapp.object_manager_client_new}.
+		 * @returns The constructed object manager client or %NULL if #error is set.
+		 */
+		public static new_finish(res: Gio.AsyncResult): ObjectManagerClient;
+		/**
+		 * Finishes an operation started with {@link Xapp.object_manager_client_new_for_bus}.
+		 * @param res The #GAsyncResult obtained from the #GAsyncReadyCallback passed to {@link Xapp.object_manager_client_new_for_bus}.
+		 * @returns The constructed object manager client or %NULL if #error is set.
+		 */
+		public static new_for_bus_finish(res: Gio.AsyncResult): ObjectManagerClient;
+		/**
+		 * Like {@link Xapp.object_manager_client_new_sync} but takes a #GBusType instead of a #GDBusConnection.
+		 * 
+		 * The calling thread is blocked until a reply is received.
+		 * 
+		 * See xapp_object_manager_client_new_for_bus() for the asynchronous version of this constructor.
+		 * @param bus_type A #GBusType.
+		 * @param flags Flags from the #GDBusObjectManagerClientFlags enumeration.
+		 * @param name A bus name (well-known or unique).
+		 * @param object_path An object path.
+		 * @param cancellable A #GCancellable or %NULL.
+		 * @returns The constructed object manager client or %NULL if #error is set.
+		 */
+		public static new_for_bus_sync(bus_type: Gio.BusType, flags: Gio.DBusObjectManagerClientFlags, name: string, object_path: string, cancellable: Gio.Cancellable | null): ObjectManagerClient;
+		/**
+		 * Synchronously creates #GDBusObjectManagerClient using {@link Xapp.object_manager_client_get_proxy_type} as the #GDBusProxyTypeFunc. See g_dbus_object_manager_client_new_sync() for more details.
+		 * 
+		 * The calling thread is blocked until a reply is received.
+		 * 
+		 * See xapp_object_manager_client_new() for the asynchronous version of this constructor.
+		 * @param connection A #GDBusConnection.
+		 * @param flags Flags from the #GDBusObjectManagerClientFlags enumeration.
+		 * @param name A bus name (well-known or unique) or %NULL if #connection is not a message bus connection.
+		 * @param object_path An object path.
+		 * @param cancellable A #GCancellable or %NULL.
+		 * @returns The constructed object manager client or %NULL if #error is set.
+		 */
+		public static new_sync(connection: Gio.DBusConnection, flags: Gio.DBusObjectManagerClientFlags, name: string | null, object_path: string, cancellable: Gio.Cancellable | null): ObjectManagerClient;
+		/**
+		 * A #GDBusProxyTypeFunc that maps #interface_name to the generated #GDBusObjectProxy derived and #GDBusProxy derived types.
+		 * @param manager A #GDBusObjectManagerClient.
+		 * @param object_path The object path of the remote object (unused).
+		 * @param interface_name Interface name of the remote object or %NULL to get the object proxy #GType.
+		 * @returns A #GDBusProxy derived #GType if #interface_name is not %NULL, otherwise the #GType for {@link ObjectProxy}.
+		 */
+		public static get_proxy_type(manager: Gio.DBusObjectManagerClient, object_path: string, interface_name: string | null): GObject.Type;
+		/**
+		 * Asynchronously creates #GDBusObjectManagerClient using {@link Xapp.object_manager_client_get_proxy_type} as the #GDBusProxyTypeFunc. See g_dbus_object_manager_client_new() for more details.
+		 * 
+		 * When the operation is finished, #callback will be invoked in the thread-default main loop of the thread you are calling this method from (see g_main_context_push_thread_default()).
+		 * You can then call xapp_object_manager_client_new_finish() to get the result of the operation.
+		 * 
+		 * See xapp_object_manager_client_new_sync() for the synchronous, blocking version of this constructor.
+		 * @param connection A #GDBusConnection.
+		 * @param flags Flags from the #GDBusObjectManagerClientFlags enumeration.
+		 * @param name A bus name (well-known or unique) or %NULL if #connection is not a message bus connection.
+		 * @param object_path An object path.
+		 * @param cancellable A #GCancellable or %NULL.
+		 * @param callback A #GAsyncReadyCallback to call when the request is satisfied.
+		 */
+		public static new(connection: Gio.DBusConnection, flags: Gio.DBusObjectManagerClientFlags, name: string | null, object_path: string, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null): void;
+		/**
+		 * Like {@link Xapp.object_manager_client_new} but takes a #GBusType instead of a #GDBusConnection.
+		 * 
+		 * When the operation is finished, #callback will be invoked in the thread-default main loop of the thread you are calling this method from (see g_main_context_push_thread_default()).
+		 * You can then call xapp_object_manager_client_new_for_bus_finish() to get the result of the operation.
+		 * 
+		 * See xapp_object_manager_client_new_for_bus_sync() for the synchronous, blocking version of this constructor.
+		 * @param bus_type A #GBusType.
+		 * @param flags Flags from the #GDBusObjectManagerClientFlags enumeration.
+		 * @param name A bus name (well-known or unique).
+		 * @param object_path An object path.
+		 * @param cancellable A #GCancellable or %NULL.
+		 * @param callback A #GAsyncReadyCallback to call when the request is satisfied.
+		 */
+		public static new_for_bus(bus_type: Gio.BusType, flags: Gio.DBusObjectManagerClientFlags, name: string, object_path: string, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null): void;
+	}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link ObjectProxy} instead.
+	 */
+	interface IObjectProxy {
+
+	}
+
+	type ObjectProxyInitOptionsMixin = Gio.DBusObjectProxyInitOptions & Gio.DBusObjectInitOptions & ObjectInitOptions
+	export interface ObjectProxyInitOptions extends ObjectProxyInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link ObjectProxy} instead.
+	 */
+	type ObjectProxyMixin = IObjectProxy & Gio.DBusObjectProxy & Gio.DBusObject & Object;
+
+	/**
+	 * The {@link ObjectProxy} structure contains only private data and should only be accessed using the provided API.
+	 */
+	interface ObjectProxy extends ObjectProxyMixin {}
+
+	class ObjectProxy {
+		public constructor(options?: Partial<ObjectProxyInitOptions>);
+		/**
+		 * Creates a new proxy object.
+		 * @param connection A #GDBusConnection.
+		 * @param object_path An object path.
+		 * @returns The proxy object.
+		 */
+		public static new(connection: Gio.DBusConnection, object_path: string): ObjectProxy;
+	}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link ObjectSkeleton} instead.
+	 */
+	interface IObjectSkeleton {
+		/**
+		 * Sets the {@link StatusIconInterface} instance for the D-Bus interface <link linkend="gdbus-interface-org-x-StatusIcon.top_of_page">org.x.StatusIcon</link> on #object.
+		 * @param interface_ A {@link StatusIconInterface} or %NULL to clear the interface.
+		 */
+		set_status_icon_interface(interface_: StatusIconInterface | null): void;
+	}
+
+	type ObjectSkeletonInitOptionsMixin = Gio.DBusObjectSkeletonInitOptions & Gio.DBusObjectInitOptions & ObjectInitOptions
+	export interface ObjectSkeletonInitOptions extends ObjectSkeletonInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link ObjectSkeleton} instead.
+	 */
+	type ObjectSkeletonMixin = IObjectSkeleton & Gio.DBusObjectSkeleton & Gio.DBusObject & Object;
+
+	/**
+	 * The {@link ObjectSkeleton} structure contains only private data and should only be accessed using the provided API.
+	 */
+	interface ObjectSkeleton extends ObjectSkeletonMixin {}
+
+	class ObjectSkeleton {
+		public constructor(options?: Partial<ObjectSkeletonInitOptions>);
+		/**
+		 * Creates a new skeleton object.
+		 * @param object_path An object path.
+		 * @returns The skeleton object.
+		 */
+		public static new(object_path: string): ObjectSkeleton;
+	}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link PreferencesWindow} instead.
+	 */
+	interface IPreferencesWindow {
+		/**
+		 * Adds a button to the bottom action bar of the window. Where
+		 * the button is place will be determined by the #GtkPackType. The
+		 * action bar will show automatically once at least one button is
+		 * added.
+		 * @param button a #GtkWidget to add
+		 * @param pack_type a #GtkPackType to use
+		 */
+		add_button(button: Gtk.Widget, pack_type: Gtk.PackType): void;
+		/**
+		 * Adds a page to the window. The page is identified by name. The
+		 * title will be used in the sidebar so should be short. The sidebar
+		 * will show automatically once at least two pages are added.
+		 * @param widget a #GtkWidget to add
+		 * @param name the name for the page
+		 * @param title a human-readable title for the page
+		 */
+		add_page(widget: Gtk.Widget, name: string, title: string): void;
+		connect(signal: "close", callback: (owner: this) => void): number;
+
+	}
+
+	type PreferencesWindowInitOptionsMixin = Gtk.WindowInitOptions & Atk.ImplementorIfaceInitOptions & Gtk.BuildableInitOptions
+	export interface PreferencesWindowInitOptions extends PreferencesWindowInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link PreferencesWindow} instead.
+	 */
+	type PreferencesWindowMixin = IPreferencesWindow & Gtk.Window & Atk.ImplementorIface & Gtk.Buildable;
+
+	interface PreferencesWindow extends PreferencesWindowMixin {}
+
+	class PreferencesWindow {
+		public constructor(options?: Partial<PreferencesWindowInitOptions>);
+		/**
+		 * Creates a new {@link PreferencesWindow}.
+		 * @returns a newly created {@link PreferencesWindow}
+		 */
+		public static new(): PreferencesWindow;
+	}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link StackSidebar} instead.
+	 */
+	interface IStackSidebar {
+		stack: Gtk.Stack;
+		/**
+		 * Retrieves the stack.
+		 * See {@link Xapp.stack_sidebar_set_stack}.
+		 * @returns the associated #GtkStack or
+		 *     %NULL if none has been set explicitly
+		 */
+		get_stack(): Gtk.Stack | null;
+		/**
+		 * Set the #GtkStack associated with this {@link StackSidebar}.
+		 * 
+		 * The sidebar widget will automatically update according to the order
+		 * (packing) and items within the given #GtkStack.
+		 * @param stack a #GtkStack
+		 */
+		set_stack(stack: Gtk.Stack): void;
+		connect(signal: "notify::stack", callback: (owner: this, ...args: any) => void): number;
+
+	}
+
+	type StackSidebarInitOptionsMixin = Gtk.BinInitOptions & Atk.ImplementorIfaceInitOptions & Gtk.BuildableInitOptions & 
+	Pick<IStackSidebar,
+		"stack">;
+
+	export interface StackSidebarInitOptions extends StackSidebarInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link StackSidebar} instead.
+	 */
+	type StackSidebarMixin = IStackSidebar & Gtk.Bin & Atk.ImplementorIface & Gtk.Buildable;
+
+	interface StackSidebar extends StackSidebarMixin {}
+
+	class StackSidebar {
+		public constructor(options?: Partial<StackSidebarInitOptions>);
+		/**
+		 * Creates a new sidebar.
+		 * @returns the new {@link StackSidebar}
+		 */
+		public static new(): StackSidebar;
+	}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link StatusIcon} instead.
+	 */
+	interface IStatusIcon {
+		/**
+		 * The icon size that is preferred by icon monitor/host - this is usually a product
+		 * of some calculation based on the panel size.  It can be used by the client to size
+		 * an icon to be saved as a file and its path sent to the host.
+		 * 
+		 * If this value is 0 it has not been set, and its value can be unreliable if the host
+		 * has multiple {@link StatusIconMonitors} active.
+		 */
+		icon_size: number;
+		/**
+		 * The name of the icon for sorting purposes. If this is in the form of 'org.x.StatusIcon.foo`
+		 * and set immediately upon creation of the icon, it will also attempt to own this dbus name;
+		 * this can be useful in sandboxed environments where a well-defined name is required. If
+		 * additional icons are created, only the name given to the initial one will be used for dbus,
+		 * though different names can still affect the sort order. This is set to the value of
+		 * {@link G.get_prgname} if no other name is provided.
+		 */
+		name: string;
+		/**
+		 * A #GtkMenu to use when requested by the remote monitor via a left (or primary) click.
+		 * 
+		 * When this property is not %NULL, the menu will be automatically positioned and
+		 * displayed during a primary button release.
+		 * 
+		 * When this property IS %NULL, the {@link StatusIcon.activate} will be sent for primary
+		 * button presses.
+		 * 
+		 * In both cases, the #XAppStatusIcon::button-press-event and #XAppStatusIcon::button-release-events
+		 * will be fired like normal.
+		 * 
+		 * Setting this will remove any floating reference to the menu and assume ownership.
+		 * As a result, it is not necessary to maintain a reference to it in the parent
+		 * application (or unref it when finished with it - if you wish to replace the menu,
+		 * simply call this method again with a new menu.
+		 * 
+		 * The same #GtkMenu widget can be set as both the primary and secondary.
+		 */
+		primary_menu: Gtk.Widget;
+		/**
+		 * A #GtkMenu to use when requested by the remote monitor via a right (or secondary) click.
+		 * 
+		 * When this property is not %NULL, the menu will be automatically positioned and
+		 * displayed during a secondary button release.
+		 * 
+		 * When this property IS %NULL, the {@link StatusIcon.activate} will be sent for secondary
+		 * button presses.
+		 * 
+		 * In both cases, the #XAppStatusIcon::button-press-event and #XAppStatusIcon::button-release-events
+		 * will be fired like normal.
+		 * 
+		 * Setting this will remove any floating reference to the menu and assume ownership.
+		 * As a result, it is not necessary to maintain a reference to it in the parent
+		 * application (or unref it when finished with it - if you wish to replace the menu,
+		 * simply call this method again with a new menu.
+		 * 
+		 * The same #GtkMenu widget can be set as both the primary and secondary.
+		 */
+		secondary_menu: Gtk.Widget;
+		get_icon_size(): number;
+		/**
+		 * Returns a pointer to a #GtkMenu that was set previously for the
+		 * primary mouse button.  If no menu was set, this returns %NULL.
+		 * @returns the #GtkMenu or %NULL if none was set.
+		 */
+		get_primary_menu(): Gtk.Widget;
+		/**
+		 * Returns a pointer to a #GtkMenu that was set previously for the
+		 * secondary mouse button.  If no menu was set, this returns %NULL.
+		 * @returns the #GtkMenu or %NULL if none was set.
+		 */
+		get_secondary_menu(): Gtk.Widget;
+		/**
+		 * Gets the current {@link StatusIconState} of icon. The state is determined by whether
+		 * the icon is being displayed by an #XAppStatusMonitor client, a fallback tray icon,
+		 * or not being displayed at all.
+		 * 
+		 * See #XAppStatusIconState for more details.
+		 * @returns the icon's state.
+		 */
+		get_state(): StatusIconState;
+		/**
+		 * Returns whether or not the icon should currently be visible.
+		 * @returns the current visibility state.
+		 */
+		get_visible(): boolean;
+		/**
+		 * Pop up #menu using the positioning arguments. These arguments should be
+		 * those provided by a {@link StatusIcon.button_release_event}.
+		 * @param menu A #GtkMenu to display when the primary mouse button is released.
+		 * @param x The x anchor position for the menu.
+		 * @param y The y anchor position for the menu.
+		 * @param button The button used to initiate this action (or 0)
+		 * @param _time The event time (or 0)
+		 * @param panel_position The #GtkPositionType for the position of the icon.
+		 */
+		popup_menu(menu: Gtk.Menu | null, x: number, y: number, button: number, _time: number, panel_position: number): void;
+		/**
+		 * Sets the icon name or local path to use.
+		 * @param icon_name An icon name or absolute path to an icon.
+		 */
+		set_icon_name(icon_name: string): void;
+		/**
+		 * Sets a label, shown beside the icon
+		 * @param label some text
+		 */
+		set_label(label: string): void;
+		/**
+		 * Sets metadata to pass to the icon proxy for an applet's use. Right now this is only so
+		 * xapp-sn-watcher can tell the applets when the icon is originating from appindicator so panel
+		 * button 'highlighting' can behave correctly.
+		 * @param metadata A json-formatted string of key:values.
+		 */
+		set_metadata(metadata: string | null): void;
+		/**
+		 * Sets the status icon name. This is not shown to users.
+		 * @param name a name (this defaults to the name of the application, if not set)
+		 */
+		set_name(name: string): void;
+		/**
+		 * See the {@link StatusIcon.primary_menu} property for details
+		 * @param menu A #GtkMenu to display when the primary mouse button is released.
+		 */
+		set_primary_menu(menu: Gtk.Menu | null): void;
+		/**
+		 * See the {@link StatusIcon.secondary_menu} property for details
+		 * @param menu A #GtkMenu to display when the primary mouse button is released.
+		 */
+		set_secondary_menu(menu: Gtk.Menu | null): void;
+		/**
+		 * Sets the tooltip text
+		 * @param tooltip_text the text to show in the tooltip
+		 */
+		set_tooltip_text(tooltip_text: string): void;
+		/**
+		 * Sets the visibility of the status icon
+		 * @param visible whether or not the status icon should be visible
+		 */
+		set_visible(visible: boolean): void;
+		/**
+		 * Gets emitted when the user activates the status icon.  If the XAppStatusIcon:primary-menu or
+		 * XAppStatusIcon:secondary-menu is not %NULL, this signal is skipped for the respective button
+		 * presses.  A middle button click will always send this signal when pressed.
+		 * @param signal 
+		 * @param callback Callback function
+		 *  - owner: owner of the emitted event 
+		 *  - button: The button that was pressed 
+		 *  - time: The time supplied by the event, or 0 
+		 * 
+		 * @returns Callback ID
+		 */
+		connect(signal: "activate", callback: (owner: this, button: number, time: number) => void): number;
+		/**
+		 * Gets emitted when there is a button press received from an applet
+		 * @param signal 
+		 * @param callback Callback function
+		 *  - owner: owner of the emitted event 
+		 *  - x: The absolute x position to use for menu positioning 
+		 *  - y: The absolute y position to use for menu positioning 
+		 *  - button: The button that was pressed 
+		 *  - time: The time supplied by the event, or 0 
+		 *  - panel_position: The #GtkPositionType to use for menu positioning 
+		 * 
+		 * @returns Callback ID
+		 */
+		connect(signal: "button-press-event", callback: (owner: this, x: number, y: number, button: number, time: number, panel_position: number) => void): number;
+		/**
+		 * Gets emitted when there is a button release received from an applet
+		 * @param signal 
+		 * @param callback Callback function
+		 *  - owner: owner of the emitted event 
+		 *  - x: The absolute x position to use for menu positioning 
+		 *  - y: The absolute y position to use for menu positioning 
+		 *  - button: The button that was released 
+		 *  - time: The time supplied by the event, or 0 
+		 *  - panel_position: The #GtkPositionType to use for menu positioning 
+		 * 
+		 * @returns Callback ID
+		 */
+		connect(signal: "button-release-event", callback: (owner: this, x: number, y: number, button: number, time: number, panel_position: number) => void): number;
+		/**
+		 * Gets emitted when the user uses the mouse scroll wheel over the status icon.
+		 * For the most part, amounts will always be 1, unless an applet supports smooth
+		 * scrolling.  Generally the direction value is most important.
+		 * @param signal 
+		 * @param callback Callback function
+		 *  - owner: owner of the emitted event 
+		 *  - amount: The amount of movement for the scroll event 
+		 *  - direction: the {@link ScrollDirection} of the scroll event 
+		 *  - time: The time supplied by the event, or 0 
+		 * 
+		 * @returns Callback ID
+		 */
+		connect(signal: "scroll-event", callback: (owner: this, amount: number, direction: ScrollDirection, time: number) => void): number;
+		/**
+		 * Gets emitted when the state of the icon changes. If you wish
+		 * to react to changes in how the status icon is being handled
+		 * (perhaps to alter the menu or other click behavior), you should
+		 * connect to this - see {@link StatusIconState} for more details.
+		 * @param signal 
+		 * @param callback Callback function
+		 *  - owner: owner of the emitted event 
+		 *  - new_state: The new {@link StatusIconState} of the icon 
+		 * 
+		 * @returns Callback ID
+		 */
+		connect(signal: "state-changed", callback: (owner: this, new_state: StatusIconState) => void): number;
+
+		connect(signal: "notify::icon-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::primary-menu", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::secondary-menu", callback: (owner: this, ...args: any) => void): number;
+
+	}
+
+	type StatusIconInitOptionsMixin = GObject.ObjectInitOptions & 
+	Pick<IStatusIcon,
+		"icon_size" |
+		"name" |
+		"primary_menu" |
+		"secondary_menu">;
+
+	export interface StatusIconInitOptions extends StatusIconInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link StatusIcon} instead.
+	 */
+	type StatusIconMixin = IStatusIcon & GObject.Object;
+
+	interface StatusIcon extends StatusIconMixin {}
+
+	class StatusIcon {
+		public constructor(options?: Partial<StatusIconInitOptions>);
+		/**
+		 * Creates a new {@link StatusIcon} instance
+		 * @returns a new {@link StatusIcon}. Use g_object_unref when finished.
+		 */
+		public static new(): StatusIcon;
+		/**
+		 * Creates a new {@link StatusIcon} instance and sets its name to %name.
+		 * @param name
+		 * @returns a new {@link StatusIcon}. Use g_object_unref when finished.
+		 */
+		public static new_with_name(name: string): StatusIcon;
+		/**
+		 * Looks for the existence of any active {@link StatusIconMonitors} on the bus.
+		 * @returns %TRUE if at least one monitor was found.
+		 */
+		public static any_monitors(): boolean;
+	}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link StatusIconInterfaceProxy} instead.
+	 */
+	interface IStatusIconInterfaceProxy {
+
+	}
+
+	type StatusIconInterfaceProxyInitOptionsMixin = Gio.DBusProxyInitOptions & Gio.AsyncInitableInitOptions & Gio.DBusInterfaceInitOptions & Gio.InitableInitOptions & StatusIconInterfaceInitOptions
+	export interface StatusIconInterfaceProxyInitOptions extends StatusIconInterfaceProxyInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link StatusIconInterfaceProxy} instead.
+	 */
+	type StatusIconInterfaceProxyMixin = IStatusIconInterfaceProxy & Gio.DBusProxy & Gio.AsyncInitable & Gio.DBusInterface & Gio.Initable & StatusIconInterface;
+
+	/**
+	 * The {@link StatusIconInterfaceProxy} structure contains only private data and should only be accessed using the provided API.
+	 */
+	interface StatusIconInterfaceProxy extends StatusIconInterfaceProxyMixin {}
+
+	class StatusIconInterfaceProxy {
+		public constructor(options?: Partial<StatusIconInterfaceProxyInitOptions>);
+		/**
+		 * Finishes an operation started with {@link Xapp.status_icon_interface_proxy_new}.
+		 * @param res The #GAsyncResult obtained from the #GAsyncReadyCallback passed to {@link Xapp.status_icon_interface_proxy_new}.
+		 * @returns The constructed proxy object or %NULL if #error is set.
+		 */
+		public static new_finish(res: Gio.AsyncResult): StatusIconInterfaceProxy;
+		/**
+		 * Finishes an operation started with {@link Xapp.status_icon_interface_proxy_new_for_bus}.
+		 * @param res The #GAsyncResult obtained from the #GAsyncReadyCallback passed to {@link Xapp.status_icon_interface_proxy_new_for_bus}.
+		 * @returns The constructed proxy object or %NULL if #error is set.
+		 */
+		public static new_for_bus_finish(res: Gio.AsyncResult): StatusIconInterfaceProxy;
+		/**
+		 * Like {@link Xapp.status_icon_interface_proxy_new_sync} but takes a #GBusType instead of a #GDBusConnection.
+		 * 
+		 * The calling thread is blocked until a reply is received.
+		 * 
+		 * See xapp_status_icon_interface_proxy_new_for_bus() for the asynchronous version of this constructor.
+		 * @param bus_type A #GBusType.
+		 * @param flags Flags from the #GDBusProxyFlags enumeration.
+		 * @param name A bus name (well-known or unique).
+		 * @param object_path An object path.
+		 * @param cancellable A #GCancellable or %NULL.
+		 * @returns The constructed proxy object or %NULL if #error is set.
+		 */
+		public static new_for_bus_sync(bus_type: Gio.BusType, flags: Gio.DBusProxyFlags, name: string, object_path: string, cancellable: Gio.Cancellable | null): StatusIconInterfaceProxy;
+		/**
+		 * Synchronously creates a proxy for the D-Bus interface <link linkend="gdbus-interface-org-x-StatusIcon.top_of_page">org.x.StatusIcon</link>. See {@link G.dbus_proxy_new_sync} for more details.
+		 * 
+		 * The calling thread is blocked until a reply is received.
+		 * 
+		 * See xapp_status_icon_interface_proxy_new() for the asynchronous version of this constructor.
+		 * @param connection A #GDBusConnection.
+		 * @param flags Flags from the #GDBusProxyFlags enumeration.
+		 * @param name A bus name (well-known or unique) or %NULL if #connection is not a message bus connection.
+		 * @param object_path An object path.
+		 * @param cancellable A #GCancellable or %NULL.
+		 * @returns The constructed proxy object or %NULL if #error is set.
+		 */
+		public static new_sync(connection: Gio.DBusConnection, flags: Gio.DBusProxyFlags, name: string | null, object_path: string, cancellable: Gio.Cancellable | null): StatusIconInterfaceProxy;
+		/**
+		 * Asynchronously creates a proxy for the D-Bus interface <link linkend="gdbus-interface-org-x-StatusIcon.top_of_page">org.x.StatusIcon</link>. See {@link G.dbus_proxy_new} for more details.
+		 * 
+		 * When the operation is finished, #callback will be invoked in the thread-default main loop of the thread you are calling this method from (see g_main_context_push_thread_default()).
+		 * You can then call xapp_status_icon_interface_proxy_new_finish() to get the result of the operation.
+		 * 
+		 * See xapp_status_icon_interface_proxy_new_sync() for the synchronous, blocking version of this constructor.
+		 * @param connection A #GDBusConnection.
+		 * @param flags Flags from the #GDBusProxyFlags enumeration.
+		 * @param name A bus name (well-known or unique) or %NULL if #connection is not a message bus connection.
+		 * @param object_path An object path.
+		 * @param cancellable A #GCancellable or %NULL.
+		 * @param callback A #GAsyncReadyCallback to call when the request is satisfied.
+		 */
+		public static new(connection: Gio.DBusConnection, flags: Gio.DBusProxyFlags, name: string | null, object_path: string, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null): void;
+		/**
+		 * Like {@link Xapp.status_icon_interface_proxy_new} but takes a #GBusType instead of a #GDBusConnection.
+		 * 
+		 * When the operation is finished, #callback will be invoked in the thread-default main loop of the thread you are calling this method from (see g_main_context_push_thread_default()).
+		 * You can then call xapp_status_icon_interface_proxy_new_for_bus_finish() to get the result of the operation.
+		 * 
+		 * See xapp_status_icon_interface_proxy_new_for_bus_sync() for the synchronous, blocking version of this constructor.
+		 * @param bus_type A #GBusType.
+		 * @param flags Flags from the #GDBusProxyFlags enumeration.
+		 * @param name A bus name (well-known or unique).
+		 * @param object_path An object path.
+		 * @param cancellable A #GCancellable or %NULL.
+		 * @param callback A #GAsyncReadyCallback to call when the request is satisfied.
+		 */
+		public static new_for_bus(bus_type: Gio.BusType, flags: Gio.DBusProxyFlags, name: string, object_path: string, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null): void;
+	}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link StatusIconInterfaceSkeleton} instead.
+	 */
+	interface IStatusIconInterfaceSkeleton {
+
+	}
+
+	type StatusIconInterfaceSkeletonInitOptionsMixin = Gio.DBusInterfaceSkeletonInitOptions & Gio.DBusInterfaceInitOptions & StatusIconInterfaceInitOptions
+	export interface StatusIconInterfaceSkeletonInitOptions extends StatusIconInterfaceSkeletonInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link StatusIconInterfaceSkeleton} instead.
+	 */
+	type StatusIconInterfaceSkeletonMixin = IStatusIconInterfaceSkeleton & Gio.DBusInterfaceSkeleton & Gio.DBusInterface & StatusIconInterface;
+
+	/**
+	 * The {@link StatusIconInterfaceSkeleton} structure contains only private data and should only be accessed using the provided API.
+	 */
+	interface StatusIconInterfaceSkeleton extends StatusIconInterfaceSkeletonMixin {}
+
+	class StatusIconInterfaceSkeleton {
+		public constructor(options?: Partial<StatusIconInterfaceSkeletonInitOptions>);
+		/**
+		 * Creates a skeleton object for the D-Bus interface <link linkend="gdbus-interface-org-x-StatusIcon.top_of_page">org.x.StatusIcon</link>.
+		 * @returns The skeleton object.
+		 */
+		public static new(): StatusIconInterfaceSkeleton;
+	}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link StatusIconMonitor} instead.
+	 */
+	interface IStatusIconMonitor {
+		/**
+		 * List known icon proxies.
+		 * @returns a #GList of icons
+		 */
+		list_icons(): GLib.List;
+		/**
+		 * This signal is emitted by the monitor when it has discovered a new
+		 * {@link StatusIcon} on the bus.
+		 * @param signal 
+		 * @param callback Callback function
+		 *  - owner: owner of the emitted event 
+		 *  - proxy: the interface proxy for the {@link StatusIcon} that has been added. 
+		 * 
+		 * @returns Callback ID
+		 */
+		connect(signal: "icon-added", callback: (owner: this, proxy: StatusIconInterfaceProxy) => void): number;
+		/**
+		 * This signal is emitted by the monitor when an {@link StatusIcon} has disappeared
+		 * from the bus.
+		 * @param signal 
+		 * @param callback Callback function
+		 *  - owner: owner of the emitted event 
+		 *  - proxy: the {@link StatusIcon} proxy that has been removed. 
+		 * 
+		 * @returns Callback ID
+		 */
+		connect(signal: "icon-removed", callback: (owner: this, proxy: StatusIconInterfaceProxy) => void): number;
+
+	}
+
+	type StatusIconMonitorInitOptionsMixin = GObject.ObjectInitOptions
+	export interface StatusIconMonitorInitOptions extends StatusIconMonitorInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link StatusIconMonitor} instead.
+	 */
+	type StatusIconMonitorMixin = IStatusIconMonitor & GObject.Object;
+
+	interface StatusIconMonitor extends StatusIconMonitorMixin {}
+
+	class StatusIconMonitor {
+		public constructor(options?: Partial<StatusIconMonitorInitOptions>);
+		/**
+		 * Creates a new monitor.
+		 * @returns a new {@link StatusIconMonitor}. Use g_object_unref when finished.
+		 */
+		public static new(): StatusIconMonitor;
+	}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link StyleManager} instead.
+	 */
+	interface IStyleManager {
+		/**
+		 * The widget to be styled.
+		 */
+		widget: Gtk.Widget;
+		/**
+		 * Gets the #GtkWidget the style manager currently applies styles to.
+		 * @returns the #GtkWidget previously set on the style manager, or %NULL.
+		 */
+		get_widget(): Gtk.Widget;
+		/**
+		 * Removes the given style property from the widget if set.
+		 * @param name the property name
+		 */
+		remove_style_property(name: string): void;
+		/**
+		 * Sets the css font property on the widget based on the supplied pango font description string.
+		 * @param desc_string a pango font description string
+		 */
+		set_from_pango_font_string(desc_string: string): void;
+		/**
+		 * Adds the given style property to the widget. If the property has already been set, the value will be replaced.
+		 * @param name the property name
+		 * @param value the value to set the property to
+		 */
+		set_style_property(name: string, value: string): void;
+		/**
+		 * Sets the #GtkWidget the style manager will apply styles to.
+		 * @param widget the #GtkWidget that the style manager will apply styles to, or
+		 * %NULL to unset the current widget and remove all styles currently set by
+		 * this {@link StyleManager} instance.
+		 */
+		set_widget(widget: Gtk.Widget): void;
+		connect(signal: "notify::widget", callback: (owner: this, ...args: any) => void): number;
+
+	}
+
+	type StyleManagerInitOptionsMixin = GObject.ObjectInitOptions & 
+	Pick<IStyleManager,
+		"widget">;
+
+	export interface StyleManagerInitOptions extends StyleManagerInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link StyleManager} instead.
+	 */
+	type StyleManagerMixin = IStyleManager & GObject.Object;
+
+	interface StyleManager extends StyleManagerMixin {}
+
+	class StyleManager {
+		public constructor(options?: Partial<StyleManagerInitOptions>);
+		/**
+		 * Creates a new {@link StyleManager} instance
+		 * @returns a new {@link StyleManager}. Use g_object_unref when finished.
+		 */
+		public static new(): StyleManager;
+	}
+
+	export interface FavoriteInfoInitOptions {}
+	/**
+	 * Information related to a single favorite file.
+	 */
+	interface FavoriteInfo {}
+	class FavoriteInfo {
+		public constructor(options?: Partial<FavoriteInfoInitOptions>);
+		/**
+		 * The uri to the favorite file.
+		 */
+		public uri: string;
+		/**
+		 * The name for use when displaying the item. This may not exactly match
+		 * the filename if there are files with the same name but in different folders.
+		 */
+		public display_name: string;
+		/**
+		 * The mimetype calculated for the uri when it was added to favorites.
+		 */
+		public cached_mimetype: string;
+		/**
+		 * Makes an exact copy of an existing {@link FavoriteInfo}.
+		 * @returns a new {@link FavoriteInfo}.  Free using #xapp_favorite_info_free.
+		 * 
+		 * Since 2.0
+		 */
+		public copy(): FavoriteInfo;
+		/**
+		 * Destroys the {@link FavoriteInfo}.
+		 * 
+		 * Since 2.0
+		 */
+		public free(): void;
+	}
+
+	export interface ObjectIfaceInitOptions {}
+	/**
+	 * Virtual table for the {@link Object} interface.
+	 */
+	interface ObjectIface {}
+	class ObjectIface {
+		public constructor(options?: Partial<ObjectIfaceInitOptions>);
+		/**
+		 * The parent interface.
+		 */
+		public readonly parent_iface: GObject.TypeInterface;
+	}
+
+	export interface StatusIconInterfaceIfaceInitOptions {}
+	/**
+	 * Virtual table for the D-Bus interface <link linkend="gdbus-interface-org-x-StatusIcon.top_of_page">org.x.StatusIcon</link>.
+	 */
+	interface StatusIconInterfaceIface {}
+	class StatusIconInterfaceIface {
+		public constructor(options?: Partial<StatusIconInterfaceIfaceInitOptions>);
+		/**
+		 * The parent interface.
+		 */
+		public readonly parent_iface: GObject.TypeInterface;
+		public handle_button_press: {(object: StatusIconInterface, invocation: Gio.DBusMethodInvocation, arg_x: number, arg_y: number, arg_button: number, arg_time: number, arg_panel_position: number): boolean;};
+		public handle_button_release: {(object: StatusIconInterface, invocation: Gio.DBusMethodInvocation, arg_x: number, arg_y: number, arg_button: number, arg_time: number, arg_panel_position: number): boolean;};
+		public handle_scroll: {(object: StatusIconInterface, invocation: Gio.DBusMethodInvocation, arg_delta: number, arg_orientation: number, arg_time: number): boolean;};
+		public get_icon_name: {(object: StatusIconInterface): string | null;};
+		public get_icon_size: {(object: StatusIconInterface): number;};
+		public get_label: {(object: StatusIconInterface): string | null;};
+		public get_metadata: {(object: StatusIconInterface): string | null;};
+		public get_name: {(object: StatusIconInterface): string | null;};
+		public get_primary_menu_is_open: {(object: StatusIconInterface): boolean;};
+		public get_secondary_menu_is_open: {(object: StatusIconInterface): boolean;};
+		public get_tooltip_text: {(object: StatusIconInterface): string | null;};
+		public get_visible: {(object: StatusIconInterface): boolean;};
+	}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link Object} instead.
+	 */
+	interface IObject {
+		/**
+		 * The {@link StatusIconInterface} instance corresponding to the D-Bus interface <link linkend="gdbus-interface-org-x-StatusIcon.top_of_page">org.x.StatusIcon</link>, if any.
+		 * 
+		 * Connect to the #GObject::notify signal to get informed of property changes.
+		 */
+		status_icon_interface: StatusIconInterface;
+		/**
+		 * Gets the {@link StatusIconInterface} instance for the D-Bus interface <link linkend="gdbus-interface-org-x-StatusIcon.top_of_page">org.x.StatusIcon</link> on #object, if any.
+		 * @returns A {@link StatusIconInterface} that must be freed with {@link GObject.unref} or %NULL if #object does not implement the interface.
+		 */
+		get_status_icon_interface(): StatusIconInterface | null;
+		/**
+		 * Like {@link Xapp.object_get_status_icon_interface} but doesn't increase the reference count on the returned object.
+		 * 
+		 * It is not safe to use the returned object if you are on another thread than the one where the #GDBusObjectManagerClient or #GDBusObjectManagerServer for #object is running.
+		 * @returns A {@link StatusIconInterface} or %NULL if #object does not implement the interface. Do not free the returned object, it is owned by #object.
+		 */
+		peek_status_icon_interface(): StatusIconInterface | null;
+		connect(signal: "notify::status-icon-interface", callback: (owner: this, ...args: any) => void): number;
+
+	}
+
+	type ObjectInitOptionsMixin = Pick<IObject,
+		"status_icon_interface">;
+
+	export interface ObjectInitOptions extends ObjectInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link Object} instead.
+	 */
+	type ObjectMixin = IObject;
+
+	/**
+	 * The {@link Object} type is a specialized container of interfaces.
+	 */
+	interface Object extends ObjectMixin {}
+
+	class Object {
+		public constructor(options?: Partial<ObjectInitOptions>);
+	}
+
+
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link StatusIconInterface} instead.
+	 */
+	interface IStatusIconInterface {
+		/**
+		 * Represents the D-Bus property <link linkend="gdbus-property-org-x-StatusIcon.IconName">"IconName"</link>.
+		 * 
+		 * Since the D-Bus property for this #GObject property is readable but not writable, it is meaningful to read from it on both the client- and service-side. It is only meaningful, however, to write to it on the service-side.
+		 */
+		icon_name: string;
+		/**
+		 * Represents the D-Bus property <link linkend="gdbus-property-org-x-StatusIcon.IconSize">"IconSize"</link>.
+		 * 
+		 * Since the D-Bus property for this #GObject property is both readable and writable, it is meaningful to both read from it and write to it on both the service- and client-side.
+		 */
+		icon_size: number;
+		/**
+		 * Represents the D-Bus property <link linkend="gdbus-property-org-x-StatusIcon.Label">"Label"</link>.
+		 * 
+		 * Since the D-Bus property for this #GObject property is readable but not writable, it is meaningful to read from it on both the client- and service-side. It is only meaningful, however, to write to it on the service-side.
+		 */
+		label: string;
+		/**
+		 * Represents the D-Bus property <link linkend="gdbus-property-org-x-StatusIcon.Metadata">"Metadata"</link>.
+		 * 
+		 * Since the D-Bus property for this #GObject property is readable but not writable, it is meaningful to read from it on both the client- and service-side. It is only meaningful, however, to write to it on the service-side.
+		 */
+		metadata: string;
+		/**
+		 * Represents the D-Bus property <link linkend="gdbus-property-org-x-StatusIcon.Name">"Name"</link>.
+		 * 
+		 * Since the D-Bus property for this #GObject property is readable but not writable, it is meaningful to read from it on both the client- and service-side. It is only meaningful, however, to write to it on the service-side.
+		 */
+		name: string;
+		/**
+		 * Represents the D-Bus property <link linkend="gdbus-property-org-x-StatusIcon.PrimaryMenuIsOpen">"PrimaryMenuIsOpen"</link>.
+		 * 
+		 * Since the D-Bus property for this #GObject property is readable but not writable, it is meaningful to read from it on both the client- and service-side. It is only meaningful, however, to write to it on the service-side.
+		 */
+		primary_menu_is_open: boolean;
+		/**
+		 * Represents the D-Bus property <link linkend="gdbus-property-org-x-StatusIcon.SecondaryMenuIsOpen">"SecondaryMenuIsOpen"</link>.
+		 * 
+		 * Since the D-Bus property for this #GObject property is readable but not writable, it is meaningful to read from it on both the client- and service-side. It is only meaningful, however, to write to it on the service-side.
+		 */
+		secondary_menu_is_open: boolean;
+		/**
+		 * Represents the D-Bus property <link linkend="gdbus-property-org-x-StatusIcon.TooltipText">"TooltipText"</link>.
+		 * 
+		 * Since the D-Bus property for this #GObject property is readable but not writable, it is meaningful to read from it on both the client- and service-side. It is only meaningful, however, to write to it on the service-side.
+		 */
+		tooltip_text: string;
+		/**
+		 * Represents the D-Bus property <link linkend="gdbus-property-org-x-StatusIcon.Visible">"Visible"</link>.
+		 * 
+		 * Since the D-Bus property for this #GObject property is readable but not writable, it is meaningful to read from it on both the client- and service-side. It is only meaningful, however, to write to it on the service-side.
+		 */
+		visible: boolean;
+		/**
+		 * Asynchronously invokes the <link linkend="gdbus-method-org-x-StatusIcon.ButtonPress">ButtonPress()</link> D-Bus method on #proxy.
+		 * When the operation is finished, #callback will be invoked in the thread-default main loop of the thread you are calling this method from (see g_main_context_push_thread_default()).
+		 * You can then call xapp_status_icon_interface_call_button_press_finish() to get the result of the operation.
+		 * 
+		 * See xapp_status_icon_interface_call_button_press_sync() for the synchronous, blocking version of this method.
+		 * @param arg_x Argument to pass with the method invocation.
+		 * @param arg_y Argument to pass with the method invocation.
+		 * @param arg_button Argument to pass with the method invocation.
+		 * @param arg_time Argument to pass with the method invocation.
+		 * @param arg_panel_position Argument to pass with the method invocation.
+		 * @param cancellable A #GCancellable or %NULL.
+		 * @param callback A #GAsyncReadyCallback to call when the request is satisfied or %NULL.
+		 */
+		call_button_press(arg_x: number, arg_y: number, arg_button: number, arg_time: number, arg_panel_position: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null): void;
+		/**
+		 * Finishes an operation started with {@link Xapp.status_icon_interface_call_button_press}.
+		 * @param res The #GAsyncResult obtained from the #GAsyncReadyCallback passed to {@link Xapp.status_icon_interface_call_button_press}.
+		 * @returns %TRUE if the call succeeded, %FALSE if #error is set.
+		 */
+		call_button_press_finish(res: Gio.AsyncResult): boolean;
+		/**
+		 * Synchronously invokes the <link linkend="gdbus-method-org-x-StatusIcon.ButtonPress">ButtonPress()</link> D-Bus method on #proxy. The calling thread is blocked until a reply is received.
+		 * 
+		 * See xapp_status_icon_interface_call_button_press() for the asynchronous version of this method.
+		 * @param arg_x Argument to pass with the method invocation.
+		 * @param arg_y Argument to pass with the method invocation.
+		 * @param arg_button Argument to pass with the method invocation.
+		 * @param arg_time Argument to pass with the method invocation.
+		 * @param arg_panel_position Argument to pass with the method invocation.
+		 * @param cancellable A #GCancellable or %NULL.
+		 * @returns %TRUE if the call succeeded, %FALSE if #error is set.
+		 */
+		call_button_press_sync(arg_x: number, arg_y: number, arg_button: number, arg_time: number, arg_panel_position: number, cancellable: Gio.Cancellable | null): boolean;
+		/**
+		 * Asynchronously invokes the <link linkend="gdbus-method-org-x-StatusIcon.ButtonRelease">ButtonRelease()</link> D-Bus method on #proxy.
+		 * When the operation is finished, #callback will be invoked in the thread-default main loop of the thread you are calling this method from (see g_main_context_push_thread_default()).
+		 * You can then call xapp_status_icon_interface_call_button_release_finish() to get the result of the operation.
+		 * 
+		 * See xapp_status_icon_interface_call_button_release_sync() for the synchronous, blocking version of this method.
+		 * @param arg_x Argument to pass with the method invocation.
+		 * @param arg_y Argument to pass with the method invocation.
+		 * @param arg_button Argument to pass with the method invocation.
+		 * @param arg_time Argument to pass with the method invocation.
+		 * @param arg_panel_position Argument to pass with the method invocation.
+		 * @param cancellable A #GCancellable or %NULL.
+		 * @param callback A #GAsyncReadyCallback to call when the request is satisfied or %NULL.
+		 */
+		call_button_release(arg_x: number, arg_y: number, arg_button: number, arg_time: number, arg_panel_position: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null): void;
+		/**
+		 * Finishes an operation started with {@link Xapp.status_icon_interface_call_button_release}.
+		 * @param res The #GAsyncResult obtained from the #GAsyncReadyCallback passed to {@link Xapp.status_icon_interface_call_button_release}.
+		 * @returns %TRUE if the call succeeded, %FALSE if #error is set.
+		 */
+		call_button_release_finish(res: Gio.AsyncResult): boolean;
+		/**
+		 * Synchronously invokes the <link linkend="gdbus-method-org-x-StatusIcon.ButtonRelease">ButtonRelease()</link> D-Bus method on #proxy. The calling thread is blocked until a reply is received.
+		 * 
+		 * See xapp_status_icon_interface_call_button_release() for the asynchronous version of this method.
+		 * @param arg_x Argument to pass with the method invocation.
+		 * @param arg_y Argument to pass with the method invocation.
+		 * @param arg_button Argument to pass with the method invocation.
+		 * @param arg_time Argument to pass with the method invocation.
+		 * @param arg_panel_position Argument to pass with the method invocation.
+		 * @param cancellable A #GCancellable or %NULL.
+		 * @returns %TRUE if the call succeeded, %FALSE if #error is set.
+		 */
+		call_button_release_sync(arg_x: number, arg_y: number, arg_button: number, arg_time: number, arg_panel_position: number, cancellable: Gio.Cancellable | null): boolean;
+		/**
+		 * Asynchronously invokes the <link linkend="gdbus-method-org-x-StatusIcon.Scroll">Scroll()</link> D-Bus method on #proxy.
+		 * When the operation is finished, #callback will be invoked in the thread-default main loop of the thread you are calling this method from (see g_main_context_push_thread_default()).
+		 * You can then call xapp_status_icon_interface_call_scroll_finish() to get the result of the operation.
+		 * 
+		 * See xapp_status_icon_interface_call_scroll_sync() for the synchronous, blocking version of this method.
+		 * @param arg_delta Argument to pass with the method invocation.
+		 * @param arg_orientation Argument to pass with the method invocation.
+		 * @param arg_time Argument to pass with the method invocation.
+		 * @param cancellable A #GCancellable or %NULL.
+		 * @param callback A #GAsyncReadyCallback to call when the request is satisfied or %NULL.
+		 */
+		call_scroll(arg_delta: number, arg_orientation: number, arg_time: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null): void;
+		/**
+		 * Finishes an operation started with {@link Xapp.status_icon_interface_call_scroll}.
+		 * @param res The #GAsyncResult obtained from the #GAsyncReadyCallback passed to {@link Xapp.status_icon_interface_call_scroll}.
+		 * @returns %TRUE if the call succeeded, %FALSE if #error is set.
+		 */
+		call_scroll_finish(res: Gio.AsyncResult): boolean;
+		/**
+		 * Synchronously invokes the <link linkend="gdbus-method-org-x-StatusIcon.Scroll">Scroll()</link> D-Bus method on #proxy. The calling thread is blocked until a reply is received.
+		 * 
+		 * See xapp_status_icon_interface_call_scroll() for the asynchronous version of this method.
+		 * @param arg_delta Argument to pass with the method invocation.
+		 * @param arg_orientation Argument to pass with the method invocation.
+		 * @param arg_time Argument to pass with the method invocation.
+		 * @param cancellable A #GCancellable or %NULL.
+		 * @returns %TRUE if the call succeeded, %FALSE if #error is set.
+		 */
+		call_scroll_sync(arg_delta: number, arg_orientation: number, arg_time: number, cancellable: Gio.Cancellable | null): boolean;
+		/**
+		 * Helper function used in service implementations to finish handling invocations of the <link linkend="gdbus-method-org-x-StatusIcon.ButtonPress">ButtonPress()</link> D-Bus method. If you instead want to finish handling an invocation by returning an error, use g_dbus_method_invocation_return_error() or similar.
+		 * 
+		 * This method will free #invocation, you cannot use it afterwards.
+		 * @param invocation A #GDBusMethodInvocation.
+		 */
+		complete_button_press(invocation: Gio.DBusMethodInvocation): void;
+		/**
+		 * Helper function used in service implementations to finish handling invocations of the <link linkend="gdbus-method-org-x-StatusIcon.ButtonRelease">ButtonRelease()</link> D-Bus method. If you instead want to finish handling an invocation by returning an error, use g_dbus_method_invocation_return_error() or similar.
+		 * 
+		 * This method will free #invocation, you cannot use it afterwards.
+		 * @param invocation A #GDBusMethodInvocation.
+		 */
+		complete_button_release(invocation: Gio.DBusMethodInvocation): void;
+		/**
+		 * Helper function used in service implementations to finish handling invocations of the <link linkend="gdbus-method-org-x-StatusIcon.Scroll">Scroll()</link> D-Bus method. If you instead want to finish handling an invocation by returning an error, use g_dbus_method_invocation_return_error() or similar.
+		 * 
+		 * This method will free #invocation, you cannot use it afterwards.
+		 * @param invocation A #GDBusMethodInvocation.
+		 */
+		complete_scroll(invocation: Gio.DBusMethodInvocation): void;
+		/**
+		 * Gets a copy of the <link linkend="gdbus-property-org-x-StatusIcon.IconName">"IconName"</link> D-Bus property.
+		 * 
+		 * Since this D-Bus property is readable, it is meaningful to use this function on both the client- and service-side.
+		 * @returns The property value or %NULL if the property is not set. The returned value should be freed with {@link G.free}.
+		 */
+		dup_icon_name(): string | null;
+		/**
+		 * Gets a copy of the <link linkend="gdbus-property-org-x-StatusIcon.Label">"Label"</link> D-Bus property.
+		 * 
+		 * Since this D-Bus property is readable, it is meaningful to use this function on both the client- and service-side.
+		 * @returns The property value or %NULL if the property is not set. The returned value should be freed with {@link G.free}.
+		 */
+		dup_label(): string | null;
+		/**
+		 * Gets a copy of the <link linkend="gdbus-property-org-x-StatusIcon.Metadata">"Metadata"</link> D-Bus property.
+		 * 
+		 * Since this D-Bus property is readable, it is meaningful to use this function on both the client- and service-side.
+		 * @returns The property value or %NULL if the property is not set. The returned value should be freed with {@link G.free}.
+		 */
+		dup_metadata(): string | null;
+		/**
+		 * Gets a copy of the <link linkend="gdbus-property-org-x-StatusIcon.Name">"Name"</link> D-Bus property.
+		 * 
+		 * Since this D-Bus property is readable, it is meaningful to use this function on both the client- and service-side.
+		 * @returns The property value or %NULL if the property is not set. The returned value should be freed with {@link G.free}.
+		 */
+		dup_name(): string | null;
+		/**
+		 * Gets a copy of the <link linkend="gdbus-property-org-x-StatusIcon.TooltipText">"TooltipText"</link> D-Bus property.
+		 * 
+		 * Since this D-Bus property is readable, it is meaningful to use this function on both the client- and service-side.
+		 * @returns The property value or %NULL if the property is not set. The returned value should be freed with {@link G.free}.
+		 */
+		dup_tooltip_text(): string | null;
+		/**
+		 * Gets the value of the <link linkend="gdbus-property-org-x-StatusIcon.IconName">"IconName"</link> D-Bus property.
+		 * 
+		 * Since this D-Bus property is readable, it is meaningful to use this function on both the client- and service-side.
+		 * 
+		 * The returned value is only valid until the property changes so on the client-side it is only safe to use this function on the thread where #object was constructed. Use {@link Xapp.status_icon_interface_dup_icon_name} if on another thread.
+		 * @returns The property value or %NULL if the property is not set. Do not free the returned value, it belongs to #object.
+		 */
+		get_icon_name(): string | null;
+		/**
+		 * Gets the value of the <link linkend="gdbus-property-org-x-StatusIcon.IconSize">"IconSize"</link> D-Bus property.
+		 * 
+		 * Since this D-Bus property is both readable and writable, it is meaningful to use this function on both the client- and service-side.
+		 * @returns The property value.
+		 */
+		get_icon_size(): number;
+		/**
+		 * Gets the value of the <link linkend="gdbus-property-org-x-StatusIcon.Label">"Label"</link> D-Bus property.
+		 * 
+		 * Since this D-Bus property is readable, it is meaningful to use this function on both the client- and service-side.
+		 * 
+		 * The returned value is only valid until the property changes so on the client-side it is only safe to use this function on the thread where #object was constructed. Use {@link Xapp.status_icon_interface_dup_label} if on another thread.
+		 * @returns The property value or %NULL if the property is not set. Do not free the returned value, it belongs to #object.
+		 */
+		get_label(): string | null;
+		/**
+		 * Gets the value of the <link linkend="gdbus-property-org-x-StatusIcon.Metadata">"Metadata"</link> D-Bus property.
+		 * 
+		 * Since this D-Bus property is readable, it is meaningful to use this function on both the client- and service-side.
+		 * 
+		 * The returned value is only valid until the property changes so on the client-side it is only safe to use this function on the thread where #object was constructed. Use {@link Xapp.status_icon_interface_dup_metadata} if on another thread.
+		 * @returns The property value or %NULL if the property is not set. Do not free the returned value, it belongs to #object.
+		 */
+		get_metadata(): string | null;
+		/**
+		 * Gets the value of the <link linkend="gdbus-property-org-x-StatusIcon.Name">"Name"</link> D-Bus property.
+		 * 
+		 * Since this D-Bus property is readable, it is meaningful to use this function on both the client- and service-side.
+		 * 
+		 * The returned value is only valid until the property changes so on the client-side it is only safe to use this function on the thread where #object was constructed. Use {@link Xapp.status_icon_interface_dup_name} if on another thread.
+		 * @returns The property value or %NULL if the property is not set. Do not free the returned value, it belongs to #object.
+		 */
+		get_name(): string | null;
+		/**
+		 * Gets the value of the <link linkend="gdbus-property-org-x-StatusIcon.PrimaryMenuIsOpen">"PrimaryMenuIsOpen"</link> D-Bus property.
+		 * 
+		 * Since this D-Bus property is readable, it is meaningful to use this function on both the client- and service-side.
+		 * @returns The property value.
+		 */
+		get_primary_menu_is_open(): boolean;
+		/**
+		 * Gets the value of the <link linkend="gdbus-property-org-x-StatusIcon.SecondaryMenuIsOpen">"SecondaryMenuIsOpen"</link> D-Bus property.
+		 * 
+		 * Since this D-Bus property is readable, it is meaningful to use this function on both the client- and service-side.
+		 * @returns The property value.
+		 */
+		get_secondary_menu_is_open(): boolean;
+		/**
+		 * Gets the value of the <link linkend="gdbus-property-org-x-StatusIcon.TooltipText">"TooltipText"</link> D-Bus property.
+		 * 
+		 * Since this D-Bus property is readable, it is meaningful to use this function on both the client- and service-side.
+		 * 
+		 * The returned value is only valid until the property changes so on the client-side it is only safe to use this function on the thread where #object was constructed. Use {@link Xapp.status_icon_interface_dup_tooltip_text} if on another thread.
+		 * @returns The property value or %NULL if the property is not set. Do not free the returned value, it belongs to #object.
+		 */
+		get_tooltip_text(): string | null;
+		/**
+		 * Gets the value of the <link linkend="gdbus-property-org-x-StatusIcon.Visible">"Visible"</link> D-Bus property.
+		 * 
+		 * Since this D-Bus property is readable, it is meaningful to use this function on both the client- and service-side.
+		 * @returns The property value.
+		 */
+		get_visible(): boolean;
+		/**
+		 * Sets the <link linkend="gdbus-property-org-x-StatusIcon.IconName">"IconName"</link> D-Bus property to #value.
+		 * 
+		 * Since this D-Bus property is not writable, it is only meaningful to use this function on the service-side.
+		 * @param value The value to set.
+		 */
+		set_icon_name(value: string): void;
+		/**
+		 * Sets the <link linkend="gdbus-property-org-x-StatusIcon.IconSize">"IconSize"</link> D-Bus property to #value.
+		 * 
+		 * Since this D-Bus property is both readable and writable, it is meaningful to use this function on both the client- and service-side.
+		 * @param value The value to set.
+		 */
+		set_icon_size(value: number): void;
+		/**
+		 * Sets the <link linkend="gdbus-property-org-x-StatusIcon.Label">"Label"</link> D-Bus property to #value.
+		 * 
+		 * Since this D-Bus property is not writable, it is only meaningful to use this function on the service-side.
+		 * @param value The value to set.
+		 */
+		set_label(value: string): void;
+		/**
+		 * Sets the <link linkend="gdbus-property-org-x-StatusIcon.Metadata">"Metadata"</link> D-Bus property to #value.
+		 * 
+		 * Since this D-Bus property is not writable, it is only meaningful to use this function on the service-side.
+		 * @param value The value to set.
+		 */
+		set_metadata(value: string): void;
+		/**
+		 * Sets the <link linkend="gdbus-property-org-x-StatusIcon.Name">"Name"</link> D-Bus property to #value.
+		 * 
+		 * Since this D-Bus property is not writable, it is only meaningful to use this function on the service-side.
+		 * @param value The value to set.
+		 */
+		set_name(value: string): void;
+		/**
+		 * Sets the <link linkend="gdbus-property-org-x-StatusIcon.PrimaryMenuIsOpen">"PrimaryMenuIsOpen"</link> D-Bus property to #value.
+		 * 
+		 * Since this D-Bus property is not writable, it is only meaningful to use this function on the service-side.
+		 * @param value The value to set.
+		 */
+		set_primary_menu_is_open(value: boolean): void;
+		/**
+		 * Sets the <link linkend="gdbus-property-org-x-StatusIcon.SecondaryMenuIsOpen">"SecondaryMenuIsOpen"</link> D-Bus property to #value.
+		 * 
+		 * Since this D-Bus property is not writable, it is only meaningful to use this function on the service-side.
+		 * @param value The value to set.
+		 */
+		set_secondary_menu_is_open(value: boolean): void;
+		/**
+		 * Sets the <link linkend="gdbus-property-org-x-StatusIcon.TooltipText">"TooltipText"</link> D-Bus property to #value.
+		 * 
+		 * Since this D-Bus property is not writable, it is only meaningful to use this function on the service-side.
+		 * @param value The value to set.
+		 */
+		set_tooltip_text(value: string): void;
+		/**
+		 * Sets the <link linkend="gdbus-property-org-x-StatusIcon.Visible">"Visible"</link> D-Bus property to #value.
+		 * 
+		 * Since this D-Bus property is not writable, it is only meaningful to use this function on the service-side.
+		 * @param value The value to set.
+		 */
+		set_visible(value: boolean): void;
+		/**
+		 * Signal emitted when a remote caller is invoking the <link linkend="gdbus-method-org-x-StatusIcon.ButtonPress">ButtonPress()</link> D-Bus method.
+		 * 
+		 * If a signal handler returns %TRUE, it means the signal handler will handle the invocation (e.g. take a reference to #invocation and eventually call xapp_status_icon_interface_complete_button_press() or e.g. g_dbus_method_invocation_return_error() on it) and no order signal handlers will run. If no signal handler handles the invocation, the %G_DBUS_ERROR_UNKNOWN_METHOD error is returned.
+		 * @param signal 
+		 * @param callback Callback function
+		 *  - owner: owner of the emitted event 
+		 *  - invocation: A #GDBusMethodInvocation. 
+		 *  - arg_x: Argument passed by remote caller. 
+		 *  - arg_y: Argument passed by remote caller. 
+		 *  - arg_button: Argument passed by remote caller. 
+		 *  - arg_time: Argument passed by remote caller. 
+		 *  - arg_panel_position: Argument passed by remote caller. 
+		 *  - returns %G_DBUS_METHOD_INVOCATION_HANDLED or %TRUE if the invocation was handled, %G_DBUS_METHOD_INVOCATION_UNHANDLED or %FALSE to let other signal handlers run. 
+		 * 
+		 * @returns Callback ID
+		 */
+		connect(signal: "handle-button-press", callback: (owner: this, invocation: Gio.DBusMethodInvocation, arg_x: number, arg_y: number, arg_button: number, arg_time: number, arg_panel_position: number) => boolean): number;
+		/**
+		 * Signal emitted when a remote caller is invoking the <link linkend="gdbus-method-org-x-StatusIcon.ButtonRelease">ButtonRelease()</link> D-Bus method.
+		 * 
+		 * If a signal handler returns %TRUE, it means the signal handler will handle the invocation (e.g. take a reference to #invocation and eventually call xapp_status_icon_interface_complete_button_release() or e.g. g_dbus_method_invocation_return_error() on it) and no order signal handlers will run. If no signal handler handles the invocation, the %G_DBUS_ERROR_UNKNOWN_METHOD error is returned.
+		 * @param signal 
+		 * @param callback Callback function
+		 *  - owner: owner of the emitted event 
+		 *  - invocation: A #GDBusMethodInvocation. 
+		 *  - arg_x: Argument passed by remote caller. 
+		 *  - arg_y: Argument passed by remote caller. 
+		 *  - arg_button: Argument passed by remote caller. 
+		 *  - arg_time: Argument passed by remote caller. 
+		 *  - arg_panel_position: Argument passed by remote caller. 
+		 *  - returns %G_DBUS_METHOD_INVOCATION_HANDLED or %TRUE if the invocation was handled, %G_DBUS_METHOD_INVOCATION_UNHANDLED or %FALSE to let other signal handlers run. 
+		 * 
+		 * @returns Callback ID
+		 */
+		connect(signal: "handle-button-release", callback: (owner: this, invocation: Gio.DBusMethodInvocation, arg_x: number, arg_y: number, arg_button: number, arg_time: number, arg_panel_position: number) => boolean): number;
+		/**
+		 * Signal emitted when a remote caller is invoking the <link linkend="gdbus-method-org-x-StatusIcon.Scroll">Scroll()</link> D-Bus method.
+		 * 
+		 * If a signal handler returns %TRUE, it means the signal handler will handle the invocation (e.g. take a reference to #invocation and eventually call xapp_status_icon_interface_complete_scroll() or e.g. g_dbus_method_invocation_return_error() on it) and no order signal handlers will run. If no signal handler handles the invocation, the %G_DBUS_ERROR_UNKNOWN_METHOD error is returned.
+		 * @param signal 
+		 * @param callback Callback function
+		 *  - owner: owner of the emitted event 
+		 *  - invocation: A #GDBusMethodInvocation. 
+		 *  - arg_delta: Argument passed by remote caller. 
+		 *  - arg_orientation: Argument passed by remote caller. 
+		 *  - arg_time: Argument passed by remote caller. 
+		 *  - returns %G_DBUS_METHOD_INVOCATION_HANDLED or %TRUE if the invocation was handled, %G_DBUS_METHOD_INVOCATION_UNHANDLED or %FALSE to let other signal handlers run. 
+		 * 
+		 * @returns Callback ID
+		 */
+		connect(signal: "handle-scroll", callback: (owner: this, invocation: Gio.DBusMethodInvocation, arg_delta: number, arg_orientation: number, arg_time: number) => boolean): number;
+
+		connect(signal: "notify::icon-name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::icon-size", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::label", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::metadata", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::name", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::primary-menu-is-open", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::secondary-menu-is-open", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::tooltip-text", callback: (owner: this, ...args: any) => void): number;
+		connect(signal: "notify::visible", callback: (owner: this, ...args: any) => void): number;
+
+	}
+
+	type StatusIconInterfaceInitOptionsMixin = Pick<IStatusIconInterface,
+		"icon_name" |
+		"icon_size" |
+		"label" |
+		"metadata" |
+		"name" |
+		"primary_menu_is_open" |
+		"secondary_menu_is_open" |
+		"tooltip_text" |
+		"visible">;
+
+	export interface StatusIconInterfaceInitOptions extends StatusIconInterfaceInitOptionsMixin {}
+
+	/** This construct is only for enabling class multi-inheritance,
+	 * use {@link StatusIconInterface} instead.
+	 */
+	type StatusIconInterfaceMixin = IStatusIconInterface;
+
+	/**
+	 * Abstract interface type for the D-Bus interface <link linkend="gdbus-interface-org-x-StatusIcon.top_of_page">org.x.StatusIcon</link>.
+	 */
+	interface StatusIconInterface extends StatusIconInterfaceMixin {}
+
+	class StatusIconInterface {
+		public constructor(options?: Partial<StatusIconInterfaceInitOptions>);
+		/**
+		 * Gets a machine-readable description of the <link linkend="gdbus-interface-org-x-StatusIcon.top_of_page">org.x.StatusIcon</link> D-Bus interface.
+		 * @returns A #GDBusInterfaceInfo. Do not free.
+		 */
+		public static interface_info(): Gio.DBusInterfaceInfo;
+		/**
+		 * Overrides all #GObject properties in the {@link StatusIconInterface} interface for a concrete class.
+		 * The properties are overridden in the order they are defined.
+		 * @param klass The class structure for a #GObject derived class.
+		 * @param property_id_begin The property id to assign to the first overridden property.
+		 * @returns The last property id.
+		 */
+		public static override_properties(klass: any, property_id_begin: number): number;
+	}
+
+
+
+	enum IconSize {
+		_16 = 16,
+		_22 = 22,
+		_24 = 24,
+		_32 = 32,
+		_48 = 48,
+		_96 = 96
+	}
+
+	/**
+	 * Represents the direction of icon scroll events.
+	 */
+	enum ScrollDirection {
+		/**
+		 * Scroll theoretical content up.
+		 */
+		UP = 0,
+		/**
+		 * Scroll theoretical content down.
+		 */
+		DOWN = 1,
+		/**
+		 * Scroll theoretical content left.
+		 */
+		LEFT = 2,
+		/**
+		 * Scroll theoretical content right.
+		 */
+		RIGHT = 3
+	}
+
+	enum StatusIconState {
+		/**
+		 * The {@link StatusIcon} is currently being handled
+		 * by an #XAppStatusIconMonitor (usually in an applet).
+		 */
+		NATIVE = 0,
+		/**
+		 * The {@link StatusIcon} is currently being handled
+		 * by a legacy system tray implementation (using GtkStatusIcon).
+		 */
+		FALLBACK = 1,
+		/**
+		 * The {@link StatusIcon} is not currently being handled by any
+		 * kind of status icon implementation.
+		 */
+		NO_SUPPORT = 2
+	}
+
+	interface FavoritesItemSelectedCallback {
+		(favorites: Favorites, uri: string): void;
+	}
+
+	/**
+	 * Converts a pango font description string to a string suitable for use with the css "font" tag. The font description must contain the font family and font size or conversion will fail and %NULL will be returned
+	 * @param pango_font_string a pango font description string
+	 * @returns the css compatible font string or %NULL if the conversion failed.
+	 */
+	function pango_font_string_to_css(pango_font_string: string): string;
+
+	/**
+	 * Sets the icon name hint for a window manager (like muffin) to make
+	 * available when applications want to change their icons during runtime
+	 * without having to resort to the internal low-res pixbufs that GdkWindow
+	 * sets on the client side.  This also chains up and calls GtkWindow.set_icon_from_file
+	 * for convenience and compatibility.  Set to %NULL to unset.
+	 * @param window The #GtkWindow to set the icon name for
+	 * @param file_name The icon path to set, or %NULL to unset.
+	 */
+	function set_window_icon_from_file(window: Gtk.Window, file_name: string | null): void;
+
+	/**
+	 * Sets the icon name hint for a window manager (like muffin) to make
+	 * available when applications want to change their icons during runtime
+	 * without having to resort to the internal low-res pixbufs that GdkWindow
+	 * sets on the client side.  This is a function, not a method, for taking
+	 * advantage of this feature with descendants of GtkWindows, such as
+	 * GtkDialogs.  Sets gtk_window_set_icon_name as well, to avoid needing
+	 * to have two calls each time.  Set to %NULL to unset.
+	 * @param window The #GtkWindow to set the icon name for
+	 * @param icon_name The icon name to set, or %NULL to unset.
+	 */
+	function set_window_icon_name(window: Gtk.Window, icon_name: string | null): void;
+
+	/**
+	 * Sets the progress hint for a window manager (like muffin) to make
+	 * available when applications want to display the application's progress
+	 * in some operation. The value sent to the WM will be clamped to
+	 * between 0 and 100.
+	 * 
+	 * Note: If a window will stick around after progress is complete, you will
+	 * probaby need to set progress to 0 to remove any progress effects on taskbars
+	 * and window lists.
+	 * 
+	 * Setting progress will also cancel the 'pulsing' flag on the window as
+	 * well, if it has been set.
+	 * @param window The #GtkWindow to set the progress for
+	 * @param progress The value to set for progress.
+	 */
+	function set_window_progress(window: Gtk.Window, progress: number): void;
+
+	/**
+	 * Sets the progress pulse hint hint for a window manager (like muffin)
+	 * to make available when applications want to display indeterminate or
+	 * ongoing progress in a task manager.
+	 * 
+	 * Note: If a window will stick around after progress is complete, you will
+	 * probaby need to set progress to 0 to remove any progress effects on taskbars
+	 * and window lists.  This will also remove the pulse state, if it is set.
+	 * 
+	 * Setting an explicit progress value will unset this flag.
+	 * @param window The #GtkWindow to set the progress for
+	 * @param pulse Whether to have pulsing set or not.
+	 */
+	function set_window_progress_pulse(window: Gtk.Window, pulse: boolean): void;
+
+	/**
+	 * Sets the icon name hint for a window manager (like muffin) to make
+	 * available when applications want to change their icons during runtime
+	 * without having to resort to the internal low-res pixbufs that GdkWindow
+	 * sets on the client side.  This is a function, not a method, for applying
+	 * the icon name property for a given (possibly foreign) window, by passing
+	 * the window's XID.  Set to %NULL to unset.
+	 * @param xid The Window to set the icon name for
+	 * @param file_name The icon path to set, or %NULL to unset.
+	 */
+	function set_xid_icon_from_file(xid: number, file_name: string | null): void;
+
+	/**
+	 * Sets the icon name hint for a window manager (like muffin) to make
+	 * available when applications want to change their icons during runtime
+	 * without having to resort to the internal low-res pixbufs that GdkWindow
+	 * sets on the client side.  This is a function, not a method, for applying
+	 * the icon name property for a given (possibly foreign) window, by passing
+	 * the window's XID.  Set to %NULL to unset.
+	 * @param xid The Window to set the icon name for
+	 * @param icon_name The icon name to set, or %NULL to unset.
+	 */
+	function set_xid_icon_name(xid: number, icon_name: string | null): void;
+
+	/**
+	 * Sets the progress hint for a window manager (like muffin) to make
+	 * available when applications want to display the application's progress
+	 * in some operation. The value sent to the WM will be clamped to
+	 * between 0 and 100.
+	 * 
+	 * Setting progress will also cancel the 'pulsing' flag on the window as
+	 * well, if it has been set.
+	 * 
+	 * Note: If a window will stick around after progress is complete, you will
+	 * probaby need to set progress to 0 to remove any progress effects on taskbars
+	 * and window lists.
+	 * 
+	 * This is a function, not a method, for applying the progress property for
+	 * a given (possibly foreign) window, by passing the window's XID.
+	 * @param xid The Window to set the progress for
+	 * @param progress The value to set for progress.
+	 */
+	function set_xid_progress(xid: number, progress: number): void;
+
+	/**
+	 * Sets the progress pulse hint hint for a window manager (like muffin)
+	 * to make available when applications want to display indeterminate or
+	 * ongoing progress in a task manager.
+	 * 
+	 * Note: If a window will stick around after progress is complete, you will
+	 * probaby need to set progress to 0 to remove any progress effects on taskbars
+	 * and window lists.
+	 * 
+	 * Setting an explicit progress value will unset this flag.
+	 * @param xid The Window to set the progress for
+	 * @param pulse Whether to have pulsing set or not.
+	 */
+	function set_xid_progress_pulse(xid: number, pulse: boolean): void;
+
+	/**
+	 * Gets a machine-readable description of the <link linkend="gdbus-interface-org-x-StatusIcon.top_of_page">org.x.StatusIcon</link> D-Bus interface.
+	 * @returns A #GDBusInterfaceInfo. Do not free.
+	 */
+	function status_icon_interface_interface_info(): Gio.DBusInterfaceInfo;
+
+	/**
+	 * Overrides all #GObject properties in the {@link StatusIconInterface} interface for a concrete class.
+	 * The properties are overridden in the order they are defined.
+	 * @param klass The class structure for a #GObject derived class.
+	 * @param property_id_begin The property id to assign to the first overridden property.
+	 * @returns The last property id.
+	 */
+	function status_icon_interface_override_properties(klass: any, property_id_begin: number): number;
+
+	/**
+	 * Check if the Session Manager is currently in the "Running" phase.
+	 * @returns %TRUE if the session is running.
+	 */
+	function util_get_session_is_running(): boolean;
+
+	/**
+	 * Performs a check to see if on-demand mode for discrete graphics
+	 * is supported.
+	 * @returns %TRUE if supported.
+	 */
+	function util_gpu_offload_supported(): boolean;
+
+}

--- a/.typescript-declarations/cinnamon/globals.d.ts
+++ b/.typescript-declarations/cinnamon/globals.d.ts
@@ -1,9 +1,9 @@
 declare function require(path: string): any;
 
-declare function setInterval(callback: { (): void }, delay: number): number;
-declare function clearInterval(intervalID: number): void;
-declare function setTimeout(callback: { (): void }, delay: number): number;
-declare function clearTimeout(timeoutID: number): void;
+declare const setInterval: typeof imports.misc.util.setInterval
+declare const clearInterval: typeof imports.misc.util.clearInterval
+declare const setTimeout: typeof imports.misc.util.setTimeout
+declare const clearTimeout: typeof imports.misc.util.clearTimeout
 
 /** Interface typing for the global variable.
  * Extendable, for example overloading in a d.ts file:
@@ -23,7 +23,7 @@ declare interface Global {
     set_cursor(cursor: imports.gi.Cinnamon.Cursor): void;
     unset_cursor(): void;
     /** equivalent to imports.gi.Meta */
-    screen: any;
+    screen: imports.gi.Meta.Screen;
     display: imports.gi.Meta.Display;
     stage: imports.gi.Clutter.Stage;
     /** Gets the pointer coordinates and current modifier key state */
@@ -50,18 +50,23 @@ interface String {
     format(...args: string[]): string
 }
 
-declare class __meta {
-    static uuid: string;
-    static path: string;
-    static name: string;
-    static description: string;
-    static "max-instances": number;
-    static multiversion: boolean;
-    static author: string;
-    static "last-edited": number;
-    static error: any;
-    static "force-loaded": boolean
+declare interface  Meta {
+    uuid: string;
+    path: string;
+    name: string;
+    description: string;
+    "max-instances": number;
+    multiversion: boolean;
+    author: string;
+    "last-edited": number;
+    error: any;
+    "force-loaded": boolean
 }
+
+declare const __meta: Meta
+
+declare const __dirname: string
+declare const __filename: string
 
 declare class GJSError extends Error {
     stack: any;
@@ -84,7 +89,7 @@ declare namespace imports.cairo {
     }
 }
 
-/** DEPRECATED. Mainloop is simply a layer of convenience and backwards-compatibility over some GLib functions (such as `GLib.timeout_add()` which in GJS is mapped to `g_timeout_add_full()`). It's use is not generally recommended anymore */
+/** @deprecated Mainloop is simply a layer of convenience and backwards-compatibility over some GLib functions (such as `GLib.timeout_add()` which in GJS is mapped to `g_timeout_add_full()`). It's use is not generally recommended anymore */
 declare namespace imports.mainloop {
     /**
      * Calls callback function after given seconds

--- a/.typescript-declarations/cinnamon/ui/applet.d.ts
+++ b/.typescript-declarations/cinnamon/ui/applet.d.ts
@@ -12,7 +12,7 @@ declare namespace imports.ui.applet {
 	 * @short_description: Deprecated. Use #PopupMenu.PopupIconMenuItem instead.
 	 */
 	export class MenuItem extends ui.popupMenu.PopupIconMenuItem {
-		constructor(label: string, icon: string, callback: Function);
+		constructor(label: string, icon: string, callback: (owner: MenuItem, event: gi.Clutter.Event, keepMenu: boolean) => void);
 	}
 
 	/**
@@ -21,7 +21,7 @@ declare namespace imports.ui.applet {
 	* A context menu (right-click menu) to be used by an applet
 	*/
 	export class AppletContextMenu extends popupMenu.PopupMenu {
-		constructor(launcher: any, orientation: gi.St.Side);
+		constructor(launcher: Applet, orientation: gi.St.Side);
 
 		private _onOpenStateChanged(menu: popupMenu.PopupMenuBase, open: boolean, sourceActor: gi.St.Widget): void;
 	}
@@ -38,9 +38,9 @@ declare namespace imports.ui.applet {
 		 * @param launcher The applet that contains the context menu
 		 * @param orinentation The orientation of the applet
 		 */
-		constructor(launcher: any, orinentation: gi.St.Side);
+		constructor(launcher: Applet, orinentation: gi.St.Side);
 
-		private _onOrientationChanged(a: any, orientation: gi.St.Side): void;
+		private _onOrientationChanged(a: Applet, orientation: gi.St.Side): void;
 		private _onOpenStateChanged(menu: popupMenu.PopupMenuBase, open: boolean, sourceActor: gi.St.Widget): void;
 	}
 
@@ -48,14 +48,14 @@ declare namespace imports.ui.applet {
 		uuid: string;
 		name: string;
 		description: string;
-    	"max-instances"?: number;
-    	version?: string;
-    	multiversion?: boolean;
-    	"cinnamon-version"?: string[];
-    	state?: number;
-    	path: string;
+		"max-instances"?: number;
+		version?: string;
+		multiversion?: boolean;
+		"cinnamon-version"?: string[];
+		state?: number;
+		path: string;
 		error?: string;
-    	force_loaded: boolean;
+		force_loaded: boolean;
 	}
 
 	/**
@@ -70,7 +70,7 @@ declare namespace imports.ui.applet {
 		public readonly instance_id: number;
 		/** The panel object containing the applet. This is set by
 		* appletManager *after* the applet is loaded. */
-		public readonly panel: panel.Panel;
+		public readonly panel: panel.Panel | null;
 
 		/** UUID of the applet. This is set by appletManager *after*
 		* the applet is loaded. */
@@ -97,10 +97,10 @@ declare namespace imports.ui.applet {
 		/** The allowed layout of the applet. This
 		 * determines the type of panel an applet is allowed in. By default this is set
 		 * to Applet.AllowedLayout.HORIZONTAL */
-		 protected _allowedLayout: AllowedLayout;
+		protected _allowedLayout: AllowedLayout;
 
-		 /** orientation of the panel the applet is on */
-		 protected _orientation: gi.St.Side;
+		/** orientation of the panel the applet is on */
+		protected _orientation: gi.St.Side
 
 		/**
 		 * 
@@ -130,7 +130,7 @@ declare namespace imports.ui.applet {
 
 		protected _onDragCancelled(): void;
 
-		protected _onButtonPressEvent(actor: gi.St.Widget, event: any): boolean;
+		protected _onButtonPressEvent(actor: gi.St.Widget, event: imports.gi.Clutter.Event): boolean;
 
 		/**
 		 * Sets the tooltip of the applet
@@ -151,16 +151,23 @@ declare namespace imports.ui.applet {
 		 *
 		 * This is meant to be overridden in individual applets.
 		 * @param event the event object
+		 * 
+		 *	returns %TRUE if the event has been handled by the actor,
+		 *  or %FALSE to continue the emission. 
+		 * 
 		 */
-		public on_applet_clicked(event: gi.Clutter.Event): any;
+		public on_applet_clicked(event: gi.Clutter.Event): boolean;
 
 		/**
 		 * This function is called when the applet is clicked with the middle mouse button.
 		 *
 		 * This is meant to be overridden in individual applets.
 		 * @param event the event object
+		 * 
+		 *  returns %TRUE if the event has been handled by the actor,
+		 *  or %FALSE to continue the emission. 
 		 */
-		public on_applet_middle_clicked(event: gi.Clutter.Event): any;
+		public on_applet_middle_clicked(event: gi.Clutter.Event): boolean;
 
 		/**
 		 * This function is called when an applet *of the same uuid* is added or
@@ -173,7 +180,7 @@ declare namespace imports.ui.applet {
 		 * This is meant to be overridden in individual applets
 		 * @param instance the instance that was changed
 		 */
-		public on_applet_instances_changed(instance?: Applet): any;
+		public on_applet_instances_changed(instance?: Applet): void;
 
 		private on_applet_added_to_panel_internal(userEnabled: boolean): boolean | void;
 
@@ -183,7 +190,7 @@ declare namespace imports.ui.applet {
 		 * This is meant to be overridden in individual applets.
 		 * @param userEnabled 
 		 */
-		public on_applet_added_to_panel(userEnabled: boolean): any;
+		public on_applet_added_to_panel(userEnabled: boolean): void;
 
 		/**
 		 * This function is called by appletManager when the applet is removed from the panel.
@@ -191,7 +198,7 @@ declare namespace imports.ui.applet {
 		 * This is meant to be overridden in individual applets.
 		 * @param deleteConfig 
 		 */
-		public on_applet_removed_from_panel(deleteConfig: any): any;
+		public on_applet_removed_from_panel(deleteConfig: boolean): void;
 
 		/**
 		 * This function is called by appletManager when the applet is reloaded.
@@ -199,10 +206,10 @@ declare namespace imports.ui.applet {
 		 * This is meant to be overridden in individual applets.
 		 * @param deleteConfig 
 		 */
-		public on_applet_reloaded(deleteConfig: any): any;
+		public on_applet_reloaded(deleteConfig?: boolean): void;
 
 		// should only be called by appletManager
-		private _onAppletRemovedFromPanel(deleteConfig: any): void;
+		private _onAppletRemovedFromPanel(deleteConfig: boolean): void;
 
 		/**
 		 * Sets the orientation of the St.BoxLayout.
@@ -238,7 +245,7 @@ declare namespace imports.ui.applet {
 		 * This is meant to be overridden in individual applets.
 		 * @param orientation new orientation of the applet
 		 */
-		public on_orientation_changed(orientation: gi.St.Side): any;
+		public on_orientation_changed(orientation: gi.St.Side): void;
 
 		public getPanelIconSize(iconType: gi.St.IconType): number;
 
@@ -252,7 +259,7 @@ declare namespace imports.ui.applet {
 		 *
 		 * This is meant to be overridden in individual applets.
 		 */
-		protected on_panel_height_changed(): any;
+		protected on_panel_height_changed(): void;
 
 		private on_panel_icon_size_changed_internal(): void;
 
@@ -263,9 +270,9 @@ declare namespace imports.ui.applet {
 		 * This is meant to be overridden in individual applets.
 		 * @param size new icon size
 		 */
-		public on_panel_icon_size_changed(size: number): any;
+		public on_panel_icon_size_changed(size: number): void;
 
-		public confirmRemoveApplet(event: any): void;
+		public confirmRemoveApplet(event: imports.gi.Clutter.Event): void;
 
 		public finalizeContextMenu(): void;
 
@@ -288,6 +295,8 @@ declare namespace imports.ui.applet {
 		public get _panelHeight(): number;
 
 		public get _scaleMode(): boolean;
+
+		public connect(event: 'orientation-changed', cb: (actor: this, orientation: imports.gi.St.Side) => void): number
 	}
 
 	/** Applet with icon */

--- a/.typescript-declarations/cinnamon/ui/layout.d.ts
+++ b/.typescript-declarations/cinnamon/ui/layout.d.ts
@@ -5,7 +5,7 @@ declare namespace imports.ui.layout {
 
 	interface ChromeParams {
 		/** The actor should be hidden when a window on the same monitor is fullscreen. Default %false. */
-		visibleInFullcreen: boolean;
+		visibleInFullscreen: boolean;
 		/** The actor's allocation should be used to add window manager struts. Default %false. */
 		affectsStruts: boolean;
 		/**  The actor should be added to the stage input region. Default %true. */
@@ -48,7 +48,7 @@ declare namespace imports.ui.layout {
 		public edgeRight: edgeFlip.EdgeFlipper;
 		public edgeLeft: edgeFlip.EdgeFlipper;
 		public hideIdleId: number;
-		protected _Chrome: Chrome;
+		protected _chrome: Chrome;
 		public enabledEdgeFlip: boolean;
 		public edgeFlipDelay: number;
 		public keyboardBox: gi.St.BoxLayout;

--- a/.typescript-declarations/cinnamon/ui/modalDialog.d.ts
+++ b/.typescript-declarations/cinnamon/ui/modalDialog.d.ts
@@ -45,7 +45,7 @@ declare namespace imports.ui.modalDialog {
         protected _activeKeys: any
         protected _backgrounddBin: imports.gi.St.Bin
         protected _dialogLayout: imports.gi.St.BoxLayout
-        protected _lightbox: imports.ui.lightbox.Lightbox
+        protected _lightbox: lightbox.Lightbox
         public stack: any
         protected _eventBlocker: any
         public contentLayout: imports.gi.St.BoxLayout

--- a/.typescript-declarations/cinnamon/ui/settings.d.ts
+++ b/.typescript-declarations/cinnamon/ui/settings.d.ts
@@ -68,88 +68,99 @@ declare namespace imports.ui.settings {
 		public constructor(bindObject: any, uuid: string, instanceId: number)
 
 		/**
-		 * Like bind this allows you to bind a setting to a property on an object. But unlike
-		 * {@link bind}, this function allows you to specify the bindObject to which the property will
-		 * be bound.
-		 * 
-		 * @param bindObject the object to which the setting will be bound
+		 * bindWithObject:
+		 * @bindObject (object): (optional) the object to which the setting will be bound
 		 * or null to use the bindObject passed to %_init
-		 * @param key the id of the setting
-		 * @param applet_prop the variable name that is used to hold the
+		 * @key (string): the id of the setting
+		 * @applet_prop (string): the variable name that is used to hold the
 		 * setting (eg. `this.value` passes as `"value`")
-		 * @param callback the function to call when the setting changes
-		 * @param user_data any extra data/object you wish to pass to the callback
+		 * @callback (function): (optional) the function to call when the setting changes
+		 * @user_data: (optional) any extra data/object you wish to pass to the callback
 		 *
-		 * @returns Whether the bind was successful
+		 * Like bind this allows you to bind a setting to a property on an object. But unlike
+		 * %bind, this function allows you to specify the bindObject to which the property will
+		 * be bound.
+		 *
+		 * Returns (boolean): Whether the bind was successful
 		 */
-		public bindWithObject<T>(bindObject: any | null, key: string, applet_prop: string, callback?: (arg?: T) => any, user_data?: T): boolean;
+		public bindWithObject<T>(bindObject: any, key: string, applet_prop: string, callback?: (arg?: T) => any, user_data?: T): boolean;
 
 		/**
-		 * Bind a setting to a property on the bindObject passed to %_init.
-		 * @param key the id of the setting
-		 * @param applet_prop the variable name that is used to hold the
+		 * bind:
+		 * @key (string): the id of the setting
+		 * @applet_prop (string): the variable name that is used to hold the
 		 * setting (eg. `this.value` passes as `"value`")
-		 * @param callback the function to call when the setting changes
-		 * @param user_data any extra data/object you wish to pass to the callback
+		 * @callback (function): (optional) the function to call when the setting changes
+		 * @user_data: (optional) any extra data/object you wish to pass to the callback
 		 *
-		 * @returns Whether the bind was successful
+		 * Bind a setting to a property on the @bindObject passed to %_init.
+		 *
+		 * Returns (boolean): Whether the bind was successful
 		 */
-		public bind<T>(key: string, applet_prop: string, callback?: (arg?: T) => any, user_data?: T): boolean;
+		public bind<T = undefined>(key: string, applet_prop: string, callback?: (arg: T) => any, user_data?: T): boolean;
 
 		/**
-		 * @deprecated
-		 * Bind a setting to a property on the object passed to %_init. This
-		 * function is deprecated and is now only a wrapper around {@link bind} for backward
-		 * compatibility. Please use {@link bind} instead.
-		 * 
-		 * @param direction the direction of the binding
-		 * @param key the id of the setting
-		 * @param applet_prop the variable name that is used to hold the
+		 * bindProperty:
+		 * @direction (Settings.BindingDirection): the direction of the binding
+		 * @key (string): the id of the setting
+		 * @applet_prop (string): the variable name that is used to hold the
 		 * setting (eg. `this.value` passes as `"value`")
-		 * @param callback the function to call when the setting changes
-		 * @param user_data any extra data/object you wish to pass to the callback
+		 * @callback (function): (optional) the function to call when the setting changes
+		 * @user_data: (optional) any extra data/object you wish to pass to the callback
 		 *
-		 * @returns Whether the bind was successful
+		 * Bind a setting to a property on the object @bindObject passed to %_init. This
+		 * function is deprecaed and is now only a wrapper around %bind for backward
+		 * compatibility. Please use %bind instead.
+		 *
+		 * Returns (boolean): Whether the bind was successful
 		 */
 		public bindProperty<T>(direction: BindingDirection, key: string, applet_prop: string, callback?: (arg?: T) => any, user_data?: T): boolean;
 
 		/**
-		 * Removes the binding on an object. If you have bound {@link key} to multiple objects, this will
-		 * only remove the one bound to {@link bindObject}. If you wish to remove all bindings, or you used
-		 * {@link bind} or {@link bindProperty} to bind the setting, it is recommended that you use {@link unbindProperty}
+		 * unbindWithObject:
+		 * @bindObject (object): (optional) the object from which the setting will be unbound
+		 * @key (string): the previously bound key to remove
+		 *
+		 * Removes the binding on an object. If you have bound @key to multiple objects, this will
+		 * only remove the one bound to @bindObject. If you wish to remove all bindings, or you used
+		 * %bind or %bindProperty to bind the setting, it is recommended that you use %unbindPropery
 		 * instead.
-		 * 
-		 * @param bindObject the object from which the setting will be unbound
-		 * @param key the previously bound key to remove
-		 *		 *
-		 * @returns Whether the unbind was successful.
+		 *
+		 * Returns (boolean): Whether the unbind was successful.
 		 */
 		public unbindWithObject(bindObject: any, key: string): boolean;
 
 		/**
-		 * Removes the binding on an object that was bound using the {@link bind} function. If you have bound
-		 * {@link key} to multiple objects using {@link bindWithObject}, you should use {@link unbindWithObject} or {@link unbindAll}
-		 * instead.
-		 * @param key the previously bound key to remove
+		 * unbind:
+		 * @key (string): the previously bound key to remove
 		 *
-		 * @returns Whether the unbind was successful.
+		 * Removes the binding on an object that was bound using the %bind function. If you have bound
+		 * @key to multiple objects using %bindWithObject, you should use %unbindWithObject or %unbindAll
+		 * instead.
+		 *
+		 * Returns (boolean): Whether the unbind was successful.
 		 */
 		public unbind(key: string): boolean;
 
 		/**
-		 * @deprecated
-		 * Removes the binding of a key that was bound using {@link bind}, or {@link bindProperty}. This
-		 * function is deprecated and is now only a wrapper around {@link unbind} for backward
-		 * compatibility. Please use {@link unbind} instead.
-		 * @param key the previously bound key to remove
-		 * @returns Whether the unbind was successful.
+		 * unbindProperty:
+		 * @key (string): the previously bound key to remove
+		 *
+		 * Removes the binding of a key that was bound using %bind, or %bindProperty. This
+		 * function is deprecaed and is now only a wrapper around %unbind for backward
+		 * compatibility. Please use %unbind instead.
+		 *
+		 * Returns (boolean): Whether the unbind was successful.
 		 */
 		public unbindProperty(key: string): boolean;
 
 		/**
-		 * Removes all bindings of a key that were bound using {@link bind}, {@link bindWithObject}, or {@link bindProperty}.
-		 * @param key the previously bound key to remove
-		 * @returns Whether the unbind was successful.
+		 * unbindAll:
+		 * @key (string): the previously bound key to remove
+		 *
+		 * Removes all bindings of a key that were bound using %bind, %bindWithObject, or %bindProperty.
+		 *
+		 * Returns (boolean): Whether the unbind was successful.
 		 */
 		public unbindAll(key: string): boolean;
 
@@ -158,40 +169,52 @@ declare namespace imports.ui.settings {
 		protected _setValue(value: any, key: string): void;
 
 		/**
+		 * getValue:
+		 * @key (string): the name of the settings key
+		 *
 		 * Gets the value of the setting @key.
-		 * @param key (string): the name of the settings key
-		 * @returns: The current value of the setting
+		 *
+		 * Returns: The current value of the setting
 		 */
 		public getValue<T = any>(key: string): T;
 
 		/**
-		 * Sets the value of the setting @key to @value.
-		 * @param key the name of the settings key
-		 * @param value the new value
+		 * setValue:
+		 * @key (string): the name of the settings key
+		 * @value: the new value
 		 *
+		 * Sets the value of the setting @key to @value.
 		 */
 		public setValue<T = any>(key: string, value: T): void;
 
 		/**
+		 * getDefaultValue:
+		 * @key (string): the name of the settings key
+		 *
 		 * Gets the default value of the setting @key.
-		 * @param key the name of the settings key
-		 * @returns The default value of the setting
+		 *
+		 * Returns: The default value of the setting
 		 */
 		public getDefaultValue<T = any>(key: string): T;
 
 		/**
+		 * getOptions:
+		 * @key (String): the name of the settings key
+		 *
 		 * Gets the current available options for the setting @key.
-		 * @param key the name of the settings key
-		 * @returns The currently stored options of the key (or undefined if the key does
+		 *
+		 * Returns: The currently stored options of the key (or undefined if the key does
 		 * not support options)
 		 */
 		public getOptions(key: string): any | null;
 
 		/**
-		 * Sets the available options of {@link key} to {@link options}. An error is given if the setting
+		 * setOptions:
+		 * @key (string): the name of the settings key
+		 * @options: the new options to set
+		 *
+		 * Sets the available options of @key to @options. An error is given if the setting
 		 * does not support options.
-		 * @param key the name of the settings key
-		 * @param options the new options to set
 		 */
 		public setOptions(key: string, options: any): void;
 
@@ -216,6 +239,7 @@ declare namespace imports.ui.settings {
 		protected remoteUpdate(key: string, payload: any): void;
 
 		/**
+		 * finalize:
 		 *
 		 * Removes all bindings and disconnects all signals. This function should be called prior
 		 * to deleting the object.

--- a/.typescript-declarations/cinnamon/ui/tooltips.d.ts
+++ b/.typescript-declarations/cinnamon/ui/tooltips.d.ts
@@ -86,7 +86,7 @@ declare namespace imports.ui.tooltips {
 		 * @param item  the actor owning the tooltip
 		 * @param initTitle the string to display initially
 		 */
-		constructor(item: gi.Clutter.Actor, initTitle: string);
+		constructor(item: gi.Clutter.Actor, initTitle?: string | null);
 
 		public hide(): void;
 
@@ -131,7 +131,7 @@ declare namespace imports.ui.tooltips {
 		 * @param initTitle the initial string of the tooltip
 		 * @param orientation the orientation of the applet.
 		 */
-		constructor(panelItem: applet.Applet, initTitle: string, orientation: gi.St.Side);
+		constructor(panelItem: applet.Applet, initTitle: string | null | undefined, orientation: gi.St.Side);
 
 		public show(): void;
 

--- a/.typescript-declarations/manual-overrides/St-1.0.d.ts
+++ b/.typescript-declarations/manual-overrides/St-1.0.d.ts
@@ -3,4 +3,8 @@ declare namespace imports.gi.St {
     interface IBoxLayout {
         add(first_child: Clutter.Actor, options?: Partial<BoxLayoutChildInitOptions>): void;
     }
+
+    interface ITable {
+        add(first_child: Clutter.Actor, options?: Partial<TableChildInitOptions>): void;
+    }
 }

--- a/.typescript-declarations/xfixes-4.0.d.ts
+++ b/.typescript-declarations/xfixes-4.0.d.ts
@@ -1,0 +1,9 @@
+/** Generated with https://github.com/Gr3q/GIR2TS - If possible do not modify. */
+declare namespace imports.gi.xfixes {
+	export interface XserverRegionInitOptions {}
+	interface XserverRegion {}
+	class XserverRegion {
+		public constructor(options?: Partial<XserverRegionInitOptions>);
+	}
+
+}

--- a/.typescript-declarations/xrandr-1.3.d.ts
+++ b/.typescript-declarations/xrandr-1.3.d.ts
@@ -1,0 +1,45 @@
+/** Generated with https://github.com/Gr3q/GIR2TS - If possible do not modify. */
+declare namespace imports.gi.xrandr {
+	export interface ScreenSizeInitOptions {}
+	interface ScreenSize {}
+	class ScreenSize {
+		public constructor(options?: Partial<ScreenSizeInitOptions>);
+	}
+
+	export interface ScreenChangeNotifyEventInitOptions {}
+	interface ScreenChangeNotifyEvent {}
+	class ScreenChangeNotifyEvent {
+		public constructor(options?: Partial<ScreenChangeNotifyEventInitOptions>);
+	}
+
+	export interface NotifyEventInitOptions {}
+	interface NotifyEvent {}
+	class NotifyEvent {
+		public constructor(options?: Partial<NotifyEventInitOptions>);
+	}
+
+	export interface ScreenResourcesInitOptions {}
+	interface ScreenResources {}
+	class ScreenResources {
+		public constructor(options?: Partial<ScreenResourcesInitOptions>);
+	}
+
+	export interface OutputChangeNotifyEventInitOptions {}
+	interface OutputChangeNotifyEvent {}
+	class OutputChangeNotifyEvent {
+		public constructor(options?: Partial<OutputChangeNotifyEventInitOptions>);
+	}
+
+	export interface CrtcChangeNotifyEventInitOptions {}
+	interface CrtcChangeNotifyEvent {}
+	class CrtcChangeNotifyEvent {
+		public constructor(options?: Partial<CrtcChangeNotifyEventInitOptions>);
+	}
+
+	export interface OutputPropertyNotifyEventInitOptions {}
+	interface OutputPropertyNotifyEvent {}
+	class OutputPropertyNotifyEvent {
+		public constructor(options?: Partial<OutputPropertyNotifyEventInitOptions>);
+	}
+
+}


### PR DESCRIPTION
Changes:
* Fix `connect` signal keys for notify, it was using incorrectly formatted prop names (generated output)
* Remove readonly properties from class init options (generated output)
* Add few more generated declarations instead of dummy/handwritten ones
* Various fixes in JS side of the declarations