### PR TITLE
[CassiaWindowList@klangman] Add new smart numeric hotkeys

### DIFF
--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/applet.js
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/applet.js
@@ -47,6 +47,7 @@ const Settings = imports.ui.settings;
 const SignalManager = imports.misc.signalManager;
 const CinnamonDesktop = imports.gi.CinnamonDesktop;
 const ModalDialog = imports.ui.modalDialog;
+const Config = imports.misc.config;
 
 const UUID = "CassiaWindowList@klangman";
 
@@ -119,6 +120,7 @@ const ICON_NAMES = {
    writer: 'x-office-document'
 }
 
+const majorVersion = parseInt(Config.PACKAGE_VERSION.substring(0,1));
 
 // The possible user setting for the caption contents
 const CaptionType = {
@@ -316,6 +318,21 @@ function animatedRemoveAppButton(workspace, time, button) {
       }
     }
   }
+  // If we removed a button for an application that is part of a "Smart numeric hotkey" then we might need to update the tooltips for the remaining app buttons
+  if (app && button._settings.getValue("hotkey-sequence")) {
+    let hotKeys = button._applet._keyBindings;
+    let hotKeyWindows = workspace._keyBindingsWindows;
+    for (let i=0 ; i < hotKeys.length ; i++) {
+       if (hotKeys[i].enabled===true && hotKeys[i].keyCombo!==null && hotKeyWindows[i] && app === workspace.getAppForWindow(hotKeyWindows[i]))
+       {
+          let [seqCombo,secondCombo] = getSmartNumericHotkey(hotKeys[i].keyCombo);
+          if (seqCombo) {
+             let allButtons = workspace._lookupAllAppButtonsForApp(app);
+             allButtons.forEach( (element) => {element._updateTooltip()} );
+          }
+       }
+    }
+  }
   Tweener.addTween(button._labelBox, {
     natural_width: 0,
     time: time * 0.001,
@@ -387,6 +404,72 @@ function getKeyAndButtonMouseAction(mouseActionList, modifier, context, mouseBtn
       }
    }
    return -1;
+}
+
+function moveTitleBarToScreen(window) {
+   if (majorVersion < 5) {
+      return; // Cinnamon 4 does not support get_frame_rect()
+   }
+   let rec = window.get_frame_rect();
+   let topOffset = 0;
+   let leftOffset = 0;
+   let monitor = window.get_monitor();
+   let panels = Main.panelManager.getPanelsInMonitor(monitor);
+   for (let i = 0; i < panels.length; i++) {
+      if (panels[i].panelPosition == Panel.PanelLoc.top) {
+         topOffset += panels[i].actor.height;
+      } else if (panels[i].panelPosition == Panel.PanelLoc.left) {
+         leftOffset += panels[i].actor.width;
+      }
+   }
+   if (rec.x < leftOffset || rec.y < topOffset) {
+      let x = rec.x;
+      let y = rec.y;
+      if (x < leftOffset) x = leftOffset;
+      if (y < topOffset) y = topOffset;
+      window.move_frame(true, x, y);
+   }
+}
+
+function isTitleBarOnScreen(window) {
+   if (majorVersion < 5) {
+      return true; // Cinnamon 4 does not support get_frame_rect()
+   }
+   let rec = window.get_frame_rect();
+   let topOffset = 0;
+   let leftOffset = 0;
+   let monitor = window.get_monitor();
+   let panels = Main.panelManager.getPanelsInMonitor(monitor);
+   for (let i = 0; i < panels.length; i++) {
+      if (panels[i].panelPosition == Panel.PanelLoc.top) {
+         topOffset += panels[i].actor.height;
+      } else if (panels[i].panelPosition == Panel.PanelLoc.left) {
+         leftOffset += panels[i].actor.width;
+      }
+   }
+   if (rec.x < leftOffset || rec.y < topOffset) return false;
+   return true;
+}
+
+// Returns a 2 element array
+//          1) Modifier keys for the sequence i.e. <Super>1 --> <Super>
+//          2) The other full key combination i.e. <Super>W --> <Super>W
+//          Returns [null,null] if there is no key "1" in any of the key combinations
+function getSmartNumericHotkey(keyCombo) {
+   let one = keyCombo.indexOf(">1");
+   if (one >= 0) {
+      let colons = keyCombo.indexOf("::");
+      if (one < colons ) {
+         if (colons == keyCombo.length-2) {
+            return [keyCombo.slice(0,colons-1), null];
+         } else {
+            return [keyCombo.slice(0,colons-1), keyCombo.slice(colons+2)];
+         }
+      } else {
+         return [keyCombo.slice(colons+2,-1), keyCombo.slice(0,colons)];
+      }
+   }
+   return [null,null];
 }
 
 // Represents an item in the Thumbnail popup menu
