### PR TITLE
places-with-terminal@mtwebster: Fix place buttons not working

### DIFF
--- a/places-with-terminal@mtwebster/files/places-with-terminal@mtwebster/applet.js
+++ b/places-with-terminal@mtwebster/files/places-with-terminal@mtwebster/applet.js
@@ -2,8 +2,6 @@ const St = imports.gi.St;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
 const Applet = imports.ui.applet;
-const Clutter = imports.gi.Clutter;
-const Cinnamon = imports.gi.Cinnamon;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Lang = imports.lang;
@@ -65,14 +63,6 @@ MyPopupMenuItem.prototype =
                 this.buttonbox.add_actor(button);
                 this.addActor(this.buttonbox);
 			}
-        },
-
-        _onButtonReleaseEvent: function (actor, event)
-        {
-            if ( Cinnamon.get_event_state(event) & Clutter.ModifierType.BUTTON1_MASK ) {
-                this.activate(event);
-            }
-            return true;
         },
 
         _terminal: function () {


### PR DESCRIPTION
Fixes #4566

When a place button (e.g. for your Home folder) was clicked `Cinnamon.get_event_state(event)` returned 0, so `activate` wasn't called and nothing happened.

I removed `_onButtonReleaseEvent` and now the parent class (PopupBaseMenuItem) correctly calls `activate`. I think the left mouse button check is unneeded as other applets with PopupMenus let you use any mouse button.

The applet has no author to ping.