### PR TITLE
[CassiaWindowList@klangman] Use CSS class grouped-window-list-box

### DIFF
--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/applet.js
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/applet.js
@@ -2614,7 +2614,7 @@ class Workspace {
     this._settings = this._applet._settings;
     this._signalManager = new SignalManager.SignalManager(null);
 
-    this.actor = new St.BoxLayout({ style_class: "window-list-box", track_hover: false, hover: false });
+    this.actor = new St.BoxLayout({ style_class: "grouped-window-list-box", track_hover: false, hover: false });
     this.actor.set_style('border:0px;padding:0px;margin:0px');
     this.actor._delegate = this;
 


### PR DESCRIPTION
Change the Workspace BoxLayout to use the CSS class grouped-window-list-box which is consistent with the classes used for other elements. This has the benefit of removing some padding at the start and end of the window-list as well as reduce the padding between buttons on the list when on a horizontal panel.