### PR TITLE
[CassiaWindowList@klangman] A bunch of fixes and new features

### DIFF
--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/applet.js
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/applet.js
@@ -159,7 +159,7 @@ const GroupingType = {
   ForcedOn:    2,   // Button is grouped and can't be ungrouped automatically
   Auto:        3,   // Button was grouped automatically and can be ungrouped automatically 
   Tray:        4,   // Button is a "tray" and therefore only represents a group of windows not a specific window or application
-  Unspecified: 5    // Only used to signal that the user setting shuld be queried, not a valid WindowListButton._grouped value
+  Unspecified: 5    // Only used to signal that the user setting should be queried, not a valid WindowListButton._grouped value
 }
 
 // Possible value for the Mouse Action setting
@@ -182,7 +182,12 @@ const MouseAction = {
   MoveMonitor2: 15,   // 2
   MoveMonitor3: 16,   // 3
   MoveMonitor4: 17,   // 4
-  MoveCurrMonitor: 18 // Move window to the current monitor (or to next monitor if window is already on current monitor)
+  MoveCurrMonitor: 18,// Move window to the current monitor (or to next monitor if window is already on current monitor)
+  ShoveTitlebar: 19,  // Move the titlebar so that it is visible on the screen
+  MovePrevWorkspace: 20, // Move window to the workspace -1 from it's current workspace
+  MoveNextWorkspace: 21, // Move window to the workspace +1 from it's current workspace
+  MovePrevMonitor: 22,   // Move window to the monitor -1 from it's current monitor
+  MoveNextMonitor: 23    // Move window to the monitor +1 from it's current monitor
 }
 
 // Possible settings for the left mouse action for grouped buttons
