### PR TITLE
[windowlist@cobinja.de] Remove unnecessary padding

### DIFF
--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/3.2/applet.js
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/3.2/applet.js
@@ -1505,12 +1505,12 @@ CobiWorkspace.prototype = {
     if (orientation == St.Side.TOP || orientation == St.Side.BOTTOM) {
       this.actor.set_vertical(false);
       this.actor.remove_style_class_name("vertical");
-      this.actor.set_style("margin-bottom: 0px; padding-bottom: 0px; margin-top: 0px; padding-top: 0px;");
+      this.actor.set_style("margin-bottom: 0px; padding-bottom: 0px; padding-left: 0px; margin-top: 0px; padding-top: 0px;");
     }
     else {
       this.actor.set_vertical(true);
       this.actor.add_style_class_name("vertical");
-      this.actor.set_style("margin-right: 0px; padding-right: 0px; padding-left: 0px; margin-left: 0px;");
+      this.actor.set_style("margin-right: 0px; padding-right: 0px; padding-left: 0px; padding-top: 0px; padding-bottom: 0px; margin-left: 0px;");
     }
     for (let i = 0; i < this._appButtons.length; i++) {
       this._appButtons[i]._updateOrientation();

--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/3.2/applet.js
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/3.2/applet.js
@@ -1505,12 +1505,12 @@ CobiWorkspace.prototype = {
     if (orientation == St.Side.TOP || orientation == St.Side.BOTTOM) {
       this.actor.set_vertical(false);
       this.actor.remove_style_class_name("vertical");
-      this.actor.set_style("margin-bottom: 0px; padding-bottom: 0px; padding-left: 0px; margin-top: 0px; padding-top: 0px;");
+      this.actor.set_style("margin-bottom: 0px; margin-top: 0px; padding: 0px;");
     }
     else {
       this.actor.set_vertical(true);
       this.actor.add_style_class_name("vertical");
-      this.actor.set_style("margin-right: 0px; padding-right: 0px; padding-left: 0px; padding-top: 0px; padding-bottom: 0px; margin-left: 0px;");
+      this.actor.set_style("margin-right: 0px; margin-left: 0px; padding: 0px");
     }
     for (let i = 0; i < this._appButtons.length; i++) {
       this._appButtons[i]._updateOrientation();

--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/4.0/applet.js
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/4.0/applet.js
@@ -1651,12 +1651,12 @@ class CobiWorkspace {
     if (orientation == St.Side.TOP || orientation == St.Side.BOTTOM) {
       this.actor.set_vertical(false);
       this.actor.remove_style_class_name("vertical");
-      this.actor.set_style("margin-bottom: 0px; padding-bottom: 0px; margin-top: 0px; padding-top: 0px;");
+      this.actor.set_style("margin-bottom: 0px; padding-bottom: 0px; padding-left: 0px; margin-top: 0px; padding-top: 0px;");
     }
     else {
       this.actor.set_vertical(true);
       this.actor.add_style_class_name("vertical");
-      this.actor.set_style("margin-right: 0px; padding-right: 0px; padding-left: 0px; margin-left: 0px;");
+      this.actor.set_style("margin-right: 0px; padding-right: 0px; padding-left: 0px; padding-top: 0px; padding-bottom: 0px; margin-left: 0px;");
     }
     for (let i = 0; i < this._appButtons.length; i++) {
       this._appButtons[i]._updateOrientation();

--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/4.0/applet.js
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/4.0/applet.js
@@ -1651,12 +1651,12 @@ class CobiWorkspace {
     if (orientation == St.Side.TOP || orientation == St.Side.BOTTOM) {
       this.actor.set_vertical(false);
       this.actor.remove_style_class_name("vertical");
-      this.actor.set_style("margin-bottom: 0px; padding-bottom: 0px; padding-left: 0px; margin-top: 0px; padding-top: 0px;");
+      this.actor.set_style("margin-bottom: 0px; margin-top: 0px; padding: 0px;");
     }
     else {
       this.actor.set_vertical(true);
       this.actor.add_style_class_name("vertical");
-      this.actor.set_style("margin-right: 0px; padding-right: 0px; padding-left: 0px; padding-top: 0px; padding-bottom: 0px; margin-left: 0px;");
+      this.actor.set_style("margin-right: 0px; margin-left: 0px; padding: 0px");
     }
     for (let i = 0; i < this._appButtons.length; i++) {
       this._appButtons[i]._updateOrientation();

--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/5.4/applet.js
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/5.4/applet.js
@@ -1659,12 +1659,12 @@ class CobiWorkspace {
     if (orientation == St.Side.TOP || orientation == St.Side.BOTTOM) {
       this.actor.set_vertical(false);
       this.actor.remove_style_class_name("vertical");
-      this.actor.set_style("margin-bottom: 0px; padding-bottom: 0px; margin-top: 0px; padding-top: 0px;");
+      this.actor.set_style("margin-bottom: 0px; padding-bottom: 0px; padding-left: 0px; margin-top: 0px; padding-top: 0px;");
     }
     else {
       this.actor.set_vertical(true);
       this.actor.add_style_class_name("vertical");
-      this.actor.set_style("margin-right: 0px; padding-right: 0px; padding-left: 0px; margin-left: 0px;");
+      this.actor.set_style("margin-right: 0px; padding-right: 0px; padding-left: 0px; padding-top: 0px; padding-bottom: 0px; margin-left: 0px;");
     }
     for (let i = 0; i < this._appButtons.length; i++) {
       this._appButtons[i]._updateOrientation();

--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/5.4/applet.js
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/5.4/applet.js
@@ -1659,12 +1659,12 @@ class CobiWorkspace {
     if (orientation == St.Side.TOP || orientation == St.Side.BOTTOM) {
       this.actor.set_vertical(false);
       this.actor.remove_style_class_name("vertical");
-      this.actor.set_style("margin-bottom: 0px; padding-bottom: 0px; padding-left: 0px; margin-top: 0px; padding-top: 0px;");
+      this.actor.set_style("margin-bottom: 0px; margin-top: 0px; padding: 0px;");
     }
     else {
       this.actor.set_vertical(true);
       this.actor.add_style_class_name("vertical");
-      this.actor.set_style("margin-right: 0px; padding-right: 0px; padding-left: 0px; padding-top: 0px; padding-bottom: 0px; margin-left: 0px;");
+      this.actor.set_style("margin-right: 0px; margin-left: 0px; padding: 0px");
     }
     for (let i = 0; i < this._appButtons.length; i++) {
       this._appButtons[i]._updateOrientation();


### PR DESCRIPTION
mentioning @Cobinja so they see this

windowlist@cobinja.de, aka CobiWindowList, takes up some space in the panel that appears to be unused for anything. See below for examples in both horizonal and vertical panels.

![horiz-old](https://github.com/linuxmint/cinnamon-spices-applets/assets/91234915/524fe7a7-57a5-4599-b02d-0269d0fed894)
![vert-old](https://github.com/linuxmint/cinnamon-spices-applets/assets/91234915/e75c5cb4-d6c1-4cc0-a672-974bf258cf63)

After some trial and error, I found that this extra space is primarily taken up by the CobiWorkspace module (class? element?). See below for screenshots showing how CobiWorkspace takes the space. The blue border is the applet itself, and the red border is just CobiWorkspace.
![horiz-old-border](https://github.com/linuxmint/cinnamon-spices-applets/assets/91234915/2784831a-9292-4d12-9e35-62e60edafbcb)
![vert-old-border](https://github.com/linuxmint/cinnamon-spices-applets/assets/91234915/5c31d887-69e6-4527-803b-c358de998eb8)

After getting these screenshots, I noticed that on the horizontal panel, the right side of CobiWorkspace does not have any padding, which (aside from the padding looking bad) makes me think the padding wasn't intentional.

The changes I made remove this padding, by setting padding to 0 for CobiWorkspace. See below for results (both with and without borders):
![horiz-new](https://github.com/linuxmint/cinnamon-spices-applets/assets/91234915/43b656af-9042-4acb-b71c-39f8ea9d41ac)
![horiz-new-border](https://github.com/linuxmint/cinnamon-spices-applets/assets/91234915/40914d3d-e35d-45eb-b4f6-6dffaa6f7b3a)
![vert-new](https://github.com/linuxmint/cinnamon-spices-applets/assets/91234915/3cd3b901-7f3a-4f07-8ca2-35262c5fb3a9)
![vert-new-border](https://github.com/linuxmint/cinnamon-spices-applets/assets/91234915/a13d0689-1baa-487a-9a11-a3ec1b780dcb)

The applet itself still has padding, and I'm not sure how multiple CobiWorkspace modules could be created, so I don't think this change causes any problems. However, one could alternatively reduce the padding in CobiWorkspace and remove the applet's own padding.

I only tested this on my system, running Cinnamon 5.8.4, but given that the CobiWorkspace onOrientationChanged function is the same across all versions, I doubt this will be an issue.