### PR TITLE
InternetTimeApplet@stefan: Fix timezone for accurate Beat Time calculation

### DIFF
--- a/InternetTimeApplet@stefan/files/InternetTimeApplet@stefan/applet.js
+++ b/InternetTimeApplet@stefan/files/InternetTimeApplet@stefan/applet.js
@@ -26,11 +26,17 @@ NetBeatApplet.prototype = {
 
 	refresh: function() {
 		let d = new Date();
-		let h = d.getHours();
-		let m = d.getMinutes();
-		let s = d.getSeconds();
-		let tzoff = 60 + d.getTimezoneOffset();
-		let beats = ('000' + Math.floor((s + (m + tzoff) * 60 + h * 3600) / 86.4) % 1000).slice(-3);
+		let h = d.getUTCHours() + 1;
+		let m = d.getUTCMinutes();
+		let s = d.getUTCSeconds();
+		//let tzoff = 60 + d.getTimezoneOffset();
+		//let beats = ('000' + Math.floor((s + (m + tzoff) * 60 + h * 3600) / 86.4) % 1000).slice(-3);
+
+        // calculation fix
+        let beatSecs = (s + m * 60 + h * 3600);
+        let netBeats = beatSecs / 86.4;
+        let beats = ("000" + parseInt(netBeats)).slice(-3);
+
 		this.set_applet_label(_("@" + beats));
 		// only update, if the applet is running
 		return this.keepUpdating;

--- a/InternetTimeApplet@stefan/files/InternetTimeApplet@stefan/applet.js
+++ b/InternetTimeApplet@stefan/files/InternetTimeApplet@stefan/applet.js
@@ -32,10 +32,10 @@ NetBeatApplet.prototype = {
 		//let tzoff = 60 + d.getTimezoneOffset();
 		//let beats = ('000' + Math.floor((s + (m + tzoff) * 60 + h * 3600) / 86.4) % 1000).slice(-3);
 
-        // calculation fix
-        let beatSecs = (s + m * 60 + h * 3600);
-        let netBeats = beatSecs / 86.4;
-        let beats = ("000" + parseInt(netBeats)).slice(-3);
+		// calculation fix
+		let beatSecs = (s + m * 60 + h * 3600);
+		let netBeats = beatSecs / 86.4;
+		let beats = ("000" + parseInt(netBeats)).slice(-3);
 
 		this.set_applet_label(_("@" + beats));
 		// only update, if the applet is running


### PR DESCRIPTION
Change the hour/minute/second variable assignments to explicitly be in UTC format. Also, add one hour to the "getUTCHours()" call, as "Biel Mean Time" (BMT), which Beat Time is based upon, is defined by Swatch as UTC+1.

Previously this was calling Date's getHours/getMinutes/getSeconds function family, which returns LOCAL time. This had the effect of the Beat time returned by this desklet always being incorrect unless your computer's time is set to the UTC+1 timezone.

This commit fixes that and ensures that the correct universal Beat Time will be displayed regardless of the user's timezone. It also incorporates the calculation changes from @nstoeckigt via his previously-merged PR [here.](https://github.com/linuxmint/cinnamon-spices-desklets/pull/784)

Original author of this applet is @stefan12O, and I'm submitting this PR per his request [here.](https://github.com/linuxmint/cinnamon-spices-desklets/pull/909#issuecomment-1679223083)