### PR TITLE
ddcci-multi-monitor@tim-we: Prevent the applet from crashing when invalid displays are present

### DIFF
--- a/ddcci-multi-monitor@tim-we/files/ddcci-multi-monitor@tim-we/applet.js
+++ b/ddcci-multi-monitor@tim-we/files/ddcci-multi-monitor@tim-we/applet.js
@@ -224,23 +224,26 @@ async function getDisplays() {
             const index = parseInt(displayMR[1], 10);
 
             if (currentDisplay) {
+                if (currentDisplay.name === undefined) {
+                    currentDisplay.name = currentDisplay.fallbackName;
+                }
                 displays.push(currentDisplay);
             }
 
             currentDisplay = {
                 index,
-                name: displayMR[0],
+                fallbackName: displayMR[0],
             };
         } else {
             if (currentDisplay) {
                 const busMR = line.match(/^\s+I2C bus:\s+\/dev\/i2c-(\d+)$/);
 
-                if (busMR && busMR.length === 2) {
+                if (busMR && busMR.length === 2 && currentDisplay.bus === undefined) {
                     currentDisplay.bus = parseInt(busMR[1], 10);
                 } else {
                     const modelMR = line.match(/^\s+Model:\s+(.+)$/);
 
-                    if (modelMR && modelMR.length === 2) {
+                    if (modelMR && modelMR.length === 2 && currentDisplay.name === undefined) {
                         currentDisplay.name = modelMR[1];
                     }
                 }
@@ -251,6 +254,9 @@ async function getDisplays() {
     }
 
     if (currentDisplay) {
+        if (currentDisplay.name === undefined) {
+            currentDisplay.name = currentDisplay.fallbackName;
+        }
         displays.push(currentDisplay);
     }
 


### PR DESCRIPTION
### Issue

The applet has issues when running on laptops where displays do not support DDC/CI,

![image](https://user-images.githubusercontent.com/56594989/189744159-9a7436a8-49e1-4561-bebd-dbacfc30e06b.png)

The parsing code for the command 'ddcutil detect' incorrectly identifies 'i2c-7' as the bus for my external monitor (which should be 'i2c-4') because there is no guard condition that prevents execution when it meets an 'invalid display'. 

This results in the applet crashing,

![image](https://user-images.githubusercontent.com/56594989/189745168-caa721ab-798c-4ab8-8426-19887226c916.png)

### Fix

The proposed fix makes sure that the code does not continue execution and update values (currentDisplay.bus and currentDisplay.name) that have already been assigned. This effectively gets rid of 'invalid displays' with minimal changes to the codebase. Also, it preserves the existing display naming scheme (with an added fallbackName property).

**TL;DR - Applet can now be used with laptop displays and external monitors**

@tim-we 

