### PR TITLE
windowlist@cobinja.de: Update middle click for Cinammon 5.4

### DIFF
--- a/windowlist@cobinja.de/files/windowlist@cobinja.de/5.4/applet.js
+++ b/windowlist@cobinja.de/files/windowlist@cobinja.de/5.4/applet.js
@@ -385,7 +385,7 @@ class CobiPopupMenuItem extends PopupMenu.PopupBaseMenuItem {
   }
   
   _onButtonReleaseEvent (actor, event) {
-    if (this._settings.getValue("preview-close-on-middle-click") && (event.get_state() & Clutter.ModifierType.BUTTON2_MASK)) {
+    if (this._settings.getValue("preview-close-on-middle-click") && (event.get_button() === 2)) {
       this._onClose();
       return true;
     }


### PR DESCRIPTION
This is in line with changes to ClutterButtonEvent listed at https://github.com/linuxmint/cinnamon-spices-applets/issues/4364
Applet author: @Cobinja 

The old version of the code no longer worked on my machine - the "Close window on mouse-wheel click" setting is on, but middle-clicking results in the same behaviour as left-clicking.

```
Linux Mint 21.1 Cinnamon
Cinnamon 5.6.8
Kernel 5.15.0-76-generic
newest version of the applet installed
```