### PR TITLE
calc-js@ptandler fix: in info.json the `author` field had an array instead of a string…

### DIFF
--- a/calc-js@ptandler/info.json
+++ b/calc-js@ptandler/info.json
@@ -1,4 +1,4 @@
 {
-  "author": ["ptandler"],
+  "author": "ptandler",
   "license": "GPL-3.0"
 }


### PR DESCRIPTION
maybe this fixes #4177 ...?