### PR TITLE
[MuteToggler@jebeaudet.com] Automatically decides which 'amixer' parameter to use (Closes #3979)

### DIFF
--- a/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
+++ b/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
@@ -86,8 +86,7 @@ MyApplet.prototype = {
                 ];
             Util.spawn_async(cmd, (stdout) => {
                 try{
-                    var string = new TextDecoder().decode(stdout);
-                    if(string().indexOf("] [on]") != -1){
+                    if(stdout.indexOf("] [on]") != -1){
                         this.set_not_muted_icon();
                     } else {
                         this.set_muted_icon();

--- a/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
+++ b/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
@@ -13,14 +13,14 @@ MyApplet.prototype = {
     
     _init: function(metadata, orientation, panel_height, instance_id) {
         try {
-            global.log("Initializing MuteToggler applet")
+            global.log("MuteToggler: Initializing applet")
             Applet.IconApplet.prototype._init.call(this, orientation, panel_height, instance_id);
             this.uuid = UUID;
             
             this.set_applet_tooltip(_("Click to mute/unmute microphone"));
 
             try {
-                global.log("Initializing MuteToggler Settings")
+                global.log("MuteToggler: Initializing settings")
                 this.settings = new Settings.AppletSettings(this, this.uuid, instance_id);
                 this.settings.bindProperty(Settings.BindingDirection.IN,
                                      "keybinding",
@@ -42,7 +42,7 @@ MyApplet.prototype = {
             this.is_audio_muted();
             
             this.refresh_loop();
-            global.log("Done initializing MuteToggler applet")
+            global.log("MuteToggler: Done initializing applet")
         } catch (e) {
             global.logError(e);
         }

--- a/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
+++ b/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
@@ -62,7 +62,7 @@ MyApplet.prototype = {
     is_audio_muted: function() {
         try {
             let cmd = [
-                "bash",
+                "sh",
                 "-c",
                 "amixer sget Capture"
                 ];
@@ -95,7 +95,7 @@ MyApplet.prototype = {
     on_applet_clicked: function(event) {
         try{
             let cmd = [
-                "bash",
+                "sh",
                 "-c",
                 "amixer set Capture toggle"
             ];

--- a/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
+++ b/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
@@ -4,6 +4,7 @@ const Main = imports.ui.main;
 const Mainloop = imports.mainloop;
 const Util = imports.misc.util;
 const Settings = imports.ui.settings;
+const GLib = imports.gi.GLib;
 
 const UUID = 'MuteToggler@jebeaudet.com';
 

--- a/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
+++ b/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
@@ -68,7 +68,8 @@ MyApplet.prototype = {
                 ];
             Util.spawn_async(cmd, (stdout) => {
                 try{
-                    if(stdout.toString().indexOf("] [on]") != -1){
+                    var string = new TextDecoder().decode(stdout);
+                    if(string().indexOf("] [on]") != -1){
                         this.set_not_muted_icon();
                     } else {
                         this.set_muted_icon();

--- a/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
+++ b/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
@@ -37,6 +37,23 @@ MyApplet.prototype = {
             if (this.settings) {
                 this.on_settings_changed();
             }
+
+            this.amixer = "";
+            const parameters = ["", " -D pulse"];
+            for (let param of parameters) {
+                let cmd = "amixer" + param + " scontrols";
+                global.log("MuteToggler: Test mixer command '" + cmd + "'");
+                let [res, stdout] = GLib.spawn_command_line_sync(cmd);
+                var string = new TextDecoder().decode(stdout);
+                if (res && string.indexOf("'Capture'") != -1) {
+                    this.amixer = "amixer" + param;
+                    global.log("MuteToggler: Use mixer command '" + this.amixer + "'"
+                    break;
+                } 
+            }
+            if (this.amixer == "") {
+                throw "No working mixer command found!";
+            }
             
             this.set_not_muted_icon();
             this.is_audio_muted();
@@ -64,7 +81,7 @@ MyApplet.prototype = {
             let cmd = [
                 "sh",
                 "-c",
-                "amixer sget Capture"
+                this.amixer + " sget Capture"
                 ];
             Util.spawn_async(cmd, (stdout) => {
                 try{
@@ -98,7 +115,7 @@ MyApplet.prototype = {
             let cmd = [
                 "sh",
                 "-c",
-                "amixer set Capture toggle"
+                this.amixer + " set Capture toggle"
             ];
             Util.spawn_async(cmd, (stdout) => {
                 this.is_audio_muted();

--- a/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
+++ b/MuteToggler@jebeaudet.com/files/MuteToggler@jebeaudet.com/applet.js
@@ -39,21 +39,18 @@ MyApplet.prototype = {
                 this.on_settings_changed();
             }
 
-            this.amixer = "";
+            this.amixer = "amixer";
             const parameters = ["", " -D pulse"];
             for (let param of parameters) {
-                let cmd = "amixer" + param + " scontrols";
+                let cmd = this.amixer + param + " scontrols";
                 global.log("MuteToggler: Test mixer command '" + cmd + "'");
                 let [res, stdout] = GLib.spawn_command_line_sync(cmd);
                 var string = new TextDecoder().decode(stdout);
                 if (res && string.indexOf("'Capture'") != -1) {
-                    this.amixer = "amixer" + param;
-                    global.log("MuteToggler: Use mixer command '" + this.amixer + "'"
+                    this.amixer += param;
+                    global.log("MuteToggler: Use mixer command '" + this.amixer + "'");
                     break;
                 } 
-            }
-            if (this.amixer == "") {
-                throw "No working mixer command found!";
             }
             
             this.set_not_muted_icon();


### PR DESCRIPTION
On some installations it is not enough to call 'amixer'. There an
additional parameter is needed: 'amixer -D pulse' for amixer to find the
proper channel. This PR checks, if it can find the 'Capture' channel
with 'amixer' and if not successful with 'amixer -D pulse'.