### PR TITLE
[bluetooth-battery@zamszowy]: notification, filtering, sorting and fixes

### DIFF
--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
@@ -338,9 +338,7 @@ BtBattery.prototype = {
         }
 
         if (this.monitored_devs == 0) {
-            this.set_applet_label("");
-            this.set_applet_tooltip("all BT devices has been disabled");
-            this.set_applet_icon_name("bluetooth-disabled");
+            this.set_applet_enabled(false);
         } else {
             const [min_name, min_kind, min_perc] = this.get_lowest_battery_device();
 

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
@@ -48,6 +48,9 @@ BtBattery.prototype = {
         });
 
         this.dbus_map = new Map();
+        this.dbus_map[Symbol.iterator] = function* () {
+            yield* [...this.entries()].sort((a, b) => b[1].device.percentage - a[1].device.percentage);
+        }
         this.monitored_devs = new Array();
     },
 
@@ -387,7 +390,7 @@ BtBattery.prototype = {
             }
 
             const dev = this.dbus_map.get(name).device;
-            if (lowest_bat_dev == null || dev.percentage < lowest_bat_dev.percentage) {
+            if (lowest_bat_dev == null || dev.percentage <= lowest_bat_dev.percentage) {
                 lowest_bat_dev = dev;
                 lowest_bat_dev_ident = name;
             }

--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/settings-schema.json
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/settings-schema.json
@@ -56,14 +56,14 @@
 
     "section6": {
       "type": "section",
-      "title": "Showing of configured applet icon/text",
-      "keys": ["notification-applet-icon"]
+      "title": "Ignore small changes of battery levels - if device reports small battery changes back and forth, this setting would help",
+      "keys": ["notification-filter"]
     },
 
     "section7": {
       "type": "section",
-      "title": "Display notification only once in session,\nor every time battery drops below warning/critical level (e.g. after recharge)",
-      "keys": ["notification-multiple"]
+      "title": "Showing of configured applet icon/text",
+      "keys": ["notification-applet-icon"]
     }
   },
 
@@ -196,9 +196,13 @@
     }
   },
 
-  "notification-multiple": {
-    "type": "switch",
-    "default": false,
-    "description": "Display multiple times per session"
+  "notification-filter": {
+    "type": "spinbutton",
+    "description": "Notify again only if battery increased above configured level by at least: ",
+    "min": 0,
+    "max": 11,
+    "step": 1,
+    "units": "%",
+    "default": 0
   }
 }


### PR DESCRIPTION
This patchset includes following changes:

- sort (by battery level) devices in menu
- hide applet entirely if no devices are monitored
- correctly skip unnamed devices: skip devices without model and serial property always, instead of just
    when its type is "uncommon".
- notification filtering

This fixes: #4351 
