### PR TITLE
[radio@driglu4it] HOT FIX - Fix config not working on fresh install

### DIFF
--- a/radio@driglu4it/files/radio@driglu4it/4.6/radio-applet.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/radio-applet.js
@@ -2564,7 +2564,9 @@ const createConfig = () => {
     appletSettings.bind('initial-volume', 'customInitVolume');
     appletSettings.bind('last-volume', 'lastVolume');
     appletSettings.bind('tree', 'userStations', (newVal) => {
-        const trimmedStations = newVal.map(val => { return Object.assign(Object.assign({}, val), { url: val.url.trim() }); });
+        // temporariy solution to fix typo in settings-schema
+        // @ts-ignore
+        const trimmedStations = newVal.map(val => { var _a; return Object.assign(Object.assign({}, val), { url: ((_a = val.url) === null || _a === void 0 ? void 0 : _a.trim()) || val.ur.trim() }); });
         if (lodash_es_isEqual(previousUserStations, trimmedStations))
             return;
         stationsHandler.forEach(changeHandler => changeHandler(trimmedStations));

--- a/radio@driglu4it/files/radio@driglu4it/4.6/settings-schema.json
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/settings-schema.json
@@ -105,7 +105,7 @@
 				"inc": true
 			},{
 				"name": "Rádio KIKS Rock", 
-				"ur": "https://stream.radiokiks.sk/kiks_rock.mp3", 
+				"url": "https://stream.radiokiks.sk/kiks_rock.mp3", 
 				"inc": true
 			},
 			{

--- a/radio@driglu4it/files/radio@driglu4it/metadata.json
+++ b/radio@driglu4it/files/radio@driglu4it/metadata.json
@@ -1,1 +1,1 @@
-{"uuid":"radio@driglu4it","name":"Radio++","description":"A simple radio applet for Cinnamon","max-instances":1,"multiversion":true,"version":"2.0.2"}
+{"uuid":"radio@driglu4it","name":"Radio++","description":"A simple radio applet for Cinnamon","max-instances":1,"multiversion":true,"version":"2.0.3"}

--- a/radio@driglu4it/src/services/Config.ts
+++ b/radio@driglu4it/src/services/Config.ts
@@ -69,7 +69,9 @@ const createConfig = () => {
 
     appletSettings.bind<Channel[]>('tree', 'userStations',
         (newVal) => {
-            const trimmedStations = newVal.map(val => { return { ...val, url: val.url.trim() } })
+            // temporariy solution to fix typo in settings-schema
+            // @ts-ignore
+            const trimmedStations = newVal.map(val => { return { ...val, url: val.url?.trim() || val.ur.trim() } })
             if (isEqual(previousUserStations, trimmedStations)) return
             stationsHandler.forEach(changeHandler => changeHandler(trimmedStations))
             previousUserStations = trimmedStations

--- a/radio@driglu4it/webpack.config.js
+++ b/radio@driglu4it/webpack.config.js
@@ -9,7 +9,7 @@ const DESCRIPTION = 'A simple radio applet for Cinnamon'
 const NAME = 'Radio++'
 const MAX_INSTANCES = 1
 const CINNAMON_VERSION = '4.6' // When set to null, the build output path is set to the files applet folder, else to a sub dir inside the applet files dir
-const APPLET_VERSION = '2.0.2'
+const APPLET_VERSION = '2.0.3'
 
 // Automatic calculated constants
 const UUID = __dirname.split('/').slice(-1)[0]


### PR DESCRIPTION
In the last pr I have accidentally used `ur` instead of `url`. This lead to a type Error each time the applet makes some changes in the settings for new users (which is very often the case and makes the applet almost useless for new users). 

@brownsr when possible please accept this soon. There are just very few changes. 