### PR TITLE
hwmonitor@sylfurd: Shorten tabbed page titles so they appear when config dialog is first opened.

### DIFF
--- a/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/settings-schema.json
+++ b/hwmonitor@sylfurd/files/hwmonitor@sylfurd/3.8/settings-schema.json
@@ -36,35 +36,35 @@
       },
       "NET_IN": {
         "type": "page",
-        "title": "NET (in)",
+        "title": "NET in",
         "sections": [
           "NET_IN_settings"
         ]
       },
       "NET_OUT": {
         "type": "page",
-        "title": "NET (out)",
+        "title": "NET out",
         "sections": [
           "NET_OUT_settings"
         ]
       },
       "DISK_READ": {
         "type": "page",
-        "title": "DISK (read)",
+        "title": "DISK read",
         "sections": [
           "DISK_READ_settings"
         ]
       },
       "DISK_WRITE": {
         "type": "page",
-        "title": "DISK (write)",
+        "title": "DISK write",
         "sections": [
           "DISK_WRITE_settings"
         ]
       },
       "BAT": {
         "type": "page",
-        "title": "BAT (battery)",
+        "title": "BAT",
         "sections": [
           "BAT_settings"
         ]


### PR DESCRIPTION
fixes #5065
fixes #4439
fixes #3818

@Hultan 