### PR TITLE
spices-notifier@germanfr: Bug fix.

### DIFF
--- a/spices-notifier@germanfr/files/spices-notifier@germanfr/applet.js
+++ b/spices-notifier@germanfr/files/spices-notifier@germanfr/applet.js
@@ -127,7 +127,13 @@ class SpicesNotifier extends Applet.TextIconApplet {
       counter += 1;
     }
     this.uuidList = uuidList;
-    this.reload()
+    
+    //Cinnamon seems to be triggering this function multiple times even though
+    //uuids haven't changed so only reload when uuids have actually changed.
+    if (this.uuidList != this.previous_uuidList) {
+      this.reload();
+    }
+    this.previous_uuidList = this.uuidList;
   }
 
   on_applet_clicked() {


### PR DESCRIPTION
Fix bug causing cinnamon to crash.

For some reason cinnamon is triggering make_uuidList() multiple times. For instance, with 3 applets in total to update, one in the uuid list and 2 from the owner name, make_uuidList() is called about 88 times on each timed update.

Not sure if this is caused by the applet or a bug in ui/settings.js, but I can't see any reason for it in the applet so it seems likely to be in settings.js. This fix works as a temporary solution until the real cause of the bug can be found.

The real issue with reload being called many times is that it seems to cause ui/settings.js's filemonitor to be repeatedly triggered, greatly increasing the chances of it occurring during spidermonkey's garbage collection phase. This causes the following errors and often causes cinnamon to freeze or crash.

```
(cinnamon:784): Gjs-CRITICAL **: 08:03:02.963: Attempting to run a JS callback during garbage collection. This is most likely caused by destroying a Clutter actor or GTK widget with ::destroy signal connected, or using the destroy(), dispose(), or remove() vfuncs. Because it would crash the application, it has been blocked.

(cinnamon:784): Gjs-CRITICAL **: 08:03:02.963: The offending callback was SessionCallback().
== Stack trace for context 0x55d558558570 ==

(cinnamon:784): Gjs-CRITICAL **: 08:03:02.964: Attempting to run a JS callback during garbage collection. This is most likely caused by destroying a Clutter actor or GTK widget with ::destroy signal connected, or using the destroy(), dispose(), or remove() vfuncs. Because it would crash the application, it has been blocked.

(cinnamon:784): Gjs-CRITICAL **: 08:03:02.964: The offending callback was SourceFunc().
== Stack trace for context 0x55d558558570 ==

(cinnamon:784): Gjs-CRITICAL **: 08:03:02.964: Attempting to run a JS callback during garbage collection. This is most likely caused by destroying a Clutter actor or GTK widget with ::destroy signal connected, or using the destroy(), dispose(), or remove() vfuncs. Because it would crash the application, it has been blocked.

(cinnamon:784): Gjs-CRITICAL **: 08:03:02.964: The offending callback was SourceFunc().
== Stack trace for context 0x55d558558570 ==

```

Long term I think settings.js has to be rewritten without the filemonitor (which incidentally seems unnecessary) as this seems to be a continuing source of occasional cinnamon crashes. It's for this reason that I used a customised version of settings.js (without the filemonitor) in the previous version (4.0 ) of Cinnamenu.

@germanfr 
@claudiux 

Edit: even with this bugfix, make_uuidList() is still called 9 or 12 times, but so far without causing cinnamon to crash.