### PR TITLE
bluetooth-battery@zamszowy: notifications, manual device and fixes

### DIFF
--- a/bluetooth-battery@zamszowy/README.md
+++ b/bluetooth-battery@zamszowy/README.md
@@ -1,20 +1,20 @@
 # Bluetooth (and other) devices battery monitor
 
-This applet monitors (through UPowerGlib) battery levels of mice, keyboards, headphones and other connected devices.\
-It displays icon and text with battery level information, and for mice, keyboards and headphones, battery icon contains also mouse/keyboard/headphones symbol.\
+This applet monitors (through UPowerGlib) battery levels of mice, keyboards, headphones and other connected devices.  
+It displays icon and text with battery level information, and for mice, keyboards and headphones, battery icon contains also mouse/keyboard/headphones symbol.  
 Device with lowest battery is displayed in panel. When clicked, it displays list with all monitored devices.
 
 ## Settings
-You can disable monitoring (it also disables blacklist configuration) of keyboards, mice, headphones or all other devices.\
+You can disable monitoring (it also disables blacklist configuration) of keyboards, mice, headphones or all other devices.  
 You can also choose to display in applet icon only, text only or icon and text.
 
 ## Blacklist
-You can blacklist any device detected by the applet.\
+You can blacklist any device detected by the applet.  
 All detected devices are automatically added to blacklist (common devices like mice and keyboards are added just as comments, other are disabled right away).
 
 ## Bluetooth Headphones
 Currently (with bluetoothd v5.64) reporting battery percentage for bluetooth headphones can be enabled by starting bluetoothd with experimental features,
