### PR TITLE
Remove libmpv1 or libmpv2 dependency for LM and Debian

### DIFF
--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/CHANGELOG.md
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v1.10.1~20231126
+  * Remove libmpv1 or libmpv2 dependency for LM and Debian.
+
 ### v1.10.0~20231126
   * Added the ability to swap artist and song title for certain radio stations.
 

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/lib/checkDependencies.js
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/lib/checkDependencies.js
@@ -40,7 +40,7 @@ const NEEDS_FONTS_SYMBOLA = false;
  *
  * Example: To install the executable 'sox' and the library 'libsox-fmt-mp3.so', we need to install two packages in
  * Debian and derivatives distros (default) and only one package (named sox) in Arch and Fedora distros.
-const DEPENDENCIES = {
+var DEPENDENCIES = {
   "default": [
     ["sox", "/usr/bin/sox",  "sox"],
     ["", "/usr/share/doc/libsox-fmt-mp3/copyright", "libsox-fmt-mp3"]
@@ -66,7 +66,6 @@ var DEPENDENCIES = {
   "default": [
     ["mpv", "/usr/bin/mpv",  "mpv"],
     ["wget", "/usr/bin/wget", "wget"],
-    ["", "/usr/share/doc/libmpv1/copyright", "libmpv1"],
     ["", "/usr/share/doc/libmpv-dev/copyright", "libmpv-dev"],
     ["pacmd", "/usr/bin/pacmd", "pulseaudio-utils"],
     ["pulseaudio", "/usr/bin/pulseaudio", "pulseaudio"],
@@ -94,7 +93,6 @@ var DEPENDENCIES = {
   "debian": [
     ["mpv", "/usr/bin/mpv",  "mpv"],
     ["wget", "/usr/bin/wget", "wget"],
-    ["", "/usr/lib/x86_64-linux-gnu/libmpv.so", "libmpv?"],
     ["", "/usr/share/doc/libmpv-dev/copyright", "libmpv-dev"],
     ["pacmd", "/usr/bin/pacmd", "pulseaudio-utils"],
     ["pulseaudio", "/usr/bin/pulseaudio", "pulseaudio"],

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/metadata.json
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "The Ultimate Internet Radio Receiver & Recorder for Cinnamon",
   "max-instances": 1,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "uuid": "Radio3.0@claudiux",
   "name": "Radio3.0",
   "author": "claudiux",


### PR DESCRIPTION
Fixes the bug reported by @Neonteepee on https://cinnamon-spices.linuxmint.com/applets/view/360.