### PR TITLE
[CassiaWindowList@klangman] improvements with button pinning

### DIFF
--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
@@ -47,7 +47,7 @@
     "general-settings" : {
       "type" : "section",
       "title" : "General window list settings",
-      "keys" : ["group-windows", "display-pinned", "trailing-pinned-behaviour", "show-windows-for-current-monitor", "show-tooltips", "hide-panel-apps"]
+      "keys" : ["group-windows", "display-pinned", "synchronize-pinned", "trailing-pinned-behaviour", "show-windows-for-current-monitor", "show-tooltips", "hide-panel-apps"]
     },
     "general-mouse" : {
       "type" : "section",
@@ -197,10 +197,23 @@
     "tooltip": "Grouped: All windows for an application are managed by one button,\nPooled: All window list buttons for an application are pooled side by side,\nAutomatic: Windows are pooled, and then grouped when space is limited,\nOne to one: Each window gets their own button with no forced ordering,\nLauncher: Only pinned button are shown, behaves like a panel launcher."
   },
   "display-pinned": {
-    "type": "switch",
-    "default": true,
+    "type": "combobox",
+    "default": 1,
+    "options": {
+       "Disabled": 0,
+       "Unique for each workspace": 1,
+       "Common across workspaces": 2
+    },
     "dependency" : "group-windows<4",
-    "description": "Allow pinning of window list buttons"
+    "description": "Pinning of window list buttons",
+    "tooltip": "Controls whether window list buttons can be pinned, and whether each workspace has a unique set of pinned buttons or one common set shared across all workspaces. When in \"Common across workspaces\" mode the order of the pinned buttons is also maintained across workspaces."
+  },
+  "synchronize-pinned": {
+    "type": "switch",
+    "default": false,
+    "dependency" : "group-windows=4",
+    "description": "Synchronize launcher buttons across all workspaces",
+    "tooltip": "If enabled, the number and order of launcher buttons on the panel will be synchronize across all workspaces."
   },
   "show-windows-for-current-monitor": {
     "type": "switch",
@@ -308,6 +321,7 @@
       "Move to next monitor": 23,
       "Move to current/next monitor": 18,
       "Move titlebar on to screen": 19,
+      "Pin to panel toggle": 24,
       "Do nothing": 12
     },
     "description": "Thumbnail window middle button action"
@@ -337,6 +351,7 @@
       "Move to next monitor": 23,
       "Move to current/next monitor": 18,
       "Move titlebar on to screen": 19,
+      "Pin to panel toggle": 24,
       "Do nothing": 12
     },
     "description": "Thumbnail window back button action"
@@ -366,6 +381,7 @@
       "Move to next monitor": 23,
       "Move to current/next monitor": 18,
       "Move titlebar on to screen": 19,
+      "Pin to panel toggle": 24,
       "Do nothing": 12
     },
     "description": "Thumbnail window forward button action"
@@ -410,6 +426,7 @@
       "Move to next monitor": 23,
       "Move to current/next monitor": 18,
       "Move titlebar on to screen": 19,
+      "Pin to panel toggle": 24,
       "Do nothing": 12
     },
     "description": "Middle button action",
@@ -442,6 +459,7 @@
       "Move to next monitor": 23,
       "Move to current/next monitor": 18,
       "Move titlebar on to screen": 19,
+      "Pin to panel toggle": 24,
       "Do nothing": 12
     },
     "description": "Back button action",
@@ -474,6 +492,7 @@
       "Move to next monitor": 23,
       "Move to current/next monitor": 18,
       "Move titlebar on to screen": 19,
+      "Pin to panel toggle": 24,
       "Do nothing": 12
     },
     "description": "Forward button action",
@@ -584,6 +603,7 @@
            "Move to next monitor": 23,
            "Move to current/next monitor": 18,
            "Move titlebar on to screen": 19,
+           "Pin to panel toggle": 24,
            "Do nothing": 12
            }
         }
@@ -616,6 +636,11 @@
     "default": [
       ["nemo.desktop", "firefox.desktop"]
     ]
