### PR TITLE
bettersettings@bownz direct "Start up Applications" to Cinnamons

### DIFF
--- a/bettersettings@bownz/files/bettersettings@bownz/applet.js
+++ b/bettersettings@bownz/files/bettersettings@bownz/applet.js
@@ -123,7 +123,7 @@ MyApplet.prototype = {
             });
 
 	    this.menu.addAction(_("Start up Applications"), function(event) {
-                Util.spawnCommandLine("gnome-session-properties");
+                Util.spawnCommandLine("cinnamon-settings startup");
             });
 
             this.menu.addAction(_("Cinnamon Settings"), function(event) {


### PR DESCRIPTION
Have the applet direct to using Cinnamons default startup manager instead of pursuing a gnome application thats not installed by default