### PR TITLE
Change calls to python to /usr/bin/python

### DIFF
--- a/app-launcher@mchilli/files/app-launcher@mchilli/applet.js
+++ b/app-launcher@mchilli/files/app-launcher@mchilli/applet.js
@@ -788,7 +788,7 @@ class MyPopupSubMenuItem extends PopupMenu.PopupSubMenuMenuItem {
     _onButtonDelete() {
         this.applet.menu.close();
         Util.spawn_async(
-            ['python3', `${this.applet.metadata.path}/dialogs.py`, 'confirm', this.icon, this.name],
+            ['/usr/bin/python3', `${this.applet.metadata.path}/dialogs.py`, 'confirm', this.icon, this.name],
             (response) => {
                 response = JSON.parse(response);
                 if (response === Gtk.ResponseType.YES) {
@@ -803,7 +803,7 @@ class MyPopupSubMenuItem extends PopupMenu.PopupSubMenuMenuItem {
         this.applet.menu.close();
         Util.spawn_async(
             [
-                'python3',
+                '/usr/bin/python3',
                 `${this.applet.metadata.path}/dialogs.py`,
                 'edit',
                 JSON.stringify(this.applet.listGroups),
@@ -1045,7 +1045,7 @@ class MyPopupMenuItem extends PopupMenu.PopupIconMenuItem {
     _onButtonDelete() {
         this.applet.menu.close();
         Util.spawn_async(
-            ['python3', `${this.applet.metadata.path}/dialogs.py`, 'confirm', this.icon, this.name],
+            ['/usr/bin/python3', `${this.applet.metadata.path}/dialogs.py`, 'confirm', this.icon, this.name],
             (response) => {
                 response = JSON.parse(response);
                 if (response === Gtk.ResponseType.YES) {
@@ -1060,7 +1060,7 @@ class MyPopupMenuItem extends PopupMenu.PopupIconMenuItem {
         this.applet.menu.close();
         Util.spawn_async(
             [
-                'python3',
+                '/usr/bin/python3',
                 `${this.applet.metadata.path}/dialogs.py`,
                 'edit',
                 JSON.stringify(this.applet.listGroups),

--- a/batterypower@joka42/files/batterypower@joka42/applet.js
+++ b/batterypower@joka42/files/batterypower@joka42/applet.js
@@ -77,7 +77,7 @@ BatteryPowerApplet.prototype = {
 		}
 
 		if (!this.UPowerRefreshed){
-			Main.Util.spawnCommandLine(`python3 ${__meta.path}/update_upower.py`);
+			Main.Util.spawnCommandLine(`/usr/bin/python3 ${__meta.path}/update_upower.py`);
 			this.UPowerRefreshed = true;
 		}
 		const stateFile = ".batterystate";
@@ -114,7 +114,7 @@ BatteryPowerApplet.prototype = {
 		// If the files could not be used, we need to update upower information and use info
 		// from there.
 		if (!this.UPowerRefreshed){
-			Main.Util.spawnCommandLine(`python3 ${__meta.path}/update_upower.py`);
+			Main.Util.spawnCommandLine(`/usr/bin/python3 ${__meta.path}/update_upower.py`);
 			this.UPowerRefreshed = true;
 		}
 		const upowerEnergyRateFile = ".energyrate"

--- a/color-picker@fmete/files/color-picker@fmete/applet.js
+++ b/color-picker@fmete/files/color-picker@fmete/applet.js
@@ -140,7 +140,7 @@ MyApplet.prototype = {
         if(Gio.file_new_for_path("/usr/bin/xclip").query_exists(null)) {
             global.set_stage_input_mode(Cinnamon.StageInputMode.FULLSCREEN);
             global.set_cursor(Cinnamon.Cursor.CROSSHAIR);
-            Util.spawn_async(["python3", this.appletPath + "/cp.py", this.combo_choice], Lang.bind(this, function(output) {
+            Util.spawn_async(["/usr/bin/python3", this.appletPath + "/cp.py", this.combo_choice], Lang.bind(this, function(output) {
                 global.unset_cursor();
                 global.set_stage_input_mode(Cinnamon.StageInputMode.NORMAL);
 

--- a/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/applet.js
+++ b/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/applet.js
@@ -150,7 +150,7 @@ FeedApplet.prototype = {
 
     /* private function to check, confirm and install any dependencies */
     _check_dependencies: function() {
-       Util.spawn_async(['python3', APPLET_PATH + '/check_feedparser.py'], Lang.bind(this, this._check_feedparser));
+       Util.spawn_async(['/usr/bin/python3', APPLET_PATH + '/check_feedparser.py'], Lang.bind(this, this._check_feedparser));
     },
 
     /* private function that connects to the settings-schema and initializes the variables */
@@ -262,7 +262,7 @@ FeedApplet.prototype = {
             this.instance_name = instance_name.trim();
         }
         // Read the json config file.
-        let argv = ["python3", APPLET_PATH + "/ConfigFileManager.py", FEED_CONFIG_FILE];
+        let argv = ["/usr/bin/python3", APPLET_PATH + "/ConfigFileManager.py", FEED_CONFIG_FILE];
         Util.spawn_async(argv, Lang.bind(this, this._load_feeds));                    
     },
     /* Private method used to load / reload all the feeds. */
@@ -456,7 +456,7 @@ FeedApplet.prototype = {
         try {            
             this._set_permissions(pythonfile);
 
-            let argv = ['python3', APPLET_PATH + '/' + pythonfile, FEED_CONFIG_FILE, this.instance_name];
+            let argv = ['/usr/bin/python3', APPLET_PATH + '/' + pythonfile, FEED_CONFIG_FILE, this.instance_name];
             Util.spawn_async(argv, Lang.bind(this, this._read_json_config));     
         }
         catch (e) {
@@ -472,7 +472,7 @@ FeedApplet.prototype = {
         let pythonfile = 'ConfigFileManager.py';
         try {
             this._set_permissions(pythonfile);        
-            let argv = ['python3', APPLET_PATH + '/' + pythonfile, FEED_CONFIG_FILE];
+            let argv = ['/usr/bin/python3', APPLET_PATH + '/' + pythonfile, FEED_CONFIG_FILE];
             argv.push('--instance', this.instance_name);
             argv.push('--oldurl', current_url);
             argv.push('--newurl', redirected_url);

--- a/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/feedreader.js
+++ b/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/feedreader.js
@@ -122,7 +122,7 @@ FeedReader.prototype = {
 
         let path = DataPath + '/' + this.id;
         // Let the python script grab the items and load them using an async method
-        Util.spawn_async(['python3', AppletPath + '/loadItems.py', path], Lang.bind(this, this.load_items));
+        Util.spawn_async(['/usr/bin/python3', AppletPath + '/loadItems.py', path], Lang.bind(this, this.load_items));
     },
 
     get_url: function() {
@@ -131,7 +131,7 @@ FeedReader.prototype = {
 
     download_feed: function() {
         this.logger.debug("FeedReader.get");
-        Util.spawn_async(['python3', AppletPath + '/getFeed.py', this.url], Lang.bind(this, this.process_feed));
+        Util.spawn_async(['/usr/bin/python3', AppletPath + '/getFeed.py', this.url], Lang.bind(this, this.process_feed));
     },
 
     process_feed: function(response) {

--- a/gmail@lauritsriple/files/gmail@lauritsriple/applet.js
+++ b/gmail@lauritsriple/files/gmail@lauritsriple/applet.js
@@ -110,13 +110,13 @@ MyApplet.prototype = {
     	//Crypt password with pythonscript
 		if ((this.oldUsername!=this.username) && (this.password!="Crypted")){
 			//Try to delete old password
-			Util.spawn_async(['python3',APPLET_PATH+'/removeCredentials.py',this.oldUsername],Lang.bind(this,function(){
+			Util.spawn_async(['/usr/bin/python3',APPLET_PATH+'/removeCredentials.py',this.oldUsername],Lang.bind(this,function(){
 				this.oldUsername=this.username
 			}));
 		}
-		//Util.spawn_async(['python3',APPLETPATH+'/storeCredentials.py',this.username,this.password]);
+		//Util.spawn_async(['/usr/bin/python3',APPLETPATH+'/storeCredentials.py',this.username,this.password]);
 		if(this.password!="Crypted"){
-    		Util.spawn_async(['python3',APPLET_PATH+'/storeCredentials.py',this.username,this.password],Lang.bind(this,function(response){
+    		Util.spawn_async(['/usr/bin/python3',APPLET_PATH+'/storeCredentials.py',this.username,this.password],Lang.bind(this,function(response){
 			this.password="Crypted";
 			}));
 		}
@@ -211,7 +211,7 @@ MyApplet.prototype = {
 
     getJsonFeed: function(){
 		//this.logger.debug("getJsonFeed Called");
-    	Util.spawn_async(['python3',APPLET_PATH+'/getGmailFeedJson.py',this.username],Lang.bind(this,this.processJsonFeed));
+    	Util.spawn_async(['/usr/bin/python3',APPLET_PATH+'/getGmailFeedJson.py',this.username],Lang.bind(this,this.processJsonFeed));
 		//this.logger.debug("getJsonFeed finished process. ProcessJsonFeed finished as well");
     },
 

--- a/pomodoro@gregfreeman.org/files/pomodoro@gregfreeman.org/applet.js
+++ b/pomodoro@gregfreeman.org/files/pomodoro@gregfreeman.org/applet.js
@@ -100,7 +100,7 @@ PomodoroApplet.prototype = {
         this._loadSoundEffects();
 
         // If cinnamon crashes or restarts, we want to make sure no zombie sounds are still looping
-        let killLoopingSoundCommand = 'python3 %s %s'.format(metadata.path + '/bin/kill-looping-sound.py', this._sounds.tick.getSoundPath());
+        let killLoopingSoundCommand = '/usr/bin/python3 %s %s'.format(metadata.path + '/bin/kill-looping-sound.py', this._sounds.tick.getSoundPath());
         Util.trySpawnCommandLine(killLoopingSoundCommand);
 
         this._timers = {

--- a/radio@driglu4it/files/radio@driglu4it/4.6/radio-applet.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/radio-applet.js
@@ -5406,7 +5406,7 @@ function downloadMrisPluginInteractive() {
         if (checkMprisPluginDownloaded()) {
             return resolve();
         }
-        let [stderr, stdout, exitCode] = await spawnCommandLinePromise(`python3  ${__meta.path}/download-dialog-mpris.py`);
+        let [stderr, stdout, exitCode] = await spawnCommandLinePromise(`/usr/bin/python3  ${__meta.path}/download-dialog-mpris.py`);
         if ((stdout === null || stdout === void 0 ? void 0 : stdout.trim()) !== 'Continue') {
             return reject();
         }

--- a/radio@driglu4it/src/services/mpv/CheckInstallation.ts
+++ b/radio@driglu4it/src/services/mpv/CheckInstallation.ts
@@ -52,7 +52,7 @@ function downloadMrisPluginInteractive() {
         }
 
         let [stderr, stdout, exitCode] = await spawnCommandLinePromise(
-            `python3  ${__meta.path}/download-dialog-mpris.py`
+            `/usr/bin/python3  ${__meta.path}/download-dialog-mpris.py`
         )
 
         if (stdout?.trim() !== 'Continue') { return reject() }

--- a/softyubikey@yubiserver.include.gr/files/softyubikey@yubiserver.include.gr/applet.js
+++ b/softyubikey@yubiserver.include.gr/files/softyubikey@yubiserver.include.gr/applet.js
@@ -69,11 +69,11 @@ MyApplet.prototype = {
      },
 
     config_yubikey: function() {
-                Util.trySpawn(['python',softyubikey_settings]);
+                Util.trySpawn(['/usr/bin/python',softyubikey_settings]);
     },
 
     on_applet_clicked: function(event) {
-            Util.trySpawn(['python',ykey,'\n']);
+            Util.trySpawn(['/usr/bin/python',ykey,'\n']);
     }
 };
 

--- a/standardIconNames@jerrywham/files/standardIconNames@jerrywham/applet.js
+++ b/standardIconNames@jerrywham/files/standardIconNames@jerrywham/applet.js
@@ -470,7 +470,7 @@ MyApplet.prototype = {
   	let item = new PopupMenu.PopupIconMenuItem(_(""+label+""), ""+label+"", St.IconType.SYMBOLIC);
     item.connect('activate', Lang.bind(this, function() {
         if(Gio.file_new_for_path("/usr/bin/xclip").query_exists(null)) {
-           Util.spawn_async(["python3", this.appletPath + "/copyscript.py", item.label.get_text()], Lang.bind(this, function(output) {
+           Util.spawn_async(["/usr/bin/python3", this.appletPath + "/copyscript.py", item.label.get_text()], Lang.bind(this, function(output) {
                global.unset_cursor();
                output = output.replace(/\n$/, "");
                if (output == "ImportError Xlib") {

--- a/text-to-speech-applet@cardsurf/files/text-to-speech-applet@cardsurf/applet.js
+++ b/text-to-speech-applet@cardsurf/files/text-to-speech-applet@cardsurf/applet.js
@@ -45,7 +45,7 @@ MyApplet.prototype = {
 
         this.panel_height = panel_height;
         this.orientation = orientation;
-        this.python_name = "python3";
+        this.python_name = "/usr/bin/python3";
         this.tts_engine_name = "espeak";
         this.start_stop_keybind_id = uuid + instance_id + "start-stop";
         this.pause_resume_keybind_id = uuid + instance_id + "pause-resume";

--- a/text-to-speech-applet@cardsurf/files/text-to-speech-applet@cardsurf/clipboard.js
+++ b/text-to-speech-applet@cardsurf/files/text-to-speech-applet@cardsurf/clipboard.js
@@ -64,7 +64,7 @@ ClipboardReader.prototype = {
     },
 
     _execute_script_and_get_output: function(script) {
-        let process = new ShellUtils.ShellOutputProcess(['python3', script]);
+        let process = new ShellUtils.ShellOutputProcess(['/usr/bin/python3', script]);
         let output = process.spawn_sync_and_get_output();
         return output;
     },

--- a/weather@mockturtl/files/weather@mockturtl/3.0/yahoo.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.0/yahoo.js
@@ -69,7 +69,7 @@ var Yahoo = (function () {
                         _a.label = 1;
                     case 1:
                         _a.trys.push([1, 3, , 4]);
-                        return [4, this.app.SpawnProcess(["python3", this.app.appletDir + "/../yahoo-bridge.py", "--params", JSON.stringify({ lat: loc.lat.toString(), lon: loc.lon.toString() })])];
+                        return [4, this.app.SpawnProcess(["/usr/bin/python3", this.app.appletDir + "/../yahoo-bridge.py", "--params", JSON.stringify({ lat: loc.lat.toString(), lon: loc.lon.toString() })])];
                     case 2:
                         json = _a.sent();
                         return [3, 4];

--- a/weather@mockturtl/src/3_0/yahoo.ts
+++ b/weather@mockturtl/src/3_0/yahoo.ts
@@ -49,7 +49,7 @@ class Yahoo implements WeatherProvider {
         let json;
         if (loc != null) {
             try {
-                json = await this.app.SpawnProcess(["python3", this.app.appletDir + "/../yahoo-bridge.py", "--params", JSON.stringify({ lat: loc.lat.toString(), lon: loc.lon.toString() })]);
+                json = await this.app.SpawnProcess(["/usr/bin/python3", this.app.appletDir + "/../yahoo-bridge.py", "--params", JSON.stringify({ lat: loc.lat.toString(), lon: loc.lon.toString() })]);
             }
             catch (e) {
                 this.app.HandleError({ type: "hard", service: "yahoo", detail: "unknown", message: _("Unknown Error happened while calling Yahoo bridge,\n see Looking Glass log for errors") })


### PR DESCRIPTION
As discussed in #4331, it probably makes more sense to call to `/usr/bin/python` or `/usr/bin/python3` directly, instead of letting the `PATH` decide the python binary to use.

The main argument is that applets usually recommend/require certain apt `python-something` packages to be installed, which always target the python system installation at `/usr/bin/python`, while the user may choose to prefer another installation for most non-system use cases.

*I have only tested the color-picker applet, as this change should be pretty straight-forward.*
Someone should still look over this and check if I accidentally broke anything.

As mentioned in #4331, I would completely understand if this is deemed to be only a minor edge case.

---

Not sure if I should mention every applet author that is concerned :thinking: 

---

It should probably be considered to look for other binaries that are invoked similarly in this repository.
I chose to focus on python because of simplicity and because the `color-picker` was my main concern.