### PR TITLE
[calc-js@ptandler] Fix enter/return key not recognised + history.

### DIFF
--- a/calc-js@ptandler/files/calc-js@ptandler/applet.js
+++ b/calc-js@ptandler/files/calc-js@ptandler/applet.js
@@ -335,7 +335,8 @@ class MiniCalc extends Applet.IconApplet {
         const keySymbol = event.get_key_symbol();
         // logInfo("keySymbol = ", keySymbol, " control = ", event.has_control_modifier());
         switch (keySymbol) {
-            case Clutter.Return:
+            case Clutter.KEY_KP_Enter:
+            case Clutter.KEY_Return:
             case Clutter.KP_Enter:
                 this.pushToHistory(input, result);
                 this.updateExpression(result);


### PR DESCRIPTION
Fix enter/return key was not recognised meaning history didn't work.

Fixes: #4851

@ptandler 