-but bear in mind that enabling it can cause some issues, like mice not connecting automatically (see https://github.com/bluez/bluez/issues/236 for details).\
+but bear in mind that enabling it can cause some issues, like mice not connecting automatically (see https://github.com/bluez/bluez/issues/236 for details).  
 This could be somehow circumvented by enabling only one experimental UUID, but it's still not guaranteed to be bug free - expect issues!
 
 ## Icons

--- a/bluetooth-battery@zamszowy/README.md
+++ b/bluetooth-battery@zamszowy/README.md
@@ -8,6 +8,12 @@ Device with lowest battery is displayed in panel. When clicked, it displays list
 You can disable monitoring (it also disables blacklist configuration) of keyboards, mice, headphones or all other devices.  
 You can also choose to display in applet icon only, text only or icon and text.
 
+## Notifications
+Notifications are enabled by default and the applet will emit notification when battery level of any of the monitored devices will drop below configured level.  
+Another notification with "critical" urgency will be emitted when battery level will drop even further below another configured level.
+
+You can also rely on notifications alone and disable applet icon and text entirely, but configure it to show only when battery drops below configured warning/critical level.
+
 ## Blacklist
 You can blacklist any device detected by the applet.  
 All detected devices are automatically added to blacklist (common devices like mice and keyboards are added just as comments, other are disabled right away).

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
@@ -186,7 +186,6 @@ BtBattery.prototype = {
 
         for (let [ident, props] of this.dbus_map) {
             let dev = props.device;
-            dev.refresh_sync(null);
 
             if (dev.battery_level != UPower.DeviceLevel.NONE) {
                 continue;

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
@@ -61,12 +61,12 @@ BtBattery.prototype = {
         this.menuManager.addMenu(this.menu);
 
         this.settings = new Settings.AppletSettings(this, metadata.uuid, instance_id);
-        this.settings.bindProperty(Settings.BindingDirection.IN, "enable-keyboards", "enable_keyboards", this._on_settings_change, null);
-        this.settings.bindProperty(Settings.BindingDirection.IN, "enable-mice", "enable_mice", this._on_settings_change, null);
-        this.settings.bindProperty(Settings.BindingDirection.IN, "enable-headphones", "enable_headphones", this._on_settings_change, null);
-        this.settings.bindProperty(Settings.BindingDirection.IN, "enable-others", "enable_others", this._on_settings_change, null);
-        this.settings.bindProperty(Settings.BindingDirection.IN, "applet-icon", "applet_icon", this._on_settings_change, null);
-        this.settings.bindProperty(Settings.BindingDirection.BIDIRECTIONAL, "blacklist", "blacklist", null, null);
+        this.settings.bind("enable-keyboards", "enable_keyboards", this._on_settings_change, null);
+        this.settings.bind("enable-mice", "enable_mice", this._on_settings_change, null);
+        this.settings.bind("enable-headphones", "enable_headphones", this._on_settings_change, null);
+        this.settings.bind("enable-others", "enable_others", this._on_settings_change, null);
+        this.settings.bind("applet-icon", "applet_icon", this._on_settings_change, null);
+        this.settings.bind("blacklist", "blacklist", null, null);
 
         this._init_dbus();
 
@@ -82,6 +82,10 @@ BtBattery.prototype = {
         if (this.added_count > 0) {
             this.menu.toggle();
         }
+    },
+
+    on_applet_removed: function() {
+        this.settings.finalize();
     },
 
     setup: function() {

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/metadata.json
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/metadata.json
@@ -1,5 +1,5 @@
 {
     "uuid": "bluetooth-battery@zamszowy",
-    "name": "Device battery",
+    "name": "Bluetooth battery",
     "description": "Shows battery levels of different devices"
 }

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/override-select.js
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/override-select.js
@@ -1,0 +1,37 @@
+#!/usr/bin/gjs
+
+imports.gi.versions.Gtk = "3.0";
+const Gtk = imports.gi.Gtk;
+
+Gtk.init(null);
+
+let win = new Gtk.Window({title:""});
+
+let box = new Gtk.Box({orientation: Gtk.Orientation.HORIZONTAL});
+win.add(box);
+
+let label = new Gtk.Label({"label":" Device:  "});
+box.add(label);
+
+let cbox = new Gtk.ComboBoxText();
+for (let i = 0; i < (ARGV.length > 1 ? ARGV.length - 1 : ARGV.length); i+=1) {
+   cbox.append("text", ARGV[i]);
+}
+// last param is active index
+cbox.set_active(ARGV.length > 1 ? parseInt(ARGV[ARGV.length - 1], 10) : 0);
+box.add(cbox);
+
+let butOK = new Gtk.Button({"label":"OK"});
+butOK.connect("clicked", function() {print(cbox.get_active_text()); Gtk.main_quit()});
+box.add(butOK);
+
+win.connect("delete-event", () => Gtk.main_quit());
+win.connect("key-press-event", function(unused, event) {
+   let [ok, key] = event.get_keycode();
+   /* ESC */
+   if (key == 9) {
+      Gtk.main_quit();
+   }});
+
+win.show_all();
+Gtk.main();

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/settings-schema.json
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/settings-schema.json
@@ -57,8 +57,7 @@
   },
 
   "applet-icon": {
-    "type": "radiogroup",
-    "default": true,
+    "type": "combobox",
     "description": "Display",
     "default": "icon-text",
     "options": {

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/settings-schema.json
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/settings-schema.json
@@ -1,13 +1,18 @@
 {
   "layout1": {
     "type": "layout",
-    "pages": ["page1", "page2"],
+    "pages": ["page1", "page2", "page3"],
       "page1": {
         "type": "page",
         "title": "Settings",
         "sections": ["section0", "section1", "section2"]
       },
       "page2": {
+        "type": "page",
+        "title": "Notifications",
+        "sections": ["section4", "section5", "section6", "section7"]
+      },
+      "page3": {
         "type": "page",
         "title": "Blacklist",
         "sections": ["section3"]
@@ -35,6 +40,30 @@
       "type": "section",
       "title": "Disable monitoring for selected devices. You can use model or serial of the device.\nComment starts with '#'",
       "keys": ["blacklist", "blacklist-apply"]
+    },
+
+    "section4": {
+      "type": "section",
+      "title": "Warning notifications",
+      "keys": ["notification-warn-enable", "notification-warn-level", "notification-warn-demo"]
+    },
+
+    "section5": {
+      "type": "section",
+      "title": "Critical notifications",
+      "keys": ["notification-crit-enable", "notification-crit-level", "notification-crit-demo"]
+    },
+
+    "section6": {
+      "type": "section",
+      "title": "Showing of configured applet icon/text",
+      "keys": ["notification-applet-icon"]
+    },
+
+    "section7": {
+      "type": "section",
+      "title": "Display notification only once in session,\nor every time battery drops below warning/critical level (e.g. after recharge)",
+      "keys": ["notification-multiple"]
     }
   },
 
@@ -106,5 +135,70 @@
     "callback": "_on_override_select",
     "dependency":"override-enable",
     "description": "Select device to display"
+  },
+
+  "notification-warn-enable": {
+    "type": "switch",
+    "default": true,
+    "description": "Enable notification for battery warning level"
+  },
+
+  "notification-warn-level" : {
+    "type" : "scale",
+    "default" : 20,
+    "min" : 1,
+    "max" : 100,
+    "step" : 1,
+    "show-value" : true,
+    "description" : "Notify when battery below [%]",
+    "dependency": "notification-warn-enable"
+  },
+
+  "notification-warn-demo": {
+    "type": "button",
+    "callback": "_on_notification_warn_demo",
+    "dependency": "notification-warn-enable",
+    "description": "Test notification"
+  },
+
+  "notification-crit-enable": {
+    "type": "switch",
+    "default": true,
+    "description": "Enable notification for battery critical level"
+  },
+
+  "notification-crit-level" : {
+    "type" : "scale",
+    "default" : 10,
+    "min" : 1,
+    "max" : 100,
+    "step" : 1,
+    "show-value" : true,
+    "description" : "Notify when battery below [%]",
+    "dependency": "notification-crit-enable"
+  },
+
+  "notification-crit-demo": {
+    "type": "button",
+    "callback": "_on_notification_crit_demo",
+    "dependency": "notification-crit-enable",
+    "description": "Test notification"
+  },
+
+  "notification-applet-icon": {
+    "type": "combobox",
+    "description": "Show icon/text only if:",
+    "default": "always",
+    "options": {
+      "show always" : "always",
+      "battery below warning level" : "warn",
+      "battery below critical level" : "crit"
+    }
+  },
+
+  "notification-multiple": {
+    "type": "switch",
+    "default": false,
+    "description": "Display multiple times per session"
   }
 }

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/settings-schema.json
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/settings-schema.json
@@ -5,12 +5,12 @@
       "page1": {
         "type": "page",
         "title": "Settings",
-        "sections": ["section0", "section1"]
+        "sections": ["section0", "section1", "section2"]
       },
       "page2": {
         "type": "page",
         "title": "Blacklist",
-        "sections": ["section2"]
+        "sections": ["section3"]
       },
 
     "section0": {
@@ -26,6 +26,12 @@
     },
 
     "section2": {
+      "type": "section",
+      "title": "Device to display",
+      "keys": ["override-enable", "override-entry", "override-select"]
+    },
+
+    "section3": {
       "type": "section",
       "title": "Disable monitoring for selected devices. You can use model or serial of the device.\nComment starts with '#'",
       "keys": ["blacklist", "blacklist-apply"]
@@ -80,5 +86,25 @@
     "callback": "_on_settings_change",
     "description": "Apply",
     "tooltip": "Apply changes"
+  },
+
+  "override-enable": {
+    "type": "switch",
+    "default": false,
+    "description": "Manually select main device to display (instead of the one with lowest battery)"
+  },
+
+  "override-entry": {
+    "type": "entry",
+    "default": "",
+    "dependency":"override-enable",
+    "description": "Selected device:"
+  },
+
+  "override-select": {
+    "type": "button",
+    "callback": "_on_override_select",
+    "dependency":"override-enable",
+    "description": "Select device to display"
   }
 }


### PR DESCRIPTION
This patchset:
- removes usage od deleted Glib-Upower interface - this crashes applet if using latest upower. (fixes #4338)
- uses non-deprecated AppletSettings API.
- adds possibility to display user selected device (instead of one with lowest battery).
- changes name to match applet UUID
- take two at markdown newlines (to have them displayed at https://cinnamon-spices.linuxmint.com/)
- add notifications (closes #4345)