@@ -885,6 +968,7 @@ class ThumbnailMenuManager extends PopupMenu.PopupMenuManager {
 class WindowListButton {
 
   constructor(workspace, applet, app) {
+    this.closing = false;
     this._toggle = 0
     this._workspace = workspace;
     this._applet = applet;
@@ -1102,6 +1186,7 @@ class WindowListButton {
         this.menu.removeWindow(metaWindow);
       }
     }
+    this._updateUrgentState()
     if (this._pinned) {
       if (!this._currentWindow) {
         this.actor.remove_style_pseudo_class("focus");
@@ -1172,9 +1257,32 @@ class WindowListButton {
     // If this button's window is associated with a hotkey sequence, then append the hotkey sequence to the tooltip
     let hotKeys = this._applet._keyBindings;
     let hotKeyWindows = this._workspace._keyBindingsWindows;
+    let keySequence = this._settings.getValue("hotkey-sequence");
+    let keyNew = this._settings.getValue("hotkey-new");
     for (let i=0 ; i < hotKeys.length ; i++) {
-       if (hotKeys[i].enabled===true && hotKeys[i].keyCombo!==null) {
-          if (hotKeyWindows[i] === this._currentWindow || (hotKeys[i].cycle===true && (hotKeys[i].description == this._app.get_name() || hotKeys[i].description == this._app.get_id()))) {
+       let [seqCombo,secondCombo] = getSmartNumericHotkey(hotKeys[i].keyCombo);
+       if (hotKeys[i].enabled===true && hotKeys[i].keyCombo!==null && (hotKeyWindows[i] === this._currentWindow ||
+          (this._pinned && keyNew && !hotKeyWindows[i] && (this._app.get_name() == hotKeys[i].description || this._app.get_id() == hotKeys[i].description)) ||
+          ((hotKeys[i].cycle===true || (seqCombo && keySequence)) && hotKeyWindows[i] && this._app === this._workspace.getAppForWindow(hotKeyWindows[i]))))
+       {
+          if ( seqCombo ) {
+             let btns = this._workspace._lookupAllAppButtonsForApp(this._app);
+             let idx = btns.indexOf(this);
+             if (idx == 0 && btns[0]._windows.length > 1) {
+                idx = btns[0]._windows.indexOf(this._currentWindow);
+             }
+             if (idx >= 0 && idx < 9) {
+                seqCombo = seqCombo.replace( /</g, "");
+                seqCombo = seqCombo.replace( />/g, "+");
+                text = text + "\n" + seqCombo + (idx+1);
+             }
+             if (secondCombo) {
+                secondCombo = secondCombo.replace( /</g, "");
+                secondCombo = secondCombo.replace( />/g, "+");
+                let end = secondCombo.slice(secondCombo.lastIndexOf("+"))
+                text = text + "\n" + secondCombo.slice(0,secondCombo.lastIndexOf("+")) + end.toUpperCase();
+             }
+          } else {
              // i.e.  "<Alt><Super><e>::" -> "Alt+Super+E"
              let keyString = hotKeys[i].keyCombo.toString();
              keyString = keyString.replace( /</g, "");
@@ -1183,11 +1291,11 @@ class WindowListButton {
                 keyString = keyString.slice(0,-2);
              }else{
                 let first = keyString.slice(0, keyString.lastIndexOf("::"));
-                let end = first.slice(first.lastIndexOf("+"), first.length)
+                let end = first.slice(first.lastIndexOf("+"))
                 text = text + "\n" + first.slice(0,first.lastIndexOf("+")) + end.toUpperCase();
-                keyString = keyString.slice( keyString.indexOf("::")+2, keyString.length );
+                keyString = keyString.slice(keyString.indexOf("::")+2);
              }
-             let end = keyString.slice(keyString.lastIndexOf("+"), keyString.length)
+             let end = keyString.slice(keyString.lastIndexOf("+"))
              text = text + "\n" + keyString.slice(0,keyString.lastIndexOf("+")) + end.toUpperCase();
           }
        }
@@ -1512,6 +1620,12 @@ class WindowListButton {
 
     if (newUrgent) {
       this._flashButton();
+    }
+    // Remove any needsAttention windows that don't exist
+    for (let i=this._needsAttention.length-1 ; i >= 0 ; i-- ) {
+      if (this._window && this._window.indexOf(this._needsAttention[i]) < 0) {
+         this._needsAttention.splice(i,1);
+      }
     }
     if (this._needsAttention.length == 0) {
       this._unflashButton();
@@ -1876,8 +1990,8 @@ class WindowListButton {
            }
            break;
         case MouseAction.ShoveTitlebar:
-           if (window) {
-              window.shove_titlebar_onscreen();
+           if (window && !isTitleBarOnScreen(window)) {
+              moveTitleBarToScreen(window);
            }
            break;
         case MouseAction.MovePrevWorkspace:
@@ -2295,7 +2409,7 @@ class WindowListButton {
       let hotKeys = this._applet._keyBindings;
       item = null;
       for (let i=0 ; i < hotKeys.length ; i++) {
-         if (hotKeys[i].enabled===true && (hotKeys[i].description.endsWith(".desktop")!==true || (hotKeys[i].cycle===false && hotKeys[i].description==this._app.get_id()))) {
+         if (hotKeys[i].enabled===true && hotKeys[i].description.endsWith(".desktop")!==true) {
             let idx = i;
             let keyString;
             if (hotKeys[i].keyCombo!==null) {
@@ -2325,8 +2439,18 @@ class WindowListButton {
                let workspace = this._applet.getCurrentWorkSpace();
                let oldButton = (workspace._keyBindingsWindows[idx]) ? workspace._lookupAppButtonForWindow(workspace._keyBindingsWindows[idx]) : null;
                workspace._keyBindingsWindows[idx] = metaWindow;
-               this._updateTooltip();
-               if (oldButton) oldButton._updateTooltip();
+               let [seqCombo, secondCombo] = getSmartNumericHotkey(hotKeys[idx].keyCombo);
+               if ((this._settings.getValue("hotkey-sequence") && seqCombo) || hotKeys[idx].cycle) {
+                  let btns = workspace._lookupAllAppButtonsForApp(this._app);
+                  btns.forEach( (element) => {element._updateTooltip()} );
+                  if (oldButton) {
+                     btns = workspace._lookupAllAppButtonsForApp(oldButton._app);
+                     btns.forEach( (element) => {element._updateTooltip()} );
+                  }
+               } else {
+                  this._updateTooltip();
+                  if (oldButton) oldButton._updateTooltip();
+               }
                }));
             item.menu.addMenuItem(hotKeyItem);
          }
@@ -2443,6 +2567,11 @@ class WindowListButton {
 
       this._contextMenu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
       // window specific
+      if (!isTitleBarOnScreen(metaWindow)) {
+        item = new PopupMenu.PopupMenuItem(_("Move titlebar on to screen"));
+        item.connect("activate", Lang.bind(this, function() { moveTitleBarToScreen(metaWindow); }));
+        this._contextMenu.addMenuItem(item);
+      }
       if (!hasFocus(metaWindow)) {
         item = new PopupMenu.PopupIconMenuItem(_("Restore"), "view-sort-descending", St.IconType.SYMBOLIC);
         item.connect("activate", Lang.bind(this, function() { Main.activateWindow(metaWindow); }));
@@ -2760,21 +2889,10 @@ class Workspace {
   }
 
   _removeAppButton(appButton) {
-    let app = appButton._app;
     let index = this._appButtons.indexOf(appButton);
     if (index >= 0) {
        this._appButtons.splice(index, 1);
        appButton.destroy();
-    }
-    if (app && appButton._shrukenLabel===false){
-       // Do we have a new button in a pool that needs a label
-       let captionType = this._settings.getValue("display-caption-for");
-       if (captionType == DisplayCaption.One) {
-          let allButtons = this._lookupAllAppButtonsForApp(app);
-          if (allButtons.length >= 1) {
-             allButtons[allButtons.length-1]._updateLabel();
-          }
-       }
     }
   }
 
@@ -2814,10 +2932,7 @@ class Workspace {
       return;
     }
 
-    let app = this._windowTracker.get_window_app(metaWindow);
-    if (!app) {
-      app = this._windowTracker.get_app_from_pid(metaWindow.get_pid());
-    }
+    let app = this.getAppForWindow(metaWindow);
     if (!app) {
       return false;
     }
@@ -2889,6 +3004,10 @@ class Workspace {
               // Since we removed a window from a hotkey, maybe there is another window that can get this hot key?
               this._applet.assignHotKeysToExistingWindows(this._applet._keyBindings[i].description, i);
               i = this._keyBindingsWindows.lastIndexOf(metaWindow);
+           }
+           // If the button is pinned and now has no windows attached, we might need to refresh the tooltip to make sure a hotkey is correctly added to the tooltip text
+           if (appButton._windows.length === 0 && appButton._pinned) {
+              appButton._updateTooltip();
            }
         }
         // Now that we removed a window, see if there is enough space to expand automatically grouped windows
@@ -3308,6 +3427,23 @@ class Workspace {
               }
            }
         }
+        // If "smart numeric hotkeys" are enabled then we might need to update all the tooltips for this application
+        if (this._settings.getValue("hotkey-sequence")) {
+           let hotKeys = this._applet._keyBindings;
+           let hotKeyWindows = source._workspace._keyBindingsWindows;
+           for (let i=0 ; i < hotKeys.length ; i++) {
+              if (hotKeys[i].enabled===true && hotKeys[i].keyCombo!==null && hotKeyWindows[i] && source._workspace.getAppForWindow(hotKeyWindows[i]) === source._app) {
+                 let [seqCombo, secondCombo] = getSmartNumericHotkey(hotKeys[i].keyCombo);
+                 if (seqCombo) {
+                    let btns = source._workspace._lookupAllAppButtonsForApp(source._app);
+                    for( let idx=0 ; idx < btns.length ; idx++) {
+                       btns[idx]._updateTooltip()
+                    }
+                    break;
+                 }
+              }
+           }
+        }
         if (this._settings.getValue("display-caption-for") === DisplayCaption.One) {
            source._updateLabel(); // The moved button might need it's label restored
            if (groupingType != GroupType.Pooled && groupingType != GroupType.Auto) {
@@ -3480,6 +3616,7 @@ class Workspace {
     let x = btns[btns.length-1]._windows.shift();
     btns[btns.length-1]._windows.push(x);
     this._updateFocus();
+    btns[btns.length-1]._updateTooltip();
   }
 
   // Ungroup the windows in the passed in buttons, set the button so it's not grouping, add windows back
@@ -3536,6 +3673,14 @@ class Workspace {
         this._delayId = null;
      }
   }
+
+  getAppForWindow(window){
+    let app = this._windowTracker.get_window_app(window);
+    if (!app) {
+      app = this._windowTracker.get_app_from_pid(window.get_pid());
+    }
+    return app;
+  }
 }
 
 // The windowlist manager, one instance for each windowlist
@@ -3561,101 +3706,158 @@ class WindowList extends Applet.Applet {
     this.on_orientation_changed(orientation);
   }
 
+  // Hotkey handler function!!!
+  _performHotkey(idx, seqNum=0) {
+     //log( `Hotkey pressed for ${this._keyBindings[idx].description} @ index ${idx} and with a seqNum of ${seqNum}` );
+     let minimize = this._settings.getValue("hotkey-minimize");
+     let workspace = this.getCurrentWorkSpace();
+     workspace.closeThumbnailMenu();
+     if (workspace._keyBindingsWindows.length > idx && workspace._keyBindingsWindows[idx] != undefined) {
+        if (seqNum > 0) {
+           let app = workspace.getAppForWindow(workspace._keyBindingsWindows[idx]);
+           if (app) {
+              let btns = workspace._lookupAllAppButtonsForApp(app);
+              if (btns && btns.length > seqNum-1) {
+                 if (minimize && hasFocus(btns[seqNum-1]._windows[0])){
+                    btns[seqNum-1]._windows[0].minimize();
+                 } else {
+                    Main.activateWindow(btns[seqNum-1]._windows[0]);
+                 }
+              } else if (btns && btns[0]._windows.length > seqNum-1) {
+                 if (minimize && hasFocus(btns[0]._windows[seqNum-1])){
+                    btns[0]._windows[seqNum-1].minimize();
+                 } else {
+                    Main.activateWindow(btns[0]._windows[seqNum-1]);
+                 }
+              }
+           }
+           return;
+        } else if (this._keyBindings[idx].cycle === true){
+           let window = workspace._keyBindingsWindows[idx];
+           let appButton = workspace._lookupAppButtonForWindow(window);
+           if (appButton && appButton._windows.length > 1) {
+              // All app windows are grouped under one appButton
+              if (hasFocus(appButton._currentWindow)===true) {
+                 if (appButton._nextWindow===null || appButton._nextWindow===appButton._currentWindow) {
+                    appButton._updateCurrentWindow(); // This will set appButton.sortedWindows
+                    appButton._nextWindow = appButton.sortedWindows[1];
+                 }
+                 let idx = appButton.sortedWindows.indexOf(appButton._nextWindow);
+                 Main.activateWindow(appButton._nextWindow);
+                 if (idx === appButton.sortedWindows.length-1) {
+                    appButton._nextWindow = appButton.sortedWindows[0];
+                 } else {
+                    appButton._nextWindow = appButton.sortedWindows[idx+1];
+                 }
+              } else {
+                 appButton._updateCurrentWindow(); // This will set appButton.sortedWindows
+                 appButton._nextWindow = appButton.sortedWindows[1];
+                 Main.activateWindow(appButton._currentWindow);
+              }
+              return;
+           } else if(appButton) {
+              // App windows are not grouped under one button
+              let focusWindow = global.display.get_focus_window();
+              if (workspace.cycleBtns !== undefined && appButton._app === workspace.cycleBtns[workspace.cycleIdx]._app &&
+                  workspace.cycleBtns[workspace.cycleIdx]._windows[0] === focusWindow)
+              {
+                 workspace.cycleIdx++;
+                 if (workspace.cycleIdx >= workspace.cycleBtns.length)
+                    workspace.cycleIdx = 0;
+                 Main.activateWindow(workspace.cycleBtns[workspace.cycleIdx]._windows[0]);
+                 return;
+              } else {
+                 let btns = workspace._lookupAllAppButtonsForApp(appButton._app);
+                 if (btns.length > 1) {
+                    // Sort the app buttons array by most recently focused
+                    btns = btns.sort(function(a, b) {
+                       return b._windows[0].user_time - a._windows[0].user_time;
+                    });
+                    workspace.cycleBtns = btns;
+                    if (btns[0]._windows[0] === focusWindow) {
+                       workspace.cycleIdx = 1
+                    } else {
+                       workspace.cycleIdx = 0;
+                    }
+                    Main.activateWindow(btns[workspace.cycleIdx]._windows[0]);
+                    return;
+                 }
+              }
+           }
+        }
+        // cycling is disabled or app does not have the focus, so restore or minimize the selected window
+        if (minimize && hasFocus(workspace._keyBindingsWindows[idx])){
+           workspace._keyBindingsWindows[idx].minimize();
+        } else {
+           Main.activateWindow(workspace._keyBindingsWindows[idx]);
+        }
+     } else if (this._keyBindings[idx].description && this._settings.getValue("hotkey-new")) {
+        // Try to find a app if the description is a .desktop file name
+        let app = workspace._lookupApp(this._keyBindings[idx].description);
+        // If that didn't work, then look for a pinned button matching the description
+        if (!app) {
+           for (let i=0 ; i < workspace._appButtons.length ; i++) {
+              if (workspace._appButtons[i]._pinned && workspace._appButtons[i]._app.get_name() == this._keyBindings[idx].description) {
+                 app = workspace._appButtons[i]._app;
+                 break;
+              }
+           }
+        }
+        // If we found an app start a new window
+        if (app) {
+           app.open_new_window(-1);
+        }
+     }
+  }
+
   _updateKeybinding() {
      let oldBindings = this._keyBindings;
+     let oldKeySequence = this._keySequenece;
      let keyBindings = this._settings.getValue("hotkey-bindings");
+     let keySequence = this._settings.getValue("hotkey-sequence");  // Is smart numeric hotkeys enabled?
      let i=0;
+     let seqCombo;
+     let secondCombo;
      for ( ; i < keyBindings.length ; i++) {
-        // Is the new keyBinding enabled and different to the old binding
-        if (keyBindings[i].enabled && (oldBindings.length <= i || oldBindings[i].enabled === false || keyBindings[i].keyCombo != oldBindings[i].keyCombo)) {
-           let idx = i;
-           // Register the hotkey
-           Main.keybindingManager.addHotKey("hotkey-" + i + this.instanceId, keyBindings[i].keyCombo, Lang.bind(this, function() {
-                 // Hotkey handler function!!!
-                 //
-                 //log( "Hotkey pressed for "+this._keyBindings[idx].description );
-                 let minimize = this._settings.getValue("hotkey-minimize");
-                 let workspace = this.getCurrentWorkSpace();
-                 workspace.closeThumbnailMenu();
-                 if (workspace._keyBindingsWindows.length > idx && workspace._keyBindingsWindows[idx] != undefined) {
-                    if (this._keyBindings[idx].cycle === true){
-                       let window = workspace._keyBindingsWindows[idx];
-                       let appButton = workspace._lookupAppButtonForWindow(window);
-                       if (appButton && appButton._windows.length > 1) {
-                          // All app windows are grouped under one appButton
-                          if (hasFocus(appButton._currentWindow)===true) {
-                             if (appButton._nextWindow===null || appButton._nextWindow===appButton._currentWindow) {
-                                appButton._updateCurrentWindow(); // This will set appButton.sortedWindows
-                                appButton._nextWindow = appButton.sortedWindows[1];
-                             }
-                             let idx = appButton.sortedWindows.indexOf(appButton._nextWindow);
-                             Main.activateWindow(appButton._nextWindow);
-                             if (idx === appButton.sortedWindows.length-1) {
-                                appButton._nextWindow = appButton.sortedWindows[0];
-                             } else {
-                                appButton._nextWindow = appButton.sortedWindows[idx+1];
-                             }
-                          } else {
-                             appButton._updateCurrentWindow(); // This will set appButton.sortedWindows
-                             appButton._nextWindow = appButton.sortedWindows[1];
-                             Main.activateWindow(appButton._currentWindow);
-                          }
-                          return;
-                       } else if(appButton) {
-                          // App windows are not grouped under one button
-                          let focusWindow = global.display.get_focus_window();
-                          if (workspace.cycleBtns !== undefined && appButton._app === workspace.cycleBtns[workspace.cycleIdx]._app &&
-                              workspace.cycleBtns[workspace.cycleIdx]._windows[0] === focusWindow)
-                          {
-                             workspace.cycleIdx++;
-                             if (workspace.cycleIdx >= workspace.cycleBtns.length)
-                                workspace.cycleIdx = 0;
-                             Main.activateWindow(workspace.cycleBtns[workspace.cycleIdx]._windows[0]);
-                             return;
-                          } else {
-                             let btns = workspace._lookupAllAppButtonsForApp(appButton._app);
-                             if (btns.length > 1) {
-                                // Sort the app buttons array by most recently focused
-                                btns = btns.sort(function(a, b) {
-                                   return b._windows[0].user_time - a._windows[0].user_time;
-                                });
-                                workspace.cycleBtns = btns;
-                                if (btns[0]._windows[0] === focusWindow) {
-                                   workspace.cycleIdx = 1
-                                } else {
-                                   workspace.cycleIdx = 0;
-                                }
-                                Main.activateWindow(btns[workspace.cycleIdx]._windows[0]);
-                                return;
-                             }
-                          }
-                       }
-                    }
-                    // cycling is disabled or app does not have the focus, so restore or minimize the selected window
-                    if (minimize && hasFocus(workspace._keyBindingsWindows[idx])){
-                       workspace._keyBindingsWindows[idx].minimize();
-                    } else {
-                       Main.activateWindow(workspace._keyBindingsWindows[idx]);
-                    }
-                 } else if(this._keyBindings[idx].description && this._settings.getValue("hotkey-new")) {
-                    // The window is not bound. Start a new process if there is a pinned button matching the Description
-                    for (let i=0 ; i < workspace._appButtons.length ; i++) {
-                       if (workspace._appButtons[i]._pinned && workspace._appButtons[i]._app.get_name() == this._keyBindings[idx].description) {
-                          workspace._appButtons[i]._startApp();
-                          return;
-                       }
-                    }
-                    // Try to find a app if the description is a .desktop file name
-                    let app = workspace._lookupApp(this._keyBindings[idx].description);
-                    if (app) {
-                       app.open_new_window(-1);
-                    }
+        // Does the old binding need to be removed?
+        if (oldBindings.length > i) {
+           [seqCombo,secondCombo] = getSmartNumericHotkey(oldBindings[i].keyCombo);
+           if (oldBindings[i].enabled && (!keyBindings[i].enabled || keyBindings[i].keyCombo != oldBindings[i].keyCombo || (seqCombo && oldKeySequence != keySequence))) {
+              if (seqCombo && oldKeySequence) {
+                 //log( `removing smart numeric hotkeys for ${oldBindings[i].description}` );
+                 for( let num=1 ; num < 10 ; num++ ) {
+                    Main.keybindingManager.removeHotKey("hotkey-" + i + "-" + num + this.instanceId);
                  }
-              }));
-
-        } else if(keyBindings[i].enabled === false && oldBindings.length > i) {
-           // deregister the previously registered hotkey
-           Main.keybindingManager.removeHotKey("hotkey-" + i + this.instanceId);
+                 if (secondCombo) {
+                    Main.keybindingManager.removeHotKey("hotkey-" + i + this.instanceId);
+                 }
+              } else {
+                 Main.keybindingManager.removeHotKey("hotkey-" + i + this.instanceId);
+              }
+              // Clear out the existing key->window mapping
+              for (let wsIdx=0 ; wsIdx<this._workspaces.length ; wsIdx++) {
+                 let ws = this._workspaces[wsIdx];
+                 ws._keyBindingsWindows[i] = null;
+              }
+           }
+        }
+        [seqCombo,secondCombo] = getSmartNumericHotkey(keyBindings[i].keyCombo);
+        // Does the new keyBinding need to be added?
+        if (keyBindings[i].enabled && (oldBindings.length <= i || !oldBindings[i].enabled || keyBindings[i].keyCombo != oldBindings[i].keyCombo || (seqCombo && oldKeySequence != keySequence))) {
+           let idx = i;
+           // Register smart numeric hotkeys if applicable
+           if (seqCombo && keySequence) {
+              //log( `Registering smart numeric hotkeys for ${keyBindings[i].description}  i.e. ${seqCombo+1}` );
+              for( let num=1 ; num < 10 ; num++ ) {
+                 Main.keybindingManager.addHotKey("hotkey-" + i + "-" + num + this.instanceId, seqCombo+num, Lang.bind(this, function() {this._performHotkey(idx, num)} ));
+              }
+              if (secondCombo) {
+                 Main.keybindingManager.addHotKey("hotkey-" + i + this.instanceId, secondCombo, Lang.bind(this, function() {this._performHotkey(idx)} ));
+              }
+           } else {
+              // Register the hotkey
+              Main.keybindingManager.addHotKey("hotkey-" + i + this.instanceId, keyBindings[i].keyCombo, Lang.bind(this, function() {this._performHotkey(idx)} ));
+           }
         }
         // If the key is enabled, set the keyBindingWindows for each workspace to the windows that match the description
         if (keyBindings[i].enabled === true) {
@@ -3665,11 +3867,24 @@ class WindowList extends Applet.Applet {
      if (i < oldBindings.length) {
         // deregister the all the hotkeys that have been removed
         while (i < oldBindings.length) {
-           Main.keybindingManager.removeHotKey("hotkey-" + i + this.instanceId);
+           if (oldKeySequence) {
+              let [seqCombo, secondCombo] = getSmartNumericHotkey(oldBindings[i].keyCombo);
+              if (seqCombo) {
+                 for( let num=1 ; num < 10 ; num++ ) {
+                    Main.keybindingManager.removeHotKey("hotkey-" + i + "-" + num + this.instanceId);
+                 }
+                 if (secondCombo) {
+                    Main.keybindingManager.removeHotKey("hotkey-" + i + this.instanceId);
+                 }
+              }
+           } else {
+              Main.keybindingManager.removeHotKey("hotkey-" + i + this.instanceId);
+           }
            i++;
         }
      }
      this._keyBindings = keyBindings;
+     this._keySequenece = keySequence;
      for (let wsIdx=0 ; wsIdx<this._workspaces.length ; wsIdx++) {
         let ws = this._workspaces[wsIdx];
         for (let btnIdx=0 ; btnIdx < ws._appButtons.length ; btnIdx++) {
@@ -3799,6 +4014,7 @@ class WindowList extends Applet.Applet {
     this._signalManager.connect(global.display, "notify::focus-window", this._onFocusChanged, this);
     this._signalManager.connect(Main.layoutManager, "monitors-changed", this._updateMonitor, this);
     this._signalManager.connect(this._settings, "changed::hotkey-bindings", this._updateKeybinding, this);
+    this._signalManager.connect(this._settings, "changed::hotkey-sequence", this._updateKeybinding, this);
     this._signalManager.connect(this._settings, "changed::display-indicators", this._updateIndicators, this);
     this._signalManager.connect(this._settings, "changed::number-of-unshrunk-previews", this._updateThumbnailWindowSize, this);
     this._signalManager.connect(this._settings, "changed::hide-panel-apps", this._updateCurrentWorkspace, this);

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
@@ -67,7 +67,7 @@
     "hotkey-settings" : {
       "type" : "section",
       "title" : "Hotkey settings",
-      "keys" : ["hotkey-bindings", "hotkey-minimize", "hotkey-new", "hotkey-help"]
+      "keys" : ["hotkey-bindings", "hotkey-minimize", "hotkey-new", "hotkey-sequence", "hotkey-help"]
     },
     "adv-mouse-settings" : {
       "type" : "section",
@@ -525,10 +525,16 @@
     "description": "Open a new window when the application is not running",
     "tooltip": "Start a new window if no window is attached to a hotkey and the hotkey description is an exact match for the application name of a pinned button or a desktop file name"
   },
+  "hotkey-sequence": {
+    "type": "switch",
+    "default": true,
+    "description": "Smart numeric hotkeys (using \"1\" automatically extends to 1-9)",
+    "tooltip": "If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The first 9 windows of the assigned application, as ordered on the window-list, will be activated by the 9 hotkeys."
+  },
 
   "hotkey-help" : {
     "type" : "label",
-    "description" : "Hotkeys can be assigned to a window in two ways:\n1. Manual:  Use the \"Assign window to a hotkey\" item in a button context menu.\n2. Automatic:  Enter a \"Description\" matching an application name or desktop file. For example: \"Google Chrome\" or \"firefox.desktop\"\n\nNote: 1) If a hotkey is not working, it's possible that a key combination is already assigned elsewhere. 2) If you remove or rearrange any hotkeys, manual window assignments may need to be reassigned"
+    "description" : "Hotkeys can be assigned to a window in two ways:\n1) Manual: Use \"Assign window to a hotkey\" in the button context menu.\n2) Automatic:  Enter a \"Description\" matching an application name or desktop file. i.e: \"Google Chrome\" or \"firefox.desktop\"\nNote: 1) Hotkey not working? it's possible the key combination is already assigned elsewhere. 2) If you remove or rearrange hotkeys, manual hotkey assignments might need to be reassigned. 3) Hotkeys associated with desktop files can not be manually assigned."
   },
 
   "adv-mouse-list": {

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-17 23:01-0400\n"
+"POT-Creation-Date: 2023-08-20 23:41-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,24 +17,24 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: 4.0/applet.js:2052
+#: 4.0/applet.js:2170
 msgid "Applet Preferences"
 msgstr ""
 
-#: 4.0/applet.js:2056
+#: 4.0/applet.js:2174
 msgid "About..."
 msgstr ""
 
-#: 4.0/applet.js:2060
+#: 4.0/applet.js:2178
 msgid "Configure..."
 msgstr ""
 
-#: 4.0/applet.js:2064
+#: 4.0/applet.js:2182
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
 
-#: 4.0/applet.js:2066
+#: 4.0/applet.js:2184
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 
@@ -44,115 +44,125 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2075
+#: 4.0/applet.js:2193
 msgid "Open new window"
 msgstr ""
 
-#: 4.0/applet.js:2081
+#: 4.0/applet.js:2199
 msgid "Pin to this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2119
+#: 4.0/applet.js:2237
 msgid "Pin to other workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2140
+#: 4.0/applet.js:2258
 msgid "Pin to all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2165 4.0/applet.js:2338
+#: 4.0/applet.js:2283 4.0/applet.js:2466
 msgid "Add new Hotkey for"
 msgstr ""
 
-#: 4.0/applet.js:2179
+#: 4.0/applet.js:2297
 msgid "Recent files"
 msgstr ""
 
-#: 4.0/applet.js:2203
+#: 4.0/applet.js:2321
 msgid "Places"
 msgstr ""
 
-#: 4.0/applet.js:2245
+#: 4.0/applet.js:2363
 msgid "Only on this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2247
+#: 4.0/applet.js:2365
 msgid "Visible on all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2248
+#: 4.0/applet.js:2366
 msgid "Move to another workspace"
 msgstr ""
 
-#: 4.0/applet.js:2267
+#: 4.0/applet.js:2385
 msgid "Move to another monitor"
 msgstr ""
 
-#: 4.0/applet.js:2275
+#: 4.0/applet.js:2393
 msgid "Monitor"
 msgstr ""
 
-#: 4.0/applet.js:2303
+#: 4.0/applet.js:2421
 msgid "unassigned"
 msgstr ""
 
-#: 4.0/applet.js:2314 4.0/applet.js:2335
+#: 4.0/applet.js:2432 4.0/applet.js:2463
 msgid "Assign window to a hotkey"
 msgstr ""
 
-#: 4.0/applet.js:2358
+#: 4.0/applet.js:2486
 msgid "Change application label contents"
 msgstr ""
 
-#: 4.0/applet.js:2361
+#: 4.0/applet.js:2489
 msgid "Remove custom setting"
 msgstr ""
 
-#: 4.0/applet.js:2368
+#: 4.0/applet.js:2496
 msgid "Use window title"
 msgstr ""
 
-#: 4.0/applet.js:2375
+#: 4.0/applet.js:2503
 msgid "Use application name"
 msgstr ""
 
-#: 4.0/applet.js:2382
+#: 4.0/applet.js:2510
 msgid "No label"
 msgstr ""
 
-#: 4.0/applet.js:2393
+#: 4.0/applet.js:2521
 msgid "Ungroup application windows"
 msgstr ""
 
-#: 4.0/applet.js:2404
+#: 4.0/applet.js:2532
 msgid "Group application windows"
 msgstr ""
 
-#: 4.0/applet.js:2414
+#: 4.0/applet.js:2542
 msgid "Automatic grouping/ungrouping"
 msgstr ""
 
-#: 4.0/applet.js:2443
+#. 4.0->settings-schema.json->preview-middle-click->options
+#. 4.0->settings-schema.json->preview-back-click->options
+#. 4.0->settings-schema.json->preview-forward-click->options
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#: 4.0/applet.js:2571
+msgid "Move titlebar on to screen"
+msgstr ""
+
+#: 4.0/applet.js:2576
 msgid "Restore"
 msgstr ""
 
-#: 4.0/applet.js:2447
+#: 4.0/applet.js:2580
 msgid "Minimize"
 msgstr ""
 
-#: 4.0/applet.js:2453
+#: 4.0/applet.js:2586
 msgid "Unmaximize"
 msgstr ""
 
-#: 4.0/applet.js:2460
+#: 4.0/applet.js:2593
 msgid "Close others"
 msgstr ""
 
-#: 4.0/applet.js:2471
+#: 4.0/applet.js:2604
 msgid "Close all"
 msgstr ""
 
-#: 4.0/applet.js:2480
+#: 4.0/applet.js:2613
 msgid "Close"
 msgstr ""
 
@@ -722,15 +732,6 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
-msgid "Move titlebar on to screen"
-msgstr ""
-
-#. 4.0->settings-schema.json->preview-middle-click->options
-#. 4.0->settings-schema.json->preview-back-click->options
-#. 4.0->settings-schema.json->preview-forward-click->options
-#. 4.0->settings-schema.json->mouse-action-btn2->options
-#. 4.0->settings-schema.json->mouse-action-btn8->options
-#. 4.0->settings-schema.json->mouse-action-btn9->options
 msgid "Do nothing"
 msgstr ""
 
@@ -889,17 +890,28 @@ msgid ""
 "a desktop file name"
 msgstr ""
 
+#. 4.0->settings-schema.json->hotkey-sequence->description
+msgid "Smart numeric hotkeys (using \"1\" automatically extends to 1-9)"
+msgstr ""
+
+#. 4.0->settings-schema.json->hotkey-sequence->tooltip
+msgid ""
+"If enabled, hotkeys ending with the \"1\" key (i.e. Alt+1) will "
+"automatically create hotkeys 1 through 9 (i.e. Alt+1 through Alt+9). The "
+"first 9 windows of the assigned application, as ordered on the window-list, "
+"will be activated by the 9 hotkeys."
+msgstr ""
+
 #. 4.0->settings-schema.json->hotkey-help->description
 msgid ""
 "Hotkeys can be assigned to a window in two ways:\n"
-"1. Manual:  Use the \"Assign window to a hotkey\" item in a button context "
-"menu.\n"
-"2. Automatic:  Enter a \"Description\" matching an application name or "
-"desktop file. For example: \"Google Chrome\" or \"firefox.desktop\"\n"
-"\n"
-"Note: 1) If a hotkey is not working, it's possible that a key combination is "
-"already assigned elsewhere. 2) If you remove or rearrange any hotkeys, "
-"manual window assignments may need to be reassigned"
+"1) Manual: Use \"Assign window to a hotkey\" in the button context menu.\n"
+"2) Automatic:  Enter a \"Description\" matching an application name or "
+"desktop file. i.e: \"Google Chrome\" or \"firefox.desktop\"\n"
+"Note: 1) Hotkey not working? it's possible the key combination is already "
+"assigned elsewhere. 2) If you remove or rearrange hotkeys, manual hotkey "
+"assignments might need to be reassigned. 3) Hotkeys associated with desktop "
+"files can not be manually assigned."
 msgstr ""
 
 #. 4.0->settings-schema.json->adv-mouse-list->columns->title


### PR DESCRIPTION
1. Added an option in the "Hotkeys" setting tab (enabled by default) called "Smart numeric hotkeys" which allows you to switch to the first 9 windows of a specific application as ordered on the window list. Creating a Hotkey containing the "1" key will automatically be extended to 1-9. For example, using a key sequence of "Alt+1" with a "description" of "firefox.desktop" will register hotkeys Alt+1 through Alt+9. Using those hotkeys will switch to one of the first 9 firefox windows based on the order of the windows on the window-list.

2. Fix a number of issues with hotkey sequence text not being properly added to button tool-tips.

3. Fix a number of issues with hotkeys not working properly after deleting, rearranging or modifying hotkey entries.

4. Fixed some issue around deciding which hotkeys are available for manual assignment using the button context menu.

5. When a windows titlebar is not visible on the screen, a new context menu item "Move titlebar on to screen" has been added to the button context menu which will move the window so it's titlebar will be visible.

6. Fixed an issue where sometimes the "urgent" status of a pinned button will remain even after the window that caused the urgent status is closed.

7. Fixed some other minor bugs and some issues running on Mint 19.x