### PR TITLE
clean-show-desktop@filipetorresbr: Made the applet look more like Windows 10

### DIFF
--- a/clean-show-desktop@filipetorresbr/files/clean-show-desktop@filipetorresbr/applet.js
+++ b/clean-show-desktop@filipetorresbr/files/clean-show-desktop@filipetorresbr/applet.js
@@ -32,6 +32,7 @@ class CleanShowDesktop extends Applet.IconApplet {
         this.settings.bind("on-hover-background", "hoverbackground");
         this.settings.bind("on-hover-border", "hoverborder");
         this.settings.bind("border-width", "borderwidth");
+        this.settings.bind("margin", "margin");
         this.settings.bind("custom-color", "custom_color");
         this.actor.track_hover = true;
         this.signals = new SignalManager.SignalManager(null);
@@ -63,20 +64,20 @@ class CleanShowDesktop extends Applet.IconApplet {
     fillcolor(state){
 	  	if (this.custom_color == true) {
 	  		if (state == "hover") {
-        		const STYLE = "padding: " + this.width + "px;background: " + this.hoverbackground + ";border-color: " + this.hoverborder +  ";border-width: " + this.borderwidth + "px;";
+        		const STYLE = "padding: " + this.width + "px;background: " + this.hoverbackground + ";border-color: " + this.hoverborder +  ";border-left: " + this.borderwidth + "px;" + "margin-left: " + this.margin + "px";
         		this.actor.set_style(STYLE);
 
 	  		}else{
-        	   	const STYLE = "padding: " + this.width + "px;background: " + this.background + ";border-color: " + this.border +  ";border-width: " + this.borderwidth + "px;";
+        	   	const STYLE = "padding: " + this.width + "px;background: " + this.background + ";border-color: " + this.border +  ";border-left: " + this.borderwidth + "px;" + "margin-left: " + this.margin + "px";
 	        	this.actor.set_style(STYLE);		
 	  		}	
     	}else{
 	  		if (state == "hover") {
-        		const STYLE = "padding: " + this.width + "px;background: " + this.color + ", 1);border-color: " + this.color +  ", 1);border-width: " + this.borderwidth + "px;";
+        		const STYLE = "padding: " + this.width + "px;background: " + this.color + ", 1);border-color: " + this.color +  ", 1);border-left: " + this.borderwidth + "px;" + "margin-left: " + this.margin + "px";
         		this.actor.set_style(STYLE);
 
 	  		}else{
-        	   	const STYLE = "padding: " + this.width + "px;background: " + this.color + ", 0.5);border-color: " + this.color +  ", 1);border-width: " + this.borderwidth + "px;";
+        	   	const STYLE = "padding: " + this.width + "px;background: " + this.color + ", 0.5);border-color: " + this.color +  ", 1);border-left: " + this.borderwidth + "px;" + "margin-left: " + this.margin + "px";
 	        	this.actor.set_style(STYLE);
 	  		}	
     	}

--- a/clean-show-desktop@filipetorresbr/files/clean-show-desktop@filipetorresbr/settings-schema.json
+++ b/clean-show-desktop@filipetorresbr/files/clean-show-desktop@filipetorresbr/settings-schema.json
@@ -58,6 +58,16 @@
     "description" : "Border width",
     "tooltip" : "Select the border width"
  },
+  "margin": {
+    "type": "scale",
+    "default" : 0,
+    "min" : 0,
+    "max" : 10,
+    "step" : 1,
+    "units" : "pixels",
+    "description" : "Margin",
+    "tooltip" : "Select the margin"
+ },
   "custom-color":{
     "type" : "switch",
     "default" : "false",


### PR DESCRIPTION
Made the border to be left-only, and added an option for left-margin
it looks better if it's on the right side, but I'm sure that's where most people who come from windows are going to put it anyway