### PR TITLE
[sound150@claudiux] Updates the contextual menu when flipping the 'Mute input' switch in the settings

### DIFF
--- a/sound150@claudiux/files/sound150@claudiux/5.4/applet.js
+++ b/sound150@claudiux/files/sound150@claudiux/5.4/applet.js
@@ -1233,6 +1233,11 @@ class Sound150Applet extends Applet.TextIconApplet {
         else
             this.setAppletTextIcon();
 
+       if (this.alwaysCanChangeMic)
+            this.mute_in_switch.actor.show();
+        else if (this._recordingAppsNum === 0)
+            this.mute_in_switch.actor.hide();
+
         this._changeActivePlayer(this._activePlayer);
     }
 

--- a/sound150@claudiux/files/sound150@claudiux/CHANGELOG.md
+++ b/sound150@claudiux/files/sound150@claudiux/CHANGELOG.md
@@ -1,10 +1,13 @@
 ## CHANGELOG
 
+### v4.4.1~20231103
+  * Update the contextual menu when flipping the 'Mute input' switch in the settings.
+
 ### v4.4.0~20231101
   * Allow to always show the 'Mute input' switch in contextual menu.
 
 ### v4.3.0~20231026
-  * Fixes 5005: Icon color changing with theme 
+  * Fixes 5005: Icon color changing with theme
 
 ### v4.2.0~20231012
   * Try to distinguish between the artist and the song title.

--- a/sound150@claudiux/files/sound150@claudiux/metadata.json
+++ b/sound150@claudiux/files/sound150@claudiux/metadata.json
@@ -5,7 +5,7 @@
   "max-instances": "1",
   "description": "An applet, based on the Cinnamon one, to control sound (up to 150% of nominal volume) and music",
   "hide-configuration": false,
-  "version": "4.4.0",
+  "version": "4.4.1",
   "cinnamon-version": [
     "2.8",
     "3.0",


### PR DESCRIPTION
This makes use of the PR
https://github.com/linuxmint/cinnamon/pull/11914.

@claudiux 