### PR TITLE
[rwall@typicalfoobar] v1.0.2 - Make this applet not 'dangerous'

### DIFF
--- a/rwall@typicalfoobar/files/rwall@typicalfoobar/applet.js
+++ b/rwall@typicalfoobar/files/rwall@typicalfoobar/applet.js
@@ -114,17 +114,7 @@ MyApplet.prototype = {
     
     // Returns true if the cron job is running, false otherwise
     isCronBeingUsed: function() {
-        let usingCron = false;
-        try {
-            // If this file exists, then cron is being used
-            Cinnamon.get_file_contents_utf8_sync(AppletDir + '/etc/USING-CRON.lock');
-            usingCron = true;
-        }
-        catch (e) {
-            usingCron = false;
-        }
-        
-        return usingCron;
+        return GLib.file_test(AppletDir + '/etc/USING-CRON.lock', GLib.FileTest.EXISTS);
     },
     
     // Called when the Save Wallpaper button is clicked

--- a/rwall@typicalfoobar/files/rwall@typicalfoobar/metadata.json
+++ b/rwall@typicalfoobar/files/rwall@typicalfoobar/metadata.json
@@ -1,6 +1,6 @@
 {
     "uuid": "rwall@typicalfoobar",
     "name": "rwall",
-    "description": "Random Wallpaper Changer\nVersion: 1.0.1",
+    "description": "Random Wallpaper Changer\nVersion: 1.0.2",
     "max-instances": -1
 }


### PR DESCRIPTION
The signal "Dangerous!" :warning: has now disappeared. 

![Capture d’écran du 2023-04-29 03-10-35](https://user-images.githubusercontent.com/33965039/235275007-36016c5d-5478-4c69-8c50-8a06a0397855.png)

Author of this applet: none.