### PR TITLE
[batterymonitor@pdcurtis] - BAMS 1.5.1 - Improving default battery path logic over hard-coding it

### DIFF
--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/5.4/applet.js
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/5.4/applet.js
@@ -14,6 +14,7 @@ const St = imports.gi.St;
 const PopupMenu = imports.ui.popupMenu; // Needed for menus
 const Lang = imports.lang; // Needed for menus
 const GLib = imports.gi.GLib; // Needed for starting programs and translations
+const Gio = imports.gi.Gio; // Needed for path/file checks
 const Mainloop = imports.mainloop; // Needed for timer update loop
 const ModalDialog = imports.ui.modalDialog; // Needed for Modal Dialog used in Alert
 const Gettext = imports.gettext; // Needed for translations
@@ -102,7 +103,6 @@ MyApplet.prototype = {
             this.changelog = metadata.path + "/../CHANGELOG.md";
             this.helpfile = metadata.path + "/../README.md";
             this.cssfile = metadata.path + "/stylesheet.css";
-            this.batteryPath = "/sys/class/power_supply/BAT0";
             this.battery100 = metadata.path + "/icons/battery-100.png";
             this.battery080 = metadata.path + "/icons/battery-080.png";
             this.battery060 = metadata.path + "/icons/battery-060.png";
@@ -115,6 +115,19 @@ MyApplet.prototype = {
             this.batteryCharging040 = metadata.path + "/icons/battery-charging-040.png";
             this.batteryChargingCaution = metadata.path + "/icons/battery-charging-caution.png";
             this.batteryChargingLow = metadata.path + "/icons/battery-charging-low.png";
+
+            // Determine best default battery path if possible
+            let batteryBasePath = "/sys/class/power_supply";
+            let batteryObjectDir, batteryCapacityFile, batteryStatusFile;
+            for (let i = 0; i < 10; i++) {
+                batteryObjectDir = "BAT" + i.toString();
+                this.batteryPath = batteryBasePath + '/' + batteryObjectDir;
+                batteryCapacityFile = Gio.File.new_for_path(this.batteryPath + '/capacity');
+                batteryStatusFile = Gio.File.new_for_path(this.batteryPath + '/status');
+                if (batteryCapacityFile.query_exists(null) && batteryStatusFile.query_exists(null)) {
+                    break;
+                }
+            }
 
             // Set initial value
             this.set_applet_icon_path(this.batteryCharging100);

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/CHANGELOG.md
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 1.5.1
+ * Improved the logic for determining the default kernel path (some systems default to BAT1 instead of BAT0)
+   - Fixes "-- Warning" permanent message and removes the need for manual configuration in the single battery condition to address it
+
 ### 1.5.0
  * Switched from `upower` to the power status module provided by the kernel at /sys/class/power_supply/BAT0
    (`upower` updates on a two minute interval while the kernel module updates live and the applet supports smaller increments, increasing the overall accuracy of the applet.)

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/metadata.json
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/metadata.json
@@ -2,7 +2,7 @@
     "max-instances": "1",
     "description": "Displays Charge as Percentage and allows Alerts and Actions",
     "name": "Battery Applet with Monitoring and Shutdown (BAMS)",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "uuid": "batterymonitor@pdcurtis",
     "multiversion": true,
     "cinnamon-version": [

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/batterymonitor.pot
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/batterymonitor.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-08 22:29-0500\n"
+"POT-Creation-Date: 2022-12-27 19:21-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,30 +17,30 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: 5.4/applet.js:135 3.2/applet.js:135
+#: 5.4/applet.js:139 3.2/applet.js:135
 msgid "--%"
 msgstr ""
 
-#: 5.4/applet.js:136 3.2/applet.js:136
+#: 5.4/applet.js:140 3.2/applet.js:136
 msgid "Waiting"
 msgstr ""
 
-#: 5.4/applet.js:160 3.2/applet.js:165
+#: 5.4/applet.js:164 3.2/applet.js:165
 msgid "Some Dependencies not Installed"
 msgstr ""
 
-#: 5.4/applet.js:160
+#: 5.4/applet.js:164
 msgid ""
 "Both 'sox' and 'zenity' are required for this applet to have all of its functionality including notifications and audible alerts .\n"
 "\n"
 "Please view the README for help on installing them."
 msgstr ""
 
-#: 5.4/applet.js:170 3.2/applet.js:198
+#: 5.4/applet.js:174 3.2/applet.js:198
 msgid "Battery Monitor Applet"
 msgstr ""
 
-#: 5.4/applet.js:170
+#: 5.4/applet.js:174
 msgid ""
 "A user-defined sound file has been specified for Low Battery.\n"
 "\n"
@@ -48,44 +48,44 @@ msgid ""
 "especially if a long or loud file is specified.\n"
 msgstr ""
 
-#: 5.4/applet.js:243 3.2/applet.js:297
+#: 5.4/applet.js:247 3.2/applet.js:297
 msgid "Open Power Statistics"
 msgstr ""
 
-#: 5.4/applet.js:249 3.2/applet.js:303
+#: 5.4/applet.js:253 3.2/applet.js:303
 msgid "Open System Monitor"
 msgstr ""
 
-#: 5.4/applet.js:258
+#: 5.4/applet.js:262
 msgid "Housekeeping and System Submenu"
 msgstr ""
 
-#: 5.4/applet.js:261 3.2/applet.js:315
+#: 5.4/applet.js:265 3.2/applet.js:315
 msgid "View the Changelog"
 msgstr ""
 
-#: 5.4/applet.js:267
+#: 5.4/applet.js:271
 msgid "Open the README"
 msgstr ""
 
-#: 5.4/applet.js:273 3.2/applet.js:327
+#: 5.4/applet.js:277 3.2/applet.js:327
 msgid "Open stylesheet.css (Advanced Function)"
 msgstr ""
 
 #. metadata.json->name
-#: 5.4/applet.js:289 3.2/applet.js:343
+#: 5.4/applet.js:293 3.2/applet.js:343
 msgid "Battery Applet with Monitoring and Shutdown (BAMS)"
 msgstr ""
 
-#: 5.4/applet.js:294 3.2/applet.js:348
+#: 5.4/applet.js:298 3.2/applet.js:348
 msgid "Waiting for battery information"
 msgstr ""
 
-#: 5.4/applet.js:372
+#: 5.4/applet.js:389
 msgid "Battery Low - turn off or connect to power supply"
 msgstr ""
 
-#: 5.4/applet.js:377 3.2/applet.js:433
+#: 5.4/applet.js:394 3.2/applet.js:433
 msgid ""
 "The Battery Level has fallen to your alert level\n"
 "\n"
@@ -95,31 +95,31 @@ msgid ""
 "\n"
 msgstr ""
 
-#: 5.4/applet.js:392
+#: 5.4/applet.js:409
 msgid "Battery Critical - will suspend unless connected to power supply"
 msgstr ""
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Charge:"
 msgstr ""
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Alert:"
 msgstr ""
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Suspend:"
 msgstr ""
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Percentage Charge:"
 msgstr ""
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Alert at:"
 msgstr ""
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Suspend at:"
 msgstr ""
 
@@ -326,8 +326,7 @@ msgid "Advanced"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->description
-msgid ""
-"Path to battery capacity directory (device path)"
+msgid "Path to battery capacity directory (device path)"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->tooltip

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/da.po
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/da.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-08 22:29-0500\n"
-"PO-Revision-Date: 2022-12-08 22:33-0500\n"
+"POT-Creation-Date: 2022-12-27 19:21-0500\n"
+"PO-Revision-Date: 2022-12-29 13:38-0500\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
 "Language: da\n"
@@ -18,19 +18,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: 5.4/applet.js:135 3.2/applet.js:135
+#: 5.4/applet.js:139 3.2/applet.js:135
 msgid "--%"
 msgstr "--%"
 
-#: 5.4/applet.js:136 3.2/applet.js:136
+#: 5.4/applet.js:140 3.2/applet.js:136
 msgid "Waiting"
 msgstr "Venter"
 
-#: 5.4/applet.js:160 3.2/applet.js:165
+#: 5.4/applet.js:164 3.2/applet.js:165
 msgid "Some Dependencies not Installed"
 msgstr "Nogle afhængigheder er ikke installerede"
 
-#: 5.4/applet.js:160
+#: 5.4/applet.js:164
 msgid ""
 "Both 'sox' and 'zenity' are required for this applet to have all of its "
 "functionality including notifications and audible alerts .\n"
@@ -42,11 +42,11 @@ msgstr ""
 "\n"
 "Læs hjælpefilen for information om, hvordan de installeres."
 
-#: 5.4/applet.js:170 3.2/applet.js:198
+#: 5.4/applet.js:174 3.2/applet.js:198
 msgid "Battery Monitor Applet"
 msgstr "Batteriovervågning"
 
-#: 5.4/applet.js:170
+#: 5.4/applet.js:174
 msgid ""
 "A user-defined sound file has been specified for Low Battery.\n"
 "\n"
@@ -58,44 +58,44 @@ msgstr ""
 "Sikr dig, at lydstyrken er fornuftigt indstillet på offentlige steder,\n"
 "især hvis en lang, høj fil er angivet\n"
 
-#: 5.4/applet.js:243 3.2/applet.js:297
+#: 5.4/applet.js:247 3.2/applet.js:297
 msgid "Open Power Statistics"
 msgstr "Åbn strømstatistik"
 
-#: 5.4/applet.js:249 3.2/applet.js:303
+#: 5.4/applet.js:253 3.2/applet.js:303
 msgid "Open System Monitor"
 msgstr "Åbn systemovervågning"
 
-#: 5.4/applet.js:258
+#: 5.4/applet.js:262
 msgid "Housekeeping and System Submenu"
 msgstr "Vedligehold og systemundermenu"
 
-#: 5.4/applet.js:261 3.2/applet.js:315
+#: 5.4/applet.js:265 3.2/applet.js:315
 msgid "View the Changelog"
 msgstr "Vis ændringsloggen"
 
-#: 5.4/applet.js:267
+#: 5.4/applet.js:271
 msgid "Open the README"
 msgstr ""
 
-#: 5.4/applet.js:273 3.2/applet.js:327
+#: 5.4/applet.js:277 3.2/applet.js:327
 msgid "Open stylesheet.css (Advanced Function)"
 msgstr "Åbn stylesheet.css (Avanceret funktion)"
 
 #. metadata.json->name
-#: 5.4/applet.js:289 3.2/applet.js:343
+#: 5.4/applet.js:293 3.2/applet.js:343
 msgid "Battery Applet with Monitoring and Shutdown (BAMS)"
 msgstr "Batteriovervågning og nedlukning"
 
-#: 5.4/applet.js:294 3.2/applet.js:348
+#: 5.4/applet.js:298 3.2/applet.js:348
 msgid "Waiting for battery information"
 msgstr "Venter på information om batteriet"
 
-#: 5.4/applet.js:372
+#: 5.4/applet.js:389
 msgid "Battery Low - turn off or connect to power supply"
 msgstr "Lavt batteriniveau - sluk eller sæt strømstikket i"
 
-#: 5.4/applet.js:377 3.2/applet.js:433
+#: 5.4/applet.js:394 3.2/applet.js:433
 msgid ""
 "The Battery Level has fallen to your alert level\n"
 "\n"
@@ -111,33 +111,33 @@ msgstr ""
 "og sluk computeren eller sæt den i hviletilstand\n"
 "\n"
 
-#: 5.4/applet.js:392
+#: 5.4/applet.js:409
 msgid "Battery Critical - will suspend unless connected to power supply"
 msgstr ""
 "Ved kritisk batteriniveau aktiveres hviletilstand, med mindre strømforsyning "
 "er tilsluttet"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Charge:"
 msgstr "Batteriniveau:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Alert:"
 msgstr "Advarsel:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Suspend:"
 msgstr "Hviletilstand:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Percentage Charge:"
 msgstr "Procent opladt:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Alert at:"
 msgstr "Advarsel ved:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Suspend at:"
 msgstr "Sæt i hviletilstand ved:"
 
@@ -380,8 +380,7 @@ msgid "Advanced"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->description
-msgid ""
-"Path to battery capacity directory (device path)"
+msgid "Path to battery capacity directory (device path)"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->tooltip

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/de.po
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/de.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-08 22:29-0500\n"
-"PO-Revision-Date: 2022-12-08 22:32-0500\n"
+"POT-Creation-Date: 2022-12-27 19:21-0500\n"
+"PO-Revision-Date: 2022-12-29 13:38-0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: de\n"
@@ -18,19 +18,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: 5.4/applet.js:135 3.2/applet.js:135
+#: 5.4/applet.js:139 3.2/applet.js:135
 msgid "--%"
 msgstr ""
 
-#: 5.4/applet.js:136 3.2/applet.js:136
+#: 5.4/applet.js:140 3.2/applet.js:136
 msgid "Waiting"
 msgstr "Es wird gewartet"
 
-#: 5.4/applet.js:160 3.2/applet.js:165
+#: 5.4/applet.js:164 3.2/applet.js:165
 msgid "Some Dependencies not Installed"
 msgstr ""
 
-#: 5.4/applet.js:160
+#: 5.4/applet.js:164
 msgid ""
 "Both 'sox' and 'zenity' are required for this applet to have all of its "
 "functionality including notifications and audible alerts .\n"
@@ -38,11 +38,11 @@ msgid ""
 "Please view the README for help on installing them."
 msgstr ""
 
-#: 5.4/applet.js:170 3.2/applet.js:198
+#: 5.4/applet.js:174 3.2/applet.js:198
 msgid "Battery Monitor Applet"
 msgstr ""
 
-#: 5.4/applet.js:170
+#: 5.4/applet.js:174
 msgid ""
 "A user-defined sound file has been specified for Low Battery.\n"
 "\n"
@@ -50,44 +50,44 @@ msgid ""
 "especially if a long or loud file is specified.\n"
 msgstr ""
 
-#: 5.4/applet.js:243 3.2/applet.js:297
+#: 5.4/applet.js:247 3.2/applet.js:297
 msgid "Open Power Statistics"
 msgstr "Energiestatistiken öffnen"
 
-#: 5.4/applet.js:249 3.2/applet.js:303
+#: 5.4/applet.js:253 3.2/applet.js:303
 msgid "Open System Monitor"
 msgstr "Systemüberwachung öffnen"
 
-#: 5.4/applet.js:258
+#: 5.4/applet.js:262
 msgid "Housekeeping and System Submenu"
 msgstr "Organisation und System-Untermenü"
 
-#: 5.4/applet.js:261 3.2/applet.js:315
+#: 5.4/applet.js:265 3.2/applet.js:315
 msgid "View the Changelog"
 msgstr "Das Änderungsprotokoll anschauen"
 
-#: 5.4/applet.js:267
+#: 5.4/applet.js:271
 msgid "Open the README"
 msgstr ""
 
-#: 5.4/applet.js:273 3.2/applet.js:327
+#: 5.4/applet.js:277 3.2/applet.js:327
 msgid "Open stylesheet.css (Advanced Function)"
 msgstr "stylesheet.css öffnen (Erweiterte Funktion)"
 
 #. metadata.json->name
-#: 5.4/applet.js:289 3.2/applet.js:343
+#: 5.4/applet.js:293 3.2/applet.js:343
 msgid "Battery Applet with Monitoring and Shutdown (BAMS)"
 msgstr "Akku-Applet mit Überwachung und Herunterfahren (BAMS)"
 
-#: 5.4/applet.js:294 3.2/applet.js:348
+#: 5.4/applet.js:298 3.2/applet.js:348
 msgid "Waiting for battery information"
 msgstr ""
 
-#: 5.4/applet.js:372
+#: 5.4/applet.js:389
 msgid "Battery Low - turn off or connect to power supply"
 msgstr "Batterie Niedrig - Rechner ausschalten oder an das Netz anschließen"
 
-#: 5.4/applet.js:377 3.2/applet.js:433
+#: 5.4/applet.js:394 3.2/applet.js:433
 msgid ""
 "The Battery Level has fallen to your alert level\n"
 "\n"
@@ -102,33 +102,33 @@ msgstr ""
 "Rechner in den Ruhezustand versetzen oder herunterfahren\n"
 "\n"
 
-#: 5.4/applet.js:392
+#: 5.4/applet.js:409
 msgid "Battery Critical - will suspend unless connected to power supply"
 msgstr ""
 "Akku kritisch - Rechner wird in Ruhezustand versetzt, wenn er nicht an das "
 "Netz angeschlossen wird"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Charge:"
 msgstr "Aufladen:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Alert:"
 msgstr "Alarm:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Suspend:"
 msgstr "Ruhezustand:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Percentage Charge:"
 msgstr "Aufgeladener Prozentsatz:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Alert at:"
 msgstr "Alarmieren bei:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Suspend at:"
 msgstr "In Ruhezustand versetzen bei:"
 
@@ -350,8 +350,7 @@ msgid "Advanced"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->description
-msgid ""
-"Path to battery capacity directory (device path)"
+msgid "Path to battery capacity directory (device path)"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->tooltip

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/es.po
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-12-08 22:29-0500\n"
-"PO-Revision-Date: 2022-12-08 22:32-0500\n"
+"PO-Revision-Date: 2022-12-27 11:15-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -78,7 +78,7 @@ msgstr "Ver el registro de cambios"
 
 #: 5.4/applet.js:267
 msgid "Open the README"
-msgstr ""
+msgstr "Abrir archivo README"
 
 #: 5.4/applet.js:273 3.2/applet.js:327
 msgid "Open stylesheet.css (Advanced Function)"
@@ -214,7 +214,7 @@ msgstr ""
 
 #. 5.4->settings-schema.json->head->description
 msgid "General Settings"
-msgstr ""
+msgstr "Configuración general"
 
 #. 5.4->settings-schema.json->refreshInterval-spinner->units
 #. 3.2->settings-schema.json->refreshInterval-spinner->units
@@ -285,7 +285,7 @@ msgstr "Sólo icono sobre fondo de color que indica el estado"
 
 #. 5.4->settings-schema.json->displayType->description
 msgid "Toolbar Display Type"
-msgstr ""
+msgstr "Tipo de visualización de la barra de herramientas"
 
 #. 5.4->settings-schema.json->displayType->tooltip
 #. 3.2->settings-schema.json->displayType->tooltip
@@ -396,12 +396,11 @@ msgstr ""
 
 #. 5.4->settings-schema.json->head4->description
 msgid "Advanced"
-msgstr ""
+msgstr "Avanzado"
 
 #. 5.4->settings-schema.json->customBatteryPath->description
-msgid ""
-"Path to battery capacity directory (device path)"
-msgstr ""
+msgid "Path to battery capacity directory (device path)"
+msgstr "Ruta al directorio de capacidad de la batería (ruta del dispositivo)"
 
 #. 5.4->settings-schema.json->customBatteryPath->tooltip
 msgid ""
@@ -411,6 +410,11 @@ msgid ""
 "Default:\n"
 "/sys/class/power_supply/BAT0"
 msgstr ""
+"Elija su propio objeto power_supply, por ejemplo, para controlar su batería "
+"secundaria.\n"
+"\n"
+"Por defecto:\n"
+"/sys/class/suministro_de_energía/BAT0"
 
 #. 3.2->settings-schema.json->head->description
 msgid "General Settings for the Battery Applet with Monitoring and Shutdown"

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/es.po
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/es.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-08 22:29-0500\n"
-"PO-Revision-Date: 2022-12-27 11:15-0300\n"
+"POT-Creation-Date: 2022-12-27 19:21-0500\n"
+"PO-Revision-Date: 2022-12-29 13:38-0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -18,19 +18,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: 5.4/applet.js:135 3.2/applet.js:135
+#: 5.4/applet.js:139 3.2/applet.js:135
 msgid "--%"
 msgstr "--%"
 
-#: 5.4/applet.js:136 3.2/applet.js:136
+#: 5.4/applet.js:140 3.2/applet.js:136
 msgid "Waiting"
 msgstr "Esperando"
 
-#: 5.4/applet.js:160 3.2/applet.js:165
+#: 5.4/applet.js:164 3.2/applet.js:165
 msgid "Some Dependencies not Installed"
 msgstr "Algunas dependencias no están instaladas"
 
-#: 5.4/applet.js:160
+#: 5.4/applet.js:164
 msgid ""
 "Both 'sox' and 'zenity' are required for this applet to have all of its "
 "functionality including notifications and audible alerts .\n"
@@ -42,11 +42,11 @@ msgstr ""
 "\n"
 "Por favor, lea el archivo de ayuda sobre cómo instalarlos."
 
-#: 5.4/applet.js:170 3.2/applet.js:198
+#: 5.4/applet.js:174 3.2/applet.js:198
 msgid "Battery Monitor Applet"
 msgstr "Applet de monitoreo de la batería"
 
-#: 5.4/applet.js:170
+#: 5.4/applet.js:174
 msgid ""
 "A user-defined sound file has been specified for Low Battery.\n"
 "\n"
@@ -60,44 +60,44 @@ msgstr ""
 "lugares públicos\n"
 "especialmente si se especifica un archivo de sonido largo\n"
 
-#: 5.4/applet.js:243 3.2/applet.js:297
+#: 5.4/applet.js:247 3.2/applet.js:297
 msgid "Open Power Statistics"
 msgstr "Abrir estadísticas de energía"
 
-#: 5.4/applet.js:249 3.2/applet.js:303
+#: 5.4/applet.js:253 3.2/applet.js:303
 msgid "Open System Monitor"
 msgstr "Abrir monitor del sistema"
 
-#: 5.4/applet.js:258
+#: 5.4/applet.js:262
 msgid "Housekeeping and System Submenu"
 msgstr "Submenú de Mantenimiento y Sistema"
 
-#: 5.4/applet.js:261 3.2/applet.js:315
+#: 5.4/applet.js:265 3.2/applet.js:315
 msgid "View the Changelog"
 msgstr "Ver el registro de cambios"
 
-#: 5.4/applet.js:267
+#: 5.4/applet.js:271
 msgid "Open the README"
 msgstr "Abrir archivo README"
 
-#: 5.4/applet.js:273 3.2/applet.js:327
+#: 5.4/applet.js:277 3.2/applet.js:327
 msgid "Open stylesheet.css (Advanced Function)"
 msgstr "Abrir stylesheet.css (Función avanzada)"
 
 #. metadata.json->name
-#: 5.4/applet.js:289 3.2/applet.js:343
+#: 5.4/applet.js:293 3.2/applet.js:343
 msgid "Battery Applet with Monitoring and Shutdown (BAMS)"
 msgstr "Applet de batería con monitorización y apagado (BAMS)"
 
-#: 5.4/applet.js:294 3.2/applet.js:348
+#: 5.4/applet.js:298 3.2/applet.js:348
 msgid "Waiting for battery information"
 msgstr "A la espera de información sobre la batería"
 
-#: 5.4/applet.js:372
+#: 5.4/applet.js:389
 msgid "Battery Low - turn off or connect to power supply"
 msgstr "Batería baja - apague o conecte a la red eléctrica"
 
-#: 5.4/applet.js:377 3.2/applet.js:433
+#: 5.4/applet.js:394 3.2/applet.js:433
 msgid ""
 "The Battery Level has fallen to your alert level\n"
 "\n"
@@ -113,33 +113,33 @@ msgstr ""
 "cierre su trabajo y suspenda o apague la máquina\n"
 "\n"
 
-#: 5.4/applet.js:392
+#: 5.4/applet.js:409
 msgid "Battery Critical - will suspend unless connected to power supply"
 msgstr ""
 "Nivel de batería crítica se sSuspenderá a menos que se conecte a la red "
 "eléctrica"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Charge:"
 msgstr "Carga:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Alert:"
 msgstr "Alerta:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Suspend:"
 msgstr "Suspender:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Percentage Charge:"
 msgstr "Porcentaje de carga:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Alert at:"
 msgstr "Alertar en:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Suspend at:"
 msgstr "Suspender en:"
 

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/fr.po
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/fr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-08 22:29-0500\n"
-"PO-Revision-Date: 2022-12-08 22:32-0500\n"
+"POT-Creation-Date: 2022-12-27 19:21-0500\n"
+"PO-Revision-Date: 2022-12-29 13:38-0500\n"
 "Last-Translator: Claude CLERC <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -18,19 +18,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: 5.4/applet.js:135 3.2/applet.js:135
+#: 5.4/applet.js:139 3.2/applet.js:135
 msgid "--%"
 msgstr ""
 
-#: 5.4/applet.js:136 3.2/applet.js:136
+#: 5.4/applet.js:140 3.2/applet.js:136
 msgid "Waiting"
 msgstr "En attente..."
 
-#: 5.4/applet.js:160 3.2/applet.js:165
+#: 5.4/applet.js:164 3.2/applet.js:165
 msgid "Some Dependencies not Installed"
 msgstr ""
 
-#: 5.4/applet.js:160
+#: 5.4/applet.js:164
 msgid ""
 "Both 'sox' and 'zenity' are required for this applet to have all of its "
 "functionality including notifications and audible alerts .\n"
@@ -38,11 +38,11 @@ msgid ""
 "Please view the README for help on installing them."
 msgstr ""
 
-#: 5.4/applet.js:170 3.2/applet.js:198
+#: 5.4/applet.js:174 3.2/applet.js:198
 msgid "Battery Monitor Applet"
 msgstr ""
 
-#: 5.4/applet.js:170
+#: 5.4/applet.js:174
 msgid ""
 "A user-defined sound file has been specified for Low Battery.\n"
 "\n"
@@ -50,44 +50,44 @@ msgid ""
 "especially if a long or loud file is specified.\n"
 msgstr ""
 
-#: 5.4/applet.js:243 3.2/applet.js:297
+#: 5.4/applet.js:247 3.2/applet.js:297
 msgid "Open Power Statistics"
 msgstr "Statistiques"
 
-#: 5.4/applet.js:249 3.2/applet.js:303
+#: 5.4/applet.js:253 3.2/applet.js:303
 msgid "Open System Monitor"
 msgstr "Moniteur système"
 
-#: 5.4/applet.js:258
+#: 5.4/applet.js:262
 msgid "Housekeeping and System Submenu"
 msgstr "Résoudre les problèmes et personnaliser"
 
-#: 5.4/applet.js:261 3.2/applet.js:315
+#: 5.4/applet.js:265 3.2/applet.js:315
 msgid "View the Changelog"
 msgstr "Voir le récapitulatif des modifications (Changelog)"
 
-#: 5.4/applet.js:267
+#: 5.4/applet.js:271
 msgid "Open the README"
 msgstr ""
 
-#: 5.4/applet.js:273 3.2/applet.js:327
+#: 5.4/applet.js:277 3.2/applet.js:327
 msgid "Open stylesheet.css (Advanced Function)"
 msgstr "Modifier la feuille de style (pour experts en css)"
 
 #. metadata.json->name
-#: 5.4/applet.js:289 3.2/applet.js:343
+#: 5.4/applet.js:293 3.2/applet.js:343
 msgid "Battery Applet with Monitoring and Shutdown (BAMS)"
 msgstr "BAMS - Applet Moniteur de batterie et arrêt d'urgence"
 
-#: 5.4/applet.js:294 3.2/applet.js:348
+#: 5.4/applet.js:298 3.2/applet.js:348
 msgid "Waiting for battery information"
 msgstr "En attente d'information sur la batterie"
 
-#: 5.4/applet.js:372
+#: 5.4/applet.js:389
 msgid "Battery Low - turn off or connect to power supply"
 msgstr "Batterie faible - arrêter ou brancher sur secteur"
 
-#: 5.4/applet.js:377 3.2/applet.js:433
+#: 5.4/applet.js:394 3.2/applet.js:433
 msgid ""
 "The Battery Level has fallen to your alert level\n"
 "\n"
@@ -103,33 +103,33 @@ msgstr ""
 "ordinateur.\n"
 "\n"
 
-#: 5.4/applet.js:392
+#: 5.4/applet.js:409
 msgid "Battery Critical - will suspend unless connected to power supply"
 msgstr ""
 "Niveau critique de la batterie. L'ordinateur va se mettre en veille sauf si "
 "vous le branchez sur secteur."
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Charge:"
 msgstr "Charge :"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Alert:"
 msgstr "Alerte :"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Suspend:"
 msgstr "Mise en veille :"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Percentage Charge:"
 msgstr "Pourcentage de charge :"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Alert at:"
 msgstr "Alerte à :"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Suspend at:"
 msgstr "Mise en veille à :"
 
@@ -357,8 +357,7 @@ msgid "Advanced"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->description
-msgid ""
-"Path to battery capacity directory (device path)"
+msgid "Path to battery capacity directory (device path)"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->tooltip

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/hr.po
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/hr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: batterymonitor@pdcurtis 1.2.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-08 22:29-0500\n"
-"PO-Revision-Date: 2022-12-08 22:32-0500\n"
+"POT-Creation-Date: 2022-12-27 19:21-0500\n"
+"PO-Revision-Date: 2022-12-29 13:37-0500\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian\n"
 "Language: hr\n"
@@ -19,19 +19,19 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: 5.4/applet.js:135 3.2/applet.js:135
+#: 5.4/applet.js:139 3.2/applet.js:135
 msgid "--%"
 msgstr ""
 
-#: 5.4/applet.js:136 3.2/applet.js:136
+#: 5.4/applet.js:140 3.2/applet.js:136
 msgid "Waiting"
 msgstr "Čekanje"
 
-#: 5.4/applet.js:160 3.2/applet.js:165
+#: 5.4/applet.js:164 3.2/applet.js:165
 msgid "Some Dependencies not Installed"
 msgstr ""
 
-#: 5.4/applet.js:160
+#: 5.4/applet.js:164
 msgid ""
 "Both 'sox' and 'zenity' are required for this applet to have all of its "
 "functionality including notifications and audible alerts .\n"
@@ -39,11 +39,11 @@ msgid ""
 "Please view the README for help on installing them."
 msgstr ""
 
-#: 5.4/applet.js:170 3.2/applet.js:198
+#: 5.4/applet.js:174 3.2/applet.js:198
 msgid "Battery Monitor Applet"
 msgstr ""
 
-#: 5.4/applet.js:170
+#: 5.4/applet.js:174
 msgid ""
 "A user-defined sound file has been specified for Low Battery.\n"
 "\n"
@@ -51,44 +51,44 @@ msgid ""
 "especially if a long or loud file is specified.\n"
 msgstr ""
 
-#: 5.4/applet.js:243 3.2/applet.js:297
+#: 5.4/applet.js:247 3.2/applet.js:297
 msgid "Open Power Statistics"
 msgstr "Otvori energetsku statistiku"
 
-#: 5.4/applet.js:249 3.2/applet.js:303
+#: 5.4/applet.js:253 3.2/applet.js:303
 msgid "Open System Monitor"
 msgstr "Otvori nadgledatelja sustava"
 
-#: 5.4/applet.js:258
+#: 5.4/applet.js:262
 msgid "Housekeeping and System Submenu"
 msgstr "Upravljanje i podizbornici sustava"
 
-#: 5.4/applet.js:261 3.2/applet.js:315
+#: 5.4/applet.js:265 3.2/applet.js:315
 msgid "View the Changelog"
 msgstr "Pogledaj zapis promjena"
 
-#: 5.4/applet.js:267
+#: 5.4/applet.js:271
 msgid "Open the README"
 msgstr ""
 
-#: 5.4/applet.js:273 3.2/applet.js:327
+#: 5.4/applet.js:277 3.2/applet.js:327
 msgid "Open stylesheet.css (Advanced Function)"
 msgstr "Otvori stylesheet.css (Napredne funkcije)"
 
 #. metadata.json->name
-#: 5.4/applet.js:289 3.2/applet.js:343
+#: 5.4/applet.js:293 3.2/applet.js:343
 msgid "Battery Applet with Monitoring and Shutdown (BAMS)"
 msgstr "Aplet baterije s nadgledanjem i isključivanjem (BAMS)"
 
-#: 5.4/applet.js:294 3.2/applet.js:348
+#: 5.4/applet.js:298 3.2/applet.js:348
 msgid "Waiting for battery information"
 msgstr "Čekanje informacija baterije"
 
-#: 5.4/applet.js:372
+#: 5.4/applet.js:389
 msgid "Battery Low - turn off or connect to power supply"
 msgstr "Slaba baterija- isključite računalo ili priključite napajanje"
 
-#: 5.4/applet.js:377 3.2/applet.js:433
+#: 5.4/applet.js:394 3.2/applet.js:433
 msgid ""
 "The Battery Level has fallen to your alert level\n"
 "\n"
@@ -103,33 +103,33 @@ msgstr ""
 "ili završite s vašim radom i suspendirajte ili isključite računalo\n"
 "\n"
 
-#: 5.4/applet.js:392
+#: 5.4/applet.js:409
 msgid "Battery Critical - will suspend unless connected to power supply"
 msgstr ""
 "Baterija je kritično računalo će se suspendirati osim ako ne priključite "
 "napajanje"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Charge:"
 msgstr "Punjenje:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Alert:"
 msgstr "Upozorenje:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Suspend:"
 msgstr "Suspenzija:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Percentage Charge:"
 msgstr "Postotak napunjenosti:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Alert at:"
 msgstr "Upozori pri:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Suspend at:"
 msgstr "Suspendiraj pri:"
 
@@ -352,8 +352,7 @@ msgid "Advanced"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->description
-msgid ""
-"Path to battery capacity directory (device path)"
+msgid "Path to battery capacity directory (device path)"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->tooltip

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/hu.po
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/hu.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-08 22:29-0500\n"
-"PO-Revision-Date: 2022-12-08 22:32-0500\n"
+"POT-Creation-Date: 2022-12-27 19:21-0500\n"
+"PO-Revision-Date: 2022-12-29 13:39-0500\n"
 "Last-Translator: Bosák Balázs <bossbob88@gmail.com>\n"
 "Language-Team: \n"
 "Language: hu\n"
@@ -17,19 +17,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: 5.4/applet.js:135 3.2/applet.js:135
+#: 5.4/applet.js:139 3.2/applet.js:135
 msgid "--%"
 msgstr "--%"
 
-#: 5.4/applet.js:136 3.2/applet.js:136
+#: 5.4/applet.js:140 3.2/applet.js:136
 msgid "Waiting"
 msgstr "Várakozik"
 
-#: 5.4/applet.js:160 3.2/applet.js:165
+#: 5.4/applet.js:164 3.2/applet.js:165
 msgid "Some Dependencies not Installed"
 msgstr "Néhány függőség nincs telepítve"
 
-#: 5.4/applet.js:160
+#: 5.4/applet.js:164
 msgid ""
 "Both 'sox' and 'zenity' are required for this applet to have all of its "
 "functionality including notifications and audible alerts .\n"
@@ -42,11 +42,11 @@ msgstr ""
 "\n"
 "Kérjük, olvassa el a súgófájlt a telepítésükhöz."
 
-#: 5.4/applet.js:170 3.2/applet.js:198
+#: 5.4/applet.js:174 3.2/applet.js:198
 msgid "Battery Monitor Applet"
 msgstr "Akkumulátor Figyelő Kisalkalmazás"
 
-#: 5.4/applet.js:170
+#: 5.4/applet.js:174
 msgid ""
 "A user-defined sound file has been specified for Low Battery.\n"
 "\n"
@@ -60,46 +60,46 @@ msgstr ""
 "be\n"
 "különösen, ha hosszú hangos fájlt választott ki\n"
 
-#: 5.4/applet.js:243 3.2/applet.js:297
+#: 5.4/applet.js:247 3.2/applet.js:297
 msgid "Open Power Statistics"
 msgstr "Energiastatisztika megjelenítése"
 
-#: 5.4/applet.js:249 3.2/applet.js:303
+#: 5.4/applet.js:253 3.2/applet.js:303
 msgid "Open System Monitor"
 msgstr "Rendszer Figyelő megjelenítése"
 
-#: 5.4/applet.js:258
+#: 5.4/applet.js:262
 msgid "Housekeeping and System Submenu"
 msgstr "Karbantartás és Rendszer Almenü"
 
-#: 5.4/applet.js:261 3.2/applet.js:315
+#: 5.4/applet.js:265 3.2/applet.js:315
 msgid "View the Changelog"
 msgstr "Változásnapló megtekintése"
 
-#: 5.4/applet.js:267
+#: 5.4/applet.js:271
 msgid "Open the README"
 msgstr ""
 
-#: 5.4/applet.js:273 3.2/applet.js:327
+#: 5.4/applet.js:277 3.2/applet.js:327
 msgid "Open stylesheet.css (Advanced Function)"
 msgstr "Stylesheet.css fájl megnyitása (haladó funkció)"
 
 #. metadata.json->name
-#: 5.4/applet.js:289 3.2/applet.js:343
+#: 5.4/applet.js:293 3.2/applet.js:343
 msgid "Battery Applet with Monitoring and Shutdown (BAMS)"
 msgstr "Akkumulátor Kisalkalmazás figyelés és kikapcsolás funkcióval (BAMS)"
 
-#: 5.4/applet.js:294 3.2/applet.js:348
+#: 5.4/applet.js:298 3.2/applet.js:348
 msgid "Waiting for battery information"
 msgstr "Várakozás az akkumulátor információra"
 
-#: 5.4/applet.js:372
+#: 5.4/applet.js:389
 msgid "Battery Low - turn off or connect to power supply"
 msgstr ""
 "Akkumulátor töltöttség alacsony - kapcsolja ki vagy csatlakoztassa az "
 "elektromos hálózathoz"
 
-#: 5.4/applet.js:377 3.2/applet.js:433
+#: 5.4/applet.js:394 3.2/applet.js:433
 msgid ""
 "The Battery Level has fallen to your alert level\n"
 "\n"
@@ -115,33 +115,33 @@ msgstr ""
 "fejezze be a munkáját, és függessze fel vagy állítsa le a gépet\n"
 "\n"
 
-#: 5.4/applet.js:392
+#: 5.4/applet.js:409
 msgid "Battery Critical - will suspend unless connected to power supply"
 msgstr ""
 "Akkumulátor kritikus szinten, a rendszer fel lesz függesztve, hacsak nem "
 "csatlakozik az elektromos hálózathoz"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Charge:"
 msgstr "Töltés:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Alert:"
 msgstr "Riasztás:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Suspend:"
 msgstr "Felfüggesztés:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Percentage Charge:"
 msgstr "Százalékos töltöttség:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Alert at:"
 msgstr "Riasztás ekkor:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Suspend at:"
 msgstr "Felfüggesztés ekkor:"
 
@@ -404,8 +404,7 @@ msgid "Advanced"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->description
-msgid ""
-"Path to battery capacity directory (device path)"
+msgid "Path to battery capacity directory (device path)"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->tooltip

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/it.po
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/it.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-08 22:29-0500\n"
-"PO-Revision-Date: 2022-12-08 22:32-0500\n"
+"POT-Creation-Date: 2022-12-27 19:21-0500\n"
+"PO-Revision-Date: 2022-12-29 13:37-0500\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
 "Language: it\n"
@@ -18,19 +18,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: 5.4/applet.js:135 3.2/applet.js:135
+#: 5.4/applet.js:139 3.2/applet.js:135
 msgid "--%"
 msgstr "--%"
 
-#: 5.4/applet.js:136 3.2/applet.js:136
+#: 5.4/applet.js:140 3.2/applet.js:136
 msgid "Waiting"
 msgstr "In attesa"
 
-#: 5.4/applet.js:160 3.2/applet.js:165
+#: 5.4/applet.js:164 3.2/applet.js:165
 msgid "Some Dependencies not Installed"
 msgstr "Alcune Dipendenze non sono Installate"
 
-#: 5.4/applet.js:160
+#: 5.4/applet.js:164
 msgid ""
 "Both 'sox' and 'zenity' are required for this applet to have all of its "
 "functionality including notifications and audible alerts .\n"
@@ -42,11 +42,11 @@ msgstr ""
 "\n"
 "Leggi il file di aiuto per scoprire come installarli."
 
-#: 5.4/applet.js:170 3.2/applet.js:198
+#: 5.4/applet.js:174 3.2/applet.js:198
 msgid "Battery Monitor Applet"
 msgstr "Applet Monitoraggio Batteria"
 
-#: 5.4/applet.js:170
+#: 5.4/applet.js:174
 msgid ""
 "A user-defined sound file has been specified for Low Battery.\n"
 "\n"
@@ -60,44 +60,44 @@ msgstr ""
 "pubblici\n"
 "soprattutto se viene specificato un audio lungo e ad alto volume\n"
 
-#: 5.4/applet.js:243 3.2/applet.js:297
+#: 5.4/applet.js:247 3.2/applet.js:297
 msgid "Open Power Statistics"
 msgstr "Apri Statistiche Energetiche"
 
-#: 5.4/applet.js:249 3.2/applet.js:303
+#: 5.4/applet.js:253 3.2/applet.js:303
 msgid "Open System Monitor"
 msgstr "Apri Monitor di Sistema"
 
-#: 5.4/applet.js:258
+#: 5.4/applet.js:262
 msgid "Housekeeping and System Submenu"
 msgstr "Sottomenù Pulizia e Sistema"
 
-#: 5.4/applet.js:261 3.2/applet.js:315
+#: 5.4/applet.js:265 3.2/applet.js:315
 msgid "View the Changelog"
 msgstr "Vedi il Changelog"
 
-#: 5.4/applet.js:267
+#: 5.4/applet.js:271
 msgid "Open the README"
 msgstr ""
 
-#: 5.4/applet.js:273 3.2/applet.js:327
+#: 5.4/applet.js:277 3.2/applet.js:327
 msgid "Open stylesheet.css (Advanced Function)"
 msgstr "Apri stylesheet.css (Funzionalità Avanzate)"
 
 #. metadata.json->name
-#: 5.4/applet.js:289 3.2/applet.js:343
+#: 5.4/applet.js:293 3.2/applet.js:343
 msgid "Battery Applet with Monitoring and Shutdown (BAMS)"
 msgstr "Batteria Applet con Monitoraggio e Spegnimento (BAMS)"
 
-#: 5.4/applet.js:294 3.2/applet.js:348
+#: 5.4/applet.js:298 3.2/applet.js:348
 msgid "Waiting for battery information"
 msgstr "In attesa di informazioni sulla batteria"
 
-#: 5.4/applet.js:372
+#: 5.4/applet.js:389
 msgid "Battery Low - turn off or connect to power supply"
 msgstr "Batteria Scarica - spegnere o collegare alla rete elettrica"
 
-#: 5.4/applet.js:377 3.2/applet.js:433
+#: 5.4/applet.js:394 3.2/applet.js:433
 msgid ""
 "The Battery Level has fallen to your alert level\n"
 "\n"
@@ -113,32 +113,32 @@ msgstr ""
 "o termina il tuo lavoro e sospendi o spegni la macchina\n"
 "\n"
 
-#: 5.4/applet.js:392
+#: 5.4/applet.js:409
 msgid "Battery Critical - will suspend unless connected to power supply"
 msgstr ""
 "Batteria Critica causerà la Sospensione se non collegata alla rete elettrica"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Charge:"
 msgstr "Carica:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Alert:"
 msgstr "Avviso:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Suspend:"
 msgstr "Sospensione:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Percentage Charge:"
 msgstr "Livello Carica:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Alert at:"
 msgstr "Avviso al:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Suspend at:"
 msgstr "Sospendi al:"
 
@@ -394,8 +394,7 @@ msgid "Advanced"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->description
-msgid ""
-"Path to battery capacity directory (device path)"
+msgid "Path to battery capacity directory (device path)"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->tooltip

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/ru.po
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/ru.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-08 22:29-0500\n"
-"PO-Revision-Date: 2022-12-08 22:32-0500\n"
+"POT-Creation-Date: 2022-12-27 19:21-0500\n"
+"PO-Revision-Date: 2022-12-29 13:37-0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ru\n"
@@ -19,19 +19,19 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: 5.4/applet.js:135 3.2/applet.js:135
+#: 5.4/applet.js:139 3.2/applet.js:135
 msgid "--%"
 msgstr ""
 
-#: 5.4/applet.js:136 3.2/applet.js:136
+#: 5.4/applet.js:140 3.2/applet.js:136
 msgid "Waiting"
 msgstr "Ожидание"
 
-#: 5.4/applet.js:160 3.2/applet.js:165
+#: 5.4/applet.js:164 3.2/applet.js:165
 msgid "Some Dependencies not Installed"
 msgstr ""
 
-#: 5.4/applet.js:160
+#: 5.4/applet.js:164
 msgid ""
 "Both 'sox' and 'zenity' are required for this applet to have all of its "
 "functionality including notifications and audible alerts .\n"
@@ -39,11 +39,11 @@ msgid ""
 "Please view the README for help on installing them."
 msgstr ""
 
-#: 5.4/applet.js:170 3.2/applet.js:198
+#: 5.4/applet.js:174 3.2/applet.js:198
 msgid "Battery Monitor Applet"
 msgstr ""
 
-#: 5.4/applet.js:170
+#: 5.4/applet.js:174
 msgid ""
 "A user-defined sound file has been specified for Low Battery.\n"
 "\n"
@@ -51,44 +51,44 @@ msgid ""
 "especially if a long or loud file is specified.\n"
 msgstr ""
 
-#: 5.4/applet.js:243 3.2/applet.js:297
+#: 5.4/applet.js:247 3.2/applet.js:297
 msgid "Open Power Statistics"
 msgstr "Открыть статистику питания"
 
-#: 5.4/applet.js:249 3.2/applet.js:303
+#: 5.4/applet.js:253 3.2/applet.js:303
 msgid "Open System Monitor"
 msgstr "Открыть системный монитор"
 
-#: 5.4/applet.js:258
+#: 5.4/applet.js:262
 msgid "Housekeeping and System Submenu"
 msgstr "Подменю «Уборка» и «Система»"
 
-#: 5.4/applet.js:261 3.2/applet.js:315
+#: 5.4/applet.js:265 3.2/applet.js:315
 msgid "View the Changelog"
 msgstr "Просмотр списка изменений"
 
-#: 5.4/applet.js:267
+#: 5.4/applet.js:271
 msgid "Open the README"
 msgstr ""
 
-#: 5.4/applet.js:273 3.2/applet.js:327
+#: 5.4/applet.js:277 3.2/applet.js:327
 msgid "Open stylesheet.css (Advanced Function)"
 msgstr "Открыть файл stylesheet.css (расширенная функция)"
 
 #. metadata.json->name
-#: 5.4/applet.js:289 3.2/applet.js:343
+#: 5.4/applet.js:293 3.2/applet.js:343
 msgid "Battery Applet with Monitoring and Shutdown (BAMS)"
 msgstr "Апплет батареи с контролем и выключением (BAMS)"
 
-#: 5.4/applet.js:294 3.2/applet.js:348
+#: 5.4/applet.js:298 3.2/applet.js:348
 msgid "Waiting for battery information"
 msgstr ""
 
-#: 5.4/applet.js:372
+#: 5.4/applet.js:389
 msgid "Battery Low - turn off or connect to power supply"
 msgstr "Батарея разряжена - выключите или подключите к сети"
 
-#: 5.4/applet.js:377 3.2/applet.js:433
+#: 5.4/applet.js:394 3.2/applet.js:433
 msgid ""
 "The Battery Level has fallen to your alert level\n"
 "\n"
@@ -103,33 +103,33 @@ msgstr ""
 "или прекратите вашу работу и приостановите или выключите машину\n"
 "\n"
 
-#: 5.4/applet.js:392
+#: 5.4/applet.js:409
 msgid "Battery Critical - will suspend unless connected to power supply"
 msgstr ""
 "Критический уровень заряда, работа будет приостановлена, если не подлючить к "
 "сети"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Charge:"
 msgstr "Заряд:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Alert:"
 msgstr "Предупреждение:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Suspend:"
 msgstr "Приостановить:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Percentage Charge:"
 msgstr "Процент заряда:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Alert at:"
 msgstr "Оповещение по:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Suspend at:"
 msgstr "Приостановить на:"
 
@@ -348,8 +348,7 @@ msgid "Advanced"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->description
-msgid ""
-"Path to battery capacity directory (device path)"
+msgid "Path to battery capacity directory (device path)"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->tooltip

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/sv.po
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/sv.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: batterymonitor@pdcurtis\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-08 22:29-0500\n"
-"PO-Revision-Date: 2022-12-08 22:32-0500\n"
+"POT-Creation-Date: 2022-12-27 19:21-0500\n"
+"PO-Revision-Date: 2022-12-29 13:37-0500\n"
 "Last-Translator: eson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
 "Language: sv\n"
@@ -18,19 +18,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: 5.4/applet.js:135 3.2/applet.js:135
+#: 5.4/applet.js:139 3.2/applet.js:135
 msgid "--%"
 msgstr "--%"
 
-#: 5.4/applet.js:136 3.2/applet.js:136
+#: 5.4/applet.js:140 3.2/applet.js:136
 msgid "Waiting"
 msgstr "Väntar"
 
-#: 5.4/applet.js:160 3.2/applet.js:165
+#: 5.4/applet.js:164 3.2/applet.js:165
 msgid "Some Dependencies not Installed"
 msgstr "Vissa beroenden är inte installerade"
 
-#: 5.4/applet.js:160
+#: 5.4/applet.js:164
 msgid ""
 "Both 'sox' and 'zenity' are required for this applet to have all of its "
 "functionality including notifications and audible alerts .\n"
@@ -42,11 +42,11 @@ msgstr ""
 "\n"
 "Läs i hjälpfilen hur de installeras."
 
-#: 5.4/applet.js:170 3.2/applet.js:198
+#: 5.4/applet.js:174 3.2/applet.js:198
 msgid "Battery Monitor Applet"
 msgstr "Panelprogram för batteriövervakning"
 
-#: 5.4/applet.js:170
+#: 5.4/applet.js:174
 msgid ""
 "A user-defined sound file has been specified for Low Battery.\n"
 "\n"
@@ -58,44 +58,44 @@ msgstr ""
 "Tillse att ljudvolymen är på en lämplig nivå för offentliga miljöer,\n"
 "särskilt om en lång ljudfil används.\n"
 
-#: 5.4/applet.js:243 3.2/applet.js:297
+#: 5.4/applet.js:247 3.2/applet.js:297
 msgid "Open Power Statistics"
 msgstr "Öppna Strömstatistik"
 
-#: 5.4/applet.js:249 3.2/applet.js:303
+#: 5.4/applet.js:253 3.2/applet.js:303
 msgid "Open System Monitor"
 msgstr "Öppna systemövervakaren"
 
-#: 5.4/applet.js:258
+#: 5.4/applet.js:262
 msgid "Housekeeping and System Submenu"
 msgstr "Underhåll och systemundermeny"
 
-#: 5.4/applet.js:261 3.2/applet.js:315
+#: 5.4/applet.js:265 3.2/applet.js:315
 msgid "View the Changelog"
 msgstr "Visa ändringslogg"
 
-#: 5.4/applet.js:267
+#: 5.4/applet.js:271
 msgid "Open the README"
 msgstr ""
 
-#: 5.4/applet.js:273 3.2/applet.js:327
+#: 5.4/applet.js:277 3.2/applet.js:327
 msgid "Open stylesheet.css (Advanced Function)"
 msgstr "Öppna stylesheet.css (Avancerad funktion)"
 
 #. metadata.json->name
-#: 5.4/applet.js:289 3.2/applet.js:343
+#: 5.4/applet.js:293 3.2/applet.js:343
 msgid "Battery Applet with Monitoring and Shutdown (BAMS)"
 msgstr "Batteriprogram med övervakning och avstängning (BAMS)"
 
-#: 5.4/applet.js:294 3.2/applet.js:348
+#: 5.4/applet.js:298 3.2/applet.js:348
 msgid "Waiting for battery information"
 msgstr "Väntar på batteriinformation"
 
-#: 5.4/applet.js:372
+#: 5.4/applet.js:389
 msgid "Battery Low - turn off or connect to power supply"
 msgstr "Låg batterinivå - Stäng av eller anslut laddkabel"
 
-#: 5.4/applet.js:377 3.2/applet.js:433
+#: 5.4/applet.js:394 3.2/applet.js:433
 msgid ""
 "The Battery Level has fallen to your alert level\n"
 "\n"
@@ -110,33 +110,33 @@ msgstr ""
 "\n"
 "eller avsluta ditt arbete och pausa eller stäng av datorn.\n"
 
-#: 5.4/applet.js:392
+#: 5.4/applet.js:409
 msgid "Battery Critical - will suspend unless connected to power supply"
 msgstr ""
 "Batterinivån kritisk! Datorn kommer att pausas om den inte ansluts till "
 "strömkälla."
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Charge:"
 msgstr "Laddning:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Alert:"
 msgstr "Varning:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Suspend:"
 msgstr "Pausa:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Percentage Charge:"
 msgstr "Laddning:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Alert at:"
 msgstr "Varna vid:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Suspend at:"
 msgstr "Pausa vid:"
 
@@ -380,8 +380,7 @@ msgid "Advanced"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->description
-msgid ""
-"Path to battery capacity directory (device path)"
+msgid "Path to battery capacity directory (device path)"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->tooltip

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/tr.po
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/tr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.2.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-08 22:29-0500\n"
-"PO-Revision-Date: 2022-12-08 22:32-0500\n"
+"POT-Creation-Date: 2022-12-27 19:21-0500\n"
+"PO-Revision-Date: 2022-12-29 13:38-0500\n"
 "Last-Translator: Serkan ÖNDER <serkanonder@outlook.com>\n"
 "Language-Team: \n"
 "Language: tr\n"
@@ -18,19 +18,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: 5.4/applet.js:135 3.2/applet.js:135
+#: 5.4/applet.js:139 3.2/applet.js:135
 msgid "--%"
 msgstr "--%"
 
-#: 5.4/applet.js:136 3.2/applet.js:136
+#: 5.4/applet.js:140 3.2/applet.js:136
 msgid "Waiting"
 msgstr "Bekleniyor"
 
-#: 5.4/applet.js:160 3.2/applet.js:165
+#: 5.4/applet.js:164 3.2/applet.js:165
 msgid "Some Dependencies not Installed"
 msgstr "Bazı Bağımlılıklar Yüklenmedi"
 
-#: 5.4/applet.js:160
+#: 5.4/applet.js:164
 msgid ""
 "Both 'sox' and 'zenity' are required for this applet to have all of its "
 "functionality including notifications and audible alerts .\n"
@@ -42,11 +42,11 @@ msgstr ""
 "\n"
 "Lütfen bunların nasıl kurulacağına ilişkin yardım dosyasını okuyun."
 
-#: 5.4/applet.js:170 3.2/applet.js:198
+#: 5.4/applet.js:174 3.2/applet.js:198
 msgid "Battery Monitor Applet"
 msgstr "Pil İzleme Uygulaması"
 
-#: 5.4/applet.js:170
+#: 5.4/applet.js:174
 msgid ""
 "A user-defined sound file has been specified for Low Battery.\n"
 "\n"
@@ -59,44 +59,44 @@ msgstr ""
 "emin olun\n"
 "özellikle uzun yüksek sesli bir dosya belirtilmişse\n"
 
-#: 5.4/applet.js:243 3.2/applet.js:297
+#: 5.4/applet.js:247 3.2/applet.js:297
 msgid "Open Power Statistics"
 msgstr "Güç İstatistiklerini Aç"
 
-#: 5.4/applet.js:249 3.2/applet.js:303
+#: 5.4/applet.js:253 3.2/applet.js:303
 msgid "Open System Monitor"
 msgstr "Sistem Gözlemcisini Aç"
 
-#: 5.4/applet.js:258
+#: 5.4/applet.js:262
 msgid "Housekeeping and System Submenu"
 msgstr "Düzenleme ve Sistem Alt Menüsü"
 
-#: 5.4/applet.js:261 3.2/applet.js:315
+#: 5.4/applet.js:265 3.2/applet.js:315
 msgid "View the Changelog"
 msgstr "Değişim Günlüğünü İncele"
 
-#: 5.4/applet.js:267
+#: 5.4/applet.js:271
 msgid "Open the README"
 msgstr ""
 
-#: 5.4/applet.js:273 3.2/applet.js:327
+#: 5.4/applet.js:277 3.2/applet.js:327
 msgid "Open stylesheet.css (Advanced Function)"
 msgstr "Stylesheet.css aç (Gelişmiş İşlev)"
 
 #. metadata.json->name
-#: 5.4/applet.js:289 3.2/applet.js:343
+#: 5.4/applet.js:293 3.2/applet.js:343
 msgid "Battery Applet with Monitoring and Shutdown (BAMS)"
 msgstr "Pil İzleme ve Kapatma Uygulamacığı (BAMS)"
 
-#: 5.4/applet.js:294 3.2/applet.js:348
+#: 5.4/applet.js:298 3.2/applet.js:348
 msgid "Waiting for battery information"
 msgstr "Pil bilgileri bekleniyor"
 
-#: 5.4/applet.js:372
+#: 5.4/applet.js:389
 msgid "Battery Low - turn off or connect to power supply"
 msgstr "Düşük Pil - kapat veya ana şebekeye bağla"
 
-#: 5.4/applet.js:377 3.2/applet.js:433
+#: 5.4/applet.js:394 3.2/applet.js:433
 msgid ""
 "The Battery Level has fallen to your alert level\n"
 "\n"
@@ -112,31 +112,31 @@ msgstr ""
 "işinizi kapatın ve makineyi askıya alın veya kapatın\n"
 "\n"
 
-#: 5.4/applet.js:392
+#: 5.4/applet.js:409
 msgid "Battery Critical - will suspend unless connected to power supply"
 msgstr "Pil Kritik, şebekeye bağlanmazsa askıya alınacak"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Charge:"
 msgstr "Şarj:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Alert:"
 msgstr "Uyarı:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Suspend:"
 msgstr "Askı:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Percentage Charge:"
 msgstr "Şarj Oranı:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Alert at:"
 msgstr "Uyarı durumu:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Suspend at:"
 msgstr "Askı durumu:"
 
@@ -381,8 +381,7 @@ msgid "Advanced"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->description
-msgid ""
-"Path to battery capacity directory (device path)"
+msgid "Path to battery capacity directory (device path)"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->tooltip

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/uk.po
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/uk.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-08 22:29-0500\n"
-"PO-Revision-Date: 2022-12-08 22:31-0500\n"
+"POT-Creation-Date: 2022-12-27 19:21-0500\n"
+"PO-Revision-Date: 2022-12-29 13:37-0500\n"
 "Last-Translator: \n"
 "Language-Team: Nicholas Fox <nicholaslisovenko@gmail.com>\n"
 "Language: uk\n"
@@ -19,19 +19,19 @@ msgstr ""
 "%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: 5.4/applet.js:135 3.2/applet.js:135
+#: 5.4/applet.js:139 3.2/applet.js:135
 msgid "--%"
 msgstr ""
 
-#: 5.4/applet.js:136 3.2/applet.js:136
+#: 5.4/applet.js:140 3.2/applet.js:136
 msgid "Waiting"
 msgstr "Очікування"
 
-#: 5.4/applet.js:160 3.2/applet.js:165
+#: 5.4/applet.js:164 3.2/applet.js:165
 msgid "Some Dependencies not Installed"
 msgstr ""
 
-#: 5.4/applet.js:160
+#: 5.4/applet.js:164
 msgid ""
 "Both 'sox' and 'zenity' are required for this applet to have all of its "
 "functionality including notifications and audible alerts .\n"
@@ -39,11 +39,11 @@ msgid ""
 "Please view the README for help on installing them."
 msgstr ""
 
-#: 5.4/applet.js:170 3.2/applet.js:198
+#: 5.4/applet.js:174 3.2/applet.js:198
 msgid "Battery Monitor Applet"
 msgstr ""
 
-#: 5.4/applet.js:170
+#: 5.4/applet.js:174
 msgid ""
 "A user-defined sound file has been specified for Low Battery.\n"
 "\n"
@@ -51,44 +51,44 @@ msgid ""
 "especially if a long or loud file is specified.\n"
 msgstr ""
 
-#: 5.4/applet.js:243 3.2/applet.js:297
+#: 5.4/applet.js:247 3.2/applet.js:297
 msgid "Open Power Statistics"
 msgstr "Відкрити статистику живлення"
 
-#: 5.4/applet.js:249 3.2/applet.js:303
+#: 5.4/applet.js:253 3.2/applet.js:303
 msgid "Open System Monitor"
 msgstr "Відкрити систему моніторінгу"
 
-#: 5.4/applet.js:258
+#: 5.4/applet.js:262
 msgid "Housekeeping and System Submenu"
 msgstr "Підменю «Прибирання» і «Система»"
 
-#: 5.4/applet.js:261 3.2/applet.js:315
+#: 5.4/applet.js:265 3.2/applet.js:315
 msgid "View the Changelog"
 msgstr "Перегляд списку змін"
 
-#: 5.4/applet.js:267
+#: 5.4/applet.js:271
 msgid "Open the README"
 msgstr ""
 
-#: 5.4/applet.js:273 3.2/applet.js:327
+#: 5.4/applet.js:277 3.2/applet.js:327
 msgid "Open stylesheet.css (Advanced Function)"
 msgstr "Відкрити файл stylesheet.css (розширена функція)"
 
 #. metadata.json->name
-#: 5.4/applet.js:289 3.2/applet.js:343
+#: 5.4/applet.js:293 3.2/applet.js:343
 msgid "Battery Applet with Monitoring and Shutdown (BAMS)"
 msgstr "Аплет батареї з контролем і вимиканням (BAMS)"
 
-#: 5.4/applet.js:294 3.2/applet.js:348
+#: 5.4/applet.js:298 3.2/applet.js:348
 msgid "Waiting for battery information"
 msgstr ""
 
-#: 5.4/applet.js:372
+#: 5.4/applet.js:389
 msgid "Battery Low - turn off or connect to power supply"
 msgstr "Батарея розряджена - вимкнітся або підключіть до мережі"
 
-#: 5.4/applet.js:377 3.2/applet.js:433
+#: 5.4/applet.js:394 3.2/applet.js:433
 msgid ""
 "The Battery Level has fallen to your alert level\n"
 "\n"
@@ -103,32 +103,32 @@ msgstr ""
 "або припиніть вашу роботу і на паузу або вимкніть машину\n"
 "\n"
 
-#: 5.4/applet.js:392
+#: 5.4/applet.js:409
 msgid "Battery Critical - will suspend unless connected to power supply"
 msgstr ""
 "Критичний рівень заряду, робота буде припинена, якщо не подлючен до мережі"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Charge:"
 msgstr "Заряд:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Alert:"
 msgstr "Попередження:"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Suspend:"
 msgstr "Призупинити:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Percentage Charge:"
 msgstr "Відсоток заряду:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Alert at:"
 msgstr "Оповіщення по:"
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Suspend at:"
 msgstr "Призупинити на:"
 
@@ -345,8 +345,7 @@ msgid "Advanced"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->description
-msgid ""
-"Path to battery capacity directory (device path)"
+msgid "Path to battery capacity directory (device path)"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->tooltip

--- a/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/zh_CN.po
+++ b/batterymonitor@pdcurtis/files/batterymonitor@pdcurtis/po/zh_CN.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-08 22:29-0500\n"
-"PO-Revision-Date: 2022-12-08 22:33-0500\n"
+"POT-Creation-Date: 2022-12-27 19:21-0500\n"
+"PO-Revision-Date: 2022-12-29 13:37-0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: zh_CN\n"
@@ -18,19 +18,19 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: 5.4/applet.js:135 3.2/applet.js:135
+#: 5.4/applet.js:139 3.2/applet.js:135
 msgid "--%"
 msgstr ""
 
-#: 5.4/applet.js:136 3.2/applet.js:136
+#: 5.4/applet.js:140 3.2/applet.js:136
 msgid "Waiting"
 msgstr "等待中"
 
-#: 5.4/applet.js:160 3.2/applet.js:165
+#: 5.4/applet.js:164 3.2/applet.js:165
 msgid "Some Dependencies not Installed"
 msgstr ""
 
-#: 5.4/applet.js:160
+#: 5.4/applet.js:164
 msgid ""
 "Both 'sox' and 'zenity' are required for this applet to have all of its "
 "functionality including notifications and audible alerts .\n"
@@ -38,11 +38,11 @@ msgid ""
 "Please view the README for help on installing them."
 msgstr ""
 
-#: 5.4/applet.js:170 3.2/applet.js:198
+#: 5.4/applet.js:174 3.2/applet.js:198
 msgid "Battery Monitor Applet"
 msgstr ""
 
-#: 5.4/applet.js:170
+#: 5.4/applet.js:174
 msgid ""
 "A user-defined sound file has been specified for Low Battery.\n"
 "\n"
@@ -50,44 +50,44 @@ msgid ""
 "especially if a long or loud file is specified.\n"
 msgstr ""
 
-#: 5.4/applet.js:243 3.2/applet.js:297
+#: 5.4/applet.js:247 3.2/applet.js:297
 msgid "Open Power Statistics"
 msgstr "打开电源统计"
 
-#: 5.4/applet.js:249 3.2/applet.js:303
+#: 5.4/applet.js:253 3.2/applet.js:303
 msgid "Open System Monitor"
 msgstr "打开系统监视器"
 
-#: 5.4/applet.js:258
+#: 5.4/applet.js:262
 msgid "Housekeeping and System Submenu"
 msgstr "内务处理和系统子菜单"
 
-#: 5.4/applet.js:261 3.2/applet.js:315
+#: 5.4/applet.js:265 3.2/applet.js:315
 msgid "View the Changelog"
 msgstr "查看变更日志"
 
-#: 5.4/applet.js:267
+#: 5.4/applet.js:271
 msgid "Open the README"
 msgstr ""
 
-#: 5.4/applet.js:273 3.2/applet.js:327
+#: 5.4/applet.js:277 3.2/applet.js:327
 msgid "Open stylesheet.css (Advanced Function)"
 msgstr "打开stylesheet.css（高级功能）"
 
 #. metadata.json->name
-#: 5.4/applet.js:289 3.2/applet.js:343
+#: 5.4/applet.js:293 3.2/applet.js:343
 msgid "Battery Applet with Monitoring and Shutdown (BAMS)"
 msgstr "Battery Applet with Monitoring and Shutdown (BAMS)"
 
-#: 5.4/applet.js:294 3.2/applet.js:348
+#: 5.4/applet.js:298 3.2/applet.js:348
 msgid "Waiting for battery information"
 msgstr ""
 
-#: 5.4/applet.js:372
+#: 5.4/applet.js:389
 msgid "Battery Low - turn off or connect to power supply"
 msgstr "电量低 - 关机或连接到电源"
 
-#: 5.4/applet.js:377 3.2/applet.js:433
+#: 5.4/applet.js:394 3.2/applet.js:433
 msgid ""
 "The Battery Level has fallen to your alert level\n"
 "\n"
@@ -102,31 +102,31 @@ msgstr ""
 "或停止您的工作并挂起或关闭机器\n"
 "\n"
 
-#: 5.4/applet.js:392
+#: 5.4/applet.js:409
 msgid "Battery Critical - will suspend unless connected to power supply"
 msgstr "电量不足将会挂起，除非连接到电源"
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Charge:"
 msgstr "充电："
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Alert:"
 msgstr "警报："
 
-#: 5.4/applet.js:409 3.2/applet.js:464
+#: 5.4/applet.js:426 3.2/applet.js:464
 msgid "Suspend:"
 msgstr "挂起："
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Percentage Charge:"
 msgstr "充电百分比："
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Alert at:"
 msgstr "警报于："
 
-#: 5.4/applet.js:457 3.2/applet.js:512
+#: 5.4/applet.js:474 3.2/applet.js:512
 msgid "Suspend at:"
 msgstr "挂起于："
 
@@ -341,8 +341,7 @@ msgid "Advanced"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->description
-msgid ""
-"Path to battery capacity directory (device path)"
+msgid "Path to battery capacity directory (device path)"
 msgstr ""
 
 #. 5.4->settings-schema.json->customBatteryPath->tooltip


### PR DESCRIPTION
### 1.5.1
 * Improved the logic for determining the default kernel path (some systems default to BAT1 instead of BAT0)
   - Fixes "-- Warning" permanent message and removes the need for manual configuration in the single battery condition to address it

@pdcurtis (who is on vacation but gives his blessing)