@@ -343,7 +348,7 @@ function getMonitors() {
 // Return a MouseAction if a mount action is defined for the ctrlHeld state, context and mouse button
 //       mouseBtn = 1-3 (left, middle, right) or 8-9 (back, forward)
 function getKeyAndButtonMouseAction(mouseActionList, modifier, context, mouseBtn) {
-   let keyAndButton = ((modifier)?0:5) + ((mouseBtn<4)?mouseBtn-1:mouseBtn-4);
+   let keyAndButton = ((modifier)?0:5) + ((mouseBtn<4)?mouseBtn-1:mouseBtn-5);
    //log( `Looking for adv mouse action for ctrlHeld=${modifier}, thumbContext=${context}, btn=${mouseBtn}, k&b=${keyAndButton}` );
    for (let i=0 ; i < mouseActionList.length ; i++) {
       //log( `enabled=${mouseActionList[i].enabled}, context=${mouseActionList[i].context}, k&b=${mouseActionList[i].keyAndButton}, action=${mouseActionList[i].action}` );
@@ -420,7 +425,8 @@ class ThumbnailMenuItem extends PopupMenu.PopupBaseMenuItem {
     if (this._appButton._windows.length > 1 && this._appButton._currentWindow === metaWindow) {
       this._box.add_style_pseudo_class('outlined');
     } else if (this._appButton.appLastFocus &&
-              (this._settings.getValue("group-windows")===GroupType.Pooled || this._settings.getValue("group-windows")===GroupType.Auto)) {
+              ((this._settings.getValue("group-windows")===GroupType.Pooled && this._settings.getValue("menu-all-windows-of-pool")) || 
+               (this._settings.getValue("group-windows")===GroupType.Auto && this._settings.getValue("menu-all-windows-of-auto")))) {
       let btns = appButton._workspace._lookupAllAppButtonsForApp(appButton._app);
       if (btns.length > 1)
          this._box.add_style_pseudo_class('outlined');
@@ -669,9 +675,15 @@ class ThumbnailMenu extends PopupMenu.PopupMenu {
     }
     this._updateOrientation();
     let groupingType = this._settings.getValue("group-windows");
+    let allWindowsForPool = false;
+    if (groupingType === GroupType.Pooled){
+       allWindowsForPool = this._settings.getValue("menu-all-windows-of-pool");
+    } else if (groupingType === GroupType.Auto){
+       allWindowsForPool = this._settings.getValue("menu-all-windows-of-auto");
+    }
     let btns = this._appButton._workspace._lookupAllAppButtonsForApp(this._appButton._app);
     let windows = [];
-    if (this._appButton._windows.length>1 || btns.length == 1 || (groupingType != GroupType.Pooled && groupingType != GroupType.Auto)){
+    if (this._appButton._windows.length>1 || btns.length == 1 || allWindowsForPool == false){
       windows = this._appButton._windows;
     } else {
        for( let i=0 ; i< btns.length ; i++ ) {
@@ -853,8 +865,16 @@ class WindowListButton {
 
     this._pinned = false;
 
-    this.actor = new St.BoxLayout({style_class: "grouped-window-list-item-box",
+    //this.actor = new St.Group({style_class: "grouped-window-list-item-box", style: 'border:0px;padding:0px;margin:0px',
+    //                               track_hover: false, can_focus: true, reactive: true});
+
+    //this.progressOverlay = new St.Widget({ style_class: "progress", reactive: false, important: true  });
+    //this.actor.add_actor(this.progressOverlay);
+    //this.progressOverlay.hide();
+
+    this.actor = new St.BoxLayout({style_class: "grouped-window-list-item-box", style: 'border:0px;padding:0px;margin:0px',
                                    track_hover: false, can_focus: true, reactive: true});
+    this.actor._delegate = this;
 
     this._shrukenLabel = false;
     this._minLabelSize = -1;
@@ -865,8 +885,7 @@ class WindowListButton {
 
     this._tooltip = new Tooltips.PanelItemTooltip(this, this._app.get_name(), this._applet.orientation);
 
-    this.actor._delegate = this;
-    this._iconBox = new St.Group();
+    this._iconBox = new St.Group({style: 'border:0px;padding:0px;margin:0px'});
     this.actor.add_actor(this._iconBox);
     this.actor.add_actor(this._labelBox);
 
@@ -887,10 +906,6 @@ class WindowListButton {
     this._nextWindow = null;                  // When cycling windows, keep track of the next window to cycle to
     this._grouped = GroupingType.NotGrouped;  // If button is a group of windows and why it was grouped
     this._currentWindow = null;
-
-    //this.progressOverlay = new St.Widget({ style_class: "progress", reactive: false, important: true  });
-    //this.actor.add_actor(this.progressOverlay);
-    //this.progressOverlay.hide();
 
     this._updateOrientation();
 
@@ -1797,6 +1812,65 @@ class WindowListButton {
               }
            }
            break;
+        case MouseAction.ShoveTitlebar:
+           if (window) {
+              window.shove_titlebar_onscreen();
+           }
+           break;
+        case MouseAction.MovePrevWorkspace:
+           {
+           let nWorkspace = this._applet._workspaces.length;
+           if (window && nWorkspace > 1) {
+              let curWorkspace = this._applet.getCurrentWorkSpace()._wsNum;
+              if (curWorkspace==0)
+                 curWorkspace=nWorkspace;
+              window.change_workspace_by_index(curWorkspace-1, false);
+           }
+           }
+           break;
+        case MouseAction.MoveNextWorkspace:
+           {
+           let nWorkspace = this._applet._workspaces.length;
+           if (window && nWorkspace > 1) {
+              let curWorkspace = this._applet.getCurrentWorkSpace()._wsNum;
+              if (curWorkspace==nWorkspace-1)
+                 curWorkspace=-1;
+              window.change_workspace_by_index(curWorkspace+1, false);
+           }
+           }
+           break;
+        case MouseAction.MovePrevMonitor:
+           {
+           let nMonitors = Main.layoutManager.monitors.length;
+           let curMonitor = window.get_monitor();
+           if (window && nMonitors > 1 && this._applet.xrandrMonitors[curMonitor] != null) {
+              for ( curMonitor--; true ; curMonitor--) {
+                 if (curMonitor<0 )
+                    curMonitor=nMonitors-1;
+                 if (this._applet.xrandrMonitors[curMonitor] != null) {
+                    window.move_to_monitor(curMonitor);
+                    return;
+                 }
+              }
+           }
+           }
+           break;
+        case MouseAction.MoveNextMonitor:
+           {
+           let nMonitors = Main.layoutManager.monitors.length;
+           let curMonitor = window.get_monitor();
+           if (window && nMonitors > 1 && this._applet.xrandrMonitors[curMonitor] != null) {
+              for ( curMonitor++; true ; curMonitor++) {
+                 if (curMonitor>nMonitors-1 )
+                    curMonitor=0;
+                 if (this._applet.xrandrMonitors[curMonitor] != null) {
+                    window.move_to_monitor(curMonitor);
+                    return;
+                 }
+              }
+           }
+           }
+           break;
       }
   }
 
@@ -1960,29 +2034,48 @@ class WindowListButton {
       }));
       this._contextMenu.addMenuItem(item);
 
-      if (global.screen.n_workspaces > 1) {
+      let pinSettings = this._settings.getValue("pinned-apps");
+      let appId = this._app.get_id();
+      if (global.screen.n_workspaces == 2) {
+        let i = 0
+        if (i == this._workspace._wsNum) {
+            i++;
+        }
+        let name = "Pin to " + Main.getWorkspaceName(i);
+        let pinned = pinSettings[i].indexOf(appId) >= 0;
+        let iconName = pinned ? "starred" : "non-starred";
+        let ws = new PopupMenu.PopupSwitchIconMenuItem(name, pinned, iconName, St.IconType.SYMBOLIC);
+        let j = i;
+        ws.connect("toggled", Lang.bind(this, function(menuItem, state) {
+        if (state) {
+          this._applet._workspaces[j].pinAppId(appId);
+          menuItem.setIconSymbolicName("starred");
+        } else {
+          this._applet._workspaces[j].unpinAppId(appId);
+          menuItem.setIconSymbolicName("non-starred");
+        }
+        }));
+        this._contextMenu.addMenuItem(ws);
+      }else if (global.screen.n_workspaces > 2) {
         item = new PopupMenu.PopupSubMenuMenuItem(_("Pin to other workspaces"));
-        let pinSettings = this._settings.getValue("pinned-apps");
-        let appId = this._app.get_id();
         for (let i = 0; i < global.screen.n_workspaces; i++) {
-          if (i == this._workspace._wsNum) {
-            continue;
+          if (i != this._workspace._wsNum) {
+             let name = Main.getWorkspaceName(i);
+             let pinned = pinSettings[i].indexOf(appId) >= 0;
+             let iconName = pinned ? "starred" : "non-starred";
+             let ws = new PopupMenu.PopupSwitchIconMenuItem(name, pinned, iconName, St.IconType.SYMBOLIC);
+             let j = i;
+             ws.connect("toggled", Lang.bind(this, function(menuItem, state) {
+               if (state) {
+                 this._applet._workspaces[j].pinAppId(appId);
+                 menuItem.setIconSymbolicName("starred");
+               } else {
+                 this._applet._workspaces[j].unpinAppId(appId);
+                 menuItem.setIconSymbolicName("non-starred");
+               }
+             }));
+             item.menu.addMenuItem(ws);
           }
-          let name = Main.getWorkspaceName(i);
-          let pinned = pinSettings[i].indexOf(appId) >= 0;
-          let iconName = pinned ? "starred" : "non-starred";
-          let ws = new PopupMenu.PopupSwitchIconMenuItem(name, pinned, iconName, St.IconType.SYMBOLIC);
-          let j = i;
-          ws.connect("toggled", Lang.bind(this, function(menuItem, state) {
-            if (state) {
-              this._applet._workspaces[j].pinAppId(appId);
-              menuItem.setIconSymbolicName("starred");
-            } else {
-              this._applet._workspaces[j].unpinAppId(appId);
-              menuItem.setIconSymbolicName("non-starred");
-            }
-          }));
-          item.menu.addMenuItem(ws);
         }
 
         let pinAll = new PopupMenu.PopupMenuItem(_("Pin to all workspaces"));
@@ -2008,7 +2101,7 @@ class WindowListButton {
             appHasExistingHotkey = true;
          }
       }
-      if (appHasExistingHotkey===false) {
+      if (appHasExistingHotkey===false && !this._app.is_window_backed()) {
          this._contextMenu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
          item = new PopupMenu.PopupIconMenuItem(_("Add new Hotkey for")+" \""+this._app.get_id()+"\"", "input-keyboard", St.IconType.SYMBOLIC);
          item.connect("activate", Lang.bind(this, function() {
@@ -2178,7 +2271,7 @@ class WindowListButton {
             appHasExistingHotkey = true;
          }
       }
-      if (appHasExistingHotkey===false) {
+      if (appHasExistingHotkey===false && !this._app.is_window_backed()) {
          if (item === null) {
             item = new PopupMenu.PopupSubMenuMenuItem(_("Assign window to a hotkey"));
             this._contextMenu.addMenuItem(item);
@@ -2238,7 +2331,7 @@ class WindowListButton {
          // Menu options for grouping or ungrouping a button
          this._contextMenu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
          if (this._windows.length > 1) {
-            item = new PopupMenu.PopupMenuItem(_("Ungroup windows"));
+            item = new PopupMenu.PopupMenuItem(_("Ungroup application windows"));
             item.connect("activate", Lang.bind(this, function() {
                   let type = GroupingType.NotGrouped;
                   if (this._workspace._areButtonsShrunk())
@@ -2249,7 +2342,7 @@ class WindowListButton {
          } else {
             let btns = this._workspace._lookupAllAppButtonsForApp(this._app);
             if (btns && btns.length > 1) {
-              item = new PopupMenu.PopupMenuItem(_("Group windows"));
+              item = new PopupMenu.PopupMenuItem(_("Group application windows"));
               item.connect("activate", Lang.bind(this, function() { this._workspace._groupOneApp(btns, GroupingType.ForcedOn); }));
               this._contextMenu.addMenuItem(item);
             }
@@ -2463,6 +2556,7 @@ class Workspace {
     this._signalManager = new SignalManager.SignalManager(null);
 
     this.actor = new St.BoxLayout({ style_class: "window-list-box", track_hover: false, hover: false });
+    this.actor.set_style('border:0px;padding:0px;margin:0px');
     this.actor._delegate = this;
 
     this.maxSize = this._settings.getValue("label-width"); // The size where buttons start shrinking (estimated until we see shrinking button widths)
@@ -2556,25 +2650,26 @@ class Workspace {
     }
   }
 
-  _addAppButton(app) {
+  _addAppButton(app, prepend=true) {
     if (!app) {
       return undefined;
     }
     let groupingType = this._settings.getValue("group-windows");
     let btns = this._lookupAllAppButtonsForApp(app);
     let appButton = new WindowListButton(this, this._applet, app);
-    // If existing buttons for the app are not allowed to be grouped then use the same setting for this new button
-    if (btns && btns.length > 0 && btns[0]._grouped == GroupingType.ForcedOff) {
-       appButton._grouped = GroupingType.ForcedOff;
+    // New appButton should behave like the existing buttons for the app
+    if (btns && btns.length > 0) {
+       appButton._grouped = btns[0]._grouped;
+    } else if (groupingType === GroupType.Grouped) {
+       appButton._grouped = GroupingType.ForcedOn;
     }
     this._appButtons.push(appButton);
     this.actor.add_actor(appButton.actor);
     appButton.updateIcon();
-    if ((groupingType == GroupType.Pooled || groupingType == GroupType.Auto) && btns && btns.length > 0) {
+    if ((groupingType == GroupType.Pooled || groupingType == GroupType.Auto || prepend) && btns && btns.length > 0) {
        // Move the button to the top of the list of buttons for the app
        let children = this.actor.get_children();
        let actIdx = children.indexOf(btns[0].actor);
-       let pos = children.length;
        this.actor.set_child_at_index(appButton.actor, actIdx);
     } else if (this._settings.getValue("trailing-pinned-behaviour")===true) {
        // Move the button before any trailing pinned buttons
@@ -2633,7 +2728,7 @@ class Workspace {
     return appButtons.length > 0 ? appButtons[0] : undefined;
   }
 
-  _windowAdded(metaWindow, skipSizeChk=false) {
+  _windowAdded(metaWindow, skipSizeChk=false, prepend=false) {
     if (this._settings.getValue("show-windows-for-current-monitor") &&
         this._applet.panel.monitorIndex != metaWindow.get_monitor()) {
       return;
@@ -2658,25 +2753,10 @@ class Workspace {
     if (!app) {
       return false;
     }
-    let appButton;
+    let appButton = this._lookupAppButtonForApp(app);
     let groupingType = this._settings.getValue("group-windows")
-    if (groupingType == 0) {
-      let appButtons = this._lookupAllAppButtonsForApp(app);
-      for (let i = 0; i < appButtons.length; i++) {
-        let btn = appButtons[i];
-        if (btn._pinned) {
-          appButton = btn;
-          break;
-        }
-      }
-    }
-    if (!appButton) {
-       appButton = this._lookupAppButtonForApp(app)
-    }
-    if (!appButton) {
-      appButton = this._addAppButton(app);
-    } else if (groupingType != GroupType.Grouped && groupingType != GroupType.Launcher && appButton._windows.length > 0 && appButton._grouped <= GroupingType.NotGrouped) {
-      appButton = this._addAppButton(app);
+    if (!appButton || (groupingType != GroupType.Launcher && appButton._windows.length > 0 && appButton._grouped <= GroupingType.NotGrouped)) {
+      appButton = this._addAppButton(app, prepend);
     }
     appButton.addWindow(metaWindow);
     //this._updateAppButtonVisibility();
@@ -2700,8 +2780,20 @@ class Workspace {
 
   _windowRemoved(metaWindow, removeBindings=true) {
      let appButton = this._lookupAppButtonForWindow(metaWindow);
+     let btnToUpdateLabel = null;
      if (appButton) {
+        if (this._settings.getValue("display-caption-for") === DisplayCaption.One) {
+           let children = this.actor.get_children();
+           let idx = children.indexOf(appButton.actor);
+           if (idx > 0 && children[idx-1]._delegate._app === appButton._app) {
+              // The about to be removed button is proceeded by a button for the same app, might need to restore it's label
+              btnToUpdateLabel = children[idx-1]._delegate;
+           }
+        }
         appButton.removeWindow(metaWindow);
+        if (btnToUpdateLabel){
+           btnToUpdateLabel._updateLabel();
+        }
         if (appButton._windows.length === 0 && (appButton._pinned===false || this._settings.getValue("display-pinned")===false)) {
            this._removeAppButton(appButton);
         } else {
@@ -3097,7 +3189,7 @@ class Workspace {
         let btns = source._workspace._lookupAllAppButtonsForApp(source._app);
         let groupingType = this._settings.getValue("group-windows");
         let children = this.actor.get_children();
-        // Check if we have to move an entire application pool just just the one button??
+        // Check if we have to move an entire application pool or just the one button??
         if (btns.length > 1 && (groupingType == GroupType.Pooled || groupingType == GroupType.Auto) && (actorPos < children.indexOf(btns[0].actor)-1 || actorPos > children.indexOf(btns[btns.length-1].actor)+1)) {
            if (actorPos < children.indexOf(btns[0].actor)-1) {
               for (let idx=btns.length-1 ; idx >= 0 ; idx--) {
@@ -3112,9 +3204,33 @@ class Workspace {
         } else {
            this.actor.set_child_at_index(source.actor, actorPos);
            this._clearDragPlaceholder();
-           if (this._settings.getValue("display-caption-for") === DisplayCaption.One) {
-              for (let i=0 ; i < btns.length ; i++ ) {
-                btns[i]._updateLabel();
+           if (btns.length > 1 && (groupingType == GroupType.Pooled || groupingType == GroupType.Auto)) {
+              let btns = source._workspace._lookupAllAppButtonsForApp(source._app);
+              btns[btns.length-1]._updateLabel(); // The trailing button might need it's label restored
+              if (source === btns[btns.length-1]) {
+                 btns[btns.length-2]._updateLabel(); // If the dropped button is now the last one in the pool, then update the label of the previous button
+              }
+              if (btns[btns.length-1]._pinned === false) {
+                 for(let i=0 ; i<btns.length ; i++) {
+                    if (btns[i]._pinned) {
+                       this.pinAppButton(btns[btns.length-1]); // Clear existing pin and set the last button of the pool as pinned
+                       break;
+                    }
+                 }
+              }
+           }
+        }
+        if (this._settings.getValue("display-caption-for") === DisplayCaption.One) {
+           source._updateLabel(); // The moved button might need it's label restored
+           if (groupingType != GroupType.Pooled && groupingType != GroupType.Auto) {
+              let numChildern = this.actor.get_n_children();
+              // Since a label can appear/disappear based only on the adjacent buttons, we have to look at the all buttons
+              // and update the label if any two adjacent buttons have the same application
+              for (let i=0 ; i < numChildern ; i++ ) {
+                 let child = this.actor.get_child_at_index(i)._delegate;
+                 if ((i>0 && child._app === this.actor.get_child_at_index(i-1)._delegate._app) || (i<numChildern-1 && child._app === this.actor.get_child_at_index(i+1)._delegate._app)) {
+                    child._updateLabel();
+                 }
               }
            }
         }
@@ -3287,7 +3403,7 @@ class Workspace {
      for (let i=windows.length-2 ; i>=0 ; i--) {
         window = windows[i];
         button.removeWindow(window);
-        this._windowAdded(window);
+        this._windowAdded(window, false, true); // add window, don't skip size chk, prepend to existing app buttons
      }
      button.appLastFocus = false;
      let lastFocusBtn = button._workspace._lookupAppButtonForWindow(appLastFocus);

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
@@ -57,7 +57,7 @@
     "preview-settings" : {
       "type" : "section",
       "title" : "Thumbnails menu settings",
-      "keys" : ["show-previews", "number-of-unshrunk-previews"]
+      "keys" : ["show-previews", "number-of-unshrunk-previews", "menu-all-windows-of-pool", "menu-all-windows-of-auto"]
     },
     "preview-mouse-section" : {
       "type" : "section",
@@ -248,6 +248,20 @@
     "dependency": "show-previews",
     "description": "Default thumbnail window size"
   },
+  "menu-all-windows-of-pool": {
+    "type": "switch",
+    "default": true,
+    "dependency" : "group-windows=1",
+    "description": "Show thumbnails for all windows of an application pool",
+    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather then just the selected window within the application pool"
+  },
+  "menu-all-windows-of-auto": {
+    "type": "switch",
+    "default": true,
+    "dependency" : "group-windows=2",
+    "description": "Show thumbnails for all windows of an application pool",
+    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather then just the selected window within the application pool"
+  },
   "preview-timeout-show": {
     "type": "spinbutton",
     "default": 500,
@@ -283,12 +297,17 @@
       "Move to workspace 2": 8,
       "Move to workspace 3": 9,
       "Move to workspace 4": 10,
+      "Move to previous workspace": 20,
+      "Move to next workspace": 21,
       "Visible on this/all workspaces": 11,
       "Move to monitor 1": 14,
       "Move to monitor 2": 15,
       "Move to monitor 3": 16,
       "Move to monitor 4": 17,
+      "Move to previous monitor": 22,
+      "Move to next monitor": 23,
       "Move to current/next monitor": 18,
+      "Move titlebar on to screen": 19,
       "Do nothing": 12
     },
     "description": "Thumbnail window middle button action"
@@ -307,12 +326,17 @@
       "Move to workspace 2": 8,
       "Move to workspace 3": 9,
       "Move to workspace 4": 10,
+      "Move to previous workspace": 20,
+      "Move to next workspace": 21,
       "Visible on this/all workspaces": 11,
       "Move to monitor 1": 14,
       "Move to monitor 2": 15,
       "Move to monitor 3": 16,
       "Move to monitor 4": 17,
+      "Move to previous monitor": 22,
+      "Move to next monitor": 23,
       "Move to current/next monitor": 18,
+      "Move titlebar on to screen": 19,
       "Do nothing": 12
     },
     "description": "Thumbnail window back button action"
@@ -331,12 +355,17 @@
       "Move to workspace 2": 8,
       "Move to workspace 3": 9,
       "Move to workspace 4": 10,
+      "Move to previous workspace": 20,
+      "Move to next workspace": 21,
       "Visible on this/all workspaces": 11,
       "Move to monitor 1": 14,
       "Move to monitor 2": 15,
       "Move to monitor 3": 16,
       "Move to monitor 4": 17,
+      "Move to previous monitor": 22,
+      "Move to next monitor": 23,
       "Move to current/next monitor": 18,
+      "Move titlebar on to screen": 19,
       "Do nothing": 12
     },
     "description": "Thumbnail window forward button action"
@@ -369,12 +398,17 @@
       "Move to workspace 2": 8,
       "Move to workspace 3": 9,
       "Move to workspace 4": 10,
+      "Move to previous workspace": 20,
+      "Move to next workspace": 21,
       "Visible on this/all workspaces": 11,
       "Move to monitor 1": 14,
       "Move to monitor 2": 15,
       "Move to monitor 3": 16,
       "Move to monitor 4": 17,
+      "Move to previous monitor": 22,
+      "Move to next monitor": 23,
       "Move to current/next monitor": 18,
+      "Move titlebar on to screen": 19,
       "Do nothing": 12
     },
     "description": "Middle button action",
@@ -396,12 +430,17 @@
       "Move to workspace 2": 8,
       "Move to workspace 3": 9,
       "Move to workspace 4": 10,
+      "Move to previous workspace": 20,
+      "Move to next workspace": 21,
       "Visible on this/all workspaces": 11,
       "Move to monitor 1": 14,
       "Move to monitor 2": 15,
       "Move to monitor 3": 16,
       "Move to monitor 4": 17,
+      "Move to previous monitor": 22,
+      "Move to next monitor": 23,
       "Move to current/next monitor": 18,
+      "Move titlebar on to screen": 19,
       "Do nothing": 12
     },
     "description": "Back button action",
@@ -423,12 +462,17 @@
       "Move to workspace 2": 8,
       "Move to workspace 3": 9,
       "Move to workspace 4": 10,
+      "Move to previous workspace": 20,
+      "Move to next workspace": 21,
       "Visible on this/all workspaces": 11,
       "Move to monitor 1": 14,
       "Move to monitor 2": 15,
       "Move to monitor 3": 16,
       "Move to monitor 4": 17,
+      "Move to previous monitor": 22,
+      "Move to next monitor": 23,
       "Move to current/next monitor": 18,
+      "Move titlebar on to screen": 19,
       "Do nothing": 12
     },
     "description": "Forward button action",
@@ -522,12 +566,17 @@
            "Move to workspace 2": 8,
            "Move to workspace 3": 9,
            "Move to workspace 4": 10,
+           "Move to previous workspace": 20,
+           "Move to next workspace": 21,
            "Visible on this/all workspaces": 11,
            "Move to monitor 1": 14,
            "Move to monitor 2": 15,
            "Move to monitor 3": 16,
            "Move to monitor 4": 17,
+           "Move to previous monitor": 22,
+           "Move to next monitor": 23,
            "Move to current/next monitor": 18,
+           "Move titlebar on to screen": 19,
            "Do nothing": 12
            }
         }

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-24 15:07-0400\n"
+"POT-Creation-Date: 2023-07-06 23:13-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,24 +17,24 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: 4.0/applet.js:1919
+#: 4.0/applet.js:1993
 msgid "Applet Preferences"
 msgstr ""
 
-#: 4.0/applet.js:1923
+#: 4.0/applet.js:1997
 msgid "About..."
 msgstr ""
 
-#: 4.0/applet.js:1927
+#: 4.0/applet.js:2001
 msgid "Configure..."
 msgstr ""
 
-#: 4.0/applet.js:1931
+#: 4.0/applet.js:2005
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
 
-#: 4.0/applet.js:1933
+#: 4.0/applet.js:2007
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 
@@ -44,115 +44,115 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:1942
+#: 4.0/applet.js:2016
 msgid "Open new window"
 msgstr ""
 
-#: 4.0/applet.js:1948
+#: 4.0/applet.js:2022
 msgid "Pin to this workspace"
 msgstr ""
 
-#: 4.0/applet.js:1964
+#: 4.0/applet.js:2060
 msgid "Pin to other workspaces"
 msgstr ""
 
-#: 4.0/applet.js:1988
+#: 4.0/applet.js:2081
 msgid "Pin to all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2013 4.0/applet.js:2186
+#: 4.0/applet.js:2106 4.0/applet.js:2279
 msgid "Add new Hotkey for"
 msgstr ""
 
-#: 4.0/applet.js:2027
+#: 4.0/applet.js:2120
 msgid "Recent files"
 msgstr ""
 
-#: 4.0/applet.js:2051
+#: 4.0/applet.js:2144
 msgid "Places"
 msgstr ""
 
-#: 4.0/applet.js:2093
+#: 4.0/applet.js:2186
 msgid "Only on this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2095
+#: 4.0/applet.js:2188
 msgid "Visible on all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2096
+#: 4.0/applet.js:2189
 msgid "Move to another workspace"
 msgstr ""
 
-#: 4.0/applet.js:2115
+#: 4.0/applet.js:2208
 msgid "Move to another monitor"
 msgstr ""
 
-#: 4.0/applet.js:2123
+#: 4.0/applet.js:2216
 msgid "Monitor"
 msgstr ""
 
-#: 4.0/applet.js:2151
+#: 4.0/applet.js:2244
 msgid "unassigned"
 msgstr ""
 
-#: 4.0/applet.js:2162 4.0/applet.js:2183
+#: 4.0/applet.js:2255 4.0/applet.js:2276
 msgid "Assign window to a hotkey"
 msgstr ""
 
-#: 4.0/applet.js:2206
+#: 4.0/applet.js:2299
 msgid "Change application label contents"
 msgstr ""
 
-#: 4.0/applet.js:2209
+#: 4.0/applet.js:2302
 msgid "Remove custom setting"
 msgstr ""
 
-#: 4.0/applet.js:2216
+#: 4.0/applet.js:2309
 msgid "Use window title"
 msgstr ""
 
-#: 4.0/applet.js:2223
+#: 4.0/applet.js:2316
 msgid "Use application name"
 msgstr ""
 
-#: 4.0/applet.js:2230
+#: 4.0/applet.js:2323
 msgid "No label"
 msgstr ""
 
-#: 4.0/applet.js:2241
-msgid "Ungroup windows"
+#: 4.0/applet.js:2334
+msgid "Ungroup application windows"
 msgstr ""
 
-#: 4.0/applet.js:2252
-msgid "Group windows"
+#: 4.0/applet.js:2345
+msgid "Group application windows"
 msgstr ""
 
-#: 4.0/applet.js:2262
+#: 4.0/applet.js:2355
 msgid "Automatic grouping/ungrouping"
 msgstr ""
 
-#: 4.0/applet.js:2291
+#: 4.0/applet.js:2384
 msgid "Restore"
 msgstr ""
 
-#: 4.0/applet.js:2295
+#: 4.0/applet.js:2388
 msgid "Minimize"
 msgstr ""
 
-#: 4.0/applet.js:2301
+#: 4.0/applet.js:2394
 msgid "Unmaximize"
 msgstr ""
 
-#: 4.0/applet.js:2308
+#: 4.0/applet.js:2401
 msgid "Close others"
 msgstr ""
 
-#: 4.0/applet.js:2319
+#: 4.0/applet.js:2412
 msgid "Close all"
 msgstr ""
 
-#: 4.0/applet.js:2328
+#: 4.0/applet.js:2421
 msgid "Close"
 msgstr ""
 
@@ -514,6 +514,19 @@ msgstr ""
 msgid "Default thumbnail window size"
 msgstr ""
 
+#. 4.0->settings-schema.json->menu-all-windows-of-pool->description
+#. 4.0->settings-schema.json->menu-all-windows-of-auto->description
+msgid "Show thumbnails for all windows of an application pool"
+msgstr ""
+
+#. 4.0->settings-schema.json->menu-all-windows-of-pool->tooltip
+#. 4.0->settings-schema.json->menu-all-windows-of-auto->tooltip
+msgid ""
+"If enabled, a popup menu will contain all the application windows in the "
+"application pool rather then just the selected window within the application "
+"pool"
+msgstr ""
+
 #. 4.0->settings-schema.json->preview-timeout-show->description
 msgid "Hover time before showing menu"
 msgstr ""
@@ -619,6 +632,24 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
+msgid "Move to previous workspace"
+msgstr ""
+
+#. 4.0->settings-schema.json->preview-middle-click->options
+#. 4.0->settings-schema.json->preview-back-click->options
+#. 4.0->settings-schema.json->preview-forward-click->options
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+msgid "Move to next workspace"
+msgstr ""
+
+#. 4.0->settings-schema.json->preview-middle-click->options
+#. 4.0->settings-schema.json->preview-back-click->options
+#. 4.0->settings-schema.json->preview-forward-click->options
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
 msgid "Visible on this/all workspaces"
 msgstr ""
 
@@ -664,7 +695,34 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
+msgid "Move to previous monitor"
+msgstr ""
+
+#. 4.0->settings-schema.json->preview-middle-click->options
+#. 4.0->settings-schema.json->preview-back-click->options
+#. 4.0->settings-schema.json->preview-forward-click->options
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+msgid "Move to next monitor"
+msgstr ""
+
+#. 4.0->settings-schema.json->preview-middle-click->options
+#. 4.0->settings-schema.json->preview-back-click->options
+#. 4.0->settings-schema.json->preview-forward-click->options
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
 msgid "Move to current/next monitor"
+msgstr ""
+
+#. 4.0->settings-schema.json->preview-middle-click->options
+#. 4.0->settings-schema.json->preview-back-click->options
+#. 4.0->settings-schema.json->preview-forward-click->options
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+msgid "Move titlebar on to screen"
 msgstr ""
 
 #. 4.0->settings-schema.json->preview-middle-click->options


### PR DESCRIPTION
1. Fixed the "Ungroup" action when the window-list was configured as "Grouped" so that it will actually un-group the application. Previously this option would only work when the window-list was configured as "pooled", "Automatic" or "one-to-one". Insert the new window-list buttons ahead of the original grouped button in the order they were in while grouped.

2. Fix some cases where the "one label per application pool" option was not behaving correctly.

3. When only two workspaces exist, replace the "Pin to other workspaces" context menu option to a toggle option for pinning to the other workspace. The "Pin to other workspaces" sub-menu now only appears when there are 3 or more workspaces

4. Added an option for the "Pooled"/"Automatic" configurations that allows users to decide if they want to see thumbnails for all applications in a pool or just the thumbnail for the one selected window. "Show thumbnails for all windows of an application pool"

5. Added the word "Application" to the  "Un/Group windows" context menu item to be a bit more clear

6. Make sure the last button in a "pool" is the pinned button so that the label does not appear for pinned applications when the user selected no labels for pinned buttons.

7. Added new mouse action options: "Move to previous workspace"
"Move to next workspace"
"Move to previous monitor"
"Move to next monitor"
"Move titlebar on to screen"

8. The calculation for the mouse action Ctrl/Shift + Forward/Back combinations was not matching the enumeration and therefore actions using those combinations were not resulting in the correct actions performed. Actions for those 4 combinations now works correctly.

9. Don't show the "Add new hotkey for..." context menu item for windows that are only backed by a window (i.e. no .desktop file for the app). Adding a hotkey for this type of window would not behave as expected