### PR TITLE
nordvpn-indicator@nickdurante : Fix connection status detection

### DIFF
--- a/nordvpn-indicator@nickdurante/files/nordvpn-indicator@nickdurante/applet.js
+++ b/nordvpn-indicator@nickdurante/files/nordvpn-indicator@nickdurante/applet.js
@@ -108,7 +108,8 @@ NordVPNApplet.prototype = {
 
     _get_status: function(){
         let status = this._run_cmd("nordvpn status");
-        let result = status.split("\n")[0].split(": ")[1];
+        let regex = /Status: ([a-zA-Z]+)/i;
+        let result = regex.exec(status)[1];
         let outString;
         if (result === "Connected"){
             this.connected = true;


### PR DESCRIPTION
## Issue
The new nordvpn app on linux prints about its meshnet feature any time a command is called. The breaks the connection status detection as is not as structured as before.

## Fix
Instead of assuming a structured output for `nordvpn status` , we just a regex match for the word after `Status: ` and match it with Connected or Disconnected. 