### PR TITLE
Fix left and right being the opposite in Persian

### DIFF
--- a/Cinnamenu@json/files/Cinnamenu@json/po/fa.po
+++ b/Cinnamenu@json/files/Cinnamenu@json/po/fa.po
@@ -477,10 +477,10 @@ msgid "Bottom"
 msgstr "پایین"
 
 msgid "Left"
-msgstr "چپ"
+msgstr "راست"
 
 msgid "Right"
-msgstr "راست"
+msgstr "چپ"
 
 msgid "Choose where to show the sidebar"
 msgstr "مکان نمایش نوار کناری را انتخاب کنید"


### PR DESCRIPTION
There two words are opposite in what they do. So when the system locale is set to Persian and everything is RTL, when you click left, the sidebar goes to right, and vice versa. This can possibly fix the issue.

Tested on:
LMDE 5.0 (Linux 5.10.0-14-amd64 #1 SMP Debian 5.10.113-1 (2022-04-29) x86_64 GNU/Linux)
Cinnamon 5.2.7

Here's a little proof:
![left-or-right](https://i.imgur.com/28imjKD.png)