### PR TITLE
[Radio3.0@claudiux] v1.9.0 - Use pipeware on Fedora Cinnamon 5.8+

### DIFF
--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/CHANGELOG.md
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v1.9.0~20231115
+  * Change location of yt-dlp program: from `~/bin/` to `~/.local/bin/`.
+  * Fedora (Cinnamon 5.8 and more): use pipewire packages.
+  * (Pipewire will be used in other distros, when available, in a next version of Radio3.0.)
+
 ### v1.8.1~20231110
   * Updated dependencies.js for Soup3 - Bugfix.
 

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/lib/checkDependencies.js
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/lib/checkDependencies.js
@@ -115,7 +115,6 @@ var DEPENDENCIES = {
     ["mpv", "/usr/bin/mpv",  "mpv"],
     ["", "/usr/lib64/mpv/mpris.so", "mpv-mpris"],
     ["wget", "/usr/bin/wget", "wget"],
-    ["pulseaudio", "/usr/bin/pulseaudio", "pulseaudio"],
     ["sox", "/usr/bin/sox", "sox"],
     ["at", "/usr/bin/at", "at"],
     ["notify-send", "/usr/bin/notify-send", "libnotify"],
@@ -145,7 +144,13 @@ if (versionCompare(GLib.getenv("CINNAMON_VERSION"), "5.8") >= 0) {
   DEPENDENCIES["debian"].push(["", "/usr/share/doc/gir1.2-soup-3.0/copyright", "gir1.2-soup-3.0"]);
   DEPENDENCIES["arch"].push(["", "/usr/lib/girepository-1.0/Soup-3.0.typelib", "libsoup3"]);
   DEPENDENCIES["fedora"].push(["", "/usr/share/licenses/libsoup3/COPYING", "libsoup3"]);
+  DEPENDENCIES["fedora"].push(["pipewire", "/usr/bin/pipewire", "pipewire"]);
+  DEPENDENCIES["fedora"].push(["pw-cat", "/usr/bin/pw-cat", "pipewire-utils"]);
+  DEPENDENCIES["fedora"].push(["pipewire-pulse", "/usr/bin/pipewire-pulseaudio", "pipewire-pulseaudio"]);
   DEPENDENCIES["openSUSE"].push(["", "/usr/share/licenses/libsoup-3_0-0/COPYING", "libsoup-3_0-0"]);
+} else {
+  DEPENDENCIES["fedora"].push(["pulseaudio", "/usr/bin/pulseaudio", "pulseaudio"]);
+
 }
 
 // --- Do not modify from here --- //

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/metadata.json
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "The Ultimate Internet Radio Receiver & Recorder for Cinnamon",
   "max-instances": 1,
-  "version": "1.8.1",
+  "version": "1.9.0",
   "uuid": "Radio3.0@claudiux",
   "name": "Radio3.0",
   "author": "claudiux"

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/update-yt-dlp.sh
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/scripts/update-yt-dlp.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
-OWNBIN="$HOME/bin"
+OLDOWNBIN="$HOME/bin"
+OLDYTDLP="$OLDOWNBIN/yt-dlp"
+OWNBIN="$HOME/.local/bin"
 YTDLP="$OWNBIN/yt-dlp"
 
 [ -d $OWNBIN ] || mkdir -p $OWNBIN
+
+[ -f $OLDYTDLP ] && mv -f $OLDYTDLP $YTDLP
 
 [ -e $YTDLP ] || {
   wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O $YTDLP


### PR DESCRIPTION
and change location of yt-dlp: from `~/bin/` to `~/.local/bin/`.