### PR TITLE
[timer@Severga] Preserves timer despite applet restart

### DIFF
--- a/timer@Severga/files/timer@Severga/settings-schema.json
+++ b/timer@Severga/files/timer@Severga/settings-schema.json
@@ -46,5 +46,13 @@
 		],
 		"description": "Presets",
 		"tooltip": "Presets"
-	}
+	},
+        "saved_endTime": {
+		"type": "generic",
+                "default": 0
+        },
+        "turn_off": {
+		"type": "generic",
+		"default": false
+        }
 }


### PR DESCRIPTION
@Severga 

Hi,
When mintupdate updates xlets in use, Cinnamon restarts and the timer is reset.

This PR preserves timer (and "turn off" status) despite the applet restart.

Are these changes to your liking?

Regards
Claudiux