### PR TITLE
JS update

### DIFF
--- a/printers@linux-man/files/printers@linux-man/applet.js
+++ b/printers@linux-man/files/printers@linux-man/applet.js
@@ -1,12 +1,9 @@
+const { Gio, GLib, St } = imports.gi;
+
 const Applet = imports.ui.applet;
-const Lang = imports.lang;
-const Gio = imports.gi.Gio;
 const PopupMenu = imports.ui.popupMenu;
-const Mainloop = imports.mainloop;
 const Settings = imports.ui.settings;
 const Config = imports.misc.config;
-const St = imports.gi.St;
-const GLib = imports.gi.GLib;
 const Util = imports.misc.util;
 const Gettext = imports.gettext;
 const APPLET_PATH = imports.ui.appletManager.appletMeta["printers@linux-man"].path;
@@ -14,236 +11,255 @@ const APPLET_PATH = imports.ui.appletManager.appletMeta["printers@linux-man"].pa
 Gettext.bindtextdomain('printers@linux-man', GLib.get_home_dir() + '/.local/share/locale');
 
 function _(str) {
-   let resultConf = Gettext.dgettext('printers@linux-man', str);
-   if(resultConf != str) {
-      return resultConf;
-   }
-   return Gettext.gettext(str);
+    let resultConf = Gettext.dgettext('printers@linux-man', str);
+    if(resultConf != str) {
+        return resultConf;
+    }
+    return Gettext.gettext(str);
 };
 
