### PR TITLE
[Radio3.0@claudiux] v1.4.2 - Add mpv-mpris as a dependency

### DIFF
--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/CHANGELOG.md
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/CHANGELOG.md
@@ -1,3 +1,5 @@
+### v1.4.2~20230718
+  * Add mpv-mpris to dependencies.
 ### v1.4.1~20230613
   * Minor bugfix for Cinnamon 5.8.
 

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/lib/checkDependencies.js
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/lib/checkDependencies.js
@@ -65,6 +65,7 @@ const DEPENDENCIES = {
 var DEPENDENCIES = {
   "default": [
     ["mpv", "/usr/bin/mpv",  "mpv"],
+    ["", "/usr/lib/mpv-mpris/mpris.so", "mpv-mpris"],
     ["wget", "/usr/bin/wget", "wget"],
     ["", "/usr/share/doc/libmpv1/copyright", "libmpv1"],
     ["", "/usr/share/doc/libmpv-dev/copyright", "libmpv-dev"],
@@ -81,6 +82,7 @@ var DEPENDENCIES = {
   ],
   "arch": [
     ["mpv", "/usr/bin/mpv",  "mpv"],
+    ["", "/usr/lib/mpv-mpris/mpris.so", "mpv-mpris"],
     ["wget", "/usr/bin/wget", "wget"],
     ["pulseaudio", "/usr/bin/pulseaudio", "pulseaudio"],
     ["sox", "/usr/bin/sox", "sox"],
@@ -93,6 +95,7 @@ var DEPENDENCIES = {
   ],
   "debian": [
     ["mpv", "/usr/bin/mpv",  "mpv"],
+    ["", "/usr/lib/mpv-mpris/mpris.so", "mpv-mpris"],
     ["wget", "/usr/bin/wget", "wget"],
     ["", "/usr/lib/x86_64-linux-gnu/libmpv.so", "libmpv?"],
     ["", "/usr/share/doc/libmpv-dev/copyright", "libmpv-dev"],
@@ -109,6 +112,7 @@ var DEPENDENCIES = {
   ],
   "fedora": [
     ["mpv", "/usr/bin/mpv",  "mpv"],
+    ["", "/usr/lib64/mpv/mpris.so", "mpv-mpris"],
     ["wget", "/usr/bin/wget", "wget"],
     ["pulseaudio", "/usr/bin/pulseaudio", "pulseaudio"],
     ["sox", "/usr/bin/sox", "sox"],
@@ -122,6 +126,7 @@ var DEPENDENCIES = {
   ],
   "openSUSE": [
     ["mpv", "/usr/bin/mpv",  "mpv"],
+    ["", "/usr/lib64/mpv/mpris.so", "mpv-mpris"],
     ["wget", "/usr/bin/wget", "wget"],
     ["sox", "/usr/bin/sox",  "sox"],
     ["at", "/usr/bin/at", "at"],

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/metadata.json
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "The Ultimate Internet Radio Receiver & Recorder for Cinnamon",
   "max-instances": 1,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "uuid": "Radio3.0@claudiux",
   "name": "Radio3.0",
   "author": "claudiux"


### PR DESCRIPTION
Fixes missing dependency.