### PR TITLE
[windowlist@cobinja.de] Align style for the container actor with the names used for the contents

### DIFF
--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/5.4/applet.js
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/5.4/applet.js
@@ -1618,7 +1618,7 @@ class CobiWorkspace {
     this.actor._delegate = this;
     this.actor.set_hover(false);
     this.actor.set_track_hover(false);
-    this.actor.add_style_class_name("window-list-box");
+    this.actor.add_style_class_name("grouped-window-list-box");
     
     this.dragInProgress = false;
     


### PR DESCRIPTION
This applies css class .grouped-window-list-box instead of .window-list-box. The .grouped...-names was already used for the contents, just not for the container.

This replaces #4953