### PR TITLE
[desaturatea-all@hkoosha] replace call to `has_effects(this.effect)`

### DIFF
--- a/desaturate-all@hkoosha/files/desaturate-all@hkoosha/applet.js
+++ b/desaturate-all@hkoosha/files/desaturate-all@hkoosha/applet.js
@@ -21,7 +21,7 @@ MyApplet.prototype = {
     },
 
     _toggleEffect: function() {
-        if (Main.uiGroup.has_effects(this.effect)) {
+        if (Main.uiGroup.has_effects() && Main.uiGroup.get_effects().indexOf(this.effect) > -1) {
             Main.uiGroup.remove_effect(this.effect);
         } else {
             Main.uiGroup.add_effect(this.effect);


### PR DESCRIPTION
Each time the applet is clicked, an error message like the following appears in the ~/.xsession-errors file.

```
Gjs-Message: 08:49:39.664: JS WARNING: [/usr/share/cinnamon/js/misc/fileUtils.js line 211 > Function 26]: Too many arguments to method Clutter.Actor.has_effects: expected 0, got 1
```

Addresses https://github.com/linuxmint/cinnamon-spices-applets/issues/4909

Tested on latest version of Manjaro-Cinnamon.