### PR TITLE
[bluetooth-battery@zamszowy]: remember last manual device set

### DIFF
--- a/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
+++ b/bluetooth-battery@zamszowy/files/bluetooth-battery@zamszowy/applet.js
@@ -111,7 +111,7 @@ BtBattery.prototype = {
             return;
         }
 
-        if (!this.monitored_devs.includes(this.override_entry)) {
+        if (!this.override_entry || this.override_entry == "(no device available)") {
             // entry in settings page seems to be refreshing only when external process returns after a while
             Util.spawn_async(['/usr/bin/sleep', "2"], Lang.bind(this, function(stdout){
                 this.override_entry = this.monitored_devs.length > 0 ? this.monitored_devs[0] : "(no device available)";


### PR DESCRIPTION
Don't clear manual device choice after e.g.: this device gets disconnected and reconnected.