### PR TITLE
[ipindicator@matus.benko@gmail.com] Updated the README with full URLs to images

### DIFF
--- a/ipindicator@matus.benko@gmail.com/README.md
+++ b/ipindicator@matus.benko@gmail.com/README.md
@@ -44,23 +44,23 @@ IP:
 
 Icon: 
 
-![icon](screenshot-icon.png)
+![icon](https://raw.githubusercontent.com/linuxmint/cinnamon-spices-applets/master/ipindicator%40matus.benko%40gmail.com/screenshot-icon.png)
 
 Icon and IP:
 
-![iconIp](screenshot.png)
+![iconIp](https://raw.githubusercontent.com/linuxmint/cinnamon-spices-applets/master/ipindicator%40matus.benko%40gmail.com/screenshot.png)
 
 Tooltip:
 
-![tooltip](screenshot-tooltip.png)
+![tooltip](https://raw.githubusercontent.com/linuxmint/cinnamon-spices-applets/master/ipindicator%40matus.benko%40gmail.com/screenshot-tooltip.png)
 
 Settings:
 
-![settings](screenshot-settings.png)
+![settings](https://raw.githubusercontent.com/linuxmint/cinnamon-spices-applets/master/ipindicator%40matus.benko%40gmail.com/screenshot-settings.png)
 
 Custom ISP icon:
 
-![isp](screenshot-isp.png)
+![isp](https://raw.githubusercontent.com/linuxmint/cinnamon-spices-applets/master/ipindicator%40matus.benko%40gmail.com/screenshot-isp.png)
 
 # Kudos
 


### PR DESCRIPTION
Updated the README image links to with full URLs so that the images will show up on both the README page (https://github.com/linuxmint/cinnamon-spices-applets/tree/master/ipindicator@matus.benko@gmail.com#screenshots) and on  https://cinnamon-spices.linuxmint.com/applets/view/300 (Right now they do not show up on the latter)

@PrimaMateria @brownsr