### PR TITLE
bettersettings@bownz changing how screenshot tool opens

### DIFF
--- a/bettersettings@bownz/files/bettersettings@bownz/applet.js
+++ b/bettersettings@bownz/files/bettersettings@bownz/applet.js
@@ -98,7 +98,7 @@ MyApplet.prototype = {
             this.menu.addMenuItem(this.troubleshootItem);
 
   	    this.menu.addAction(_("Screenshot"), function(event) {
-                Util.spawnCommandLine("gnome-screenshot -a");
+                Util.spawnCommandLine("gnome-screenshot -i");
             });
 
 	     this.menu.addAction(_("Terminal"), function(event) {


### PR DESCRIPTION
change to open gnome-screenshot in interactive mode  since mode it was in isn't working