### PR TITLE
Soup 3 cleanup

### DIFF
--- a/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/feedreader.js
+++ b/feeds@jonbrettdev.wordpress.com/files/feeds@jonbrettdev.wordpress.com/feedreader.js
@@ -23,7 +23,6 @@ const Gettext = imports.gettext;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Lang = imports.lang;
-const Soup = imports.gi.Soup;
 const Util = imports.misc.util;
 
 const Signals = imports.signals;
@@ -106,19 +105,6 @@ FeedReader.prototype = {
         this.items = new Array();
 
         this.image = {}
-
-        /* Init HTTP session */
-        try {
-            this.session = new Soup.SessionAsync();
-            Soup.Session.prototype.add_feature.call(this.session,
-                    new Soup.ProxyResolverDefault());
-        } catch (e) {
-            if(this.logger != undefined){
-                this.logger.error(e);
-            }
-            global.logError(e);            
-            throw "Failed to create HTTP session: " + e;
-        }
 
         let path = DataPath + '/' + this.id;
         // Let the python script grab the items and load them using an async method


### PR DESCRIPTION
We're hopefully going to switch Cinnamon to requiring soup 3 for 5.8 (distros are starting to drop soup 2), so I went thru and tried to update applets that hadn't been given soup 3 compatibility yet.

Most of these I couldn't test the actual http requests as they require accounts and api keys, but I hope to at least get the ball rolling so maybe the appropriate maintainers can cherry-pick from this, or I or they can open an individual PR for their applet.

@claudiux (VPN-Sentinel@claudiux)
@ludvigbostrom (devbar@ludvigbostrom)
@inventor96 (wakatimedisplay@inventor96)
@ImmRanneft (nightscout@ranneft)
not sure about others...

Thanks

