### PR TITLE
[radio@driglu4it] Version 2.2.1

### DIFF
--- a/radio@driglu4it/files/radio@driglu4it/4.6/radio-applet.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/radio-applet.js
@@ -4584,20 +4584,6 @@ function createPopupMenu(props) {
         event.get_key_symbol() === KEY_Escape && close();
         return false;
     });
-    launcher.connect('queue-relayout', () => {
-        if (!box.visible)
-            return;
-        setTimeout(() => {
-            setLayout();
-        }, 0);
-    });
-    bin.connect('queue-relayout', () => {
-        if (!box.visible)
-            return;
-        setTimeout(() => {
-            setLayout();
-        }, 0);
-    });
     function setLayout() {
         const freeSpace = calculateFreeSpace();
         const maxHeight = calculateMaxHeight(freeSpace);

--- a/radio@driglu4it/files/radio@driglu4it/4.6/radio-applet.js
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/radio-applet.js
@@ -40,6 +40,7 @@ __webpack_require__.r(__webpack_exports__);
 
 // EXPORTS
 __webpack_require__.d(__webpack_exports__, {
+  "addOnAppletMovedCallback": () => (/* binding */ addOnAppletMovedCallback),
   "main": () => (/* binding */ main)
 });
 
@@ -2754,7 +2755,8 @@ function createMpvHandler() {
         settingsObject.lastVolume = lastVolume;
     }
     function deactivateAllListener() {
-        dbus.disconnectSignal(nameOwnerSignalId);
+        if (nameOwnerSignalId)
+            dbus === null || dbus === void 0 ? void 0 : dbus.disconnectSignal(nameOwnerSignalId);
         if (mediaPropsListenerId)
             mediaProps === null || mediaProps === void 0 ? void 0 : mediaProps.disconnectSignal(mediaPropsListenerId);
         if (seekListenerId)
@@ -4044,8 +4046,8 @@ function initPolyfills() {
 ;// CONCATENATED MODULE: ./src/lib/AppletContainer.ts
 const { Applet, AllowedLayout } = imports.ui.applet;
 const { EventType } = imports.gi.Clutter;
-function createAppletContainer(args) {
-    const { onClick, onScroll, onMiddleClick, onMoved, onRemoved, onRightClick } = args;
+function createAppletContainer(props) {
+    const { onClick, onScroll, onMiddleClick, onAppletMovedCallbacks, onRemoved, onRightClick } = props;
     const applet = new Applet(__meta.orientation, __meta.panel.height, __meta.instanceId);
     let appletReloaded = false;
     applet.on_applet_clicked = () => {
@@ -4061,7 +4063,7 @@ function createAppletContainer(args) {
         appletReloaded = true;
     };
     applet.on_applet_removed_from_panel = function () {
-        appletReloaded ? onMoved() : onRemoved();
+        appletReloaded ? onAppletMovedCallbacks.forEach((cb) => cb()) : onRemoved();
         appletReloaded = false;
     };
     applet.actor.connect("event", (actor, event) => {
@@ -4076,6 +4078,12 @@ function createAppletContainer(args) {
     applet.actor.connect("scroll-event", (actor, event) => {
         onScroll(event.get_scroll_direction());
         return false;
+    });
+    // this is a workaround to ensure that the Applet is still clickable after the applet has dropped 
+    global.settings.connect("changed::panel-edit-mode", () => {
+        const inhibitDragging = !global.settings.get_boolean("panel-edit-mode");
+        // @ts-ignore
+        applet['_draggable'].inhibit = inhibitDragging;
     });
     return applet;
 }
@@ -4172,7 +4180,7 @@ function notifyError(prefix, errMessage, options) {
 
 ;// CONCATENATED MODULE: ./src/services/youtubeDownload/YoutubeDl.ts
 const { spawnCommandLineAsyncIO } = imports.misc.util;
-function downloadWithYoutubeDl(props) {
+function downloadWithYouTubeDl(props) {
     const { downloadDir, title, onFinished, onSuccess, onError } = props;
     let hasBeenCancelled = false;
     // ytsearch option found here https://askubuntu.com/a/731511/1013434 (not given in the youtube-dl docs ...)
@@ -4202,7 +4210,7 @@ function downloadWithYoutubeDl(props) {
 
 ;// CONCATENATED MODULE: ./src/services/youtubeDownload/YtDlp.ts
 const { spawnCommandLineAsyncIO: YtDlp_spawnCommandLineAsyncIO } = imports.misc.util;
-// TODO: there are some redudances with downloadWithYoutubeDl.
+// TODO: there are some redudances with downloadWithYouTubeDl.
 function downloadWithYtDlp(props) {
     const { downloadDir, title, onFinished, onSuccess, onError } = props;
     let hasBeenCancelled = false;
@@ -4238,9 +4246,9 @@ function downloadWithYtDlp(props) {
 const { spawnCommandLine: YoutubeDownloadManager_spawnCommandLine } = imports.misc.util;
 const { get_home_dir: YoutubeDownloadManager_get_home_dir, dir_make_tmp, DateTime } = imports.gi.GLib;
 const { File, FileCopyFlags, FileQueryInfoFlags } = imports.gi.Gio;
-const notifyYoutubeDownloadFailed = (props) => {
+const notifyYouTubeDownloadFailed = (props) => {
     const { youtubeCli, errorMessage } = props;
-    notifyError(`Couldn't download Song from Youtube due to an Error. Make Sure you have the newest version of ${youtubeCli} installed. 
+    notifyError(`Couldn't download Song from YouTube due to an Error. Make Sure you have the newest version of ${youtubeCli} installed. 
     \n<b>Important:</b> Don't use apt for the installation but follow the installation instruction given on the Radio Applet Site in the Cinnamon Store instead`, errorMessage, {
         additionalBtns: [
             {
@@ -4250,7 +4258,7 @@ const notifyYoutubeDownloadFailed = (props) => {
         ],
     });
 };
-const notifyYoutubeDownloadStarted = (title) => {
+const notifyYouTubeDownloadStarted = (title) => {
     notify(`Downloading ${title} ...`, {
         buttons: [
             {
@@ -4260,7 +4268,7 @@ const notifyYoutubeDownloadStarted = (title) => {
         ],
     });
 };
-const notifyYoutubeDownloadFinished = (props) => {
+const notifyYouTubeDownloadFinished = (props) => {
     const { downloadPath, fileAlreadyExist = false } = props;
     notify(fileAlreadyExist
         ? "Downloaded Song not saved as a file with the same name already exists"
@@ -4277,7 +4285,7 @@ const notifyYoutubeDownloadFinished = (props) => {
 };
 let downloadProcesses = [];
 const downloadingSongsChangedListener = [];
-function downloadSongFromYoutube(title) {
+function downloadSongFromYouTube(title) {
     const downloadDir = configs.settingsObject.musicDownloadDir;
     const youtubeCli = configs.settingsObject.youtubeCli;
     const music_dir_absolut = downloadDir.charAt(0) === "~"
@@ -4295,7 +4303,7 @@ function downloadSongFromYoutube(title) {
         title,
         downloadDir: tmpDirPath,
         onError: (errorMessage, downloadCommand) => {
-            notifyYoutubeDownloadFailed({
+            notifyYouTubeDownloadFailed({
                 youtubeCli,
                 errorMessage: `The following error occured at youtube download attempt: ${errorMessage}. The used download Command was: ${downloadCommand}`,
             });
@@ -4312,7 +4320,7 @@ function downloadSongFromYoutube(title) {
                     onFileMoved: (props) => {
                         const { fileAlreadyExist, targetFilePath } = props;
                         updateFileModifiedTime(targetFilePath);
-                        notifyYoutubeDownloadFinished({
+                        notifyYouTubeDownloadFinished({
                             downloadPath: targetFilePath,
                             fileAlreadyExist,
                         });
@@ -4321,7 +4329,7 @@ function downloadSongFromYoutube(title) {
             }
             catch (error) {
                 const errorMessage = error instanceof imports.gi.GLib.Error ? error.message : error;
-                notifyYoutubeDownloadFailed({
+                notifyYouTubeDownloadFailed({
                     youtubeCli,
                     errorMessage: `Failed to copy download from tmp dir. The following error occurred: ${errorMessage}`,
                 });
@@ -4329,9 +4337,9 @@ function downloadSongFromYoutube(title) {
         },
     };
     const { cancel } = youtubeCli === "youtube-dl"
-        ? downloadWithYoutubeDl(downloadProps)
+        ? downloadWithYouTubeDl(downloadProps)
         : downloadWithYtDlp(downloadProps);
-    notifyYoutubeDownloadStarted(title);
+    notifyYouTubeDownloadStarted(title);
     downloadProcesses.push({ songTitle: title, cancelDownload: cancel });
     downloadingSongsChangedListener.forEach((listener) => listener(downloadProcesses));
 }
@@ -4391,6 +4399,7 @@ function addDownloadingSongsChangeListener(callback) {
 
 
 
+
 const { PanelItemTooltip } = imports.ui.tooltips;
 const { markup_escape_text } = imports.gi.GLib;
 function createRadioAppletTooltip(args) {
@@ -4399,6 +4408,8 @@ function createRadioAppletTooltip(args) {
     tooltip['_tooltip'].set_style("text-align: left;");
     const setRefreshTooltip = () => {
         var _a;
+        // @ts-ignore
+        tooltip.orientation = __meta.orientation;
         if (mpvHandler.getPlaybackStatus() === 'Stopped') {
             tooltip.set_markup(DEFAULT_TOOLTIP_TXT);
             return;
@@ -4429,7 +4440,8 @@ function createRadioAppletTooltip(args) {
         mpvHandler.addPlaybackStatusChangeHandler,
         mpvHandler.addTitleChangeHandler,
         mpvHandler.addChannelChangeHandler,
-        addDownloadingSongsChangeListener
+        addDownloadingSongsChangeListener,
+        addOnAppletMovedCallback
     ].forEach(cb => cb(setRefreshTooltip));
     setRefreshTooltip();
     return tooltip;
@@ -5417,7 +5429,7 @@ function createDownloadButton() {
         const { currentTitleIsDownloading, currentTitle } = getState();
         if (!currentTitle)
             return; // this should actually never happe
-        currentTitleIsDownloading ? cancelDownload(currentTitle) : downloadSongFromYoutube(currentTitle);
+        currentTitleIsDownloading ? cancelDownload(currentTitle) : downloadSongFromYouTube(currentTitle);
     };
     const downloadButton = createControlBtn({
         onClick: handleBtnClicked
@@ -5425,7 +5437,7 @@ function createDownloadButton() {
     const setRefreshBtn = () => {
         const { currentTitle, currentTitleIsDownloading } = getState();
         const iconName = currentTitleIsDownloading ? CANCEL_ICON_NAME : DOWNLOAD_ICON_NAME;
-        const tooltipTxt = currentTitleIsDownloading ? `Cancel downloading ${currentTitle}` : "Download current song from Youtube";
+        const tooltipTxt = currentTitleIsDownloading ? `Cancel downloading ${currentTitle}` : "Download current song from YouTube";
         downloadButton.icon.set_icon_name(iconName);
         downloadButton.tooltip.set_text(tooltipTxt);
     };
@@ -5553,7 +5565,7 @@ function downloadMrisPluginInteractive() {
 ;// CONCATENATED MODULE: ./src/ui/RadioApplet/YoutubeDownloadIcon.ts
 
 
-function createYoutubeDownloadIcon() {
+function createYouTubeDownloadIcon() {
     const icon = createAppletIcon({
         icon_name: 'edit-download',
         visible: false
@@ -5737,22 +5749,24 @@ function createRadioContextMenu(args) {
 
 
 const { ScrollDirection: RadioAppletContainer_ScrollDirection } = imports.gi.Clutter;
-function createRadioAppletContainer() {
+let appletContainer;
+const getRadioAppletContainer = (props) => {
+    if (appletContainer) {
+        global.logWarning('radioAppletContainer already initiallized');
+        return appletContainer;
+    }
+    appletContainer = createRadioAppletContainer(props);
+    return appletContainer;
+};
+const createRadioAppletContainer = (props) => {
     let installationInProgress = false;
-    const appletContainer = createAppletContainer({
-        onMiddleClick: () => mpvHandler.togglePlayPause(),
-        onMoved: () => mpvHandler.deactivateAllListener(),
-        onRemoved: handleAppletRemoved,
-        onClick: handleClick,
-        onRightClick: () => {
+    const appletContainer = createAppletContainer(Object.assign({ onMiddleClick: () => mpvHandler.togglePlayPause(), onRemoved: handleAppletRemoved, onClick: handleClick, onRightClick: () => {
             radioPopupMenu === null || radioPopupMenu === void 0 ? void 0 : radioPopupMenu.close();
             contextMenu === null || contextMenu === void 0 ? void 0 : contextMenu.toggle();
-        },
-        onScroll: handleScroll,
-    });
+        }, onScroll: handleScroll }, props));
     [
         createRadioAppletIcon(),
-        createYoutubeDownloadIcon(),
+        createYouTubeDownloadIcon(),
         createRadioAppletLabel(),
     ].forEach((widget) => {
         appletContainer.actor.add_child(widget);
@@ -5797,19 +5811,24 @@ function createRadioAppletContainer() {
         }
     }
     return appletContainer;
-}
+};
 
 ;// CONCATENATED MODULE: ./src/index.ts
 
 
 
 
+const onAppletMovedCallbacks = [];
+const addOnAppletMovedCallback = (cb) => {
+    onAppletMovedCallbacks.push(cb);
+};
+// The function defintion must use the word "function" (not const!) as otherwilse the error: "radioApplet.main is not a constructor" is thrown
 function main() {
     // order must be retained!
     initPolyfills();
     initConfig();
     initMpvHandler();
-    return createRadioAppletContainer();
+    return getRadioAppletContainer({ onAppletMovedCallbacks });
 }
 
 radioApplet = __webpack_exports__;

--- a/radio@driglu4it/files/radio@driglu4it/4.6/settings-schema.json
+++ b/radio@driglu4it/files/radio@driglu4it/4.6/settings-schema.json
@@ -65,7 +65,7 @@
 		},
 		"youtube-section": {
 			"type": "section",
-			"title": "Youtube Download",
+			"title": "YouTube Download",
 			"keys": [
 				"youtube-download-cli",
 				"music-download-dir-select"
@@ -174,8 +174,8 @@
 	},
 	"youtube-download-cli": {
 		"type": "combobox", 
-		"description": "Youtube Download CLI tool", 
-		"tooltip": "The CLI tool used to download songs from Youtube", 
+		"description": "YouTube Download CLI tool", 
+		"tooltip": "The CLI tool used to download songs from YouTube", 
 		"default": "youtube-dl",
 		"options": {
 			"yt-dlp": "yt-dlp", 
@@ -185,7 +185,7 @@
 	"music-download-dir-select": {
 		"type": "filechooser",
 		"description": "Download directory",
-		"tooltip": "Songs downloaded from Youtube will be saved to this directory.",
+		"tooltip": "Songs downloaded from YouTube will be saved to this directory.",
 		"default": "~/Music/Radio",
 		"select-dir": true
 	},

--- a/radio@driglu4it/files/radio@driglu4it/metadata.json
+++ b/radio@driglu4it/files/radio@driglu4it/metadata.json
@@ -1,1 +1,1 @@
-{"uuid":"radio@driglu4it","name":"Radio++","description":"A radio applet with 1000's of searchable stations, mpris support, youtube-download function and more","max-instances":1,"multiversion":true,"version":"2.2.0"}
+{"uuid":"radio@driglu4it","name":"Radio++","description":"A radio applet with 1000's of searchable stations, mpris support, youtube-download function and more","max-instances":1,"multiversion":true,"version":"2.2.1"}

--- a/radio@driglu4it/files/radio@driglu4it/po/de.po
+++ b/radio@driglu4it/files/radio@driglu4it/po/de.po
@@ -53,8 +53,8 @@ msgid "Copy current song title"
 msgstr "Aktuellen Liedtitel kopieren"
 
 #: 4.6/applet.js:202
-msgid "Download from Youtube"
-msgstr "Von Youtube herunterladen"
+msgid "Download from YouTube"
+msgstr "Von YouTube herunterladen"
 
 #: 4.6/applet.js:215
 msgid "Can't copy current Song. Is the Radio playing?"
@@ -67,9 +67,9 @@ msgid "download finished. File saved to %s"
 msgstr "Download beendet. Die Datei wurde unter %s gespeichert."
 
 #: 4.6/applet.js:237
-msgid "Couldn't download song from Youtube due to an Error."
+msgid "Couldn't download song from YouTube due to an Error."
 msgstr ""
-"Das Lied konnte aufgrund eines Fehlers nicht von Youtube heruntergeladen "
+"Das Lied konnte aufgrund eines Fehlers nicht von YouTube heruntergeladen "
 "werden. "
 
 #: 4.6/applet.js:238
@@ -188,8 +188,8 @@ msgid "Volume"
 msgstr "Lautstärke"
 
 #. 4.6->settings-schema.json->youtube-section->title
-msgid "Youtube Download"
-msgstr "Youtube Download"
+msgid "YouTube Download"
+msgstr "YouTube Download"
 
 #. 4.6->settings-schema.json->tree->columns->title
 #. 3.0->settings-schema.json->tree->columns->title
@@ -272,10 +272,10 @@ msgstr "Download Verzeichnis"
 
 #. 4.6->settings-schema.json->music-download-dir-select->tooltip
 msgid ""
-"Songs downloaded from Youtube will be saved to this directory. This feature "
+"Songs downloaded from YouTube will be saved to this directory. This feature "
 "can be found in the right-click-menu of the applet"
 msgstr ""
-"Von Youtube heruntergeladene Lieder werden in diesem Verzeichnis "
+"Von YouTube heruntergeladene Lieder werden in diesem Verzeichnis "
 "gespeichert. Diese Funktion kann im Rechtsklick-Menu des Applets gefunden "
 "werden. "
 

--- a/radio@driglu4it/files/radio@driglu4it/po/es.po
+++ b/radio@driglu4it/files/radio@driglu4it/po/es.po
@@ -53,8 +53,8 @@ msgid "Copy current song title"
 msgstr "Copiar el título de la canción en reproducción"
 
 #: 4.6/applet.js:202
-msgid "Download from Youtube"
-msgstr "Descargar desde Youtube"
+msgid "Download from YouTube"
+msgstr "Descargar desde YouTube"
 
 #: 4.6/applet.js:215
 msgid "Can't copy current Song. Is the Radio playing?"
@@ -66,8 +66,8 @@ msgid "download finished. File saved to %s"
 msgstr "descarga finalizada. Archivo guardado en %s"
 
 #: 4.6/applet.js:237
-msgid "Couldn't download song from Youtube due to an Error."
-msgstr "No se pudo descargar la canción de Youtube debido a un Error."
+msgid "Couldn't download song from YouTube due to an Error."
+msgstr "No se pudo descargar la canción de YouTube debido a un Error."
 
 #: 4.6/applet.js:238
 msgid "See Logs for more information"
@@ -194,8 +194,8 @@ msgid "Volume"
 msgstr "Volumen"
 
 #. 4.6->settings-schema.json->youtube-section->title
-msgid "Youtube Download"
-msgstr "Descargar desde Youtube"
+msgid "YouTube Download"
+msgstr "Descargar desde YouTube"
 
 #. 4.6->settings-schema.json->tree->columns->title
 #. 3.0->settings-schema.json->tree->columns->title
@@ -284,10 +284,10 @@ msgstr "Directorio de descarga"
 
 #. 4.6->settings-schema.json->music-download-dir-select->tooltip
 msgid ""
-"Songs downloaded from Youtube will be saved to this directory. This feature "
+"Songs downloaded from YouTube will be saved to this directory. This feature "
 "can be found in the right-click-menu of the applet"
 msgstr ""
-"Las canciones descargadas de Youtube se guardarán en este directorio. Esta "
+"Las canciones descargadas de YouTube se guardarán en este directorio. Esta "
 "función se encuentra en el menú del botón derecho del applet"
 
 #. 3.0->settings-schema.json->page2->title

--- a/radio@driglu4it/files/radio@driglu4it/po/hr.po
+++ b/radio@driglu4it/files/radio@driglu4it/po/hr.po
@@ -53,7 +53,7 @@ msgid "Copy current song title"
 msgstr "Kopiraj trenutni naslov pjesme"
 
 #: 4.6/applet.js:202
-msgid "Download from Youtube"
+msgid "Download from YouTube"
 msgstr "Preuzmi s Youtuba"
 
 #: 4.6/applet.js:215
@@ -66,7 +66,7 @@ msgid "download finished. File saved to %s"
 msgstr "preuzimanje završeno. Datoteka je spremljena u %s"
 
 #: 4.6/applet.js:237
-msgid "Couldn't download song from Youtube due to an Error."
+msgid "Couldn't download song from YouTube due to an Error."
 msgstr "Nemoguće preuzimanje pjesme s Youtuba zbog greške."
 
 #: 4.6/applet.js:238
@@ -194,8 +194,8 @@ msgid "Volume"
 msgstr "Glasnoća zvuka"
 
 #. 4.6->settings-schema.json->youtube-section->title
-msgid "Youtube Download"
-msgstr "Youtube preuzimanje"
+msgid "YouTube Download"
+msgstr "YouTube preuzimanje"
 
 #. 4.6->settings-schema.json->tree->columns->title
 #. 3.0->settings-schema.json->tree->columns->title
@@ -282,7 +282,7 @@ msgstr "Direktorij preuzimanja"
 
 #. 4.6->settings-schema.json->music-download-dir-select->tooltip
 msgid ""
-"Songs downloaded from Youtube will be saved to this directory. This feature "
+"Songs downloaded from YouTube will be saved to this directory. This feature "
 "can be found in the right-click-menu of the applet"
 msgstr ""
 "Pjesme preuzete s Youtuba biti će spremljene u ovu mapu. Ova značajka se "

--- a/radio@driglu4it/files/radio@driglu4it/po/hu.po
+++ b/radio@driglu4it/files/radio@driglu4it/po/hu.po
@@ -52,7 +52,7 @@ msgid "Copy current song title"
 msgstr "Szám címének másolása"
 
 #: 4.6/applet.js:202
-msgid "Download from Youtube"
+msgid "Download from YouTube"
 msgstr "Letöltés a YouTube-ról"
 
 #: 4.6/applet.js:215
@@ -65,8 +65,8 @@ msgid "download finished. File saved to %s"
 msgstr "fájl letöltése sikerült. A fájl ide lett mentve: „%s”"
 
 #: 4.6/applet.js:237
-msgid "Couldn't download song from Youtube due to an Error."
-msgstr "Egy hiba miatt a zeneszám nem tölthető le a Youtube-ról."
+msgid "Couldn't download song from YouTube due to an Error."
+msgstr "Egy hiba miatt a zeneszám nem tölthető le a YouTube-ról."
 
 #: 4.6/applet.js:238
 msgid "See Logs for more information"
@@ -194,7 +194,7 @@ msgid "Volume"
 msgstr "Hangerő"
 
 #. 4.6->settings-schema.json->youtube-section->title
-msgid "Youtube Download"
+msgid "YouTube Download"
 msgstr "Letöltés a YouTube-ról"
 
 #. 4.6->settings-schema.json->tree->columns->title
@@ -285,10 +285,10 @@ msgstr "Letöltési mappa"
 
 #. 4.6->settings-schema.json->music-download-dir-select->tooltip
 msgid ""
-"Songs downloaded from Youtube will be saved to this directory. This feature "
+"Songs downloaded from YouTube will be saved to this directory. This feature "
 "can be found in the right-click-menu of the applet"
 msgstr ""
-"A Youtube webhelyről letöltött zenék ebbe a mappába kerülnek elmentésre. Ez "
+"A YouTube webhelyről letöltött zenék ebbe a mappába kerülnek elmentésre. Ez "
 "a funkció az kisalkalmazás helyi menüjében található"
 
 #. 3.0->settings-schema.json->page2->title

--- a/radio@driglu4it/files/radio@driglu4it/po/is.po
+++ b/radio@driglu4it/files/radio@driglu4it/po/is.po
@@ -53,7 +53,7 @@ msgid "Copy current song title"
 msgstr "Afrita titil núverandi lags"
 
 #: 4.6/applet.js:202
-msgid "Download from Youtube"
+msgid "Download from YouTube"
 msgstr "Sækja frá YouTube"
 
 #: 4.6/applet.js:215
@@ -66,7 +66,7 @@ msgid "download finished. File saved to %s"
 msgstr "Niðurhali lokið. Skrá vistuð í %s"
 
 #: 4.6/applet.js:237
-msgid "Couldn't download song from Youtube due to an Error."
+msgid "Couldn't download song from YouTube due to an Error."
 msgstr "Gat ekki sótt lag frá YouTube vegna villu."
 
 #: 4.6/applet.js:238
@@ -194,7 +194,7 @@ msgid "Volume"
 msgstr "Hljóðstyrkur"
 
 #. 4.6->settings-schema.json->youtube-section->title
-msgid "Youtube Download"
+msgid "YouTube Download"
 msgstr "Sækja af YouTube"
 
 #. 4.6->settings-schema.json->tree->columns->title
@@ -283,7 +283,7 @@ msgstr "Mappa fyrir sótt gögn"
 
 #. 4.6->settings-schema.json->music-download-dir-select->tooltip
 msgid ""
-"Songs downloaded from Youtube will be saved to this directory. This feature "
+"Songs downloaded from YouTube will be saved to this directory. This feature "
 "can be found in the right-click-menu of the applet"
 msgstr ""
 "Lög sem sótt eru af YouTube verða vistuð í þessa möppu. Þennan eiginleika má"

--- a/radio@driglu4it/files/radio@driglu4it/po/it.po
+++ b/radio@driglu4it/files/radio@driglu4it/po/it.po
@@ -51,8 +51,8 @@ msgid "Copy current song title"
 msgstr "Copia il titolo del brano corrente"
 
 #: 4.6/applet.js:202
-msgid "Download from Youtube"
-msgstr "Scarica da Youtube"
+msgid "Download from YouTube"
+msgstr "Scarica da YouTube"
 
 #: 4.6/applet.js:215
 msgid "Can't copy current Song. Is the Radio playing?"
@@ -64,8 +64,8 @@ msgid "download finished. File saved to %s"
 msgstr "download completato. File salvato in %s"
 
 #: 4.6/applet.js:237
-msgid "Couldn't download song from Youtube due to an Error."
-msgstr "Impossibile scaricare il brano da Youtube a causa di un errore."
+msgid "Couldn't download song from YouTube due to an Error."
+msgstr "Impossibile scaricare il brano da YouTube a causa di un errore."
 
 #: 4.6/applet.js:238
 msgid "See Logs for more information"
@@ -192,8 +192,8 @@ msgid "Volume"
 msgstr "Volume"
 
 #. 4.6->settings-schema.json->youtube-section->title
-msgid "Youtube Download"
-msgstr "Scarica da Youtube"
+msgid "YouTube Download"
+msgstr "Scarica da YouTube"
 
 #. 4.6->settings-schema.json->tree->columns->title
 #. 3.0->settings-schema.json->tree->columns->title
@@ -281,10 +281,10 @@ msgstr "Directory dei download"
 
 #. 4.6->settings-schema.json->music-download-dir-select->tooltip
 msgid ""
-"Songs downloaded from Youtube will be saved to this directory. This feature "
+"Songs downloaded from YouTube will be saved to this directory. This feature "
 "can be found in the right-click-menu of the applet"
 msgstr ""
-"I brani scaricati da Youtube verranno salvati in questa directory. Questa "
+"I brani scaricati da YouTube verranno salvati in questa directory. Questa "
 "funzione può essere trovata nel menu di scelta rapida dell'applet"
 
 #. 3.0->settings-schema.json->page2->title

--- a/radio@driglu4it/files/radio@driglu4it/po/radio@driglu4it.pot
+++ b/radio@driglu4it/files/radio@driglu4it/po/radio@driglu4it.pot
@@ -49,7 +49,7 @@ msgid "Copy current song title"
 msgstr ""
 
 #: 4.6/applet.js:202
-msgid "Download from Youtube"
+msgid "Download from YouTube"
 msgstr ""
 
 #: 4.6/applet.js:215
@@ -62,7 +62,7 @@ msgid "download finished. File saved to %s"
 msgstr ""
 
 #: 4.6/applet.js:237
-msgid "Couldn't download song from Youtube due to an Error."
+msgid "Couldn't download song from YouTube due to an Error."
 msgstr ""
 
 #: 4.6/applet.js:238
@@ -182,7 +182,7 @@ msgid "Volume"
 msgstr ""
 
 #. 4.6->settings-schema.json->youtube-section->title
-msgid "Youtube Download"
+msgid "YouTube Download"
 msgstr ""
 
 #. 4.6->settings-schema.json->tree->columns->title
@@ -268,7 +268,7 @@ msgstr ""
 
 #. 4.6->settings-schema.json->music-download-dir-select->tooltip
 msgid ""
-"Songs downloaded from Youtube will be saved to this directory. This feature "
+"Songs downloaded from YouTube will be saved to this directory. This feature "
 "can be found in the right-click-menu of the applet"
 msgstr ""
 

--- a/radio@driglu4it/files/radio@driglu4it/po/sv.po
+++ b/radio@driglu4it/files/radio@driglu4it/po/sv.po
@@ -53,8 +53,8 @@ msgid "Copy current song title"
 msgstr "Kopiera aktuell låttitel"
 
 #: 4.6/applet.js:202
-msgid "Download from Youtube"
-msgstr "Ladda ner från Youtube"
+msgid "Download from YouTube"
+msgstr "Ladda ner från YouTube"
 
 #: 4.6/applet.js:215
 msgid "Can't copy current Song. Is the Radio playing?"
@@ -66,8 +66,8 @@ msgid "download finished. File saved to %s"
 msgstr "Nerladdning slutförd. Filen sparad i %s."
 
 #: 4.6/applet.js:237
-msgid "Couldn't download song from Youtube due to an Error."
-msgstr "Kunde inte ladda ner låten från Youtube på grund av ett fel."
+msgid "Couldn't download song from YouTube due to an Error."
+msgstr "Kunde inte ladda ner låten från YouTube på grund av ett fel."
 
 #: 4.6/applet.js:238
 msgid "See Logs for more information"
@@ -194,8 +194,8 @@ msgid "Volume"
 msgstr "Volym"
 
 #. 4.6->settings-schema.json->youtube-section->title
-msgid "Youtube Download"
-msgstr "Youtube nerladdning"
+msgid "YouTube Download"
+msgstr "YouTube nerladdning"
 
 #. 4.6->settings-schema.json->tree->columns->title
 #. 3.0->settings-schema.json->tree->columns->title
@@ -283,10 +283,10 @@ msgstr "Nerladdningsmapp"
 
 #. 4.6->settings-schema.json->music-download-dir-select->tooltip
 msgid ""
-"Songs downloaded from Youtube will be saved to this directory. This feature "
+"Songs downloaded from YouTube will be saved to this directory. This feature "
 "can be found in the right-click-menu of the applet"
 msgstr ""
-"Låtar som laddas ner från Youtube sparas i den här mappen. Den här "
+"Låtar som laddas ner från YouTube sparas i den här mappen. Den här "
 "funktionen finns i panelprogrammets högerklicksmeny."
 
 #. 3.0->settings-schema.json->page2->title

--- a/radio@driglu4it/files/radio@driglu4it/po/tr.po
+++ b/radio@driglu4it/files/radio@driglu4it/po/tr.po
@@ -52,8 +52,8 @@ msgid "Copy current song title"
 msgstr "Geçerli şarkı başlığını kopyala"
 
 #: 4.6/applet.js:202
-msgid "Download from Youtube"
-msgstr "Youtube'dan indirin"
+msgid "Download from YouTube"
+msgstr "YouTube'dan indirin"
 
 #: 4.6/applet.js:215
 msgid "Can't copy current Song. Is the Radio playing?"
@@ -65,7 +65,7 @@ msgid "download finished. File saved to %s"
 msgstr "indirme tamamlandı. Dosya %s konumuna kaydedildi"
 
 #: 4.6/applet.js:237
-msgid "Couldn't download song from Youtube due to an Error."
+msgid "Couldn't download song from YouTube due to an Error."
 msgstr "Bir Hata nedeniyle YouTube'dan şarkı indirilemedi."
 
 #: 4.6/applet.js:238
@@ -192,8 +192,8 @@ msgid "Volume"
 msgstr "Ses Düzeyi"
 
 #. 4.6->settings-schema.json->youtube-section->title
-msgid "Youtube Download"
-msgstr "Youtube İndirmeleri"
+msgid "YouTube Download"
+msgstr "YouTube İndirmeleri"
 
 #. 4.6->settings-schema.json->tree->columns->title
 #. 3.0->settings-schema.json->tree->columns->title
@@ -281,10 +281,10 @@ msgstr "Dizine indir"
 
 #. 4.6->settings-schema.json->music-download-dir-select->tooltip
 msgid ""
-"Songs downloaded from Youtube will be saved to this directory. This feature "
+"Songs downloaded from YouTube will be saved to this directory. This feature "
 "can be found in the right-click-menu of the applet"
 msgstr ""
-"Youtube`dan indirilen şarkılar bu dizine kaydedilecektir. Bu özellik, "
+"YouTube`dan indirilen şarkılar bu dizine kaydedilecektir. Bu özellik, "
 "uygulamanın sağ tıklama menüsünde bulunabilir"
 
 #. 3.0->settings-schema.json->page2->title

--- a/radio@driglu4it/src/index.ts
+++ b/radio@driglu4it/src/index.ts
@@ -1,7 +1,7 @@
 import { initConfig } from './services/Config';
 import { initMpvHandler } from './services/mpv/MpvHandler';
 import { initPolyfills } from './polyfill';
-import { createRadioAppletContainer } from './ui/RadioApplet/RadioAppletContainer';
+import {  getRadioAppletContainer } from './ui/RadioApplet/RadioAppletContainer';
 
 declare global {
     // added during build (see webpack.config.js)
@@ -13,7 +13,14 @@ declare global {
     }
 }
 
+ 
+const onAppletMovedCallbacks: Array<() => void> = []
 
+export const addOnAppletMovedCallback = (cb: () => void) => {
+    onAppletMovedCallbacks.push(cb)
+}
+
+// The function defintion must use the word "function" (not const!) as otherwilse the error: "radioApplet.main is not a constructor" is thrown
 export function main(): imports.ui.applet.Applet {
 
     // order must be retained!
@@ -21,6 +28,6 @@ export function main(): imports.ui.applet.Applet {
     initConfig()
     initMpvHandler()
 
-    return createRadioAppletContainer()
+    return getRadioAppletContainer({ onAppletMovedCallbacks });
 
 }

--- a/radio@driglu4it/src/lib/PopupMenu.ts
+++ b/radio@driglu4it/src/lib/PopupMenu.ts
@@ -1,3 +1,4 @@
+import { constant } from "lodash"
 import { ChangeHandler } from "../types"
 
 const { BoxLayout, Bin, Side } = imports.gi.St
@@ -53,22 +54,6 @@ export function createPopupMenu(props: PopupMenuProps) {
     box.connect('key-press-event', (actor, event) => {
         event.get_key_symbol() === KEY_Escape && close()
         return false
-    })
-
-    launcher.connect('queue-relayout', () => {
-        if (!box.visible) return
-
-        setTimeout(() => {
-            setLayout()
-        }, 0);
-    })
-
-    bin.connect('queue-relayout', () => {
-        if (!box.visible) return
-
-        setTimeout(() => {
-            setLayout()
-        }, 0);
     })
 
     function setLayout() {

--- a/radio@driglu4it/src/services/Config.ts
+++ b/radio@driglu4it/src/services/Config.ts
@@ -1,5 +1,5 @@
 import { isEqual } from "lodash-es";
-import { Channel, AppletIcon, ChangeHandler, YoutubeClis } from "../types";
+import { Channel, AppletIcon, ChangeHandler, YouTubeClis } from "../types";
 const { AppletSettings } = imports.ui.settings;
 
 interface Settings {
@@ -14,7 +14,7 @@ interface Settings {
     userStations: Channel[]
     lastUrl: string | null,
     musicDownloadDir: string
-    youtubeCli: YoutubeClis
+    youtubeCli: YouTubeClis
 }
 
 // TODO: throw an error when importing without initiallized before

--- a/radio@driglu4it/src/services/mpv/MpvHandler.ts
+++ b/radio@driglu4it/src/services/mpv/MpvHandler.ts
@@ -123,7 +123,7 @@ function createMpvHandler() {
     }
 
     function deactivateAllListener(): void {
-        dbus.disconnectSignal(nameOwnerSignalId)
+        if (nameOwnerSignalId) dbus?.disconnectSignal(nameOwnerSignalId)
         if (mediaPropsListenerId) mediaProps?.disconnectSignal(mediaPropsListenerId)
         if (seekListenerId) mediaServerPlayer?.disconnectSignal(seekListenerId)
     }

--- a/radio@driglu4it/src/services/youtubeDownload/YoutubeDl.ts
+++ b/radio@driglu4it/src/services/youtubeDownload/YoutubeDl.ts
@@ -1,12 +1,12 @@
 import {
-  YoutubeDownloadServiceProps,
-  YoutubeDownloadServiceReturnType,
+  YouTubeDownloadServiceProps,
+  YouTubeDownloadServiceReturnType,
 } from "./YoutubeDownloadManager";
 const { spawnCommandLineAsyncIO } = imports.misc.util;
 
-export function downloadWithYoutubeDl(
-  props: YoutubeDownloadServiceProps
-): YoutubeDownloadServiceReturnType {
+export function downloadWithYouTubeDl(
+  props: YouTubeDownloadServiceProps
+): YouTubeDownloadServiceReturnType {
   const { downloadDir, title, onFinished, onSuccess, onError } = props;
 
   let hasBeenCancelled = false;

--- a/radio@driglu4it/src/services/youtubeDownload/YoutubeDownloadManager.ts
+++ b/radio@driglu4it/src/services/youtubeDownload/YoutubeDownloadManager.ts
@@ -1,15 +1,15 @@
 import { APPLET_SITE } from "../../consts";
 import { notify, notifyError } from "../../lib/notify";
-import { YoutubeClis } from "../../types";
+import { YouTubeClis } from "../../types";
 import { configs } from "../Config";
-import { downloadWithYoutubeDl } from "./YoutubeDl";
+import { downloadWithYouTubeDl } from "./YoutubeDl";
 import { downloadWithYtDlp } from "./YtDlp";
 
 const { spawnCommandLine } = imports.misc.util;
 const { get_home_dir, dir_make_tmp, DateTime } = imports.gi.GLib;
 const { File, FileCopyFlags, FileQueryInfoFlags } = imports.gi.Gio;
 
-export interface YoutubeDownloadServiceProps {
+export interface YouTubeDownloadServiceProps {
   downloadDir: string;
   title: string;
   onFinished: () => void;
@@ -17,7 +17,7 @@ export interface YoutubeDownloadServiceProps {
   onError: (errorMessage: string, downloadCommand: string) => void;
 }
 
-export interface YoutubeDownloadServiceReturnType {
+export interface YouTubeDownloadServiceReturnType {
   cancel: () => void;
 }
 
@@ -26,14 +26,14 @@ interface DownloadProcess {
   cancelDownload: () => void;
 }
 
-const notifyYoutubeDownloadFailed = (props: {
-  youtubeCli: YoutubeClis;
+const notifyYouTubeDownloadFailed = (props: {
+  youtubeCli: YouTubeClis;
   errorMessage: string;
 }) => {
   const { youtubeCli, errorMessage } = props;
 
   notifyError(
-    `Couldn't download Song from Youtube due to an Error. Make Sure you have the newest version of ${youtubeCli} installed. 
+    `Couldn't download Song from YouTube due to an Error. Make Sure you have the newest version of ${youtubeCli} installed. 
     \n<b>Important:</b> Don't use apt for the installation but follow the installation instruction given on the Radio Applet Site in the Cinnamon Store instead`,
     errorMessage,
     {
@@ -47,7 +47,7 @@ const notifyYoutubeDownloadFailed = (props: {
   );
 };
 
-const notifyYoutubeDownloadStarted = (title: string) => {
+const notifyYouTubeDownloadStarted = (title: string) => {
   notify(`Downloading ${title} ...`, {
     buttons: [
       {
@@ -58,7 +58,7 @@ const notifyYoutubeDownloadStarted = (title: string) => {
   });
 };
 
-const notifyYoutubeDownloadFinished = (props: {
+const notifyYouTubeDownloadFinished = (props: {
   downloadPath: string;
   fileAlreadyExist?: boolean;
 }) => {
@@ -87,7 +87,7 @@ const downloadingSongsChangedListener: ((
   downloadingSongs: DownloadProcess[]
 ) => void)[] = [];
 
-export function downloadSongFromYoutube(title: string) {
+export function downloadSongFromYouTube(title: string) {
   const downloadDir = configs.settingsObject.musicDownloadDir;
   const youtubeCli = configs.settingsObject.youtubeCli;
 
@@ -106,11 +106,11 @@ export function downloadSongFromYoutube(title: string) {
 
   const tmpDirPath = dir_make_tmp(null);
 
-  const downloadProps: YoutubeDownloadServiceProps = {
+  const downloadProps: YouTubeDownloadServiceProps = {
     title,
     downloadDir: tmpDirPath,
     onError: (errorMessage, downloadCommand: string) => {
-      notifyYoutubeDownloadFailed({
+      notifyYouTubeDownloadFailed({
         youtubeCli,
         errorMessage: `The following error occured at youtube download attempt: ${errorMessage}. The used download Command was: ${downloadCommand}`,
       });
@@ -133,7 +133,7 @@ export function downloadSongFromYoutube(title: string) {
 
             updateFileModifiedTime(targetFilePath);
 
-            notifyYoutubeDownloadFinished({
+            notifyYouTubeDownloadFinished({
               downloadPath: targetFilePath,
               fileAlreadyExist,
             });
@@ -142,7 +142,7 @@ export function downloadSongFromYoutube(title: string) {
       } catch (error) {
         const errorMessage =
           error instanceof imports.gi.GLib.Error ? error.message : error;
-        notifyYoutubeDownloadFailed({
+        notifyYouTubeDownloadFailed({
           youtubeCli,
           errorMessage: `Failed to copy download from tmp dir. The following error occurred: ${errorMessage}`,
         });
@@ -152,10 +152,10 @@ export function downloadSongFromYoutube(title: string) {
 
   const { cancel } =
     youtubeCli === "youtube-dl"
-      ? downloadWithYoutubeDl(downloadProps)
+      ? downloadWithYouTubeDl(downloadProps)
       : downloadWithYtDlp(downloadProps);
 
-  notifyYoutubeDownloadStarted(title);
+  notifyYouTubeDownloadStarted(title);
 
   downloadProcesses.push({ songTitle: title, cancelDownload: cancel });
   downloadingSongsChangedListener.forEach((listener) =>

--- a/radio@driglu4it/src/services/youtubeDownload/YtDlp.ts
+++ b/radio@driglu4it/src/services/youtubeDownload/YtDlp.ts
@@ -1,13 +1,13 @@
 import {
-  YoutubeDownloadServiceProps,
-  YoutubeDownloadServiceReturnType,
+  YouTubeDownloadServiceProps,
+  YouTubeDownloadServiceReturnType,
 } from "./YoutubeDownloadManager";
 const { spawnCommandLineAsyncIO } = imports.misc.util;
 
-// TODO: there are some redudances with downloadWithYoutubeDl.
+// TODO: there are some redudances with downloadWithYouTubeDl.
 export function downloadWithYtDlp(
-  props: YoutubeDownloadServiceProps
-): YoutubeDownloadServiceReturnType {
+  props: YouTubeDownloadServiceProps
+): YouTubeDownloadServiceReturnType {
   const { downloadDir, title, onFinished, onSuccess, onError } = props;
 
   let hasBeenCancelled = false;

--- a/radio@driglu4it/src/types.ts
+++ b/radio@driglu4it/src/types.ts
@@ -11,7 +11,7 @@ export interface Channel {
 }
 
 export type AppletIcon = 'SYMBOLIC' | 'FULLCOLOR' | 'BICOLOR'
-export type YoutubeClis = 'youtube-dl' | 'yt-dlp'
+export type YouTubeClis = 'youtube-dl' | 'yt-dlp'
 
 
 // MPRIS

--- a/radio@driglu4it/src/ui/RadioApplet/RadioAppletContainer.ts
+++ b/radio@driglu4it/src/ui/RadioApplet/RadioAppletContainer.ts
@@ -1,4 +1,4 @@
-import { createAppletContainer } from "../../lib/AppletContainer";
+import { createAppletContainer, CreateAppletContainerProps } from "../../lib/AppletContainer";
 import { mpvHandler } from "../../services/mpv/MpvHandler";
 import { createRadioAppletLabel } from "./RadioAppletLabel";
 import { createRadioAppletTooltip } from "./RadioAppletTooltip";
@@ -6,18 +6,33 @@ import { createRadioAppletIcon } from "./RadioAppletIcon";
 import { APPLET_SITE, MPRIS_PLUGIN_PATH, VOLUME_DELTA } from "../../consts";
 import { radioPopupMenu, initRadioPopupMenu } from "../RadioPopupMenu/RadioPopupMenu";
 import { installMpvWithMpris } from "../../services/mpv/CheckInstallation";
-import { createYoutubeDownloadIcon } from "./YoutubeDownloadIcon";
+import { createYouTubeDownloadIcon } from "./YoutubeDownloadIcon";
 import { notify } from "../../lib/notify";
 import { createRadioContextMenu } from "../RadioContextMenu";
 
 const { ScrollDirection } = imports.gi.Clutter;
 
-export function createRadioAppletContainer() {
+let appletContainer: ReturnType<typeof createAppletContainer> | undefined
+type CreateRadioAppletContainerProps = Pick<CreateAppletContainerProps, 'onAppletMovedCallbacks'>
+
+export const getRadioAppletContainer = (props: CreateRadioAppletContainerProps) => {
+
+  if (appletContainer) {
+    global.logWarning('radioAppletContainer already initiallized')
+    return appletContainer
+  }
+
+  appletContainer = createRadioAppletContainer(props)
+  return appletContainer
+} 
+
+
+const createRadioAppletContainer = (props: CreateRadioAppletContainerProps) => {
+
   let installationInProgress = false;
 
   const appletContainer = createAppletContainer({
     onMiddleClick: () => mpvHandler.togglePlayPause(),
-    onMoved: () => mpvHandler.deactivateAllListener(),
     onRemoved: handleAppletRemoved,
     onClick: handleClick,
     onRightClick: () => {
@@ -25,11 +40,12 @@ export function createRadioAppletContainer() {
       contextMenu?.toggle();
     },
     onScroll: handleScroll,
+    ...props
   });
 
   [
     createRadioAppletIcon(),
-    createYoutubeDownloadIcon(),
+    createYouTubeDownloadIcon(),
     createRadioAppletLabel(),
   ].forEach((widget) => {
     appletContainer.actor.add_child(widget);

--- a/radio@driglu4it/src/ui/RadioApplet/RadioAppletTooltip.ts
+++ b/radio@driglu4it/src/ui/RadioApplet/RadioAppletTooltip.ts
@@ -1,3 +1,4 @@
+import { addOnAppletMovedCallback } from "../.."
 import { DEFAULT_TOOLTIP_TXT } from "../../consts"
 import { mpvHandler } from "../../services/mpv/MpvHandler"
 import { addDownloadingSongsChangeListener, getCurrentDownloadingSongs } from "../../services/youtubeDownload/YoutubeDownloadManager"
@@ -16,9 +17,13 @@ export function createRadioAppletTooltip(args: Arguments) {
     } = args
 
     const tooltip = new PanelItemTooltip(appletContainer, undefined, __meta.orientation)
+    
     tooltip['_tooltip'].set_style("text-align: left;")
 
     const setRefreshTooltip = () => {
+
+        // @ts-ignore
+        tooltip.orientation = __meta.orientation
 
         if (mpvHandler.getPlaybackStatus() === 'Stopped') {
             tooltip.set_markup(DEFAULT_TOOLTIP_TXT)
@@ -55,7 +60,8 @@ export function createRadioAppletTooltip(args: Arguments) {
         mpvHandler.addPlaybackStatusChangeHandler,
         mpvHandler.addTitleChangeHandler,
         mpvHandler.addChannelChangeHandler,
-        addDownloadingSongsChangeListener
+        addDownloadingSongsChangeListener, 
+        addOnAppletMovedCallback
     ].forEach(cb => cb(setRefreshTooltip))
 
     setRefreshTooltip()

--- a/radio@driglu4it/src/ui/RadioApplet/YoutubeDownloadIcon.ts
+++ b/radio@driglu4it/src/ui/RadioApplet/YoutubeDownloadIcon.ts
@@ -1,7 +1,7 @@
 import { createAppletIcon } from "../../lib/AppletIcon";
 import { addDownloadingSongsChangeListener } from "../../services/youtubeDownload/YoutubeDownloadManager";
 
-export function createYoutubeDownloadIcon() {
+export function createYouTubeDownloadIcon() {
 
     const icon = createAppletIcon({
         icon_name: 'edit-download', 

--- a/radio@driglu4it/src/ui/RadioPopupMenu/MediaControlToolbar/DownloadButton.ts
+++ b/radio@driglu4it/src/ui/RadioPopupMenu/MediaControlToolbar/DownloadButton.ts
@@ -1,6 +1,6 @@
 import { CANCEL_ICON_NAME, COPY_ICON_NAME, DOWNLOAD_ICON_NAME } from "../../../consts";
 import { createControlBtn } from "./ControlBtn";
-import { addDownloadingSongsChangeListener, cancelDownload, downloadSongFromYoutube, getCurrentDownloadingSongs } from "../../../services/youtubeDownload/YoutubeDownloadManager";
+import { addDownloadingSongsChangeListener, cancelDownload, downloadSongFromYouTube, getCurrentDownloadingSongs } from "../../../services/youtubeDownload/YoutubeDownloadManager";
 import { mpvHandler } from "../../../services/mpv/MpvHandler";
 
 
@@ -19,7 +19,7 @@ export function createDownloadButton() {
 
         if (!currentTitle) return // this should actually never happe
 
-        currentTitleIsDownloading ? cancelDownload(currentTitle) : downloadSongFromYoutube(currentTitle)
+        currentTitleIsDownloading ? cancelDownload(currentTitle) : downloadSongFromYouTube(currentTitle)
 
     }
 
@@ -32,7 +32,7 @@ export function createDownloadButton() {
 
         const { currentTitle, currentTitleIsDownloading } = getState()
         const iconName = currentTitleIsDownloading ? CANCEL_ICON_NAME : DOWNLOAD_ICON_NAME
-        const tooltipTxt = currentTitleIsDownloading ? `Cancel downloading ${currentTitle}` : "Download current song from Youtube"
+        const tooltipTxt = currentTitleIsDownloading ? `Cancel downloading ${currentTitle}` : "Download current song from YouTube"
 
         downloadButton.icon.set_icon_name(iconName)
         downloadButton.tooltip.set_text(tooltipTxt)

--- a/radio@driglu4it/webpack.config.js
+++ b/radio@driglu4it/webpack.config.js
@@ -9,7 +9,7 @@ const DESCRIPTION =
 const NAME = "Radio++";
 const MAX_INSTANCES = 1;
 const CINNAMON_VERSION = "4.6"; // When set to null, the build output path is set to the files applet folder, else to a sub dir inside the applet files dir
-const APPLET_VERSION = "2.2.0";
+const APPLET_VERSION = "2.2.1";
 
 // Automatic calculated constants
 const UUID = __dirname.split("/").slice(-1)[0];


### PR DESCRIPTION
- Fixes #4479, 
- Fixes #4323
- Stop sticking the popup menu to the applet container. Previous the position of the popup menu has been updated as soon as the position of the applet in the panel has been changed. But this made it very difficult to use the seeker when the option "show song information on the panel" of the sound applet is selected