### PR TITLE
sysmonitor@orcus: added scaling functionality for network graph

### DIFF
--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.2/applet.js
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.2/applet.js
@@ -124,6 +124,7 @@ MyApplet.prototype = {
                 ["net_enabled", this.on_cfg_changed_graph_enabled, 3],
                 ["net_override_graph_width", this.on_cfg_changed_graph_width, 3],
                 ["net_graph_width", this.on_cfg_changed_graph_width],
+                ["net_minimum_graph_scale", this.on_cfg_changed_graph_scale],
                 ["net_color_0", this.on_cfg_changed_color, 3],
                 ["net_color_1", this.on_cfg_changed_color, 3],
                 ["load_enabled", this.on_cfg_changed_graph_enabled, 4],
@@ -261,6 +262,13 @@ MyApplet.prototype = {
         return c;
     },
 
+    getNetGraphScale: function() {
+        if (!this.cfg_net_minimum_graph_scale)
+            return 1024;
+
+        return this.cfg_net_minimum_graph_scale * 1000000 / 8; // Mb to MB
+    },
+
     getGraphTooltipDecimals: function(graph_idx) {
         let graph_id = this.graph_ids[graph_idx];
         let prop = "cfg_" + graph_id + "_tooltip_decimals";
@@ -329,7 +337,7 @@ MyApplet.prototype = {
                 else if (i == 2)
                     this.addGraph(new Providers.SwapData(), i);
                 else if (i == 3)
-                    this.addGraph(new Providers.NetData(), i).setAutoScale(1024);
+                    this.addGraph(new Providers.NetData(), i).setAutoScale(this.getNetGraphScale());
                 else if (i == 4) {
                     let ncpu = GTop.glibtop_get_sysinfo().ncpu;
                     this.addGraph(new Providers.LoadAvgData(), i).setAutoScale(2 * ncpu);
@@ -406,6 +414,11 @@ MyApplet.prototype = {
 
     on_cfg_changed_graph_spacing: function() {
         this.resizeArea();
+        this.repaint();
+    },
+
+    on_cfg_changed_graph_scale: function() {
+        this.graphs[3].setAutoScale(this.getNetGraphScale());
         this.repaint();
     },
 

--- a/sysmonitor@orcus/files/sysmonitor@orcus/3.2/settings-schema.json
+++ b/sysmonitor@orcus/files/sysmonitor@orcus/3.2/settings-schema.json
@@ -70,7 +70,7 @@
         "net_g": {
             "type": "section",
             "title": "General",
-            "keys": ["net_enabled", "net_override_graph_width", "net_graph_width"]
+            "keys": ["net_enabled", "net_override_graph_width", "net_graph_width", "net_minimum_graph_scale"]
         },
         "net_c": {
             "type": "section",
@@ -295,6 +295,16 @@
         "description": "Graph width",
         "units": "pixels",
         "dependency": "net_override_graph_width"
+    },
+    "net_minimum_graph_scale": {
+        "type": "spinbutton",
+        "default": 0,
+        "min": 0,
+        "max": 1000000,
+        "step": 10,
+        "description": "Minimum graph scale",
+        "units": "Mb/s",
+        "tooltip": "The minimum scale for the graph in Megabits per second.\nThe graph will not scale below this minimum, but it will automatically scale if the network speed exceeds this value.\n\nTo always automatically scale, set the value to 0."
     },
     "net_color_0": {
         "type": "colorchooser",


### PR DESCRIPTION
Added a minimum scaling user setting for the network graph since it is the only graph that does not have a fixed maximum (like 100% CPU or known usable RAM value) so the user can set a "soft" maximum by specifying the minimum scaling of the graph.

If the value exceeds the specified minimum the graph is auto-scaled.

The standard setting of "0" produces the same behaviour as it does without this PR.