### PR TITLE
[Cinnamenu@json] Favicons, web history search and search prefixes.

### DIFF
--- a/Cinnamenu@json/README.md
+++ b/Cinnamenu@json/README.md
@@ -15,4 +15,5 @@ Cinnamenu is a full featured alternative to the standard Cinnamon menu with grid
    * Change icon sizes.
  * Key navigation.
  * Built in calculator: (including constants and functions: E, PI, abs, acos, acosh, asin, asinh, atan, atanh, cbrt, ceil, cos, cosh, exp, floor, log, max, min, pow, random, round, sign, sin, sinh, sqrt, tan, tanh and trunc. All angles are in radians.)
+ * Browser bookmarks search
  * Wikipedia search.

--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/appsview.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/appsview.js
@@ -23,13 +23,13 @@ class AppButton {
         //----------ICON---------------------------------------------
         if (this.app.icon) { //isSearchResult(excl. emoji), isClearRecentsButton, isBackButton
             this.icon = this.app.icon;
-        } else if (this.app.iconFilename) { //some of isWebBookmark
-            const gicon = new Gio.FileIcon({file: Gio.file_new_for_path(this.app.iconFilename)});
+        } else if (this.app.icon_filename) { //some of isSearchResult
+            const gicon = new Gio.FileIcon({file: Gio.file_new_for_path(this.app.icon_filename)});
             this.icon = new St.Icon({ gicon: gicon, icon_size: this.appThis.getAppIconSize()});
-        } else if (this.app.gicon) { //isRecentFile, isFavoriteFile, some of isWebBookmark,
-                                    //isFolderviewFile/Directory, isSearchResult(wikipedia)
+        } else if (this.app.gicon) { //isRecentFile, isFavoriteFile,
+                                    //isFolderviewFile/Directory, some of isSearchResult
             let gicon = this.app.gicon;
-            if (!this.app.isWebBookmark && !this.app.isSearchResult) {
+            if (!this.app.isSearchResult) {
                 gicon = getThumbnail_gicon(this.app.uri, this.app.mimeType) || gicon;
             }
             this.icon = new St.Icon({ gicon: gicon, icon_size: this.appThis.getAppIconSize()});
@@ -296,12 +296,6 @@ class AppButton {
             this.appThis.recentApps.add(this.app.id);
             this.app.open_new_window(-1);
             this.appThis.menu.close();
-        } else if (this.app.isPlace) {
-            this.app.launch();
-            this.appThis.menu.close();
-        } else if (this.app.isWebBookmark) {
-            this.app.app.launch_uris([this.app.uri], null);
-            this.appThis.menu.close();
         } else if (this.app.isFolderviewDirectory || this.app.isBackButton) {
             this.appThis.setActiveCategory(Gio.File.new_for_uri(this.app.uri).get_path());
             //don't menu.close()
@@ -318,7 +312,7 @@ class AppButton {
             this.appThis.recentManagerDefault.purge_items();
             this.appThis.setActiveCategory('recents');
             //don't menu.close
-        } else if (this.app.isSearchResult) {
+        } else if (this.app.isSearchResult || this.app.isPlace) {
             this.app.activate(this.app);
             this.appThis.menu.close();
         }

--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/appsview.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/appsview.js
@@ -23,7 +23,10 @@ class AppButton {
         //----------ICON---------------------------------------------
         if (this.app.icon) { //isSearchResult(excl. emoji), isClearRecentsButton, isBackButton
             this.icon = this.app.icon;
-        } else if (this.app.gicon) { //isRecentFile, isFavoriteFile, isWebBookmark,
+        } else if (this.app.iconFilename) { //some of isWebBookmark
+            const gicon = new Gio.FileIcon({file: Gio.file_new_for_path(this.app.iconFilename)});
+            this.icon = new St.Icon({ gicon: gicon, icon_size: this.appThis.getAppIconSize()});
+        } else if (this.app.gicon) { //isRecentFile, isFavoriteFile, some of isWebBookmark,
                                     //isFolderviewFile/Directory, isSearchResult(wikipedia)
             let gicon = this.app.gicon;
             if (!this.app.isWebBookmark && !this.app.isSearchResult) {

--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/browserBookmarks.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/browserBookmarks.js
@@ -169,29 +169,26 @@ const readChromiumBookmarks = function(path, wmClass) {
 
     return new Promise(function(resolve, reject) {
         const appSystem = Cinnamon.AppSystem.get_default();
-        let foundBookmarks = [];
+        const foundBookmarks = [];
 
-        let foundApps = appSystem.lookup_desktop_wmclass(path[0]);
+        const foundApps = appSystem.lookup_desktop_wmclass(wmClass);
         if (!foundApps || foundApps.length === 0) {
-            foundApps = appSystem.lookup_desktop_wmclass(wmClass);
-            if (!foundApps || foundApps.length === 0) {
-                resolve(foundBookmarks);
-                return;
-            }
+            resolve([]);
+            return;
         }
+        global.log(wmClass);
+        const appInfo = foundApps.get_app_info();
 
-        let appInfo = foundApps.get_app_info();
-        let bookmarksFile = Gio.File.new_for_path(GLib.build_filenamev(
+        const bookmarksFile = Gio.File.new_for_path(GLib.build_filenamev(
                                         [GLib.get_user_config_dir(), ...path, 'Bookmarks']));
-
         if (!bookmarksFile.query_exists(null)) {
-            resolve(foundBookmarks);
+            resolve([]);
             return;
         }
 
         readJSONAsync(bookmarksFile).then(function(jsonResult) {
             if (!jsonResult.hasOwnProperty('roots')) {
-                resolve(foundBookmarks);
+                resolve([]);
                 return;
             }
 
@@ -248,7 +245,7 @@ class BookmarksManager {
         this.bookmarks = [];
 
         Promise.all([
-            readChromiumBookmarks(['chromium', 'Default'], 'chromium-browser'),
+            readChromiumBookmarks(['chromium', 'Default'], 'chromium'),
             readChromiumBookmarks(['google-chrome', 'Default'], 'google-chrome'),
             readChromiumBookmarks(['opera'], 'opera'),
             readChromiumBookmarks(['vivaldi', 'Default'], 'vivaldi-stable'),
@@ -263,7 +260,6 @@ class BookmarksManager {
                 if (!bookmark.icon_filename){
                     bookmark.gicon = bookmark.app.get_icon();
                 }
-                //bookmarks.mime = null;
                 let desc = bookmark.uri;
                 if (desc.length > 150) {
                     desc = desc.slice(0, 150) + ' ...';

--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/browserBookmarks.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/browserBookmarks.js
@@ -168,7 +168,7 @@ function readFirefoxProfiles() {
 const readChromiumBookmarks = function(path, wmClass) {
 
     return new Promise(function(resolve, reject) {
-        let appSystem = Cinnamon.AppSystem.get_default();
+        const appSystem = Cinnamon.AppSystem.get_default();
         let foundBookmarks = [];
 
         let foundApps = appSystem.lookup_desktop_wmclass(path[0]);
@@ -176,6 +176,7 @@ const readChromiumBookmarks = function(path, wmClass) {
             foundApps = appSystem.lookup_desktop_wmclass(wmClass);
             if (!foundApps || foundApps.length === 0) {
                 resolve(foundBookmarks);
+                return;
             }
         }
 
@@ -185,11 +186,13 @@ const readChromiumBookmarks = function(path, wmClass) {
 
         if (!bookmarksFile.query_exists(null)) {
             resolve(foundBookmarks);
+            return;
         }
 
         readJSONAsync(bookmarksFile).then(function(jsonResult) {
             if (!jsonResult.hasOwnProperty('roots')) {
                 resolve(foundBookmarks);
+                return;
             }
 
             const recurseBookmarks = (children, cont) => {
@@ -229,12 +232,12 @@ const readChromiumBookmarks = function(path, wmClass) {
                 results = JSON.parse(results);
                 foundBookmarks.forEach( bookmark => {
                     if (bookmark.domain in results) {
-                        bookmark.iconFilename = results[bookmark.domain];
+                        bookmark.icon_filename = results[bookmark.domain];
                     }
                 });
                 resolve(foundBookmarks);
             });
-        }).catch(() => resolve(foundBookmarks));
+        });
     });
 };
 
@@ -257,7 +260,7 @@ class BookmarksManager {
             this.bookmarks = this.bookmarks.concat(readFirefoxProfiles());
 
             this.bookmarks.forEach( bookmark => {
-                if (!bookmark.iconFilename){
+                if (!bookmark.icon_filename){
                     bookmark.gicon = bookmark.app.get_icon();
                 }
                 //bookmarks.mime = null;
@@ -266,7 +269,9 @@ class BookmarksManager {
                     desc = desc.slice(0, 150) + ' ...';
                 }
                 bookmark.description = desc;
-                bookmark.isWebBookmark = true;
+                bookmark.isSearchResult = true;
+                bookmark.activate = () => Util.spawn(['xdg-open', bookmark.uri]);
+                //bookmark.activate = () => bookmak.app.launch_uris([bookmark.uri], null);
             });
 
             // Create a unique list of bookmarks across all browsers.

--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/browserBookmarks.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/browserBookmarks.js
@@ -25,6 +25,7 @@ const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const ByteArray = imports.byteArray;
 const Cinnamon = imports.gi.Cinnamon;
+const Util = imports.misc.util;
 
 let Gda = null;
 try {
@@ -164,54 +165,76 @@ function readFirefoxProfiles() {
     return [];
 }
 
-const readChromiumBookmarks = function(bookmarks, path, wmClass) {
+const readChromiumBookmarks = function(path, wmClass) {
 
     return new Promise(function(resolve, reject) {
         let appSystem = Cinnamon.AppSystem.get_default();
+        let foundBookmarks = [];
 
         let foundApps = appSystem.lookup_desktop_wmclass(path[0]);
         if (!foundApps || foundApps.length === 0) {
             foundApps = appSystem.lookup_desktop_wmclass(wmClass);
             if (!foundApps || foundApps.length === 0) {
-                resolve(bookmarks);
+                resolve(foundBookmarks);
             }
         }
 
         let appInfo = foundApps.get_app_info();
-        let bookmarksFile = Gio.File.new_for_path(GLib.build_filenamev([GLib.get_user_config_dir(), ...path]));
+        let bookmarksFile = Gio.File.new_for_path(GLib.build_filenamev(
+                                        [GLib.get_user_config_dir(), ...path, 'Bookmarks']));
 
         if (!bookmarksFile.query_exists(null)) {
-            resolve(bookmarks);
+            resolve(foundBookmarks);
         }
 
         readJSONAsync(bookmarksFile).then(function(jsonResult) {
             if (!jsonResult.hasOwnProperty('roots')) {
-                resolve(bookmarks);
+                resolve(foundBookmarks);
             }
 
-            let recurseBookmarks = (children, cont)=>{
-                for (let i = 0, len = children.length; i < len; i++) {
-                    if (children[i].type == 'url') {
-                        bookmarks.push({
+            const recurseBookmarks = (children, cont) => {
+                children.forEach( child => {
+                    if (child.type == 'url') {
+                        const url = child.url;
+                        const domain = url.slice(0, url.indexOf('/', url.indexOf('://') + 3));
+                        foundBookmarks.push({
                             app: appInfo,
-                            name: children[i].name,
-                            uri: children[i].url
+                            name: child.name,
+                            uri: url,
+                            domain: domain
                         });
-                    } else if (children[i].hasOwnProperty('children')) {
-                        recurseBookmarks(children[i].children);
+                    } else if (child.hasOwnProperty('children')) {
+                        recurseBookmarks(child.children);
                     }
-                }
+                });
             };
 
             for (let bookmarkLocation in jsonResult.roots) {
-                let children = jsonResult.roots[bookmarkLocation].children;
+                const children = jsonResult.roots[bookmarkLocation].children;
                 if (children === undefined) {
                     continue;
                 }
                 recurseBookmarks(children);
             }
-            resolve(bookmarks);
-        }).catch(() => resolve(bookmarks));
+
+            const faviconsFile = GLib.build_filenamev([GLib.get_user_config_dir(), ...path, 'Favicons']);
+            const domains = [];
+            foundBookmarks.forEach( bookmark => {
+                domains.push(bookmark.domain);
+            });
+            const domainsJSON = JSON.stringify(domains);
+
+            Util.spawn_async(['python', __meta.path + '/getFavicons.py', faviconsFile, domainsJSON],
+                                                                                            (results) => {
+                results = JSON.parse(results);
+                foundBookmarks.forEach( bookmark => {
+                    if (bookmark.domain in results) {
+                        bookmark.iconFilename = results[bookmark.domain];
+                    }
+                });
+                resolve(foundBookmarks);
+            });
+        }).catch(() => resolve(foundBookmarks));
     });
 };
 
@@ -219,40 +242,42 @@ const readChromiumBookmarks = function(bookmarks, path, wmClass) {
 
 class BookmarksManager {
     constructor() {
-        let bookmarks = [];
+        this.bookmarks = [];
 
         Promise.all([
-            readChromiumBookmarks(bookmarks, ['chromium', 'Default', 'Bookmarks'], 'chromium-browser'),
-            readChromiumBookmarks(bookmarks, ['google-chrome', 'Default', 'Bookmarks'], 'google-chrome'),
-            readChromiumBookmarks(bookmarks, ['opera', 'Bookmarks'], 'opera'),
-            readChromiumBookmarks(bookmarks, ['vivaldi', 'Default', 'Bookmarks'], 'vivaldi-stable'),
-            readChromiumBookmarks(bookmarks, ['BraveSoftware', 'Brave-Browser', 'Default', 'Bookmarks'],
-                                                                                            'brave-browser'),
-            readChromiumBookmarks(bookmarks, ['microsoft-edge', 'Default', 'Bookmarks'], 'microsoft-edge')
-        ]).then(() => {
-            bookmarks = bookmarks.concat(readFirefoxProfiles());
+            readChromiumBookmarks(['chromium', 'Default'], 'chromium-browser'),
+            readChromiumBookmarks(['google-chrome', 'Default'], 'google-chrome'),
+            readChromiumBookmarks(['opera'], 'opera'),
+            readChromiumBookmarks(['vivaldi', 'Default'], 'vivaldi-stable'),
+            readChromiumBookmarks(['BraveSoftware', 'Brave-Browser', 'Default'], 'brave-browser'),
+            readChromiumBookmarks(['microsoft-edge', 'Default'], 'microsoft-edge')
+        ]).then((results) => {
+            results.forEach( result => this.bookmarks = this.bookmarks.concat(result));
 
-            for (let i = 0, len = bookmarks.length; i < len; i++) {
-                bookmarks[i].gicon = bookmarks[i].app.get_icon();
-                //bookmarks[i].mime = null;
-                bookmarks[i].description = bookmarks[i].uri;
-                bookmarks[i].isWebBookmark = true;
-            }
+            this.bookmarks = this.bookmarks.concat(readFirefoxProfiles());
+
+            this.bookmarks.forEach( bookmark => {
+                if (!bookmark.iconFilename){
+                    bookmark.gicon = bookmark.app.get_icon();
+                }
+                //bookmarks.mime = null;
+                let desc = bookmark.uri;
+                if (desc.length > 150) {
+                    desc = desc.slice(0, 150) + ' ...';
+                }
+                bookmark.description = desc;
+                bookmark.isWebBookmark = true;
+            });
 
             // Create a unique list of bookmarks across all browsers.
             const bm = {};
-            for (let i = 0, len = bookmarks.length; i < len; i++ ) {
-                bm[bookmarks[i].uri] = bookmarks[i];
-            }
-            const bmKeys = Object.keys(bm);
-            this.state = [];
-            for (let i = 0; i < bmKeys.length; i++ ) {
-                if (bm[bmKeys[i]]) {
-                    this.state.push(bm[bmKeys[i]]);
-                }
-            }
-            this.state.sort( (a, b) => { return (a.name.toUpperCase() > b.name.toUpperCase()) ?
-                                            1 : (a.name.toUpperCase() < b.name.toUpperCase()) ? -1 : 0;  });
+            this.bookmarks.forEach( bookmark => bm[bookmark.uri] = bookmark );
+            this.bookmarks = [];
+            Object.keys(bm).forEach( key => this.bookmarks.push(bm[key]) );
+
+            this.bookmarks.sort( (a, b) => { return (a.name.toUpperCase() > b.name.toUpperCase()) ?
+                                                1 : (a.name.toUpperCase() < b.name.toUpperCase()) ? -1 : 0;  });
+
         }).catch((e) => global.log(e.message, e.stack));
     }
 }

--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/browserHistory.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/browserHistory.js
@@ -9,13 +9,10 @@ function search_browser(path, wmClass, pattern) {
     current_pattern = pattern;
     return new Promise(function(resolve, reject) {
         const appSystem = Cinnamon.AppSystem.get_default();
-        let foundApps = appSystem.lookup_desktop_wmclass(path[0]);
+        const foundApps = appSystem.lookup_desktop_wmclass(wmClass);
         if (!foundApps || foundApps.length === 0) {
-            foundApps = appSystem.lookup_desktop_wmclass(wmClass);
-            if (!foundApps || foundApps.length === 0) {
-                resolve([]);
-                return;
-            }
+            resolve([]);
+            return;
         }
         const appInfo = foundApps.get_app_info();
 
@@ -35,9 +32,6 @@ function search_browser(path, wmClass, pattern) {
                 resolve(results);
             }
         });
-    }).catch((e) => {
-        global.log('caught error:',e.message, e.stack);
-        resolve([]);
     });
 }
 

--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/getFavicons.py
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/getFavicons.py
@@ -1,5 +1,5 @@
 #! /usr/bin/python3
-# -*- coding=utf-8 -*-
+
 
 import os
 import sys
@@ -8,14 +8,17 @@ import shutil
 import sqlite3
 import json
 import urllib.parse
-#import subprocess
 
 FAVICON_CACHE_DIR = os.path.join(os.path.split(__file__)[0], "../favicon_cache")
 
+# Params: sqlite_file: path to Favicons file from which to extract favicons
+#        domains_list: list of domains to find favicons for eg. ["https://google.com","http:/..."]
+# return: domains with a path to icon eg. {"https://google.com": "/home/USER/.local/share/cinnamon/applets/Cinnamen@json/favicons_cache/google.com", "https://...": "..."}
 def get_favicons(sqlite_file, domains_list):
     if not os.path.exists(FAVICON_CACHE_DIR):
         os.mkdir(FAVICON_CACHE_DIR)
 
+    #make temp copy of Favicons file as orignal may be locked.
     fd, temp_filename = tempfile.mkstemp()
     os.close(fd)
     shutil.copyfile(sqlite_file, temp_filename)
@@ -26,6 +29,7 @@ def get_favicons(sqlite_file, domains_list):
     domains_to_favicons = {}
     for domain in domains_list:
         cur.execute("SELECT id, url FROM favicons WHERE url LIKE ?", [domain + "%"])
+
         for favicon_id, url in cur.fetchall():
             url_parsed = urllib.parse.urlparse(domain)
             netloc = url_parsed.netloc
@@ -33,6 +37,8 @@ def get_favicons(sqlite_file, domains_list):
             if not os.path.exists(filename):
                 cur2 = conn.cursor()
                 cur2.execute("SELECT icon_id, image_data FROM favicon_bitmaps WHERE icon_id = ?", (favicon_id, ))
+                #There are usually 2 results, a 16px and a 32px PNG with the 32px being the second result.
+                #Save both to same filename so that the 32px overwrites the 16px
                 for icon_id, image_data in cur2.fetchall():
                     image_file = open(filename, "w+b")
                     image_file.write(image_data)
@@ -50,4 +56,5 @@ if __name__ == "__main__":
         sqlite_file = sys.argv[1]
         domains_json = sys.argv[2]
         domains_list = json.loads(domains_json)
-        print(json.dumps(get_favicons(sqlite_file, domains_list)))
+        results = get_favicons(sqlite_file, domains_list)
+        print(json.dumps(results))

--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/getFavicons.py
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/getFavicons.py
@@ -1,0 +1,53 @@
+#! /usr/bin/python3
+# -*- coding=utf-8 -*-
+
+import os
+import sys
+import tempfile
+import shutil
+import sqlite3
+import json
+import urllib.parse
+#import subprocess
+
+FAVICON_CACHE_DIR = os.path.join(os.path.split(__file__)[0], "../favicon_cache")
+
+def get_favicons(sqlite_file, domains_list):
+    if not os.path.exists(FAVICON_CACHE_DIR):
+        os.mkdir(FAVICON_CACHE_DIR)
+
+    fd, temp_filename = tempfile.mkstemp()
+    os.close(fd)
+    shutil.copyfile(sqlite_file, temp_filename)
+
+    conn = sqlite3.Connection(temp_filename)
+    cur = conn.cursor()
+
+    domains_to_favicons = {}
+    for domain in domains_list:
+        cur.execute("SELECT id, url FROM favicons WHERE url LIKE ?", [domain + "%"])
+        for favicon_id, url in cur.fetchall():
+            url_parsed = urllib.parse.urlparse(domain)
+            netloc = url_parsed.netloc
+            filename = os.path.join(FAVICON_CACHE_DIR, netloc)
+            if not os.path.exists(filename):
+                cur2 = conn.cursor()
+                cur2.execute("SELECT icon_id, image_data FROM favicon_bitmaps WHERE icon_id = ?", (favicon_id, ))
+                for icon_id, image_data in cur2.fetchall():
+                    image_file = open(filename, "w+b")
+                    image_file.write(image_data)
+                cur2.close()
+            if os.path.exists(filename):
+                domains_to_favicons[domain] = filename
+
+    cur.close()
+    os.unlink(temp_filename)
+
+    return domains_to_favicons
+
+if __name__ == "__main__":
+    if len(sys.argv) > 2:
+        sqlite_file = sys.argv[1]
+        domains_json = sys.argv[2]
+        domains_list = json.loads(domains_json)
+        print(json.dumps(get_favicons(sqlite_file, domains_list)))

--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/searchHistory.py
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/searchHistory.py
@@ -1,0 +1,68 @@
+#! /usr/bin/python3
+# -*- coding=utf-8 -*-
+
+import os
+import sys
+import tempfile
+import shutil
+import sqlite3
+import json
+import urllib.parse
+import subprocess
+import getFavicons
+
+if __name__ == "__main__":
+    if len(sys.argv) > 2:
+        try:
+            path = sys.argv[1]
+            fd, temp_filename = tempfile.mkstemp()
+            os.close(fd)
+            shutil.copyfile(os.path.join(path, "History"), temp_filename)
+
+            conn = sqlite3.Connection(temp_filename)
+            cur = conn.cursor()
+
+            words = []
+            for i in sys.argv[2:]:
+                words += i.split()
+            query = "SELECT url, title FROM urls WHERE " + \
+                            " AND ".join(len(words) * ["(url LIKE ? OR title LIKE ?)"]) + \
+                                " ORDER BY last_visit_time DESC, visit_count DESC LIMIT 10"
+            params = []
+            for word in words:
+                params.append("%" + word + "%")
+                params.append("%" + word + "%")
+            cur.execute(query, tuple(params))
+
+            results = []
+            domains_list = []
+            for url, title in cur.fetchall():
+                url_parsed = urllib.parse.urlparse(url)
+                domain = url_parsed.scheme + '://' + url_parsed.netloc
+                if not domain in domains_list:
+                    domains_list.append(domain)
+                if url and title:
+                    desc = url
+                    if len(url) > 150:
+                        desc = url[:150] + ' ...';
+                    results.append({
+                        "id": url,
+                        "uri": url,
+                        "domain": domain,
+                        "description": desc,
+                        "name": title
+                    })
+
+            cur.close()
+            os.unlink(temp_filename)
+
+            favicons_file = os.path.join(path, "Favicons")
+            domains_to_favicons = getFavicons.get_favicons(favicons_file, domains_list)
+
+            for i in range(len(results)):
+                if results[i]['domain'] in domains_to_favicons:
+                    results[i]['icon_filename'] = domains_to_favicons[results[i]['domain']]
+
+            print(json.dumps(results))
+        except:
+            print(json.dumps([]))

--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/settings-schema.json
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/settings-schema.json
@@ -87,9 +87,11 @@
                 "enable-emoji-search",
                 "web-search-option",
                 "enable-home-folder-search",
+                "enable-web-history-search",
                 "enable-web-bookmarks-search",
                 "enable-wikipedia-search",
-                "wikipedia-language"
+                "wikipedia-language",
+                "search-help"
             ]
         },
         "panel-appear":{
@@ -299,6 +301,12 @@
         "description":"Search home folder",
         "tooltip":"When searching, also search my home folder for files"
     },
+    "enable-web-history-search":{
+        "type":"checkbox",
+        "default":false,
+        "description":"Web history search",
+        "tooltip":"When searching, also search my browser's history (Google Chrome, Chromium, Opera, Vivaldi, Brave)\nNote: Firefox history is not currently supported."
+    },
     "enable-web-bookmarks-search":{
         "type":"checkbox",
         "default":false,
@@ -389,6 +397,10 @@
             "မြန်မာဘာသာ":"my"
         },
         "tooltip":"Wikipedia language"
+    },
+    "search-help":{
+        "type":"label",
+        "description":"\nNote: Some search options can still be used even if you have not enabled them here by prefixing your search term.\nFor example: to search for an emoji, type 'e heart' to find heart emojis. Likewise, use prefixes 'f ' for file search, 'h ' for web history and 'b ' for web bookmarks search.\n"
     },
 
     "menu-icon-custom":{

--- a/Cinnamenu@json/files/Cinnamenu@json/4.0/utils.js
+++ b/Cinnamenu@json/files/Cinnamenu@json/4.0/utils.js
@@ -17,7 +17,7 @@ function _(str) {
     return Gettext.dgettext('Cinnamenu@json', str);
 }
 
-const wordWrap = text => text.match( /.{1,80}(\s|$|-|=|\+)|\S+?(\s|$|-|=|\+)/g ).join('\n');
+const wordWrap = text => text.match( /.{1,80}(\s|$|-|=|\+|_|&|\\)|\S+?(\s|$|-|=|\+|_|&|\\)/g ).join('\n');
 
 //===========================================================
 
@@ -94,7 +94,7 @@ class NewTooltip {
 
     show() {
         this.showTimer = null;
-        
+
         this.tooltip = new St.Label({
             name: 'Tooltip'
         });

--- a/Cinnamenu@json/files/Cinnamenu@json/metadata.json
+++ b/Cinnamenu@json/files/Cinnamenu@json/metadata.json
@@ -3,7 +3,7 @@
     "name": "Cinnamenu",
     "description": "A flexible menu with grid or list layout options, file browser and emoji search.",
     "max-instances": 2,
-    "version": "4.15.3",
+    "version": "4.15.4",
     "multiversion": true,
     "website": "https://github.com/linuxmint/cinnamon-spices-applets",
     "cinnamon-version": [

--- a/Cinnamenu@json/files/Cinnamenu@json/po/Cinnamenu.pot
+++ b/Cinnamenu@json/files/Cinnamenu@json/po/Cinnamenu.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-26 15:40+0000\n"
+"POT-Creation-Date: 2022-03-16 02:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -141,6 +141,15 @@ msgid "Applications and files"
 msgstr ""
 
 msgid "Other search results"
+msgstr ""
+
+msgid "Browser history"
+msgstr ""
+
+msgid "Browser bookmarks"
+msgstr ""
+
+msgid "Emoji"
 msgstr ""
 
 msgid "Trash"
@@ -528,6 +537,14 @@ msgstr ""
 msgid "When searching, also search my home folder for files"
 msgstr ""
 
+msgid "Web history search"
+msgstr ""
+
+msgid ""
+"When searching, also search my browser's history (Google Chrome, Chromium, Opera, Vivaldi, Brave)\n"
+"Note: Firefox history is not currently supported."
+msgstr ""
+
 msgid "Web bookmarks search"
 msgstr ""
 
@@ -543,6 +560,12 @@ msgid "Show some Wikipedia results"
 msgstr ""
 
 msgid "Wikipedia language"
+msgstr ""
+
+msgid ""
+"\n"
+"Note: Some search options can still be used even if you have not enabled them here by prefixing your search term.\n"
+"For example: to search for an emoji, type 'e heart' to find heart emojis. Likewise, use prefixes 'f ' for file search, 'h ' for web history and 'b ' for web bookmarks search.\n"
 msgstr ""
 
 msgid "Use a custom icon size"


### PR DESCRIPTION
Show favicons in browser search results.
Add browser history search.
Use search prefixes for unenabled search options. (Thanks to @McBruno712 & @quadransmuralis for the suggestion)
Limit number of some search results.
Horizontally center menu when in center zone of panel. fixes #4256