### PR TITLE
[multicore-sys-monitor@ccadeptic23] Bugfix: use gtk3 only

### DIFF
--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/prefs.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/3.4/prefs.js
@@ -8,8 +8,8 @@
 // You should have received a copy of the GNU General Public License along with
 // this file. If not, see <http://www.gnu.org/licenses/>.
 const UUID = 'multicore-sys-monitor@ccadeptic23';
-const Gtk = imports.gi.Gtk;
 imports.gi.versions.Gtk = '3.0';
+const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const Gdk = imports.gi.Gdk;
 

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/4.0/prefs.js
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/4.0/prefs.js
@@ -8,8 +8,8 @@
 // You should have received a copy of the GNU General Public License along with
 // this file. If not, see <http://www.gnu.org/licenses/>.
 const UUID = 'multicore-sys-monitor@ccadeptic23';
-const Gtk = imports.gi.Gtk;
 imports.gi.versions.Gtk = '3.0';
+const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const Gdk = imports.gi.Gdk;
 

--- a/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
+++ b/multicore-sys-monitor@ccadeptic23/files/multicore-sys-monitor@ccadeptic23/metadata.json
@@ -1,7 +1,7 @@
 {
     "uuid": "multicore-sys-monitor@ccadeptic23",
     "name": "Multi-Core System Monitor",
-    "version": "1.8.91",
+    "version": "1.8.92",
     "description": "Displays in realtime the cpu usage for each core/cpu and overall memory usage.",
     "multiversion": true,
     "cinnamon-version": ["2.8", "3.0", "3.2", "3.4", "3.6", "3.8", "4.0", "4.2", "4.4", "4.6"]


### PR DESCRIPTION
Applet preferences dialog does not open on systems with gtk4 installed because gtk version info should come before the import instruction.

Fixes: #3974