### PR TITLE
[restart-cinnamon@kolle] - Add 'Show OSD' option

### DIFF
--- a/restart-cinnamon@kolle/files/restart-cinnamon@kolle/applet.js
+++ b/restart-cinnamon@kolle/files/restart-cinnamon@kolle/applet.js
@@ -4,6 +4,7 @@ const GLib = imports.gi.GLib;
 const Settings = imports.ui.settings;
 const Gtk = imports.gi.Gtk;
 const Gettext = imports.gettext;
+const { restartCinnamon } = imports.ui.main; // Main
 
 // l10n/translation support
 let UUID;
@@ -27,13 +28,16 @@ MyApplet.prototype = {
         Gtk.IconTheme.get_default().append_search_path(metadata.path);
 
         this.settings = new Settings.AppletSettings(this, metadata.uuid, instance_id);
-        this.settings.bindProperty(Settings.BindingDirection.IN, "use-symbolic-icon", "useSymbolicIcon", this._updateIcon, null);
+        //~ this.settings.bindProperty(Settings.BindingDirection.IN, "use-symbolic-icon", "useSymbolicIcon", this._updateIcon, null);
+        this.settings.bind("use-symbolic-icon", "useSymbolicIcon", this._updateIcon);
+        this.settings.bind("show-osd", "showOSD");
         this._updateIcon();
         this.set_applet_tooltip(_("Click here to restart Cinnamon"));
      },
 
     on_applet_clicked: function(event) {
-        global.reexec_self();
+        //~ global.reexec_self();
+        restartCinnamon(this.showOSD);
     },
 
     _updateIcon: function() {
@@ -46,5 +50,5 @@ MyApplet.prototype = {
 
 function main(metadata, orientation, panel_height, instance_id) {
     let myApplet = new MyApplet(metadata, orientation, panel_height, instance_id);
-    return myApplet;      
+    return myApplet;
 }

--- a/restart-cinnamon@kolle/files/restart-cinnamon@kolle/metadata.json
+++ b/restart-cinnamon@kolle/files/restart-cinnamon@kolle/metadata.json
@@ -2,5 +2,6 @@
 "uuid": "restart-cinnamon@kolle",
 "name": "Restart Cinnamon",
 "description": "Click on the applet to restart Cinnamon",
-"contributors": "bimsebasse: added symbolic icon"
+"contributors": "bimsebasse: added symbolic icon, claudiux: OSD option",
+"author": "icarter09"
 }

--- a/restart-cinnamon@kolle/files/restart-cinnamon@kolle/po/fr.po
+++ b/restart-cinnamon@kolle/files/restart-cinnamon@kolle/po/fr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-08 12:52+0100\n"
-"PO-Revision-Date: 2023-04-26 22:58+0200\n"
+"POT-Creation-Date: 2023-07-14 21:26+0200\n"
+"PO-Revision-Date: 2023-07-14 21:28+0200\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -18,27 +18,34 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:32
+#: applet.js:35
 msgid "Click here to restart Cinnamon"
 msgstr "Cliquer ici pour redémarrer Cinnamon"
 
-#. restart-cinnamon@kolle->settings-schema.json->header-settings->description
-msgid "General Settings"
-msgstr "Paramètres généraux"
+#. metadata.json->name
+msgid "Restart Cinnamon"
+msgstr "Redémarrer Cinnamon"
 
-#. restart-cinnamon@kolle->settings-schema.json->use-symbolic-
-#. icon->description
-msgid "Use symbolic icon"
-msgstr "Utiliser une icône symbolique"
-
-#. restart-cinnamon@kolle->metadata.json->description
+#. metadata.json->description
 msgid "Click on the applet to restart Cinnamon"
 msgstr "Redémarre Cinnamon en un clic"
 
-#. restart-cinnamon@kolle->metadata.json->contributors
+#. metadata.json->contributors
 msgid "bimsebasse: added symbolic icon"
 msgstr "bimsebasse: added symbolic icon"
 
-#. restart-cinnamon@kolle->metadata.json->name
-msgid "Restart Cinnamon"
-msgstr "Redémarrer Cinnamon"
+#. metadata.json->contributors
+msgid "claudiux: OSD option"
+msgstr "claudiux: option OSD"
+
+#. settings-schema.json->header-settings->description
+msgid "General Settings"
+msgstr "Paramètres généraux"
+
+#. settings-schema.json->use-symbolic-icon->description
+msgid "Use symbolic icon"
+msgstr "Utiliser une icône symbolique"
+
+#. settings-schema.json->show-osd->description
+msgid "Show OSD"
+msgstr "Afficher l'OSD"

--- a/restart-cinnamon@kolle/files/restart-cinnamon@kolle/po/restart-cinnamon.pot
+++ b/restart-cinnamon@kolle/files/restart-cinnamon@kolle/po/restart-cinnamon.pot
@@ -8,36 +8,43 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-08 12:52+0100\n"
+"POT-Creation-Date: 2023-07-14 21:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:32
+#: applet.js:35
 msgid "Click here to restart Cinnamon"
 msgstr ""
 
-#. restart-cinnamon@kolle->settings-schema.json->header-settings->description
-msgid "General Settings"
+#. metadata.json->name
+msgid "Restart Cinnamon"
 msgstr ""
 
-#. restart-cinnamon@kolle->settings-schema.json->use-symbolic-
-#. icon->description
-msgid "Use symbolic icon"
-msgstr ""
-
-#. restart-cinnamon@kolle->metadata.json->description
+#. metadata.json->description
 msgid "Click on the applet to restart Cinnamon"
 msgstr ""
 
-#. restart-cinnamon@kolle->metadata.json->contributors
+#. metadata.json->contributors
 msgid "bimsebasse: added symbolic icon"
 msgstr ""
 
-#. restart-cinnamon@kolle->metadata.json->name
-msgid "Restart Cinnamon"
+#. metadata.json->contributors
+msgid "claudiux: OSD option"
+msgstr ""
+
+#. settings-schema.json->header-settings->description
+msgid "General Settings"
+msgstr ""
+
+#. settings-schema.json->use-symbolic-icon->description
+msgid "Use symbolic icon"
+msgstr ""
+
+#. settings-schema.json->show-osd->description
+msgid "Show OSD"
 msgstr ""

--- a/restart-cinnamon@kolle/files/restart-cinnamon@kolle/settings-schema.json
+++ b/restart-cinnamon@kolle/files/restart-cinnamon@kolle/settings-schema.json
@@ -7,5 +7,10 @@
         "type" : "switch",
         "default" : true,
         "description": "Use symbolic icon"
+    },
+    "show-osd" : {
+        "type" : "switch",
+        "default" : true,
+        "description": "Show OSD"
     }
 }


### PR DESCRIPTION
@icarter09 

Some changes:

- Using `Main.restartCinnamon()` instead of `global.reexec_self()`
- Add the 'Show OSD' option; true by default.
- Updated .pot file.
- Updated fr.po file.

Is that OK for you?