+function exec_async(args) {
+    return new Promise((resolve, reject) => {
+        let strOUT = '';
+        try {
+            let proc = Gio.Subprocess.new(args, Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE);
+            proc.communicate_utf8_async(null, null, (proc, res) => {
+                try {
+                    let [, stdout, stderr] = proc.communicate_utf8_finish(res);
+                    if(proc.get_successful()) strOUT = stdout;
+                }
+                catch (e) {
+                    logError(e);
+                }
+                finally {
+                    resolve(strOUT);
+                }
+            });
+        }
+        catch (e) {
+            logError(e);
+        }
+    })
+}
+
 function MyApplet(metadata, orientation, panel_height, instance_id) {
-  this._init(orientation, panel_height, instance_id);
+    this._init(orientation, panel_height, instance_id);
 }
 
 MyApplet.prototype = {
-  __proto__: Applet.TextIconApplet.prototype,
+    __proto__: Applet.TextIconApplet.prototype,
 
-  _init: function(orientation, panel_height, instance_id) {
-    Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
+    _init: function(orientation, panel_height, instance_id) {
+        Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
 
-    if(this.setAllowedLayout) this.setAllowedLayout(Applet.AllowedLayout.BOTH);
+        if(this.setAllowedLayout) this.setAllowedLayout(Applet.AllowedLayout.BOTH);
 
-    this._cupsSignal = Gio.DBus.system.signal_subscribe(null, 'org.cups.cupsd.Notifier', null, '/org/cups/cupsd/Notifier', null, Gio.DBusSignalFlags.NONE, this.onCupsSignal.bind(this));
+        this._cupsSignal = Gio.DBus.system.signal_subscribe(null, 'org.cups.cupsd.Notifier', null, '/org/cups/cupsd/Notifier', null, Gio.DBusSignalFlags.NONE, this.onCupsSignal.bind(this));
 
-    this.set_applet_tooltip(_('Printers'));
+        this.set_applet_tooltip(_('Printers'));
 
-    this.menu = new Applet.AppletPopupMenu(this, orientation);
-    this.menu.connect('open-state-changed', Lang.bind(this, this.onMenuOpened));
+        this.menu = new Applet.AppletPopupMenu(this, orientation);
+        this.menu.connect('open-state-changed', this.onMenuOpened.bind(this));
 
-    this.menuManager = new PopupMenu.PopupMenuManager(this);
-    this.menuManager.addMenu(this.menu);
+        this.menuManager = new PopupMenu.PopupMenuManager(this);
+        this.menuManager.addMenu(this.menu);
 
-    this.settings = new Settings.AppletSettings(this, 'printers@linux-man', instance_id);
-    this.settings.bindProperty(Settings.BindingDirection.IN, 'show-icon', 'show_icon', this.onSettingsChanged, null);
-    this.settings.bindProperty(Settings.BindingDirection.IN, 'show-error', 'show_error', this.onSettingsChanged, null);
-    this.settings.bindProperty(Settings.BindingDirection.IN, 'show-jobs', 'show_jobs', this.onSettingsChanged, null);
-    this.settings.bindProperty(Settings.BindingDirection.IN, 'job-number', 'job_number', this.onSettingsChanged, null);
-    this.settings.bindProperty(Settings.BindingDirection.IN, 'send-to-front', 'send_to_front', this.onSettingsChanged, null);
-    this.settings.bindProperty(Settings.BindingDirection.IN, 'symbolic-icons', 'symbolic_icons', this.onSettingsChanged, null);
+        this.settings = new Settings.AppletSettings(this, 'printers@linux-man', instance_id);
+        this.settings.bindProperty(Settings.BindingDirection.IN, 'show-icon', 'show_icon', this.onSettingsChanged, null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, 'show-error', 'show_error', this.onSettingsChanged, null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, 'show-jobs', 'show_jobs', this.onSettingsChanged, null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, 'job-number', 'job_number', this.onSettingsChanged, null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, 'send-to-front', 'send_to_front', this.onSettingsChanged, null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, 'symbolic-icons', 'symbolic_icons', this.onSettingsChanged, null);
 
-    this.jobsCount = 0;
-    this.printersCount = 0;
-    this.printError = false;
-    this.printWarning = false;
-    this.updating = false;
-    this.showLater = false;
-    this.printers = [];
-    this.setIcon('printer-printing');
-    this.onSettingsChanged();
-    let cinnamonVersion = Config.PACKAGE_VERSION.split('.');
-    let majorVersion = parseInt(cinnamonVersion[0]);
-    let minorVersion = parseInt(cinnamonVersion[1]);
-    this.pkexec = majorVersion > 3 || (majorVersion == 3 && minorVersion > 7);
-  },
+        this.jobsCount = 0;
+        this.printersCount = 0;
+        this.printError = false;
+        this.printWarning = false;
+        this.updating = false;
+        this.showLater = false;
+        this.printers = [];
+        this.setIcon('printer-printing');
+        this.onSettingsChanged();
+        let cinnamonVersion = Config.PACKAGE_VERSION.split('.');
+        let majorVersion = parseInt(cinnamonVersion[0]);
+        let minorVersion = parseInt(cinnamonVersion[1]);
+        this.pkexec = majorVersion > 3 || (majorVersion == 3 && minorVersion > 7);
+    },
 
-  on_reload_button: function() {
-    Util.spawnCommandLine("dbus-send --session --dest=org.Cinnamon.LookingGlass --type=method_call /org/Cinnamon/LookingGlass org.Cinnamon.LookingGlass.ReloadExtension string:'printers@linux-man' string:'APPLET'");
-  },
+    on_reload_button: function() {
+        Util.spawnCommandLine("dbus-send --session --dest=org.Cinnamon.LookingGlass --type=method_call /org/Cinnamon/LookingGlass org.Cinnamon.LookingGlass.ReloadExtension string:'printers@linux-man' string:'APPLET'");
+    },
 
-  on_cups_button: function() {
-    if(this.pkexec) Util.spawnCommandLine("sh -c 'pkexec systemctl restart cups.service'");
-    else Util.spawnCommandLine("gksudo 'systemctl restart cups.service'");
-  },
+    on_cups_button: function() {
+        if(this.pkexec) Util.spawnCommandLine("sh -c 'pkexec systemctl restart cups.service'");
+        else Util.spawnCommandLine("gksudo 'systemctl restart cups.service'");
+    },
 
-  on_applet_clicked: function() {
-    if(!this.menu.isOpen && this.updating) {
-        this.showLater = true;
-        return;
-    }
-    this.menu.toggle();
-    if(!this.printWarning && !this.menu.isOpen) this.update();
-  },
+    on_applet_clicked: function() {
+        if(!this.menu.isOpen && this.updating) {
+            this.showLater = true;
+            return;
+        }
+        this.menu.toggle();
+        if(!this.printWarning && !this.menu.isOpen) this.update();
+    },
 
-  on_applet_removed_from_panel: function() {
-    this.settings.finalize();
-  },
+    on_applet_removed_from_panel: function() {
+        this.settings.finalize();
+    },
 
-  onCupsSignal: function() {
-    if(this.printWarning) return;
-    this.printWarning = true;
-    Mainloop.timeout_add_seconds(3, Lang.bind(this, this.warningTimeout));
-    this.update();
-  },
+    onCupsSignal: function() {
+        if(this.printWarning) return;
+        this.printWarning = true;
+        GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 3, this.warningTimeout.bind(this))
+        this.update();
+    },
 
