### PR TITLE
[sound150@claudiux] v3.0.0 - Overwrite AudioRaiseVolume and AudioLowerVolume keysym

### DIFF
--- a/sound150@claudiux/CHANGELOG.md
+++ b/sound150@claudiux/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### v3.0.0~20230310
+  * Rebase and update for cinnamon 5.4 (thanks to @rcalixte).
+  * Overwrite existing binding of AudioRaiseVolume and AudioLowerVolume keysym. (Fixes [issue #9919](https://github.com/linuxmint/cinnamon/issues/9919))
+
 ### v2.0.0~20200731
   * New code for Cinnamon 4.4 (Mint 19.3) and Cinnamon 4.6 (Mint 20).
   * During volume slider dragging, a tooltip containing the value of the volume percentage is shown.

--- a/sound150@claudiux/files/sound150@claudiux/5.4/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/5.4/applet.js
@@ -1281,6 +1281,15 @@ class Sound150Applet extends Applet.TextIconApplet {
             this._notifyVolumeChange(this._output);
             this.setAppletTooltip();
             this._applet_tooltip.show();
+            let volume = this.volume.slice(0, -1);
+            let icon_name = "audio-volume";
+            if (volume <1) icon_name += "-muted";
+            else if (volume < 33) icon_name += "-low";
+            else if (volume < 67) icon_name += "-medium";
+            else icon_name += "-high";
+            icon_name += "-symbolic";
+            let icon = Gio.Icon.new_for_string(icon_name);
+            Main.osdWindowManager.show(-1, icon, volume, null);
             var intervalId = null;
             intervalId = Util.setInterval(() => {
                 this._applet_tooltip.hide();

--- a/sound150@claudiux/files/sound150@claudiux/5.4/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/5.4/applet.js
@@ -1148,6 +1148,8 @@ class Sound150Applet extends Applet.TextIconApplet {
 
     _setKeybinding() {
         Main.keybindingManager.addHotKey("sound-open-" + this.instance_id, this.keyOpen, Lang.bind(this, this._openMenu));
+        Main.keybindingManager.addHotKey("raise-volume-" + this.instance_id, "AudioRaiseVolume", () => this._volumeChange(Clutter.ScrollDirection.UP));
+        Main.keybindingManager.addHotKey("lower-volume-" + this.instance_id, "AudioLowerVolume", () => this._volumeChange(Clutter.ScrollDirection.DOWN));
     }
 
     _on_sound_settings_change() {
@@ -1172,6 +1174,8 @@ class Sound150Applet extends Applet.TextIconApplet {
 
     on_applet_removed_from_panel() {
         Main.keybindingManager.removeHotKey("sound-open-" + this.instance_id);
+        Main.keybindingManager.removeHotKey("raise-volume-" + this.instance_id);
+        Main.keybindingManager.removeHotKey("lower-volume-" + this.instance_id);
         if (this.hideSystray)
             this.unregisterSystrayIcons();
         if (this._iconTimeoutId) {
@@ -1225,6 +1229,10 @@ class Sound150Applet extends Applet.TextIconApplet {
             return Clutter.EVENT_PROPAGATE;
         }
 
+        this._volumeChange(direction);
+    }
+
+    _volumeChange(direction) {
         let currentVolume = this._output.volume;
         let volumeChange = false;
         let player = this._players[this._activePlayer];
@@ -1265,7 +1273,14 @@ class Sound150Applet extends Applet.TextIconApplet {
         if (volumeChange) {
             this._output.push_volume();
             this._notifyVolumeChange(this._output);
+            this.setAppletTooltip();
             this._applet_tooltip.show();
+            var intervalId = null;
+            intervalId = Util.setInterval(() => {
+                this._applet_tooltip.hide();
+                Util.clearInterval(intervalId);
+                return false
+            }, 5000);
         } else {
             this._applet_tooltip.hide();
         }

--- a/sound150@claudiux/files/sound150@claudiux/5.4/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/5.4/applet.js
@@ -1147,7 +1147,11 @@ class Sound150Applet extends Applet.TextIconApplet {
     }
 
     _setKeybinding() {
+        Main.keybindingManager.removeHotKey("media-keys-4");
+        Main.keybindingManager.removeHotKey("media-keys-2");
+
         Main.keybindingManager.addHotKey("sound-open-" + this.instance_id, this.keyOpen, Lang.bind(this, this._openMenu));
+
         Main.keybindingManager.addHotKey("raise-volume-" + this.instance_id, "AudioRaiseVolume", () => this._volumeChange(Clutter.ScrollDirection.UP));
         Main.keybindingManager.addHotKey("lower-volume-" + this.instance_id, "AudioLowerVolume", () => this._volumeChange(Clutter.ScrollDirection.DOWN));
     }
@@ -1174,8 +1178,10 @@ class Sound150Applet extends Applet.TextIconApplet {
 
     on_applet_removed_from_panel() {
         Main.keybindingManager.removeHotKey("sound-open-" + this.instance_id);
+
         Main.keybindingManager.removeHotKey("raise-volume-" + this.instance_id);
         Main.keybindingManager.removeHotKey("lower-volume-" + this.instance_id);
+
         if (this.hideSystray)
             this.unregisterSystrayIcons();
         if (this._iconTimeoutId) {

--- a/sound150@claudiux/files/sound150@claudiux/CHANGELOG.md
+++ b/sound150@claudiux/files/sound150@claudiux/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### v3.0.0~20230310
+  * Rebase and update for cinnamon 5.4 (thanks to @rcalixte).
+  * Overwrite existing binding of AudioRaiseVolume and AudioLowerVolume keysym. (Fixes [issue #9919](https://github.com/linuxmint/cinnamon/issues/9919))
+
 ### v2.0.0~20200731
   * New code for Cinnamon 4.4 (Mint 19.3) and Cinnamon 4.6 (Mint 20).
   * During volume slider dragging, a tooltip containing the value of the volume percentage is shown.

--- a/sound150@claudiux/files/sound150@claudiux/metadata.json
+++ b/sound150@claudiux/files/sound150@claudiux/metadata.json
@@ -5,7 +5,7 @@
   "max-instances": "1",
   "description": "An applet, based on the Cinnamon one, to control sound (up to 150% of nominal volume) and music",
   "hide-configuration": false,
-  "version": "2.0.0",
+  "version": "3.0.0",
   "cinnamon-version": [
     "2.8",
     "3.0",
@@ -16,6 +16,12 @@
     "4.0",
     "4.2",
     "4.4",
-    "4.6"
-  ]
+    "4.6",
+    "4.8",
+    "5.0",
+    "5.2",
+    "5.4",
+    "5.6"
+  ],
+  "author": "claudiux"
 }


### PR DESCRIPTION
Hi @brownsr @mtwebster 

This PR fixes https://github.com/linuxmint/cinnamon/issues/9919 just replacing the `sound@cinnamon.org` applet by `sound150@claudiux`.

I hope this is suitable.

Regards
Claudiux

