### PR TITLE
redshift: Fixed flicker & darkening glitch

### DIFF
--- a/redshift@marvel4u/files/redshift@marvel4u/applet.js
+++ b/redshift@marvel4u/files/redshift@marvel4u/applet.js
@@ -307,6 +307,7 @@ MyApplet.prototype = {
         this.enabled = this.redshiftSwitch.state;
         this.updateTooltip();
         // Stop redshift before launch another instance
+        Util.spawnCommandLine('redshift -r -x');
         Util.killall('redshift');
         if (this.enabled) {
             // Icon on
@@ -314,24 +315,24 @@ MyApplet.prototype = {
                 this.set_applet_icon_symbolic_path(ICON_SUNSET);
 
                 if (this.latitude && this.longitude) {
-                    Util.spawnCommandLine('redshift -l ' + this.latitude + ':' + this.longitude
+                    Util.spawnCommandLine('redshift -r -l ' + this.latitude + ':' + this.longitude
                         + ' -t ' + this.dayColor + ':' + this.nightColor
                         + ' -b ' + (this.redshiftDayBrightness / 100) + ':' + (this.redshiftNightBrightness / 100));
                 } else {
-                    Util.spawnCommandLine('redshift -l geoclue2' + ' -t ' + this.dayColor + ':' + this.nightColor
+                    Util.spawnCommandLine('redshift -r -l geoclue2' + ' -t ' + this.dayColor + ':' + this.nightColor
                         + ' -b ' + (this.redshiftDayBrightness / 100) + ':' + (this.redshiftNightBrightness / 100));
                 }
             } else {
                 this.set_applet_icon_symbolic_path(ICON_ON);
 
-                Util.spawnCommandLine('redshift -O ' + this.dayColor + ' -b ' + (this.redshiftDayBrightness / 100));
+                Util.spawnCommandLine('redshift -r -O ' + this.dayColor + ' -b ' + (this.redshiftDayBrightness / 100));
             }
         } else {
             // Icon off
             this.set_applet_icon_symbolic_path(ICON_OFF);
 
             // reset Redshift configuration
-            Util.spawnCommandLine('redshift -x');
+            Util.spawnCommandLine('redshift -r -x');
         }
     },
 


### PR DESCRIPTION
To @Marvel4U and all the related members,

Fixes #2747

Added `redshift -r -x` to invoke immediately reset,
and `-r` options to every redshift spawning so that the color transition won't cause issues.

These changes work well so far.

Test environment:
- Arch Linux 6.0.12-arch1-1
- Cinnamon 5.6.4
- redshift 1.12