-  warningTimeout: function() {
-    this.printWarning = false;
-    this.update();
-  },
+    warningTimeout: function() {
+        this.printWarning = false;
+        this.update();
+    },
 
-  setIcon: function(iconName) {
-    if (this.symbolic_icons) this.set_applet_icon_symbolic_name(iconName);
-    else this.set_applet_icon_name(iconName);
-  },
+    setIcon: function(iconName) {
+        if (this.symbolic_icons) this.set_applet_icon_symbolic_name(iconName);
+        else this.set_applet_icon_name(iconName);
+    },
 
-  onMenuOpened: function() {
-    if(this.sendSubMenu != null) {
-      this.sendSubMenu.close();
-      this.sendSubMenu.open();
-    }
-    this.cancelSubMenu.close();
-    this.cancelSubMenu.open();
-    if(this.sendSubMenu != null) this.sendSubMenu.close();
-  },
+    onMenuOpened: function() {
+        if(this.sendSubMenu != null) {
+            this.sendSubMenu.close();
+            this.sendSubMenu.open();
+        }
+        this.cancelSubMenu.close();
+        this.cancelSubMenu.open();
+        if(this.sendSubMenu != null) this.sendSubMenu.close();
+    },
 
-  onSettingsChanged: function() {
-    if (this.symbolic_icons) this.iconType = St.IconType.SYMBOLIC;
-    else this.iconType = St.IconType.FULLCOLOR;
-    this.update();
-  },
+    onSettingsChanged: function() {
+        if (this.symbolic_icons) this.iconType = St.IconType.SYMBOLIC;
+        else this.iconType = St.IconType.FULLCOLOR;
+        this.update();
+    },
 
-  onShowPrintersClicked: function() {
-    Util.spawn(['system-config-printer']);
-  },
+    onShowPrintersClicked: function() {
+        Util.spawn(['system-config-printer']);
+    },
 
-  onShowJobsClicked: function(item) {
-    Util.spawn(['system-config-printer', '--show-jobs', item.label.text]);
-  },
+    onShowJobsClicked: function(item) {
+        Util.spawn(['system-config-printer', '--show-jobs', item.label.text]);
+    },
 
-  onCancelAllJobsClicked: function() {
-    for(var n = 0; n < this.printers.length; n++) {
-      Util.spawn(['cancel', '-a', this.printers[n]]);
-    }
-  },
+    onCancelAllJobsClicked: function() {
+        for(var n = 0; n < this.printers.length; n++) {
+            Util.spawn(['cancel', '-a', this.printers[n]]);
+        }
+    },
 
-  onCancelJobClicked: function(item) {
-    Util.spawn(['cancel', item.job]);
-  },
+    onCancelJobClicked: function(item) {
+        Util.spawn(['cancel', item.job]);
+    },
 
-  onSendToFrontClicked: function(item) {
-    Util.spawn(['lp', '-i', item.job, '-q 100']);
-  },
+    onSendToFrontClicked: function(item) {
+        Util.spawn(['lp', '-i', item.job, '-q 100']);
+    },
 
