### PR TITLE
cheaty@centurix: Add keybinding for showing the cheaty menu

### DIFF
--- a/cheaty@centurix/files/cheaty@centurix/applet.js
+++ b/cheaty@centurix/files/cheaty@centurix/applet.js
@@ -142,6 +142,7 @@ DescriptionMenuItem.prototype =
 
 
 function Cheaty(metadata, orientation, panelHeight, instanceId) {
+	this.instance_id = instanceId;
 	this.settings = new Settings.AppletSettings(this, UUID, instanceId);
 	this._init(orientation, panelHeight, instanceId);
 }
@@ -169,6 +170,9 @@ Cheaty.prototype = {
 			this.onCheatsheetFolderUpdate, 
 			null
 		);
+		this.settings.bind("keyOpen", "keyOpen", this._setKeybinding);
+		this._setKeybinding();
+
 
 		this._msgsrc = new MessageTray.SystemNotificationSource("Cheaty");
 		Main.messageTray.add(this._msgsrc);
@@ -223,6 +227,18 @@ Cheaty.prototype = {
 		}
 	},
 
+	_setKeybinding: function () {
+		Main.keybindingManager.addHotKey("cheaty-show-" + this.instance_id, this.keyOpen, Lang.bind(this, this._openMenu));
+	},
+
+	on_applet_removed_from_panel: function () {
+		Main.keybindingManager.removeHotKey("cheaty-show-" + this.instance_id);
+	},
+
+	_openMenu: function () {
+		this.menu.toggle();
+	},
+
 	onCheatsheetFolderUpdate: function() {
 	},
 
@@ -256,7 +272,7 @@ Cheaty.prototype = {
 	},
 
 	on_applet_clicked: function(event) {
-		this.menu.toggle();
+		this._openMenu();
 	}
 }
 

--- a/cheaty@centurix/files/cheaty@centurix/settings-schema.json
+++ b/cheaty@centurix/files/cheaty@centurix/settings-schema.json
@@ -4,5 +4,11 @@
 		"default": "~/.local/share/cinnamon/applets/cheaty@centurix/refdocs",
 		"description": "cheatsheetFolder",
 		"select-dir": true
+	},
+	"keyOpen": {
+		"type": "keybinding",
+		"description": "Show Cheaty popup menu",
+		"default": "<Super>m",
+		"tooltip" : "Set keybinding(s) to show the Cheaty popup menu."
 	}
 }


### PR DESCRIPTION
The default keybinding is `<super>m` which is allegedly not yet taken
by any other spice.

@Centurix 