### PR TITLE
[darkMode@linuxedo.com] Fix configuration dialog not opening

### DIFF
--- a/darkMode@linuxedo.com/README.md
+++ b/darkMode@linuxedo.com/README.md
@@ -8,6 +8,8 @@ For more details and feature requests: [Dark Mode in Cinnamon Desktop Environmen
 License: [GPL-v3](https://github.com/linuxedo/cinnamon-dark-mode-applet/blob/main/LICENSE)
 
 ## Changelog
+* Jul 12, 2022
+  - Fix configuration dialog not opening in some circumstances.
 * Apr 12, 2022
   - Fix desklet not working if local folders are missing
 * Nov 21, 2021

--- a/darkMode@linuxedo.com/files/darkMode@linuxedo.com/applet.js
+++ b/darkMode@linuxedo.com/files/darkMode@linuxedo.com/applet.js
@@ -281,15 +281,19 @@ MyApplet.prototype = {
         this.cinnamon_themes = {};
         this.window_border_themes = {};
         let local_themes_dir = Gio.File.new_for_path(LOCAL_THEMES_DIR);
+        let system_themes_dir = Gio.File.new_for_path(SYSTEM_THEMES_DIR);
         let local_icons_dir = Gio.File.new_for_path(LOCAL_ICONS_DIR);
+        let system_icons_dir = Gio.File.new_for_path(SYSTEM_ICONS_DIR);
 
         if (local_themes_dir.query_exists(null)) {
             FileUtils.listDirAsync(local_themes_dir, Lang.bind(this, this.collect_local_themes));
         }
+        FileUtils.listDirAsync(system_themes_dir, Lang.bind(this, this.collect_system_themes));
 
         if (local_icons_dir.query_exists(null)) {
             FileUtils.listDirAsync(local_icons_dir, Lang.bind(this, this.collect_local_icons));
         }
+        FileUtils.listDirAsync(system_icons_dir, Lang.bind(this, this.collect_system_icons));
     },
 
     change_mode_automatically: function () {
@@ -417,19 +421,14 @@ MyApplet.prototype = {
         this.add_to_map(cinnamon_theme_names, this.cinnamon_themes);
         this.add_to_map(win_border_theme_names, this.window_border_themes);
 
-        if (parent == LOCAL_THEMES_DIR) {
-            let system_themes_dir = Gio.File.new_for_path(SYSTEM_THEMES_DIR);
-            FileUtils.listDirAsync(system_themes_dir, Lang.bind(this, this.collect_system_themes));
-        } else {
-            this.settings.setOptions("light_win_border_theme", this.window_border_themes);
-            this.settings.setOptions("dark_win_border_theme", this.window_border_themes);
+        this.settings.setOptions("light_win_border_theme", this.window_border_themes);
+        this.settings.setOptions("dark_win_border_theme", this.window_border_themes);
 
-            this.settings.setOptions("light_gtk_theme", this.gtk_themes);
-            this.settings.setOptions("dark_gtk_theme", this.gtk_themes);
+        this.settings.setOptions("light_gtk_theme", this.gtk_themes);
+        this.settings.setOptions("dark_gtk_theme", this.gtk_themes);
 
-            this.settings.setOptions("light_cinnamon_theme", this.cinnamon_themes);
-            this.settings.setOptions("dark_cinnamon_theme", this.cinnamon_themes);
-        }
+        this.settings.setOptions("light_cinnamon_theme", this.cinnamon_themes);
+        this.settings.setOptions("dark_cinnamon_theme", this.cinnamon_themes);
     },
 
     collect_icons: function (parent, dir_entry) {
@@ -443,13 +442,8 @@ MyApplet.prototype = {
         }
         this.add_to_map(icon_names, this.icons);
 
-        if (parent == LOCAL_ICONS_DIR) {
-            let system_icons_dir = Gio.File.new_for_path(SYSTEM_ICONS_DIR);
-            FileUtils.listDirAsync(system_icons_dir, Lang.bind(this, this.collect_system_icons));
-        } else {
-            this.settings.setOptions("light_icon_theme", this.icons);
-            this.settings.setOptions("dark_icon_theme", this.icons);
-        }
+        this.settings.setOptions("light_icon_theme", this.icons);
+        this.settings.setOptions("dark_icon_theme", this.icons);
     },
 
     set_random_light_wallpaper: function () {


### PR DESCRIPTION
Fix configuration dialog crash in pre cinnamon 5.4 versions due to no icon theme being found when ~/.local/share/icons folder doesn't exist and thus no icon theme options were available for the combobox causing xlet-settings.py to crash.

Fixes #4382

@slgobinath 