-  update: function() {
-    if(this.updating || this.menu.isOpen) return;
-    this.updating = true;
-    this.jobsCount = 0;
-    this.printersCount = 0;
-    this.menu.removeAll();
-    let printers = new PopupMenu.PopupIconMenuItem(_('Printers'), 'printer-printing', this.iconType);
-    printers.connect('activate', Lang.bind(this, this.onShowPrintersClicked));
-    this.menu.addMenuItem(printers);
-    this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem);
+    update: async function() {
+        if(this.updating || this.menu.isOpen) return;
+        this.updating = true;
+        this.jobsCount = 0;
+        this.printersCount = 0;
+        this.menu.removeAll();
+        let printers = new PopupMenu.PopupIconMenuItem(_('Printers'), 'printer-printing', this.iconType);
+        printers.connect('activate', this.onShowPrintersClicked.bind(this));
+        this.menu.addMenuItem(printers);
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem);
 //Add Printers
-    Util.spawn_async(['python', APPLET_PATH + '/lpstat-a.py'], Lang.bind(this, function(out) {
-      this.printers = [];
-      Util.spawn_async(['/usr/bin/lpstat', '-d'], Lang.bind(this, function(out2) {//To check default printer
-        if(out2.split(': ')[1] != undefined) out2 = out2.split(': ')[1].trim();
-        else out2 = 'no default';
-        out = out.split('\n');
-        this.printersCount = out.length - 2;
+        let p_list = await exec_async(['/usr/bin/lpstat', '-a']);
+        this.printers = [];
+        let p_default = await exec_async(['/usr/bin/lpstat', '-d']);//----------------------------------
+        if(p_default.split(': ')[1] != undefined) p_default = p_default.split(': ')[1].trim();
+        else p_default = 'no default';
+        p_list = p_list.split('\n');
+        this.printersCount = p_list.length - 2;
         for(var n = 0; n < this.printersCount; n++) {
-          let printer = out[n].split(' ')[0].trim();
-          this.printers.push(printer);
-          let printerItem = new PopupMenu.PopupIconMenuItem(printer, 'emblem-documents', this.iconType);
-          if(out2.toString() == printer.toString()) printerItem.addActor(new St.Icon({ style_class: 'popup-menu-icon',icon_name: 'emblem-default', icon_type: this.iconType }));
-          printerItem.connect('activate', Lang.bind(printerItem, this.onShowJobsClicked));
-          this.menu.addMenuItem(printerItem);
+            let printer = p_list[n].split(' ')[0].trim();
+            this.printers.push(printer);
+            let printerItem = new PopupMenu.PopupIconMenuItem(printer, 'emblem-documents', this.iconType);
+            if(p_default.toString() == printer.toString()) printerItem.addActor(new St.Icon({ style_class: 'popup-menu-icon',icon_name: 'emblem-default', icon_type: this.iconType }));
+            printerItem.connect('activate', this.onShowJobsClicked.bind(printerItem));
+            this.menu.addMenuItem(printerItem);
         }
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem);
 //Add Jobs
-        Util.spawn_async(['/usr/bin/lpstat', '-o'], Lang.bind(this, function(out) {
+        let p_jobs = await exec_async(['/usr/bin/lpstat', '-o']);
 //Cancel all Jobs
-          if(out.length > 0) {
+        if(p_jobs.length > 0) {
             let cancelAll = new PopupMenu.PopupIconMenuItem(_('Cancel all jobs'), 'edit-delete', this.iconType);
-            cancelAll.connect('activate', Lang.bind(this, this.onCancelAllJobsClicked));
+            cancelAll.connect('activate', this.onCancelAllJobsClicked.bind(this));
             this.menu.addMenuItem(cancelAll);
 
             let _cancelSubMenu = new PopupMenu.PopupSubMenuMenuItem(null);
             _cancelSubMenu.actor.set_style_class_name('');
             this.cancelSubMenu = _cancelSubMenu.menu;
             this.menu.addMenuItem(_cancelSubMenu);
-          }
+        }
 //Cancel Job
-          out = out.split(/\n/);
-          this.jobsCount = out.length - 1;
-          Util.spawn_async(['/usr/bin/lpq', '-a'], Lang.bind(this, function(out2) {
-            out2 = out2.replace(/\n/g, ' ').split(/\s+/);
-            let sendJobs = [];
-            for(var n = 0; n < out.length - 1; n++) {
-              let line = out[n].split(' ')[0].split('-');
-              let job = line.slice(-1)[0];
-              let printer = line.slice(0, -1).join('-');
-              let doc = out2[out2.indexOf(job) + 1];
-              for(var m = out2.indexOf(job) + 2; m < out2.length - 1; m++) {
-                if(isNaN(out2[m]) || out2[m + 1] != 'bytes') doc = doc + ' ' + out2[m];
+        p_jobs = p_jobs.split(/\n/);
+        this.jobsCount = p_jobs.length - 1;
+        let p_jobs2 = await exec_async(['/usr/bin/lpq', '-a']);
+        p_jobs2 = p_jobs2.replace(/\n/g, ' ').split(/\s+/);
+        let sendJobs = [];
+        for(var n = 0; n < p_jobs.length - 1; n++) {
+            let line = p_jobs[n].split(' ')[0].split('-');
+            let job = line.slice(-1)[0];
+            let printer = line.slice(0, -1).join('-');
+            let doc = p_jobs2[p_jobs2.indexOf(job) + 1];
+            for(var m = p_jobs2.indexOf(job) + 2; m < p_jobs2.length - 1; m++) {
+                if(isNaN(p_jobs2[m]) || p_jobs2[m + 1] != 'bytes') doc = doc + ' ' + p_jobs2[m];
                 else break;
-              }
-              if(doc.length > 30) doc = doc + '...';
-              let text = doc;
-              if(this.job_number) text += ' (' + job + ')';
-              text += ' ' + _('at') + ' ' + printer;
-              let jobItem = new PopupMenu.PopupIconMenuItem(text, 'edit-delete', this.iconType);
-              if(out2[out2.indexOf(job) - 2] == 'active') jobItem.addActor(new St.Icon({ style_class: 'popup-menu-icon',icon_name: 'emblem-default', icon_type: this.iconType }));
-              jobItem.job = job;
-              jobItem.connect('activate', Lang.bind(jobItem, this.onCancelJobClicked));
-              this.cancelSubMenu.addMenuItem(jobItem);
-              if(this.send_to_front && out2[out2.indexOf(job) - 2] != 'active' && out2[out2.indexOf(job) - 2] != '1st') {
+            }
+            if(doc.length > 30) doc = doc + '...';
+            let text = doc;
+            if(this.job_number) text += ' (' + job + ')';
+            text += ' ' + _('at') + ' ' + printer;
+            let jobItem = new PopupMenu.PopupIconMenuItem(text, 'edit-delete', this.iconType);
+            if(p_jobs2[p_jobs2.indexOf(job) - 2] == 'active') jobItem.addActor(new St.Icon({ style_class: 'popup-menu-icon',icon_name: 'emblem-default', icon_type: this.iconType }));
+            jobItem.job = job;
+            jobItem.connect('activate', this.onCancelJobClicked.bind(jobItem));
+            this.cancelSubMenu.addMenuItem(jobItem);
+            if(this.send_to_front && p_jobs2[p_jobs2.indexOf(job) - 2] != 'active' && p_jobs2[p_jobs2.indexOf(job) - 2] != '1st') {
                 sendJobs.push(new PopupMenu.PopupIconMenuItem(text, 'go-up', this.iconType));
                 sendJobs[sendJobs.length - 1].job = job;
-                sendJobs[sendJobs.length - 1].connect('activate', Lang.bind(sendJobs[sendJobs.length - 1], this.onSendToFrontClicked));
-              }
+                sendJobs[sendJobs.length - 1].connect('activate', this.onSendToFrontClicked.bind(sendJobs[sendJobs.length - 1]));
             }
+        }
 //Send to Front
-            if(this.send_to_front && sendJobs.length > 0) {
-              let _sendSubMenu = new PopupMenu.PopupSubMenuMenuItem(_('Send to front'));
-              this.sendSubMenu =_sendSubMenu.menu;
-              for(var n = 0; n < sendJobs.length; n++) this.sendSubMenu.addMenuItem(sendJobs[n]);
-              this.menu.addMenuItem(_sendSubMenu);
-            }
-            this.updating = false;
-            if(this.cancelSubMenu != null) this.cancelSubMenu.open();
-            if(this.showLater) {
-              this.showLater = false;
-              this.menu.open();
-            }
+        if(this.send_to_front && sendJobs.length > 0) {
+            let _sendSubMenu = new PopupMenu.PopupSubMenuMenuItem(_('Send to front'));
+            this.sendSubMenu =_sendSubMenu.menu;
+            for(var n = 0; n < sendJobs.length; n++) this.sendSubMenu.addMenuItem(sendJobs[n]);
+            this.menu.addMenuItem(_sendSubMenu);
+        }
+        this.updating = false;
+        if(this.cancelSubMenu != null) this.cancelSubMenu.open();
+        if(this.showLater) {
+            this.showLater = false;
+            this.menu.open();
+        }
 //Update Icon
-            if(this.jobsCount > 0 && this.show_jobs) this.set_applet_label(this.jobsCount.toString());
-            else this.set_applet_label('');
-            this.set_applet_enabled(this.show_icon == 'always' || (this.show_icon == 'printers' && this.printersCount > 0) || (this.show_icon == 'jobs' && this.jobsCount > 0));
-            Util.spawn_async(['/usr/bin/lpstat', '-l'], Lang.bind(this, function(out) {
-              this.printError = out.indexOf('Unable') >= 0 || out.indexOf(' not ') >= 0 || out.indexOf(' failed') >= 0;
-              if(this.printWarning) this.setIcon('printer-warning');
-              else if(this.show_error && this.printError) this.setIcon('printer-error');
-              else this.setIcon('printer-printing');
-            }));
-          }))
-        }))
-      }))
-    }))
-  }
+        if(this.jobsCount > 0 && this.show_jobs) this.set_applet_label(this.jobsCount.toString());
+        else this.set_applet_label('');
+        this.set_applet_enabled(this.show_icon == 'always' || (this.show_icon == 'printers' && this.printersCount > 0) || (this.show_icon == 'jobs' && this.jobsCount > 0));
+        let p_error = await exec_async(['/usr/bin/lpstat', '-l']);
+        this.printError = p_error.indexOf('Unable') >= 0 || p_error.indexOf(' not ') >= 0 || p_error.indexOf(' failed') >= 0;
+        if(this.printWarning) this.setIcon('printer-warning');
+        else if(this.show_error && this.printError) this.setIcon('printer-error');
+        else this.setIcon('printer-printing');
+    }
 };
 
 function main(metadata, orientation, panel_height, instance_id) {
-  let myApplet = new MyApplet(metadata, orientation, panel_height, instance_id);
-  return myApplet;
+    let myApplet = new MyApplet(metadata, orientation, panel_height, instance_id);
+    return myApplet;
 }

--- a/printers@linux-man/files/printers@linux-man/lpstat-a.py
+++ b/printers@linux-man/files/printers@linux-man/lpstat-a.py
@@ -1,7 +1,0 @@
-import subprocess
-
-try:
-    print subprocess.check_output(['/usr/bin/lpstat', '-a'])
-except subprocess.CalledProcessError, e:
-    print ""
-

--- a/printers@linux-man/files/printers@linux-man/metadata.json
+++ b/printers@linux-man/files/printers@linux-man/metadata.json
@@ -4,6 +4,6 @@
     "contributors": "Caldas Lopes",
     "max-instances": "-1",
     "uuid": "printers@linux-man",
-    "version": "1.0",
+    "version": "2.0",
     "name": "Printers"
 }


### PR DESCRIPTION
Drop lang and mainloop libs.
Replace callbacks with async/await methods.
Replace spaw_async with Gio.subprocess.
As a side-effect, lpstat-a.py is not needed anymore.
Tested on Mint 19.0 and 20.3.
