### PR TITLE
[kdecapplet@joejoetv] Version 2.1.0

### DIFF
--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/applet.js
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/applet.js
@@ -1530,7 +1530,6 @@ class KDEConnectApplet extends Applet.TextIconApplet {
      */
     onAnnouncedNameChanged(proxy, sender, [name]) {
         this.info("AnnouncedNameChanged Signal: "+name, CommonUtils.LogLevel.DEBUG);
-        //TODO: Implement
     }
     
     /**
@@ -1760,8 +1759,6 @@ class KDEConnectApplet extends Applet.TextIconApplet {
     registerModuleSettings(modules) {
         modules.forEach(moduleID => {
             this.options.modules[moduleID] = {};
-            // TODO: Remove
-            //this.settings.bindWithObject(this.options.modules[moduleID], moduleID+"-module-enabled", "enabled", this.onModuleSettingsChanged.bind(this), moduleID);
 
             // Register any additional settings to also call onModuleSettingsChanged,
             // since we need to rebuild the context manu anyway and the user shouldn't have the popup menu open when changing settings

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/applet.js
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/applet.js
@@ -1368,6 +1368,22 @@ class KDEConnectApplet extends Applet.TextIconApplet {
     }
 
     /**
+     * Callback that gets called, if the name of a device change
+     */
+    onDeviceNameChanged() {
+        this.info("Name of a device changed!", CommonUtils.LogLevel.DEBUG);
+
+        // Update settings order list
+        this.doOrderCallback = false;
+
+        // Clean settings device list, we don't(shouldn't) need to regenerate the order array,
+        // as we only have a name change, so the cleaning procedure will only update the name in the settings
+        this.cleanDeviceOrder();
+
+        this.doOrderCallback = true;
+    }
+
+    /**
      * Callback that gets called, when a setting related to the context menu changes
      * @param {*} value - The new value
      * @param {string} option - The option that changed
@@ -1681,6 +1697,7 @@ class KDEConnectApplet extends Applet.TextIconApplet {
             // Bind signal to onDeviceDataChanged function of the applet
             newDevice._signals.connect(newDevice, "plugins-changed", this.onDevicePluginsChanged, this);
             newDevice._signals.connect(newDevice, "reachable-changed", this.onDeviceReachableChanged, this);
+            newDevice._signals.connect(newDevice, "name-changed", this.onDeviceNameChanged, this);
 
             deviceMap[deviceID] = newDevice;
         });

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/js/modules.js
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/js/modules.js
@@ -688,7 +688,7 @@ class DeviceInfoModule extends KDECModule {
 
     static REQUIRED_KDEC_PLUGINS = [];
     static MODULE_ID = "deviceinfo";
-    static DISPLAY_NAME = "Device Info Module";
+    static DISPLAY_NAME = "Device-Info Module";
     static ADDITIONAL_SETTINGS = [];
     static TYPE = ModuleType.INFO;
 

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/js/modules.js
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/js/modules.js
@@ -425,9 +425,17 @@ class KDECModule {
     // KDE Connect plugins required to be loaded, that the applet is created
     static REQUIRED_KDEC_PLUGINS = [];
 
+    // ID that identifies the module
     static MODULE_ID = "";
 
+    // Display name to display in settings
     static DISPLAY_NAME = "Module";
+
+    // Array of additional settings keys to bind
+    static ADDITIONAL_SETTINGS = [];
+
+    // Type of the module (ModuleType)
+    static TYPE = ModuleType.PASSIVE;
 
     constructor(id, type, device, compatMode) {
         // Have to be set by subclass
@@ -597,9 +605,11 @@ class BatteryModule extends KDECModule {
     static REQUIRED_KDEC_PLUGINS = ["kdeconnect_battery"];
     static MODULE_ID = "battery";
     static DISPLAY_NAME = "Battery Module";
+    static ADDITIONAL_SETTINGS = [];
+    static TYPE = ModuleType.INFO;
 
     constructor(device, compatMode) {
-        super(BatteryModule.MODULE_ID, ModuleType.INFO, device, compatMode);
+        super(BatteryModule.MODULE_ID, BatteryModule.TYPE, device, compatMode);
     }
 
     _initValues() {
@@ -679,9 +689,11 @@ class DeviceInfoModule extends KDECModule {
     static REQUIRED_KDEC_PLUGINS = [];
     static MODULE_ID = "deviceinfo";
     static DISPLAY_NAME = "Device Info Module";
+    static ADDITIONAL_SETTINGS = [];
+    static TYPE = ModuleType.INFO;
 
     constructor(device, compatMode) {
-        super(DeviceInfoModule.MODULE_ID, ModuleType.INFO, device, compatMode);
+        super(DeviceInfoModule.MODULE_ID, DeviceInfoModule.TYPE, device, compatMode);
     }
 
     _initValues() {
@@ -744,9 +756,11 @@ class ConnectivityModule extends KDECModule {
     static REQUIRED_KDEC_PLUGINS = ["kdeconnect_connectivity_report"];
     static MODULE_ID = "connectivity";
     static DISPLAY_NAME = "Connectivity Module";
+    static ADDITIONAL_SETTINGS = ["showNetworkType"];
+    static TYPE = ModuleType.INFO;
 
     constructor(device, compatMode) {
-        super(ConnectivityModule.MODULE_ID, ModuleType.INFO, device, compatMode);
+        super(ConnectivityModule.MODULE_ID, ConnectivityModule.TYPE, device, compatMode);
     }
 
     _initValues() {
@@ -857,9 +871,11 @@ class FindMyPhoneModule extends KDECModule {
     static REQUIRED_KDEC_PLUGINS = ["kdeconnect_findmyphone"];
     static MODULE_ID = "findmyphone";
     static DISPLAY_NAME = "FindMyPhone Module";
+    static ADDITIONAL_SETTINGS = [];
+    static TYPE = ModuleType.ACTION;
 
     constructor(device, compatMode) {
-        super(FindMyPhoneModule.MODULE_ID, ModuleType.ACTION, device, compatMode);
+        super(FindMyPhoneModule.MODULE_ID, FindMyPhoneModule.TYPE, device, compatMode);
     }
 
     _createProxy() {
@@ -894,9 +910,11 @@ class RequestPhotoModule extends KDECModule {
     static REQUIRED_KDEC_PLUGINS = ["kdeconnect_photo"];
     static MODULE_ID = "requestphoto";
     static DISPLAY_NAME = "Request Photo Module";
+    static ADDITIONAL_SETTINGS = ["saveToDir", "saveDirectory"];
+    static TYPE = ModuleType.ACTION;
 
     constructor(device, compatMode) {
-        super(RequestPhotoModule.MODULE_ID, ModuleType.ACTION, device, compatMode);
+        super(RequestPhotoModule.MODULE_ID, RequestPhotoModule.TYPE, device, compatMode);
     }
 
     _createProxy() {
@@ -993,9 +1011,11 @@ class PingModule extends KDECModule {
     static REQUIRED_KDEC_PLUGINS = ["kdeconnect_ping"];
     static MODULE_ID = "ping";
     static DISPLAY_NAME = "Ping Module";
+    static ADDITIONAL_SETTINGS = ["useCustomMessage", "customMessage"];
+    static TYPE = ModuleType.ACTION;
 
     constructor(device, compatMode) {
-        super(PingModule.MODULE_ID, ModuleType.ACTION, device, compatMode);
+        super(PingModule.MODULE_ID, PingModule.TYPE, device, compatMode);
     }
 
     _createProxy() {
@@ -1043,9 +1063,11 @@ class ShareModule extends KDECModule {
     static REQUIRED_KDEC_PLUGINS = ["kdeconnect_share"];
     static MODULE_ID = "share";
     static DISPLAY_NAME = "Share Module";
+    static ADDITIONAL_SETTINGS = ["useSubMenu", "enableSendURL", "enableSendText", "enableSendFiles"];
+    static TYPE = ModuleType.ACTION;
 
     constructor(device, compatMode) {
-        super(ShareModule.MODULE_ID, ModuleType.ACTION, device, compatMode);
+        super(ShareModule.MODULE_ID, ShareModule.TYPE, device, compatMode);
     }
 
     _createProxy() {
@@ -1222,9 +1244,11 @@ class SFTPModule extends KDECModule {
     static REQUIRED_KDEC_PLUGINS = ["kdeconnect_sftp"];
     static MODULE_ID = "sftp";
     static DISPLAY_NAME = "SFTP Module";
+    static ADDITIONAL_SETTINGS = [];
+    static TYPE = ModuleType.ACTION;
 
     constructor(device, compatMode) {        
-        super(SFTPModule.MODULE_ID, ModuleType.ACTION, device, compatMode);
+        super(SFTPModule.MODULE_ID, SFTPModule.TYPE, device, compatMode);
     }
 
     _initValues() {
@@ -1370,9 +1394,11 @@ class SMSModule extends KDECModule {
     static REQUIRED_KDEC_PLUGINS = ["kdeconnect_sms"];
     static MODULE_ID = "sms";
     static DISPLAY_NAME = "SMS Module";
+    static ADDITIONAL_SETTINGS = ["useSubMenu", "enableSendSMS", "enableLaunchSMSApp"];
+    static TYPE = ModuleType.ACTION;
 
     constructor(device, compatMode) {
-        super(SMSModule.MODULE_ID, ModuleType.ACTION, device, compatMode);
+        super(SMSModule.MODULE_ID, SMSModule.TYPE, device, compatMode);
     }
 
     _createProxy() {
@@ -1490,34 +1516,24 @@ moduleClasses[ShareModule.MODULE_ID] = ShareModule;
 moduleClasses[SFTPModule.MODULE_ID] = SFTPModule;
 moduleClasses[SMSModule.MODULE_ID] = SMSModule;
 
-// Register additional settings
-
-let additionalSettings = {}
-
-additionalSettings[BatteryModule.MODULE_ID] = [];
-additionalSettings[DeviceInfoModule.MODULE_ID] = [];
-additionalSettings[ConnectivityModule.MODULE_ID] = ["showNetworkType"];
-additionalSettings[FindMyPhoneModule.MODULE_ID] = [];
-additionalSettings[RequestPhotoModule.MODULE_ID] = ["saveToDir", "saveDirectory"];
-additionalSettings[PingModule.MODULE_ID] = ["useCustomMessage", "customMessage"];
-additionalSettings[ShareModule.MODULE_ID] = ["useSubMenu", "enableSendURL", "enableSendText", "enableSendFiles"];
-additionalSettings[SFTPModule.MODULE_ID] = [];
-additionalSettings[SMSModule.MODULE_ID] = ["useSubMenu", "enableSendSMS", "enableLaunchSMSApp"];
-
-// Create array of module IDs
+// Create array of supported module IDs
+// NOTE: Not necessarily sorted correctly
 let modules = Object.keys(moduleClasses);
 
-let infoModules = [
-    BatteryModule.MODULE_ID,
-    DeviceInfoModule.MODULE_ID,
-    ConnectivityModule.MODULE_ID
-]
+/**
+ * Return the subarray of "modules", which fit the type
+ * @param {ModuleType} moduleType - The ModuleType to filter
+ */
+function modulesByType(moduleType) {
+    let filteredModules = [];
 
-let actionModules = [
-    FindMyPhoneModule.MODULE_ID,
-    RequestPhotoModule.MODULE_ID,
-    PingModule.MODULE_ID,
-    ShareModule.MODULE_ID,
-    SFTPModule.MODULE_ID,
-    SMSModule.MODULE_ID
-]
+    CommonUtils.utilInfo("ModuleType: "+moduleType.toString(), CommonUtils.LogLevel.VERBOSE, "modulesByType");
+
+    modules.forEach(moduleID => {
+        if (moduleClasses[moduleID].TYPE == moduleType) {
+            filteredModules.push(moduleID);
+        }
+    });
+
+    return filteredModules;
+}

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/js/modules.js
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/js/modules.js
@@ -427,6 +427,8 @@ class KDECModule {
 
     static MODULE_ID = "";
 
+    static DISPLAY_NAME = "Module";
+
     constructor(id, type, device, compatMode) {
         // Have to be set by subclass
         this.id = id;
@@ -594,6 +596,7 @@ class BatteryModule extends KDECModule {
 
     static REQUIRED_KDEC_PLUGINS = ["kdeconnect_battery"];
     static MODULE_ID = "battery";
+    static DISPLAY_NAME = "Battery Module";
 
     constructor(device, compatMode) {
         super(BatteryModule.MODULE_ID, ModuleType.INFO, device, compatMode);
@@ -675,6 +678,7 @@ class DeviceInfoModule extends KDECModule {
 
     static REQUIRED_KDEC_PLUGINS = [];
     static MODULE_ID = "deviceinfo";
+    static DISPLAY_NAME = "Device Info Module";
 
     constructor(device, compatMode) {
         super(DeviceInfoModule.MODULE_ID, ModuleType.INFO, device, compatMode);
@@ -739,6 +743,7 @@ class ConnectivityModule extends KDECModule {
 
     static REQUIRED_KDEC_PLUGINS = ["kdeconnect_connectivity_report"];
     static MODULE_ID = "connectivity";
+    static DISPLAY_NAME = "Connectivity Module";
 
     constructor(device, compatMode) {
         super(ConnectivityModule.MODULE_ID, ModuleType.INFO, device, compatMode);
@@ -851,6 +856,7 @@ class FindMyPhoneModule extends KDECModule {
 
     static REQUIRED_KDEC_PLUGINS = ["kdeconnect_findmyphone"];
     static MODULE_ID = "findmyphone";
+    static DISPLAY_NAME = "FindMyPhone Module";
 
     constructor(device, compatMode) {
         super(FindMyPhoneModule.MODULE_ID, ModuleType.ACTION, device, compatMode);
@@ -887,6 +893,7 @@ class RequestPhotoModule extends KDECModule {
 
     static REQUIRED_KDEC_PLUGINS = ["kdeconnect_photo"];
     static MODULE_ID = "requestphoto";
+    static DISPLAY_NAME = "Request Photo Module";
 
     constructor(device, compatMode) {
         super(RequestPhotoModule.MODULE_ID, ModuleType.ACTION, device, compatMode);
@@ -985,6 +992,7 @@ class PingModule extends KDECModule {
 
     static REQUIRED_KDEC_PLUGINS = ["kdeconnect_ping"];
     static MODULE_ID = "ping";
+    static DISPLAY_NAME = "Ping Module";
 
     constructor(device, compatMode) {
         super(PingModule.MODULE_ID, ModuleType.ACTION, device, compatMode);
@@ -1034,6 +1042,7 @@ class ShareModule extends KDECModule {
 
     static REQUIRED_KDEC_PLUGINS = ["kdeconnect_share"];
     static MODULE_ID = "share";
+    static DISPLAY_NAME = "Share Module";
 
     constructor(device, compatMode) {
         super(ShareModule.MODULE_ID, ModuleType.ACTION, device, compatMode);
@@ -1212,6 +1221,7 @@ class SFTPModule extends KDECModule {
 
     static REQUIRED_KDEC_PLUGINS = ["kdeconnect_sftp"];
     static MODULE_ID = "sftp";
+    static DISPLAY_NAME = "SFTP Module";
 
     constructor(device, compatMode) {        
         super(SFTPModule.MODULE_ID, ModuleType.ACTION, device, compatMode);
@@ -1359,6 +1369,7 @@ class SMSModule extends KDECModule {
 
     static REQUIRED_KDEC_PLUGINS = ["kdeconnect_sms"];
     static MODULE_ID = "sms";
+    static DISPLAY_NAME = "SMS Module";
 
     constructor(device, compatMode) {
         super(SMSModule.MODULE_ID, ModuleType.ACTION, device, compatMode);
@@ -1495,3 +1506,18 @@ additionalSettings[SMSModule.MODULE_ID] = ["useSubMenu", "enableSendSMS", "enabl
 
 // Create array of module IDs
 let modules = Object.keys(moduleClasses);
+
+let infoModules = [
+    BatteryModule.MODULE_ID,
+    DeviceInfoModule.MODULE_ID,
+    ConnectivityModule.MODULE_ID
+]
+
+let actionModules = [
+    FindMyPhoneModule.MODULE_ID,
+    RequestPhotoModule.MODULE_ID,
+    PingModule.MODULE_ID,
+    ShareModule.MODULE_ID,
+    SFTPModule.MODULE_ID,
+    SMSModule.MODULE_ID
+]

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/js/modules.js
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/js/modules.js
@@ -1501,8 +1501,6 @@ class SMSModule extends KDECModule {
     }
 }
 
-// TODO: Maybe add telephony module
-
 // Register module classes
 let moduleClasses = {}
 

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/metadata.json
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/metadata.json
@@ -4,6 +4,6 @@
   "description": "Enables interacting with devices connected via KDE Connect",
   "comments": "KDE Connect Applet makes it easy to use the various features provided by KDE Connect to interact with connected devices, like sending files, sending SMS messages, browsing the storage of the device and more",
   "website": "https://github.com/linuxmint/cinnamon-spices-applets/tree/master/kdecapplet@joejoetv",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "contributors": "Johannes Schoeneberger - Author,Severga - Inspiration for the Applet"
 }

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/de.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/de.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-29 14:21+0100\n"
-"PO-Revision-Date: 2023-01-29 14:21+0100\n"
+"POT-Creation-Date: 2023-03-08 00:05+0100\n"
+"PO-Revision-Date: 2023-03-08 00:07+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: de\n"
@@ -18,29 +18,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:571
+#: applet.js:574
 msgid "No Modules available"
 msgstr "Keine Module verfügbar"
 
-#: applet.js:1008
+#: applet.js:1065
 msgid "KDE Connect not available"
 msgstr "KDE Connect ist nicht verfügbar"
 
-#: applet.js:1011
+#: applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr ""
 "KDE Connect ist nicht verfügbar, stelle sicher, das es installiert ist und "
 "ausgeführt wird"
 
-#: applet.js:1015 applet.js:1028 applet.js:1202
+#: applet.js:1072 applet.js:1085 applet.js:1270
 msgid "Reload Applet"
 msgstr "Applet neuladen"
 
-#: applet.js:1020
+#: applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr "Ungültige KDE Connect Version erhalten!"
 
-#: applet.js:1021 applet.js:1024
+#: applet.js:1078 applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
@@ -48,51 +48,51 @@ msgstr ""
 "Der KDE Connect DBus Dienst hat eine ungültige Version zurückgegeben, bitte "
 "versuche, das Applet neu zu laden"
 
-#: applet.js:1074
+#: applet.js:1120
 msgid "No connected Devices!"
 msgstr "Keine verbundenen Geräte!"
 
-#: applet.js:1074
+#: applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr "Füge sie in den KDE Connect Einstellungen hinzu"
 
-#: applet.js:1097
+#: applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr "Debug Zeug, nicht anfassen!"
 
-#: applet.js:1186
+#: applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr "KDE Connect Version: {version}"
 
-#: applet.js:1193
+#: applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr "Eigene ID: {own_id}"
 
-#: applet.js:1195
+#: applet.js:1263
 msgid "own ID"
 msgstr "Eigene ID"
 
-#: applet.js:1197
+#: applet.js:1265
 msgid "Click to copy own ID"
 msgstr "Klicken, um eigene ID zu kopieren"
 
-#: applet.js:1207
+#: applet.js:1275
 msgid "Configure KDE Connect"
 msgstr "KDE Connect konfigurieren"
 
-#: applet.js:1209
+#: applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr "Klicken, um die KDE Connect Einstellungen zu öffnen"
 
-#: applet.js:1253
+#: applet.js:1321
 msgid "No available devices"
 msgstr "Keine verfügbaren Geräte"
 
-#: applet.js:1255
+#: applet.js:1323
 msgid "{deviceCount} available device"
 msgstr "{deviceCount} verfügbares Gerät"
 
-#: applet.js:1257
+#: applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr "{deviceCount} verfügbare Geräte"
 
@@ -100,153 +100,161 @@ msgstr "{deviceCount} verfügbare Geräte"
 msgid "Copied {typestring} to the clipboard"
 msgstr "{typestring} in die Zwischenablage kopiert"
 
-#: js/modules.js:643
+#: js/modules.js:656
 msgid "Charging"
 msgstr "Ladend"
 
-#: js/modules.js:723
+#: js/modules.js:739
 msgid "ID: {id}"
 msgstr "ID: {id}"
 
-#: js/modules.js:727
+#: js/modules.js:743
 msgid "Device ID"
 msgstr "Geräte ID"
 
-#: js/modules.js:731
+#: js/modules.js:747
 msgid "Click to copy ID"
 msgstr "Klicken, um ID zu kopieren"
 
-#: js/modules.js:801
+#: js/modules.js:820
 msgid "No Signal"
 msgstr "Kein Empfang"
 
-#: js/modules.js:804
+#: js/modules.js:823
 msgid "Low"
 msgstr "Schlecht"
 
-#: js/modules.js:807
+#: js/modules.js:826
 msgid "Ok"
 msgstr "Ok"
 
-#: js/modules.js:810
+#: js/modules.js:829
 msgid "Good"
 msgstr "Gut"
 
-#: js/modules.js:813
+#: js/modules.js:832
 msgid "Excellent"
 msgstr "Exzellent"
 
-#: js/modules.js:825
+#: js/modules.js:844
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: js/modules.js:876
+#: js/modules.js:898
 msgid "Ring device"
 msgstr "Gerät anklingeln"
 
-#: js/modules.js:877
+#: js/modules.js:899
 msgid "Click to ring the device"
 msgstr "Klicken, um Gerät anzuklingeln"
 
-#: js/modules.js:953
+#: js/modules.js:978
 msgid "Photo received from '{deviceName}'"
 msgstr "Foto von '{deviceName}' empfangen"
 
-#: js/modules.js:953 js/modules.js:1123
+#: js/modules.js:978 js/modules.js:1154
 msgid "Click to open in default application"
 msgstr "Klicken, um in Standardanwendung zu öffnen"
 
-#: js/modules.js:962
+#: js/modules.js:987
 msgid "Request Photo"
 msgstr "Foto anfragen"
 
-#: js/modules.js:963
+#: js/modules.js:988
 msgid "Click to request a photo from the device"
 msgstr "Klicken, um Foto von dem Gerät anzufordern"
 
-#: js/modules.js:1010
+#: js/modules.js:1038
 msgid "Ping!"
 msgstr "Ping!"
 
-#: js/modules.js:1017
+#: js/modules.js:1045
 msgid "Sent ping to device '{deviceName}'"
 msgstr "Ping-Nachricht an Gerät '{deviceName}' gesendet"
 
-#: js/modules.js:1023
+#: js/modules.js:1051
 msgid "Ping Device"
 msgstr "Ping-Nachricht an Gerät senden"
 
-#: js/modules.js:1024
+#: js/modules.js:1052
 msgid "Click to send a ping to the device"
 msgstr "Klicken, um Ping-Nachricht an Gerät zu senden"
 
-#: js/modules.js:1123
+#: js/modules.js:1154
 msgid "Share received from '{deviceName}'"
 msgstr "Freigabe von '{deviceName}' empfangen"
 
-#: js/modules.js:1158
+#: js/modules.js:1189
 msgid "Share"
 msgstr "Teilen"
 
-#: js/modules.js:1171
+#: js/modules.js:1202
 msgid "Send URL"
 msgstr "Teile URL"
 
-#: js/modules.js:1172
+#: js/modules.js:1203
 msgid "Click to send a URL to the device"
 msgstr "Klicken, um eine URL an das Gerät zu senden"
 
-#: js/modules.js:1181
+#: js/modules.js:1212
 msgid "Send Text"
 msgstr "Teile Text"
 
-#: js/modules.js:1182 js/modules.js:1451
+#: js/modules.js:1213 js/modules.js:1488
 msgid "Click to send text to the device"
 msgstr "Klicken, um Text an das Gerät zu senden"
 
-#: js/modules.js:1191
+#: js/modules.js:1222
 msgid "Send File(s)"
 msgstr "Teile Datei(en)"
 
-#: js/modules.js:1192
+#: js/modules.js:1223
 msgid "Click to send file(s) to the device"
 msgstr "Klicken, um Datei(en) an das Gerät zu senden"
 
-#: js/modules.js:1245
+#: js/modules.js:1279
 msgid "Unmount"
 msgstr "Aushängen"
 
-#: js/modules.js:1247
+#: js/modules.js:1281
 msgid "Mount"
 msgstr "Einhängen"
 
-#: js/modules.js:1253
+#: js/modules.js:1287
 msgid "Click to unmount"
 msgstr "Klicken zum aushängen"
 
-#: js/modules.js:1255
+#: js/modules.js:1289
 msgid "Click to mount"
 msgstr "Klicken zum einhängen"
 
-#: js/modules.js:1328
+#: js/modules.js:1362
 msgid "Click to browse files"
 msgstr "Klicken, um Dateien zu durchsuchen"
 
-#: js/modules.js:1429
+#: js/modules.js:1466
 msgid "SMS"
 msgstr "SMS"
 
-#: js/modules.js:1442
+#: js/modules.js:1479
 msgid "Launch SMS App"
 msgstr "SMS Anwendung starten"
 
-#: js/modules.js:1443
+#: js/modules.js:1480
 msgid "Click to open the KDE Connect SMS App"
 msgstr "Klicken, um KDE Connect SMS Anwendung zu starten"
 
-#: js/modules.js:1450
+#: js/modules.js:1487
 msgid "Send SMS"
 msgstr "SMS senden"
+
+#: settingsWidgets.py:153
+msgid "Move selected entry up"
+msgstr "Ausgewählten Eintrag nach oben bewegen"
+
+#: settingsWidgets.py:160
+msgid "Move selected entry down"
+msgstr "Ausgewählten Eintrag nach unten bewegen"
 
 #: py/dialogs.py:40
 #, python-brace-format
@@ -344,207 +352,271 @@ msgstr "Johannes Schöneberger - Autor"
 msgid "Severga - Inspiration for the Applet"
 msgstr "Severga - Inspiration für das Applet"
 
-#. settings-schema.json->general-page->title
+#. settings-schema.json->page_general->title
 msgid "General"
 msgstr "Allgemein"
 
-#. settings-schema.json->modules-page->title
+#. settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr "Module"
 
-#. settings-schema.json->contextmenu-section->title
+#. settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr "Kontextmenü"
 
-#. settings-schema.json->panel-section->title
+#. settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr "Leiste"
 
-#. settings-schema.json->appearance-section->title
-msgid "Appearance"
-msgstr "Aussehen"
+#. settings-schema.json->section_devices->title
+msgid "Devices"
+msgstr "Geräte"
 
-#. settings-schema.json->other-section->title
-msgid "Other"
-msgstr "Andere"
+#. settings-schema.json->section_info-modules->title
+msgid "Info Modules"
+msgstr "Info-Module"
 
-#. settings-schema.json->battery-module-section->title
+#. settings-schema.json->section_action-modules->title
+msgid "Action Modules"
+msgstr "Aktionsmodule"
+
+#. settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr "Akku Info-Modul"
 
-#. settings-schema.json->deviceinfo-module-section->title
-msgid "Device Info Module"
-msgstr "Gerät Info-Modul"
+#. settings-schema.json->section_module_deviceinfo->title
+msgid "Device-Info Info Module"
+msgstr "Geräte-Info Info-Modul"
 
-#. settings-schema.json->connectivity-module-section->title
+#. settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr "Konnektivität Info-Modul"
 
-#. settings-schema.json->findmyphone-module-section->title
+#. settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr "FindMyPhone Aktions-Modul"
 
-#. settings-schema.json->requestphoto-module-section->title
+#. settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr "Foto-Anfragen Aktions-Modul"
 
-#. settings-schema.json->ping-module-section->title
+#. settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr "Ping Aktions-Modul"
 
-#. settings-schema.json->share-module-section->title
+#. settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr "Teilen Aktions-Modul"
 
-#. settings-schema.json->sftp-module-section->title
+#. settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr "SFTP Aktions-Modul"
 
-#. settings-schema.json->sms-module-section->title
+#. settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr "SMS Aktions-Modul"
 
-#. settings-schema.json->showownid->description
+#. settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr "Eigene ID im Kontextmenü des Applets anzeigen"
 
-#. settings-schema.json->showkdecver->description
+#. settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr "KDE Connect Version im Kontextmenü des Applets anzeigen"
 
-#. settings-schema.json->shownumdevices->description
+#. settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr "Anzahl an verfügbaren Geräten neben dem Symbol in der Leiste anzeigen"
 
-#. settings-schema.json->icontype->description
-msgid "Icon type"
-msgstr "Symboltyp"
-
-#. settings-schema.json->icontype->options
-msgid "Symbolic"
-msgstr "Symbolisch"
-
-#. settings-schema.json->icontype->options
-msgid "Color"
-msgstr "Farbig"
-
-#. settings-schema.json->usecustomicon->description
-msgid "Use custom icon"
-msgstr "Benutzerdefiniertes Symbol benutzen"
-
-#. settings-schema.json->customicon->description
-msgid "Custom icon to use"
-msgstr "Benutzerdefiniertes Symbol"
-
-#. settings-schema.json->expandfirst->description
-msgid "Expand the first device sub menu automatically"
-msgstr "Erstes Geräte-Untermenü automatisch ausklappen"
-
-#. settings-schema.json->openconfiguration->description
-msgid "Open KDE Connect Configuration"
-msgstr "KDE Connect Einstellungen öffnen"
-
-#. settings-schema.json->tooltipdevicecount->description
+#. settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr "Anzahl an verfügbaren Geräten im Tooltip des Applets anzeigen"
 
-#. settings-schema.json->battery-module-description->description
+#. settings-schema.json->combobox_icon-type->description
+msgid "Icon type"
+msgstr "Symboltyp"
+
+#. settings-schema.json->combobox_icon-type->options
+msgid "Symbolic"
+msgstr "Symbolisch"
+
+#. settings-schema.json->combobox_icon-type->options
+msgid "Color"
+msgstr "Farbig"
+
+#. settings-schema.json->switch_use-custom-icon->description
+msgid "Use custom icon"
+msgstr "Benutzerdefiniertes Symbol benutzen"
+
+#. settings-schema.json->icon_custom-icon->description
+msgid "Custom icon to use"
+msgstr "Benutzerdefiniertes Symbol"
+
+#. settings-schema.json->button_open-kdec-settings->description
+msgid "Open KDE Connect Configuration"
+msgstr "KDE Connect Einstellungen öffnen"
+
+#. settings-schema.json->switch_expand-only-device->description
+msgid ""
+"Expand the device sub menu automatically, if only one device is available"
+msgstr ""
+"Erstes Geräte-Untermenü automatisch ausklappen, wenn nur ein Gerät verfügbar "
+"ist"
+
+#. settings-schema.json->orderlist_device-order->columns->title
+#. settings-schema.json->oderlist_info-modules->columns->title
+#. settings-schema.json->oderlist_action-modules->columns->title
+msgid "Name"
+msgstr "Name"
+
+#. settings-schema.json->orderlist_device-order->columns->title
+msgid "Expand"
+msgstr "Ausklappen"
+
+#. settings-schema.json->orderlist_device-order->columns->title
+msgid "UUID"
+msgstr "UUID"
+
+#. settings-schema.json->oderlist_info-modules->columns->title
+#. settings-schema.json->oderlist_action-modules->columns->title
+msgid "Enabled"
+msgstr "Aktiviert"
+
+#. settings-schema.json->oderlist_info-modules->columns->title
+#. settings-schema.json->oderlist_action-modules->columns->title
+msgid "ID"
+msgstr "ID"
+
+#. settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr "Zeigt die momentane Akkuladung und den Ladezustand des Gerätes an"
 
-#. settings-schema.json->battery-module-enabled->description
-#. settings-schema.json->deviceinfo-module-enabled->description
-#. settings-schema.json->connectivity-module-enabled->description
-#. settings-schema.json->findmyphone-module-enabled->description
-#. settings-schema.json->requestphoto-module-enabled->description
-#. settings-schema.json->ping-module-enabled->description
-#. settings-schema.json->share-module-enabled->description
-#. settings-schema.json->sftp-module-enabled->description
-#. settings-schema.json->sms-module-enabled->description
-msgid "Module enabled"
-msgstr "Modul aktiviert"
-
-#. settings-schema.json->deviceinfo-module-description->description
+#. settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr "Zeigt das Symbol des Gerätes und dessen ID an"
 
-#. settings-schema.json->connectivity-module-description->description
+#. settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr "Zeigt die momentane Empfangsstärke und den Netzwerktyp des Gerätes an"
 
-#. settings-schema.json->connectivity-module-showNetworkType->description
+#. settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr "Zeige den mobilen Netzwerktyp an"
 
-#. settings-schema.json->findmyphone-module-description->description
+#. settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
 msgstr ""
 "Ermöglicht das Gerät anzuklingeln, so dass du es finden kannst, wenn du es "
 "verlegt hast"
 
-#. settings-schema.json->requestphoto-module-description->description
+#. settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr ""
 "Ermöglicht es, ein Foto von dem Gerät anzufragen und es lokal zu speichern"
 
-#. settings-schema.json->requestphoto-module-saveToDir->description
+#. settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr "Empfangene Fotos direkt in Verzeichnis speichern"
 
-#. settings-schema.json->requestphoto-module-saveDirectory->description
+#. settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr "Das Verzeichnis, in dem die Fotos gespeichert werden sollen"
 
-#. settings-schema.json->ping-module-description->description
+#. settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr ""
 "Ermöglicht es, dem Gerät eine Ping-Nachricht zu senden, um die Verbindung zu "
 "dem Gerät zu testen"
 
-#. settings-schema.json->ping-module-useCustomMessage->description
+#. settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr "Benutzerdefinierter Text für die Ping-Nachricht benutzen"
 
-#. settings-schema.json->ping-module-customMessage->description
+#. settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr "Benutzerdefinierter Text"
 
-#. settings-schema.json->share-module-description->description
+#. settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr "Ermöglicht das Teilen von URLs, Dateien oder Text mit dem Gerät"
 
-#. settings-schema.json->share-module-useSubMenu->description
-#. settings-schema.json->sms-module-useSubMenu->description
+#. settings-schema.json->module_share_useSubMenu->description
+#. settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr "Zeige Menüeinträge in einem Untermenü"
 
-#. settings-schema.json->share-module-enableSendURL->description
+#. settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr "Menüeintrag zum senden einer URL aktivieren"
 
-#. settings-schema.json->share-module-enableSendText->description
+#. settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr "Menüeintrag zum senden von Text aktivieren"
 
-#. settings-schema.json->share-module-enableSendFiles->description
+#. settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr "Menüeintrag zum senden von Datei(en) aktivieren"
 
-#. settings-schema.json->sftp-module-description->description
+#. settings-schema.json->module_sftp_description->description
 msgid "Lets you remotely browse the storage selected on the device"
 msgstr ""
 "Ermöglicht es, auf dem Gerät ausgewählte Speicherabschnitte zu durchsuchen"
 
-#. settings-schema.json->sms-module-description->description
+#. settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr "Ermöglicht das Senden von SMS-Nachrichten über das Gerät"
 
-#. settings-schema.json->sms-module-enableSendSMS->description
+#. settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr "Menüeintrag zum senden einer SMS-Nachricht aktivieren"
 
-#. settings-schema.json->sms-module-enableLaunchSMSApp->description
+#. settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
 msgstr "Menüeintrag zum öffnen der KDE Connect SMS Anwendung aktivieren"
+
+#: display name of module battery
+msgid "Battery Module"
+msgstr "Akku Modul"
+
+#: display name of module deviceinfo
+msgid "Device-Info Module"
+msgstr "Geräte-Info Modul"
+
+#: display name of module connectivity
+msgid "Connectivity Module"
+msgstr "Konnektivität Modul"
+
+#: display name of module findmyphone
+msgid "FindMyPhone Module"
+msgstr "FindMyPhone Modul"
+
+#: display name of module requestphoto
+msgid "Request Photo Module"
+msgstr "Foto-Anfragen Modul"
+
+#: display name of module ping
+msgid "Ping Module"
+msgstr "Ping Modul"
+
+#: display name of module share
+msgid "Share Module"
+msgstr "Teilen Modul"
+
+#: display name of module sftp
+msgid "SFTP Module"
+msgstr "SFTP Modul"
+
+#: display name of module sms
+msgid "SMS Module"
+msgstr "SMS Modul"
+
+#~ msgid "Appearance"
+#~ msgstr "Aussehen"
+
+#~ msgid "Other"
+#~ msgstr "Andere"
+
+#~ msgid "Module enabled"
+#~ msgstr "Modul aktiviert"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/de.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/de.po
@@ -1,16 +1,16 @@
-# SOME DESCRIPTIVE TITLE.
+# German translation for kdecapplet@joejoetv.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Johannes Schöneberger <hannes1033@gmail.com>, 2023.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version: kdecapplet@joejoetv\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-03-08 00:05+0100\n"
-"PO-Revision-Date: 2023-03-08 00:07+0100\n"
+"PO-Revision-Date: 2023-03-08 00:26+0100\n"
 "Last-Translator: \n"
-"Language-Team: \n"
+"Language-Team: Johannes Schöneberger <hannes1033@gmail.com>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/kdecapplet@joejoetv.pot
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/kdecapplet@joejoetv.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-29 14:21+0100\n"
+"POT-Creation-Date: 2023-03-08 00:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,77 +17,77 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:571
+#: applet.js:574
 msgid "No Modules available"
 msgstr ""
 
-#: applet.js:1008
+#: applet.js:1065
 msgid "KDE Connect not available"
 msgstr ""
 
-#: applet.js:1011
+#: applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr ""
 
-#: applet.js:1015 applet.js:1028 applet.js:1202
+#: applet.js:1072 applet.js:1085 applet.js:1270
 msgid "Reload Applet"
 msgstr ""
 
-#: applet.js:1020
+#: applet.js:1077
 msgid "Invalid KDE Connect version returned!"
 msgstr ""
 
-#: applet.js:1021 applet.js:1024
+#: applet.js:1078 applet.js:1081
 msgid ""
 "The KDE Connect DBus service returned an invalid version, please try "
 "reloading the Applet!"
 msgstr ""
 
-#: applet.js:1074
+#: applet.js:1120
 msgid "No connected Devices!"
 msgstr ""
 
-#: applet.js:1074
+#: applet.js:1120
 msgid "Add them in the KDE Connect settings"
 msgstr ""
 
-#: applet.js:1097
+#: applet.js:1165
 msgid "Debug Stuff, don't touch!"
 msgstr ""
 
-#: applet.js:1186
+#: applet.js:1254
 msgid "KDE Connect Version: {version}"
 msgstr ""
 
-#: applet.js:1193
+#: applet.js:1261
 msgid "Own ID: {own_id}"
 msgstr ""
 
-#: applet.js:1195
+#: applet.js:1263
 msgid "own ID"
 msgstr ""
 
-#: applet.js:1197
+#: applet.js:1265
 msgid "Click to copy own ID"
 msgstr ""
 
-#: applet.js:1207
+#: applet.js:1275
 msgid "Configure KDE Connect"
 msgstr ""
 
-#: applet.js:1209
+#: applet.js:1277
 msgid "Click to open KDE Connect Configuration"
 msgstr ""
 
-#: applet.js:1253
+#: applet.js:1321
 msgid "No available devices"
 msgstr ""
 
-#: applet.js:1255
+#: applet.js:1323
 msgid "{deviceCount} available device"
 msgstr ""
 
-#: applet.js:1257
+#: applet.js:1325
 msgid "{deviceCount} available devices"
 msgstr ""
 
@@ -95,152 +95,160 @@ msgstr ""
 msgid "Copied {typestring} to the clipboard"
 msgstr ""
 
-#: js/modules.js:643
+#: js/modules.js:656
 msgid "Charging"
 msgstr ""
 
-#: js/modules.js:723
+#: js/modules.js:739
 msgid "ID: {id}"
 msgstr ""
 
-#: js/modules.js:727
+#: js/modules.js:743
 msgid "Device ID"
 msgstr ""
 
-#: js/modules.js:731
+#: js/modules.js:747
 msgid "Click to copy ID"
 msgstr ""
 
-#: js/modules.js:801
+#: js/modules.js:820
 msgid "No Signal"
 msgstr ""
 
-#: js/modules.js:804
+#: js/modules.js:823
 msgid "Low"
 msgstr ""
 
-#: js/modules.js:807
+#: js/modules.js:826
 msgid "Ok"
 msgstr ""
 
-#: js/modules.js:810
+#: js/modules.js:829
 msgid "Good"
 msgstr ""
 
-#: js/modules.js:813
+#: js/modules.js:832
 msgid "Excellent"
 msgstr ""
 
-#: js/modules.js:825
+#: js/modules.js:844
 msgid "Unknown"
 msgstr ""
 
-#: js/modules.js:876
+#: js/modules.js:898
 msgid "Ring device"
 msgstr ""
 
-#: js/modules.js:877
+#: js/modules.js:899
 msgid "Click to ring the device"
 msgstr ""
 
-#: js/modules.js:953
+#: js/modules.js:978
 msgid "Photo received from '{deviceName}'"
 msgstr ""
 
-#: js/modules.js:953 js/modules.js:1123
+#: js/modules.js:978 js/modules.js:1154
 msgid "Click to open in default application"
 msgstr ""
 
-#: js/modules.js:962
+#: js/modules.js:987
 msgid "Request Photo"
 msgstr ""
 
-#: js/modules.js:963
+#: js/modules.js:988
 msgid "Click to request a photo from the device"
 msgstr ""
 
-#: js/modules.js:1010
+#: js/modules.js:1038
 msgid "Ping!"
 msgstr ""
 
-#: js/modules.js:1017
+#: js/modules.js:1045
 msgid "Sent ping to device '{deviceName}'"
 msgstr ""
 
-#: js/modules.js:1023
+#: js/modules.js:1051
 msgid "Ping Device"
 msgstr ""
 
-#: js/modules.js:1024
+#: js/modules.js:1052
 msgid "Click to send a ping to the device"
 msgstr ""
 
-#: js/modules.js:1123
+#: js/modules.js:1154
 msgid "Share received from '{deviceName}'"
 msgstr ""
 
-#: js/modules.js:1158
+#: js/modules.js:1189
 msgid "Share"
 msgstr ""
 
-#: js/modules.js:1171
+#: js/modules.js:1202
 msgid "Send URL"
 msgstr ""
 
-#: js/modules.js:1172
+#: js/modules.js:1203
 msgid "Click to send a URL to the device"
 msgstr ""
 
-#: js/modules.js:1181
+#: js/modules.js:1212
 msgid "Send Text"
 msgstr ""
 
-#: js/modules.js:1182 js/modules.js:1451
+#: js/modules.js:1213 js/modules.js:1488
 msgid "Click to send text to the device"
 msgstr ""
 
-#: js/modules.js:1191
+#: js/modules.js:1222
 msgid "Send File(s)"
 msgstr ""
 
-#: js/modules.js:1192
+#: js/modules.js:1223
 msgid "Click to send file(s) to the device"
 msgstr ""
 
-#: js/modules.js:1245
+#: js/modules.js:1279
 msgid "Unmount"
 msgstr ""
 
-#: js/modules.js:1247
+#: js/modules.js:1281
 msgid "Mount"
 msgstr ""
 
-#: js/modules.js:1253
+#: js/modules.js:1287
 msgid "Click to unmount"
 msgstr ""
 
-#: js/modules.js:1255
+#: js/modules.js:1289
 msgid "Click to mount"
 msgstr ""
 
-#: js/modules.js:1328
+#: js/modules.js:1362
 msgid "Click to browse files"
 msgstr ""
 
-#: js/modules.js:1429
+#: js/modules.js:1466
 msgid "SMS"
 msgstr ""
 
-#: js/modules.js:1442
+#: js/modules.js:1479
 msgid "Launch SMS App"
 msgstr ""
 
-#: js/modules.js:1443
+#: js/modules.js:1480
 msgid "Click to open the KDE Connect SMS App"
 msgstr ""
 
-#: js/modules.js:1450
+#: js/modules.js:1487
 msgid "Send SMS"
+msgstr ""
+
+#: settingsWidgets.py:153
+msgid "Move selected entry up"
+msgstr ""
+
+#: settingsWidgets.py:160
+msgid "Move selected entry down"
 msgstr ""
 
 #: py/dialogs.py:40
@@ -332,201 +340,254 @@ msgstr ""
 msgid "Severga - Inspiration for the Applet"
 msgstr ""
 
-#. settings-schema.json->general-page->title
+#. settings-schema.json->page_general->title
 msgid "General"
 msgstr ""
 
-#. settings-schema.json->modules-page->title
+#. settings-schema.json->page_modules->title
 msgid "Modules"
 msgstr ""
 
-#. settings-schema.json->contextmenu-section->title
+#. settings-schema.json->section_contextmenu->title
 msgid "Context Menu"
 msgstr ""
 
-#. settings-schema.json->panel-section->title
+#. settings-schema.json->section_panel->title
 msgid "Panel"
 msgstr ""
 
-#. settings-schema.json->appearance-section->title
-msgid "Appearance"
+#. settings-schema.json->section_devices->title
+msgid "Devices"
 msgstr ""
 
-#. settings-schema.json->other-section->title
-msgid "Other"
+#. settings-schema.json->section_info-modules->title
+msgid "Info Modules"
 msgstr ""
 
-#. settings-schema.json->battery-module-section->title
+#. settings-schema.json->section_action-modules->title
+msgid "Action Modules"
+msgstr ""
+
+#. settings-schema.json->section_module_battery->title
 msgid "Battery Info Module"
 msgstr ""
 
-#. settings-schema.json->deviceinfo-module-section->title
-msgid "Device Info Module"
+#. settings-schema.json->section_module_deviceinfo->title
+msgid "Device-Info Info Module"
 msgstr ""
 
-#. settings-schema.json->connectivity-module-section->title
+#. settings-schema.json->section_module_connectivity->title
 msgid "Connectivity Info Module"
 msgstr ""
 
-#. settings-schema.json->findmyphone-module-section->title
+#. settings-schema.json->section_module_findmyphone->title
 msgid "FindMyPhone Action Module"
 msgstr ""
 
-#. settings-schema.json->requestphoto-module-section->title
+#. settings-schema.json->section_module_requestphoto->title
 msgid "Request-Photo Action Module"
 msgstr ""
 
-#. settings-schema.json->ping-module-section->title
+#. settings-schema.json->section_module_ping->title
 msgid "Ping Action Module"
 msgstr ""
 
-#. settings-schema.json->share-module-section->title
+#. settings-schema.json->section_module_share->title
 msgid "Share Action Module"
 msgstr ""
 
-#. settings-schema.json->sftp-module-section->title
+#. settings-schema.json->section_module_sftp->title
 msgid "SFTP Action Module"
 msgstr ""
 
-#. settings-schema.json->sms-module-section->title
+#. settings-schema.json->section_module_sms->title
 msgid "SMS Action Module"
 msgstr ""
 
-#. settings-schema.json->showownid->description
+#. settings-schema.json->switch_show-own-id->description
 msgid "Show own ID in the context menu of the applet"
 msgstr ""
 
-#. settings-schema.json->showkdecver->description
+#. settings-schema.json->switch_show-kdec-version->description
 msgid "Show KDE Connect version in the context menu of the applet"
 msgstr ""
 
-#. settings-schema.json->shownumdevices->description
+#. settings-schema.json->switch_show-device-count->description
 msgid "Show the number of connected devices next to the icon in the panel"
 msgstr ""
 
-#. settings-schema.json->icontype->description
-msgid "Icon type"
-msgstr ""
-
-#. settings-schema.json->icontype->options
-msgid "Symbolic"
-msgstr ""
-
-#. settings-schema.json->icontype->options
-msgid "Color"
-msgstr ""
-
-#. settings-schema.json->usecustomicon->description
-msgid "Use custom icon"
-msgstr ""
-
-#. settings-schema.json->customicon->description
-msgid "Custom icon to use"
-msgstr ""
-
-#. settings-schema.json->expandfirst->description
-msgid "Expand the first device sub menu automatically"
-msgstr ""
-
-#. settings-schema.json->openconfiguration->description
-msgid "Open KDE Connect Configuration"
-msgstr ""
-
-#. settings-schema.json->tooltipdevicecount->description
+#. settings-schema.json->switch_show-device-count-tooltip->description
 msgid "Show the device count in the tooltip of the applet"
 msgstr ""
 
-#. settings-schema.json->battery-module-description->description
+#. settings-schema.json->combobox_icon-type->description
+msgid "Icon type"
+msgstr ""
+
+#. settings-schema.json->combobox_icon-type->options
+msgid "Symbolic"
+msgstr ""
+
+#. settings-schema.json->combobox_icon-type->options
+msgid "Color"
+msgstr ""
+
+#. settings-schema.json->switch_use-custom-icon->description
+msgid "Use custom icon"
+msgstr ""
+
+#. settings-schema.json->icon_custom-icon->description
+msgid "Custom icon to use"
+msgstr ""
+
+#. settings-schema.json->button_open-kdec-settings->description
+msgid "Open KDE Connect Configuration"
+msgstr ""
+
+#. settings-schema.json->switch_expand-only-device->description
+msgid ""
+"Expand the device sub menu automatically, if only one device is available"
+msgstr ""
+
+#. settings-schema.json->orderlist_device-order->columns->title
+#. settings-schema.json->oderlist_info-modules->columns->title
+#. settings-schema.json->oderlist_action-modules->columns->title
+msgid "Name"
+msgstr ""
+
+#. settings-schema.json->orderlist_device-order->columns->title
+msgid "Expand"
+msgstr ""
+
+#. settings-schema.json->orderlist_device-order->columns->title
+msgid "UUID"
+msgstr ""
+
+#. settings-schema.json->oderlist_info-modules->columns->title
+#. settings-schema.json->oderlist_action-modules->columns->title
+msgid "Enabled"
+msgstr ""
+
+#. settings-schema.json->oderlist_info-modules->columns->title
+#. settings-schema.json->oderlist_action-modules->columns->title
+msgid "ID"
+msgstr ""
+
+#. settings-schema.json->module_battery_description->description
 msgid "Shows the current battery charge and charging status of the device"
 msgstr ""
 
-#. settings-schema.json->battery-module-enabled->description
-#. settings-schema.json->deviceinfo-module-enabled->description
-#. settings-schema.json->connectivity-module-enabled->description
-#. settings-schema.json->findmyphone-module-enabled->description
-#. settings-schema.json->requestphoto-module-enabled->description
-#. settings-schema.json->ping-module-enabled->description
-#. settings-schema.json->share-module-enabled->description
-#. settings-schema.json->sftp-module-enabled->description
-#. settings-schema.json->sms-module-enabled->description
-msgid "Module enabled"
-msgstr ""
-
-#. settings-schema.json->deviceinfo-module-description->description
+#. settings-schema.json->module_deviceinfo_description->description
 msgid "Shows the device icon along with its ID"
 msgstr ""
 
-#. settings-schema.json->connectivity-module-description->description
+#. settings-schema.json->module_connectivity_description->description
 msgid "Shows the current connectivity status and network type of the device"
 msgstr ""
 
-#. settings-schema.json->connectivity-module-showNetworkType->description
+#. settings-schema.json->module_connectivity_showNetworkType->description
 msgid "Show the mobile network type"
 msgstr ""
 
-#. settings-schema.json->findmyphone-module-description->description
+#. settings-schema.json->module_findmyphone_description->description
 msgid ""
 "Lets you make the device ring, so you can find it, if you have misplaced it"
 msgstr ""
 
-#. settings-schema.json->requestphoto-module-description->description
+#. settings-schema.json->module_requestphoto_description->description
 msgid ""
 "Lets you request a photo from the remote device and save it on this device"
 msgstr ""
 
-#. settings-schema.json->requestphoto-module-saveToDir->description
+#. settings-schema.json->module_requestphoto_saveToDir->description
 msgid "Save received photos directly to directory"
 msgstr ""
 
-#. settings-schema.json->requestphoto-module-saveDirectory->description
+#. settings-schema.json->module_requestphoto_saveDirectory->description
 msgid "The directory to save received photos to"
 msgstr ""
 
-#. settings-schema.json->ping-module-description->description
+#. settings-schema.json->module_ping_description->description
 msgid "Lets you ping the the device to make sure it's connected"
 msgstr ""
 
-#. settings-schema.json->ping-module-useCustomMessage->description
+#. settings-schema.json->module_ping_useCustomMessage->description
 msgid "Use custom message for ping"
 msgstr ""
 
-#. settings-schema.json->ping-module-customMessage->description
+#. settings-schema.json->module_ping_customMessage->description
 msgid "Custom message"
 msgstr ""
 
-#. settings-schema.json->share-module-description->description
+#. settings-schema.json->module_share_description->description
 msgid "Lets you share URLs, files or text to the device"
 msgstr ""
 
-#. settings-schema.json->share-module-useSubMenu->description
-#. settings-schema.json->sms-module-useSubMenu->description
+#. settings-schema.json->module_share_useSubMenu->description
+#. settings-schema.json->module_sms_useSubMenu->description
 msgid "Show menu items in sub menu"
 msgstr ""
 
-#. settings-schema.json->share-module-enableSendURL->description
+#. settings-schema.json->module_share_enableSendURL->description
 msgid "Enable the menu item to send a URL"
 msgstr ""
 
-#. settings-schema.json->share-module-enableSendText->description
+#. settings-schema.json->module_share_enableSendText->description
 msgid "Enable the menu item to send some text"
 msgstr ""
 
-#. settings-schema.json->share-module-enableSendFiles->description
+#. settings-schema.json->module_share_enableSendFiles->description
 msgid "Enable the menu item to send file(s)"
 msgstr ""
 
-#. settings-schema.json->sftp-module-description->description
+#. settings-schema.json->module_sftp_description->description
 msgid "Lets you remotely browse the storage selected on the device"
 msgstr ""
 
-#. settings-schema.json->sms-module-description->description
+#. settings-schema.json->module_sms_description->description
 msgid "Lets you remotely send SMS messages from the device"
 msgstr ""
 
-#. settings-schema.json->sms-module-enableSendSMS->description
+#. settings-schema.json->module_sms_enableSendSMS->description
 msgid "Enable the menu item to send an SMS message"
 msgstr ""
 
-#. settings-schema.json->sms-module-enableLaunchSMSApp->description
+#. settings-schema.json->module_sms_enableLaunchSMSApp->description
 msgid "Enable the menu item to launch the KDE Connect SMS app"
+msgstr ""
+
+#: display name of module battery
+msgid "Battery Module"
+msgstr ""
+
+#: display name of module deviceinfo
+msgid "Device-Info Module"
+msgstr ""
+
+#: display name of module connectivity
+msgid "Connectivity Module"
+msgstr ""
+
+#: display name of module findmyphone
+msgid "FindMyPhone Module"
+msgstr ""
+
+#: display name of module requestphoto
+msgid "Request Photo Module"
+msgstr ""
+
+#: display name of module ping
+msgid "Ping Module"
+msgstr ""
+
+#: display name of module share
+msgid "Share Module"
+msgstr ""
+
+#: display name of module sftp
+msgid "SFTP Module"
+msgstr ""
+
+#: display name of module sms
+msgid "SMS Module"
 msgstr ""

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/pot-additions.txt
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/pot-additions.txt
@@ -1,0 +1,35 @@
+#: display name of module battery
+msgid "Battery Module"
+msgstr ""
+
+#: display name of module deviceinfo
+msgid "Device-Info Module"
+msgstr ""
+
+#: display name of module connectivity
+msgid "Connectivity Module"
+msgstr ""
+
+#: display name of module findmyphone
+msgid "FindMyPhone Module"
+msgstr ""
+
+#: display name of module requestphoto
+msgid "Request Photo Module"
+msgstr ""
+
+#: display name of module ping
+msgid "Ping Module"
+msgstr ""
+
+#: display name of module share
+msgid "Share Module"
+msgstr ""
+
+#: display name of module sftp
+msgid "SFTP Module"
+msgstr ""
+
+#: display name of module sms
+msgid "SMS Module"
+msgstr ""

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/settings-schema.json
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/settings-schema.json
@@ -1,167 +1,183 @@
 {
-    "layout2": {
+    "layout": {
         "type": "layout",
-        "pages": ["general-page", "modules-page"],
-        "general-page": {
+        "pages": ["page_general", "page_modules"],
+        
+        "page_general": {
             "type": "page",
             "title": "General",
             "sections": [
-                "contextmenu-section",
-                "panel-section",
-                "appearance-section",
-                "other-section"
+                "section_contextmenu",
+                "section_panel",
+                "section_kdecsettings",
+                "section_devices"
             ]
         },
-        "modules-page": {
+        "page_modules": {
             "type": "page",
             "title": "Modules",
             "sections": [
-                "battery-module-section",
-                "deviceinfo-module-section",
-                "connectivity-module-section",
-                "findmyphone-module-section",
-                "requestphoto-module-section",
-                "ping-module-section",
-                "share-module-section",
-                "sftp-module-section",
-                "sms-module-section"
-            ]
-        },
-        "contextmenu-section": {
-            "type": "section",
-            "title": "Context Menu",
-            "keys": [
-                "showownid",
-                "showkdecver"
-            ]
-        },
-        "panel-section": {
-            "type": "section",
-            "title": "Panel",
-            "keys": [
-                "shownumdevices",
-                "tooltipdevicecount"
-            ]
-        },
-        "appearance-section": {
-            "type": "section",
-            "title": "Appearance",
-            "keys": [
-                "icontype",
-                "usecustomicon",
-                "customicon"
-            ]
-        },
-        "other-section": {
-            "type": "section",
-            "title": "Other",
-            "keys": [
-                "expandfirst",
-                "openconfiguration"
+                "section_info-modules",
+                "section_action-modules",
+                "section_module_battery",
+                "section_module_deviceinfo",
+                "section_module_connectivity",
+                "section_module_findmyphone",
+                "section_module_requestphoto",
+                "section_module_ping",
+                "section_module_share",
+                "section_module_sftp",
+                "section_module_sms"
             ]
         },
 
-        "battery-module-section": {
+        "section_contextmenu": {
+            "type": "section",
+            "title": "Context Menu",
+            "keys": [
+                "switch_show-own-id",
+                "switch_show-kdec-version"
+            ]
+        },
+        "section_panel": {
+            "type": "section",
+            "title": "Panel",
+            "keys": [
+                "switch_show-device-count",
+                "switch_show-device-count-tooltip",
+                "combobox_icon-type",
+                "switch_use-custom-icon",
+                "icon_custom-icon"
+            ]
+        },
+        "section_kdecsettings": {
+            "type": "section",
+            "keys": [
+                "button_open-kdec-settings"
+            ]
+        },
+        "section_devices": {
+            "type": "section",
+            "title": "Devices",
+            "keys": [
+                "switch_expand-only-device",
+                "orderlist_device-order"
+            ]
+        },
+
+        "section_info-modules": {
+            "type": "section",
+            "title": "Info Modules",
+            "keys": [
+                "oderlist_info-modules"
+            ]
+        },
+        "section_action-modules": {
+            "type": "section",
+            "title": "Action Modules",
+            "keys": [
+                "oderlist_action-modules"
+            ]
+        },
+        "section_module_battery": {
             "type": "section",
             "title": "Battery Info Module",
             "keys": [
-                "battery-module-description",
-                "battery-module-enabled"
+                "module_battery_description"
             ]
         },
-        "deviceinfo-module-section": {
+        "section_module_deviceinfo": {
             "type": "section",
             "title": "Device Info Module",
             "keys": [
-                "deviceinfo-module-description",
-                "deviceinfo-module-enabled"
+                "module_deviceinfo_description"
             ]
         },
-        "connectivity-module-section": {
+        "section_module_connectivity": {
             "type": "section",
             "title": "Connectivity Info Module",
             "keys": [
-                "connectivity-module-description",
-                "connectivity-module-enabled",
-                "connectivity-module-showNetworkType"
+                "module_connectivity_description",
+                "module_connectivity_showNetworkType"
             ]
         },
-        "findmyphone-module-section": {
+        "section_module_findmyphone": {
             "type": "section",
             "title": "FindMyPhone Action Module",
             "keys": [
-                "findmyphone-module-description",
-                "findmyphone-module-enabled"
+                "module_findmyphone_description"
             ]
         },
-        "requestphoto-module-section": {
+        "section_module_requestphoto": {
             "type": "section",
             "title": "Request-Photo Action Module",
             "keys": [
-                "requestphoto-module-description",
-                "requestphoto-module-enabled",
-                "requestphoto-module-saveToDir",
-                "requestphoto-module-saveDirectory"
+                "module_requestphoto_description",
+                "module_requestphoto_saveToDir",
+                "module_requestphoto_saveDirectory"
             ]
         },
-        "ping-module-section": {
+        "section_module_ping": {
             "type": "section",
             "title": "Ping Action Module",
             "keys": [
-                "ping-module-description",
-                "ping-module-enabled",
-                "ping-module-useCustomMessage",
-                "ping-module-customMessage"
+                "module_ping_description",
+                "module_ping_useCustomMessage",
+                "module_ping_customMessage"
             ]
         },
-        "share-module-section": {
+        "section_module_share": {
             "type": "section",
             "title": "Share Action Module",
             "keys": [
-                "share-module-description",
-                "share-module-enabled",
-                "share-module-useSubMenu",
-                "share-module-enableSendURL",
-                "share-module-enableSendText",
-                "share-module-enableSendFiles"
+                "module_share_description",
+                "module_share_useSubMenu",
+                "module_share_enableSendURL",
+                "module_share_enableSendText",
+                "module_share_enableSendFiles"
             ]
         },
-        "sftp-module-section": {
+        "section_module_sftp": {
             "type": "section",
             "title": "SFTP Action Module",
             "keys": [
-                "sftp-module-description",
-                "sftp-module-enabled"
+                "module_sftp_description"
             ]
         },
-        "sms-module-section": {
+        "section_module_sms": {
             "type": "section",
             "title": "SMS Action Module",
             "keys": [
-                "sms-module-description",
-                "sms-module-enabled",
-                "sms-module-useSubMenu",
-                "sms-module-enableSendSMS",
-                "sms-module-enableLaunchSMSApp"
+                "module_sms_description",
+                "module_sms_useSubMenu",
+                "module_sms_enableSendSMS",
+                "module_sms_enableLaunchSMSApp"
             ]
         }
     },
-    "showownid": {
+
+    "switch_show-own-id": {
         "type": "switch",
         "description": "Show own ID in the context menu of the applet",
         "default": true
     },
-    "showkdecver": {
+    "switch_show-kdec-version": {
         "type": "switch",
         "description": "Show KDE Connect version in the context menu of the applet",
         "default": true
     },
-    "shownumdevices": {
+
+    "switch_show-device-count": {
         "type": "switch",
         "description": "Show the number of connected devices next to the icon in the panel",
         "default": true
     },
-    "icontype": {
+    "switch_show-device-count-tooltip": {
+        "type": "switch",
+        "description": "Show the device count in the tooltip of the applet",
+        "default": true
+    },
+    "combobox_icon-type": {
         "type": "combobox",
         "description": "Icon type",
         "options": {
@@ -170,93 +186,144 @@
         },
         "default": "COLOR"
     },
-    "usecustomicon": {
+    "switch_use-custom-icon": {
         "type": "switch",
         "description": "Use custom icon",
         "default": false
     },
-    "customicon": {
+    "icon_custom-icon": {
         "type": "iconfilechooser",
         "description": "Custom icon to use",
         "default": "kdeconnect",
-        "dependency": "usecustomicon"
+        "dependency": "switch_use-custom-icon"
     },
-    "expandfirst": {
-        "type": "switch",
-        "description": "Expand the first device sub menu automatically",
-        "default": true
-    },
-    "openconfiguration": {
+
+    "button_open-kdec-settings": {
         "type": "button",
         "description": "Open KDE Connect Configuration",
         "callback": "openKDECConfiguration"
     },
-    "tooltipdevicecount": {
+
+    "switch_expand-only-device": {
         "type": "switch",
-        "description": "Show the device count in the tooltip of the applet",
+        "description": "Expand the device sub menu automatically, if only one device is available",
         "default": true
     },
+    "orderlist_device-order": {
+        "type": "custom",
+        "file": "settingsWidgets.py",
+        "widget": "OrderList",
+        "columns": [
+            {
+                "title": "Name",
+                "type": "text",
+                "align": "left",
+                "id": "name"
+            },
+            {
+                "title": "Expand?",
+                "type": "boolean",
+                "align": "center",
+                "id": "expand"
+            },
+            {
+                "title": "UUID",
+                "type": "text",
+                "align": "left",
+                "id": "uuid"
+            }
+        ],
+        "default": []
+    },
 
-    "battery-module-description": {
+    "oderlist_info-modules": {
+        "type": "custom",
+        "file": "settingsWidgets.py",
+        "widget": "OrderList",
+        "columns": [
+            {
+                "title": "Enabled",
+                "type": "boolean",
+                "align": "center",
+                "id": "enabled"
+            },
+            {
+                "title": "Name",
+                "type": "text",
+                "align": "left",
+                "id": "name"
+            },
+            {
+                "title": "ID",
+                "type": "text",
+                "align": "left",
+                "id": "id"
+            }
+        ],
+        "default": []
+    },
+    "oderlist_action-modules": {
+        "type": "custom",
+        "file": "settingsWidgets.py",
+        "widget": "OrderList",
+        "columns": [
+            {
+                "title": "Enabled",
+                "type": "boolean",
+                "align": "center",
+                "id": "enabled"
+            },
+            {
+                "title": "Name",
+                "type": "text",
+                "align": "left",
+                "id": "name"
+            },
+            {
+                "title": "ID",
+                "type": "text",
+                "align": "left",
+                "id": "id"
+            }
+        ],
+        "default": []
+    },
+
+    "module_battery_description": {
         "type": "label",
         "description": "Shows the current battery charge and charging status of the device"
     },
-    "battery-module-enabled": {
-        "type": "switch",
-        "description": "Module enabled",
-        "default": true
-    },
 
-    "deviceinfo-module-description": {
+    "module_deviceinfo_description": {
         "type": "label",
         "description": "Shows the device icon along with its ID"
     },
-    "deviceinfo-module-enabled": {
-        "type": "switch",
-        "description": "Module enabled",
-        "default": true
-    },
 
-    "connectivity-module-description": {
+    "module_connectivity_description": {
         "type": "label",
         "description": "Shows the current connectivity status and network type of the device"
     },
-    "connectivity-module-enabled": {
-        "type": "switch",
-        "description": "Module enabled",
-        "default": true
-    },
-    "connectivity-module-showNetworkType": {
+    "module_connectivity_showNetworkType": {
         "type": "switch",
         "description": "Show the mobile network type",
         "default": true
     },
 
-    "findmyphone-module-description": {
+    "module_findmyphone_description": {
         "type": "label",
         "description": "Lets you make the device ring, so you can find it, if you have misplaced it"
     },
-    "findmyphone-module-enabled": {
-        "type": "switch",
-        "description": "Module enabled",
-        "default": true
-    },
 
-    "requestphoto-module-description": {
+    "module_requestphoto_description": {
         "type": "label",
         "description": "Lets you request a photo from the remote device and save it on this device"
     },
-    "requestphoto-module-enabled": {
-        "type": "switch",
-        "description": "Module enabled",
-        "default": true
-    },
-    "requestphoto-module-saveToDir": {
+    "module_requestphoto_saveToDir": {
         "type": "switch",
         "description": "Save received photos directly to directory",
         "default": false
     },
-    "requestphoto-module-saveDirectory": {
+    "module_requestphoto_saveDirectory": {
         "type": "filechooser",
         "description": "The directory to save received photos to",
         "default": "",
@@ -264,87 +331,67 @@
         "dependency": "requestphoto-module-saveToDir"
     },
 
-    "ping-module-description": {
+    "module_ping_description": {
         "type": "label",
         "description": "Lets you ping the the device to make sure it's connected"
     },
-    "ping-module-enabled": {
-        "type": "switch",
-        "description": "Module enabled",
-        "default": true
-    },
-    "ping-module-useCustomMessage": {
+    "module_ping_useCustomMessage": {
         "type": "switch",
         "description": "Use custom message for ping",
         "default": false
     },
-    "ping-module-customMessage": {
+    "module_ping_customMessage": {
         "type": "entry",
         "description": "Custom message",
         "default": "Ping!",
-        "dependency": "ping-module-useCustomMessage"
+        "dependency": "module_ping_useCustomMessage"
     },
 
-    "share-module-description": {
+    "module_share_description": {
         "type": "label",
         "description": "Lets you share URLs, files or text to the device"
     },
-    "share-module-enabled": {
-        "type": "switch",
-        "description": "Module enabled",
-        "default": true
-    },
-    "share-module-useSubMenu": {
+    "module_share_useSubMenu": {
         "type": "switch",
         "description": "Show menu items in sub menu",
         "default": true
     },
-    "share-module-enableSendURL": {
+    "module_share_enableSendURL": {
         "type": "switch",
         "description": "Enable the menu item to send a URL",
         "default": true
     },
-    "share-module-enableSendText": {
+    "module_share_enableSendText": {
         "type": "switch",
         "description": "Enable the menu item to send some text",
         "default": true
     },
-    "share-module-enableSendFiles": {
+    "module_share_enableSendFiles": {
         "type": "switch",
         "description": "Enable the menu item to send file(s)",
         "default": true
     },
 
-    "sftp-module-description": {
+    "module_sftp_description": {
         "type": "label",
         "description": "Lets you remotely browse the storage selected on the device"
     },
-    "sftp-module-enabled": {
-        "type": "switch",
-        "description": "Module enabled",
-        "default": true
-    },
 
-    "sms-module-description": {
+    "module_sms_description": {
         "type": "label",
         "description": "Lets you remotely send SMS messages from the device"
     },
-    "sms-module-enabled": {
-        "type": "switch",
-        "description": "Module enabled",
-        "default": true
-    },
-    "sms-module-useSubMenu": {
+    "module_sms_useSubMenu": {
         "type": "switch",
         "description": "Show menu items in sub menu",
         "default": true
     },
-    "sms-module-enableSendSMS": {
+    "module_sms_enableSendSMS": {
         "type": "switch",
         "description": "Enable the menu item to send an SMS message",
         "default": true
     },
-    "sms-module-enableLaunchSMSApp": {
+    "module_sms_enableLaunchSMSApp": {
         "type": "switch",
         "description": "Enable the menu item to launch the KDE Connect SMS app",
         "default": true

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/settings-schema.json
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/settings-schema.json
@@ -89,7 +89,7 @@
         },
         "section_module_deviceinfo": {
             "type": "section",
-            "title": "Device Info Module",
+            "title": "Device-Info Info Module",
             "keys": [
                 "module_deviceinfo_description"
             ]
@@ -222,7 +222,7 @@
                 "id": "name"
             },
             {
-                "title": "Expand?",
+                "title": "Expand",
                 "type": "boolean",
                 "align": "center",
                 "id": "expand"
@@ -260,7 +260,8 @@
                 "title": "Name",
                 "type": "text",
                 "align": "left",
-                "id": "name"
+                "id": "name",
+                "translate": true
             },
             {
                 "title": "ID",
@@ -309,7 +310,8 @@
                 "title": "Name",
                 "type": "text",
                 "align": "left",
-                "id": "name"
+                "id": "name",
+                "translate": true
             },
             {
                 "title": "ID",

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/settings-schema.json
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/settings-schema.json
@@ -219,8 +219,7 @@
                 "title": "Name",
                 "type": "text",
                 "align": "left",
-                "id": "name",
-                "translate": false
+                "id": "name"
             },
             {
                 "title": "Expand?",
@@ -232,12 +231,12 @@
                 "title": "UUID",
                 "type": "text",
                 "align": "left",
-                "id": "uuid",
-                "translate": false
+                "id": "uuid"
             }
         ],
         "default": [],
-        "storage": "generic_device-order"
+        "storage": "generic_device-order",
+        "size": 200
     },
 
     "generic_device-order": {
@@ -261,19 +260,18 @@
                 "title": "Name",
                 "type": "text",
                 "align": "left",
-                "id": "name",
-                "translate": false
+                "id": "name"
             },
             {
                 "title": "ID",
                 "type": "text",
                 "align": "left",
-                "id": "id",
-                "translate": false
+                "id": "id"
             }
         ],
         "default": [],
-        "storage": "generic_info-modules"
+        "storage": "generic_info-modules",
+        "size": 100
     },
     "generic_info-modules": {
         "type": "generic",
@@ -295,19 +293,18 @@
                 "title": "Name",
                 "type": "text",
                 "align": "left",
-                "id": "name",
-                "translate": false
+                "id": "name"
             },
             {
                 "title": "ID",
                 "type": "text",
                 "align": "left",
-                "id": "id",
-                "translate": false
+                "id": "id"
             }
         ],
         "default": [],
-        "storage": "generic_action-modules"
+        "storage": "generic_action-modules",
+        "size": 200
     },
     "generic_action-modules": {
         "type": "generic",

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/settings-schema.json
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/settings-schema.json
@@ -52,6 +52,7 @@
         },
         "section_kdecsettings": {
             "type": "section",
+            "title": "",
             "keys": [
                 "button_open-kdec-settings"
             ]
@@ -218,7 +219,8 @@
                 "title": "Name",
                 "type": "text",
                 "align": "left",
-                "id": "name"
+                "id": "name",
+                "translate": false
             },
             {
                 "title": "Expand?",
@@ -230,10 +232,18 @@
                 "title": "UUID",
                 "type": "text",
                 "align": "left",
-                "id": "uuid"
+                "id": "uuid",
+                "translate": false
             }
         ],
-        "default": []
+        "default": [],
+        "storage": "generic_device-order"
+    },
+
+    "generic_device-order": {
+        "type": "generic",
+        "default": [],
+        "comment": "Data storage for 'orderlist_device-order'"
     },
 
     "oderlist_info-modules": {
@@ -251,16 +261,24 @@
                 "title": "Name",
                 "type": "text",
                 "align": "left",
-                "id": "name"
+                "id": "name",
+                "translate": false
             },
             {
                 "title": "ID",
                 "type": "text",
                 "align": "left",
-                "id": "id"
+                "id": "id",
+                "translate": false
             }
         ],
-        "default": []
+        "default": [],
+        "storage": "generic_info-modules"
+    },
+    "generic_info-modules": {
+        "type": "generic",
+        "default": [],
+        "comment": "Data storage for 'oderlist_info-modules'"
     },
     "oderlist_action-modules": {
         "type": "custom",
@@ -277,16 +295,24 @@
                 "title": "Name",
                 "type": "text",
                 "align": "left",
-                "id": "name"
+                "id": "name",
+                "translate": false
             },
             {
                 "title": "ID",
                 "type": "text",
                 "align": "left",
-                "id": "id"
+                "id": "id",
+                "translate": false
             }
         ],
-        "default": []
+        "default": [],
+        "storage": "generic_action-modules"
+    },
+    "generic_action-modules": {
+        "type": "generic",
+        "default": [],
+        "comment": "Data storage for 'oderlist_action-modules'"
     },
 
     "module_battery_description": {
@@ -328,7 +354,7 @@
         "description": "The directory to save received photos to",
         "default": "",
         "select-dir": true,
-        "dependency": "requestphoto-module-saveToDir"
+        "dependency": "module_requestphoto_saveToDir"
     },
 
     "module_ping_description": {

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/settings-schema.json
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/settings-schema.json
@@ -275,7 +275,23 @@
     },
     "generic_info-modules": {
         "type": "generic",
-        "default": [],
+        "default": [
+            {
+                "enabled": true,
+                "name": "Battery Module",
+                "id": "battery"
+            },
+            {
+                "enabled": true,
+                "name": "Device Info Module",
+                "id": "deviceinfo"
+            },
+            {
+                "enabled": true,
+                "name": "Connectivity Module",
+                "id": "connectivity"
+            }
+        ],
         "comment": "Data storage for 'oderlist_info-modules'"
     },
     "oderlist_action-modules": {
@@ -308,7 +324,38 @@
     },
     "generic_action-modules": {
         "type": "generic",
-        "default": [],
+        "default": [
+            {
+                "enabled": true,
+                "name": "FindMyPhone Module",
+                "id": "findmyphone"
+            },
+            {
+                "enabled": true,
+                "name": "Request Photo Module",
+                "id": "requestphoto"
+            },
+            {
+                "enabled": true,
+                "name": "Ping Module",
+                "id": "ping"
+            },
+            {
+                "enabled": true,
+                "name": "Share Module",
+                "id": "share"
+            },
+            {
+                "enabled": true,
+                "name": "SFTP Module",
+                "id": "sftp"
+            },
+            {
+                "enabled": true,
+                "name": "SMS Module",
+                "id": "sms"
+            }
+        ],
         "comment": "Data storage for 'oderlist_action-modules'"
     },
 

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/settingsWidgets.py
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/settingsWidgets.py
@@ -74,6 +74,11 @@ class OrderList(SettingsWidget):
         # Gett settings key for storig actual settings data
         self.storage = self.info["storage"]
         
+        if ("size" in self.info):
+            self.size = self.info["size"]
+        else:
+            self.size = 150
+        
         # Flag to stop saving settings, when loading them
         self.dontModify = False
         
@@ -95,7 +100,7 @@ class OrderList(SettingsWidget):
 
         # Make tree view scrollable, if it gets too big
         self.scrollbox = Gtk.ScrolledWindow()
-        self.scrollbox.set_size_request(-1, 150)
+        self.scrollbox.set_size_request(-1, self.size)
         self.scrollbox.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         self.pack_start(self.scrollbox, True, True, 0)
         self.scrollbox.add(self.tree_view)
@@ -214,7 +219,7 @@ class OrderList(SettingsWidget):
             
             for i, col in enumerate(self.columns):
                 if col["id"] in entry:
-                    if col["type"] == "text" and col["translate"] == True:
+                    if col["type"] == "text" and ("translate" in col and col["translate"] == True):
                         entry_value_list.append(_(entry[col["id"]]))
                     else:
                         entry_value_list.append(entry[col["id"]])
@@ -233,7 +238,7 @@ class OrderList(SettingsWidget):
             item = {}
             
             for i, col in enumerate(self.columns):
-                if col["type"] == "text" and col["translate"] == True:
+                if col["type"] == "text" and ("translate" in col and col["translate"] == True):
                     item[col["id"]] = store[treeiter][0][col["id"]]
                 else:
                     item[col["id"]] = store[treeiter][i+1]

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/settingsWidgets.py
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/settingsWidgets.py
@@ -59,6 +59,8 @@ ALIGNMENT_MAP = {
 '''
     Settings Widget that displays a list that can be reordered, but not modified anyway else
 '''
+# NOTE: The "storage" key is used to get the settings entry to store the actualy data,
+# NOTE: because the "custom" settings type can't currently be used to bind in JS code
 class OrderList(SettingsWidget):
     def __init__(self, info, key, settings):
         SettingsWidget.__init__(self)
@@ -68,6 +70,9 @@ class OrderList(SettingsWidget):
         
         # Get column structure from info
         self.columns = self.info["columns"]
+        
+        # Gett settings key for storig actual settings data
+        self.storage = self.info["storage"]
         
         # Flag to stop saving settings, when loading them
         self.dontModify = False
@@ -167,7 +172,8 @@ class OrderList(SettingsWidget):
         # Use "row-deleted" signal, as it is the only one signalled at the right time AFAIK
         self.store.connect("row-deleted", self.on_row_deleted)
         
-        self.settings.listen(self.key, self.valid_backup_restore)
+        #self.settings.listen(self.key, self.valid_backup_restore)
+        self.settings.listen(self.storage, self.valid_backup_restore)
     
     ## Callbacks
     
@@ -200,7 +206,8 @@ class OrderList(SettingsWidget):
         
         self.store.clear()
         
-        self.stored_entries = self.settings.get_value(self.key)
+        #self.stored_entries = self.settings.get_value(self.key)
+        self.stored_entries = self.settings.get_value(self.storage)
         
         for entry in self.stored_entries:
             entry_value_list = [entry]
@@ -237,7 +244,8 @@ class OrderList(SettingsWidget):
         
         self.store.foreach(get_row_data, self.stored_entries)
         
-        self.settings.set_value(self.key, self.stored_entries)
+        #self.settings.set_value(self.key, self.stored_entries)
+        self.settings.set_value(self.storage, self.stored_entries)
         
         self.update_button_sensitivity()
         

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/settingsWidgets.py
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/settingsWidgets.py
@@ -1,0 +1,275 @@
+#!/usr/bin/python3
+
+# Written by: JoeJoeTV
+# based on code from the applet app-launcher@mchilli
+
+import gi
+gi.require_version("Gtk", "3.0")
+gi.require_version('XApp', '1.0')
+
+import os
+import sys
+import time
+import math
+import gettext
+from gi.repository import GLib, Gio, Gtk, Gdk
+from JsonSettingsWidgets import *
+
+APPLET_DIR = os.path.join(os.path.dirname(os.path.normpath(__file__)))
+
+# Fallback UUID of applet
+UUID = "kdecapplet@joejoetv"
+
+# Read UUID from metadata.json file in applet directory
+try:
+    with open(os.path.join(APPLET_DIR, "metadata.json"), "r") as jsonfile:
+        JSONMetadata = json.load(jsonfile)
+
+    UUID = JSONMetadata["uuid"]
+except Exception as e:
+    print("Couldn't read metadata from metadata.json: ", e, file=sys.stderr)
+
+# I18n support
+gettext.install(UUID, GLib.get_home_dir() + '/.local/share/locale')
+
+# Teplate for colums to pass to OrderList
+# List of objects, each representing a column
+COLUMNS_TEMPLATE = [
+    {
+        "title": "Test Title",      # Title of the column
+        "type": "text",             # Type of column, can be one of: text, boolean, icon
+        "align": "center",          # Alignment of column, can be one of: left, center, right
+        "id": "test",               # The id that the entried of the column are stored as
+        "translate": False          # Wether to translate the values in the column, while keeping the underlying data the same (only for "text" type)
+    }
+]
+
+COLUMN_TYPE_MAP = {
+    "text":     str,
+    "boolean":  bool,
+    "icon":     str
+}
+
+ALIGNMENT_MAP = {
+    "left":     0,
+    "center":   0.5,
+    "right":    1
+}
+
+'''
+    Settings Widget that displays a list that can be reordered, but not modified anyway else
+'''
+class OrderList(SettingsWidget):
+    def __init__(self, info, key, settings):
+        SettingsWidget.__init__(self)
+        self.key = key
+        self.settings = settings
+        self.info = info
+        
+        # Get column structure from info
+        self.columns = self.info["columns"]
+        
+        # Flag to stop saving settings, when loading them
+        self.dontModify = False
+        
+        # Flag to use when user has dropped something on the widget
+        self.droppedDND = False
+        
+        # Remove margin and spacing around widget, since it should fill the whole space
+        self.set_orientation(Gtk.Orientation.VERTICAL)
+        self.set_spacing(0)
+        self.set_margin_left(0)
+        self.set_margin_right(0)
+        self.set_border_width(0)
+        
+        # Setup the tree view for the devices
+        self.tree_view = Gtk.TreeView()
+        self.tree_view.set_property("enable-grid-lines", 0)
+        self.tree_view.set_property("enable-tree-lines", False)
+        self.tree_view.set_property("reorderable", True)
+
+        # Make tree view scrollable, if it gets too big
+        self.scrollbox = Gtk.ScrolledWindow()
+        self.scrollbox.set_size_request(-1, 150)
+        self.scrollbox.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        self.pack_start(self.scrollbox, True, True, 0)
+        self.scrollbox.add(self.tree_view)
+        
+        # Add columns
+        
+        # List of types to initialize model with
+        model_type_list = [object]
+        
+        for i, col in enumerate(self.columns):
+            if col["type"] == "text":
+                renderer = Gtk.CellRendererText()
+                attribute = "text"
+            elif col["type"] == "icon":
+                renderer = Gtk.CellRendererPixbuf()
+                attribute = "icon-name"
+            elif col["type"] == "boolean":
+                renderer = Gtk.CellRendererToggle()
+                renderer.set_property("activatable", True)
+                renderer.connect("toggled", self.on_checkboxcolumn_toggle, i+1)
+                attribute = "active"
+            else:
+                raise ValueError("Unknown type for column "+i)
+                continue
+            
+            # Add matching type to type list, so we can later use it to build the model
+            model_type_list.append(COLUMN_TYPE_MAP[col["type"]])
+            
+            # Set alignment set in column structure, vertical alignment is always center
+            renderer.set_alignment(ALIGNMENT_MAP[col["align"]], ALIGNMENT_MAP["center"])
+            
+            column = Gtk.TreeViewColumn(col["title"], renderer)
+            column.add_attribute(renderer, attribute, i+1)
+            column.set_alignment(0)
+            column.set_resizable(True)
+            self.tree_view.append_column(column)
+        
+        # Create ListStore with created type list
+        self.store = Gtk.ListStore(*model_type_list)
+        self.tree_view.set_model(self.store)
+        
+        # Toolbar with buttons
+        button_toolbar = Gtk.Toolbar()
+        button_toolbar.set_icon_size(1)
+        self.pack_start(button_toolbar, False, False, 0)
+        
+        # Button to move row up
+        self.move_up_button = Gtk.ToolButton(None, None)
+        self.move_up_button.set_icon_name("go-up-symbolic")
+        self.move_up_button.set_tooltip_text(_("Move selected entry up"))
+        self.move_up_button.connect("clicked", self.move_item_up)
+        self.move_up_button.set_sensitive(False)
+
+        # Button to move row down
+        self.move_down_button = Gtk.ToolButton(None, None)
+        self.move_down_button.set_icon_name("go-down-symbolic")
+        self.move_down_button.set_tooltip_text(_("Move selected entry down"))
+        self.move_down_button.connect("clicked", self.move_item_down)
+        self.move_down_button.set_sensitive(False)
+        
+        button_toolbar.insert(self.move_up_button, -1)
+        button_toolbar.insert(self.move_down_button, -1)
+        
+        # Restore list from settings
+        self.restore_list()
+        
+        # NOTE: "value" property of the settings object gets added by the js part of cinnamon when installing or upgrading the settings, IF the "default" property is set
+        
+        # Connect signals for tree view
+        self.tree_view.get_selection().connect("changed", self.update_button_sensitivity)
+        self.tree_view.connect("drag-drop", self.on_drag_drop)
+        self.tree_view.connect("drag-motion", self.on_drag_motion)
+        
+        # Use "row-deleted" signal, as it is the only one signalled at the right time AFAIK
+        self.store.connect("row-deleted", self.on_row_deleted)
+        
+        self.settings.listen(self.key, self.valid_backup_restore)
+    
+    ## Callbacks
+    
+    def on_checkboxcolumn_toggle(self, renderer, path, column, *args):
+        old_value = self.store[path][column]
+        
+        self.store[path][column] = not old_value
+        
+        self.list_changed()
+        
+    def on_drag_drop(self, *args):
+        self.droppedDND = True
+    
+    def on_row_deleted(self, *args):
+        if self.droppedDND and (not self.dontModify):
+            self.list_changed()
+            
+            # Reset DND flag
+            self.droppedDND = False
+    
+    def on_drag_motion(self, *args):
+        # Reset droppedDND value, if not reset by row-deleted signal
+        self.droppedDND = False
+    
+    ## List functions
+    
+    def restore_list(self):
+        # Don't modify from callback
+        self.dontModify = True
+        
+        self.store.clear()
+        
+        self.stored_entries = self.settings.get_value(self.key)
+        
+        for entry in self.stored_entries:
+            entry_value_list = [entry]
+            
+            for i, col in enumerate(self.columns):
+                if col["id"] in entry:
+                    if col["type"] == "text" and col["translate"] == True:
+                        entry_value_list.append(_(entry[col["id"]]))
+                    else:
+                        entry_value_list.append(entry[col["id"]])
+                else:
+                    raise ValueError("Entry of column "+str(i)+" doesn't contain key: "+col["id"])
+                    continue
+            
+            self.store.append(entry_value_list)
+
+        self.tree_view.expand_all()
+        
+        self.dontModify = False
+    
+    def list_changed(self):
+        def get_row_data(store, treepath, treeiter, devices):
+            item = {}
+            
+            for i, col in enumerate(self.columns):
+                if col["type"] == "text" and col["translate"] == True:
+                    item[col["id"]] = store[treeiter][0][col["id"]]
+                else:
+                    item[col["id"]] = store[treeiter][i+1]
+            
+            devices.append(item)
+        
+        self.stored_entries = []
+        
+        self.store.foreach(get_row_data, self.stored_entries)
+        
+        self.settings.set_value(self.key, self.stored_entries)
+        
+        self.update_button_sensitivity()
+        
+    def update_button_sensitivity(self, *args):
+        model, selected = self.tree_view.get_selection().get_selected()
+        
+        if selected is None or model.iter_previous(selected) is None:
+            self.move_up_button.set_sensitive(False)
+        else:
+            self.move_up_button.set_sensitive(True)
+
+        if selected is None or model.iter_next(selected) is None:
+            self.move_down_button.set_sensitive(False)
+        else:
+            self.move_down_button.set_sensitive(True)
+    
+    def valid_backup_restore(self, key, changed_entries):
+        ''' restore list only if there are changes between internally 
+            stored apps/groups and saved apps/groups in applet settings,
+            e.g. when you restore a backup.
+        '''
+        if not changed_entries == self.stored_entries:
+            self.restore_list()
+    
+    def move_item_up(self, *args):
+        store, item = self.tree_view.get_selection().get_selected()
+        self.store.swap(item, self.store.iter_previous(item))
+        
+        self.list_changed()
+
+    def move_item_down(self, *args):
+        store, item = self.tree_view.get_selection().get_selected()
+        self.store.swap(item, self.store.iter_next(item))
+        
+        self.list_changed()


### PR DESCRIPTION
I have updated the applet to version 2.1.0, which adds support for changing the order of modules for each device sub menu and changing the order of the devices themselves.
It also adds the ability to individually choose, which device sub menus should automatically expand.

Maybe @Drugwash2 could test, if the performance issues he observed with the app-launcher@mchilli applet are happening here too, as I have also used a custom SettingsWidget.

EDIT: I have also noticed, that the screenshot on the  cinnamon-spices page is still the old one, which I had reaplced in the 2.0.0 rewrite pull request. Do I have to do more than that to properly update it?