+  },
+
+  "commoned-pinned-apps": {
+    "type": "generic",
+    "default": ["nemo.desktop", "firefox.desktop"]
   },
 
   "custom-label-app": {

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-20 23:41-0400\n"
+"POT-Creation-Date: 2023-09-18 22:14-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,24 +17,24 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: 4.0/applet.js:2170
+#: 4.0/applet.js:2192
 msgid "Applet Preferences"
 msgstr ""
 
-#: 4.0/applet.js:2174
+#: 4.0/applet.js:2196
 msgid "About..."
 msgstr ""
 
-#: 4.0/applet.js:2178
+#: 4.0/applet.js:2200
 msgid "Configure..."
 msgstr ""
 
-#: 4.0/applet.js:2182
+#: 4.0/applet.js:2204
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
 
-#: 4.0/applet.js:2184
+#: 4.0/applet.js:2206
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 
@@ -44,91 +44,107 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2193
+#: 4.0/applet.js:2215
 msgid "Open new window"
 msgstr ""
 
-#: 4.0/applet.js:2199
+#: 4.0/applet.js:2223
+msgid "Remove from panel"
+msgstr ""
+
+#: 4.0/applet.js:2225
+msgid "Remove from this workspace"
+msgstr ""
+
+#: 4.0/applet.js:2231
+msgid "Pin to panel"
+msgstr ""
+
+#: 4.0/applet.js:2233
 msgid "Pin to this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2237
+#: 4.0/applet.js:2274
 msgid "Pin to other workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2258
+#: 4.0/applet.js:2295
 msgid "Pin to all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2283 4.0/applet.js:2466
+#: 4.0/applet.js:2313
+msgid "Pin to launcher"
+msgstr ""
+
+#: 4.0/applet.js:2331 4.0/applet.js:2514
 msgid "Add new Hotkey for"
 msgstr ""
 
-#: 4.0/applet.js:2297
+#: 4.0/applet.js:2345
 msgid "Recent files"
 msgstr ""
 
-#: 4.0/applet.js:2321
+#: 4.0/applet.js:2369
 msgid "Places"
 msgstr ""
 
-#: 4.0/applet.js:2363
+#: 4.0/applet.js:2411
 msgid "Only on this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2365
+#: 4.0/applet.js:2413
 msgid "Visible on all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2366
+#: 4.0/applet.js:2414
 msgid "Move to another workspace"
 msgstr ""
 
-#: 4.0/applet.js:2385
+#: 4.0/applet.js:2433
 msgid "Move to another monitor"
 msgstr ""
 
-#: 4.0/applet.js:2393
+#: 4.0/applet.js:2441
 msgid "Monitor"
 msgstr ""
 
-#: 4.0/applet.js:2421
+#: 4.0/applet.js:2469
 msgid "unassigned"
 msgstr ""
 
-#: 4.0/applet.js:2432 4.0/applet.js:2463
+#: 4.0/applet.js:2480 4.0/applet.js:2511
 msgid "Assign window to a hotkey"
 msgstr ""
 
-#: 4.0/applet.js:2486
+#: 4.0/applet.js:2534
 msgid "Change application label contents"
 msgstr ""
 
-#: 4.0/applet.js:2489
+#: 4.0/applet.js:2537
 msgid "Remove custom setting"
 msgstr ""
 
-#: 4.0/applet.js:2496
+#: 4.0/applet.js:2544
 msgid "Use window title"
 msgstr ""
 
-#: 4.0/applet.js:2503
+#: 4.0/applet.js:2551
 msgid "Use application name"
 msgstr ""
 
-#: 4.0/applet.js:2510
+#: 4.0/applet.js:2558
 msgid "No label"
 msgstr ""
 
-#: 4.0/applet.js:2521
+#: 4.0/applet.js:2569
 msgid "Ungroup application windows"
 msgstr ""
 
-#: 4.0/applet.js:2532
+#: 4.0/applet.js:2580
 msgid "Group application windows"
 msgstr ""
 
-#: 4.0/applet.js:2542
+#: 4.0/applet.js:2590
 msgid "Automatic grouping/ungrouping"
 msgstr ""
 
@@ -138,31 +154,31 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2571
+#: 4.0/applet.js:2619
 msgid "Move titlebar on to screen"
 msgstr ""
 
-#: 4.0/applet.js:2576
+#: 4.0/applet.js:2624
 msgid "Restore"
 msgstr ""
 
-#: 4.0/applet.js:2580
+#: 4.0/applet.js:2628
 msgid "Minimize"
 msgstr ""
 
-#: 4.0/applet.js:2586
+#: 4.0/applet.js:2634
 msgid "Unmaximize"
 msgstr ""
 
-#: 4.0/applet.js:2593
+#: 4.0/applet.js:2641
 msgid "Close others"
 msgstr ""
 
-#: 4.0/applet.js:2604
+#: 4.0/applet.js:2652
 msgid "Close all"
 msgstr ""
 
-#: 4.0/applet.js:2613
+#: 4.0/applet.js:2661
 msgid "Close"
 msgstr ""
 
@@ -444,8 +460,38 @@ msgid ""
 "Launcher: Only pinned button are shown, behaves like a panel launcher."
 msgstr ""
 
+#. 4.0->settings-schema.json->display-pinned->options
+msgid "Disabled"
+msgstr ""
+
+#. 4.0->settings-schema.json->display-pinned->options
+msgid "Unique for each workspace"
+msgstr ""
+
+#. 4.0->settings-schema.json->display-pinned->options
+msgid "Common across workspaces"
+msgstr ""
+
 #. 4.0->settings-schema.json->display-pinned->description
-msgid "Allow pinning of window list buttons"
+msgid "Pinning of window list buttons"
+msgstr ""
+
+#. 4.0->settings-schema.json->display-pinned->tooltip
+msgid ""
+"Controls whether window list buttons can be pinned, and whether each "
+"workspace has a unique set of pinned buttons or one common set shared across "
+"all workspaces. When in \"Common across workspaces\" mode the order of the "
+"pinned buttons is also maintained across workspaces."
+msgstr ""
+
+#. 4.0->settings-schema.json->synchronize-pinned->description
+msgid "Synchronize launcher buttons across all workspaces"
+msgstr ""
+
+#. 4.0->settings-schema.json->synchronize-pinned->tooltip
+msgid ""
+"If enabled, the number and order of launcher buttons on the panel will be "
+"synchronize across all workspaces."
 msgstr ""
 
 #. 4.0->settings-schema.json->show-windows-for-current-monitor->description
@@ -724,6 +770,15 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
 msgid "Move to current/next monitor"
+msgstr ""
+
+#. 4.0->settings-schema.json->preview-middle-click->options
+#. 4.0->settings-schema.json->preview-back-click->options
+#. 4.0->settings-schema.json->preview-forward-click->options
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+msgid "Pin to panel toggle"
 msgstr ""
 
 #. 4.0->settings-schema.json->preview-middle-click->options


### PR DESCRIPTION
1. Added a new pinning configuration option that allows the user to force pinned buttons to be synchronized across all workspaces. This means that any changes to the pinned buttons (adding, deleting or rearranging) in one workspace will effect all workspaces. This allows you to maintain a consistent set of pinned buttons, particularly useful for the "launcher" configuration where you might like to have a consistent set of launcher buttons for all workspaces.

2. Added a new mouse action option called "Pin to panel toggle" which allows you to assign the "pin to panel" action to any mouse button or Ctrl/Shift+Button action you define. This action will toggle the pinned setting status for the panel button you clicked on.

3. If an existing "launcher" applet exists on a panel (ether a 2nd instance of CassiaWindowList setup in launcher mode or an instance of panel-launchers@cinnamon.org) a new context menu item called "Pin to launcher" will appear in the content menus. Using this context menu item will add the application of the selected window-list button to the launcher applet.

4. If an applet instance of panel-launchers@cinnamon.org exists but the CassiaWindowList acquired the "panellauncher" role, it will forward any "add to panel" requests to the panel-launchers applet rather the pinning to the CassiaWindowList. Previously the same thing was done when a 2nd instance of CassiaWindowList (setup in launcher mode) existed. This change just extends the same behaviour to cases where a panel-launchers instance exists.

5. Previously the context menu option to unpin a button from a panel for both the window-list and launcher modes was the same switch style item, but that didn't make much sense for launcher mode. So I changed it from a toggle item to a normal item when in launcher mode and changed the text to "Remove from..." rather then "Pin to...".

6. Some minor fixes.