### PR TITLE
v1.11.1 - Moves the 'Do not check dependencies' option from the Settings Behavior tab to the context menu

### DIFF
--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/CHANGELOG.md
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v1.11.1~20231128
+  * Moves the "Do not check dependencies" option from the Settings Behavior tab to the context menu. This avoids error messages.
+
 ### v1.11.0~20231128
   * Fixes dependency issues.
   * Option "Do not check about dependencies" works fine now.

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/applet.js
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/applet.js
@@ -1127,7 +1127,7 @@ WebRadioReceiverAndRecorder.prototype = {
   get_user_settings: function() {
     //log("get_user_settings");
 
-    this.settings.bind("dont-check-dependencies", "dont_check_dependencies", this.on_option_menu_reload_this_applet_clicked.bind(this));
+    this.settings.bind("dont-check-dependencies", "dont_check_dependencies");
     this.settings.bind("recentRadios", "recentRadios");
     this.settings.bind("volume-step", "volume_step");
     this.settings.bind("volume-at-startup", "volume_at_startup");
@@ -4425,8 +4425,22 @@ WebRadioReceiverAndRecorder.prototype = {
         }));
     }
     if (items.indexOf(this.context_menu_item_showLogo) == -1) {
-        this._applet_context_menu.addMenuItem(new PopupSeparatorMenuItem());
         this._applet_context_menu.addMenuItem(this.context_menu_item_showLogo);
+    }
+
+    // Do not check about dependencies
+    if (this.context_menu_item_dontCheckDep == null) {
+        this.context_menu_item_dontCheckDep = new PopupSwitchMenuItem(_("Do not check about dependencies"),
+          this.dont_check_dependencies,
+          null);
+        this.context_menu_item_dontCheckDep.connect("toggled", Lang.bind(this, function() {
+          this.dont_check_dependencies = !this.dont_check_dependencies;
+          this.on_option_menu_reload_this_applet_clicked();
+        }));
+    }
+    if (items.indexOf(this.context_menu_item_dontCheckDep) == -1) {
+        this._applet_context_menu.addMenuItem(new PopupSeparatorMenuItem());
+        this._applet_context_menu.addMenuItem(this.context_menu_item_dontCheckDep);
     }
 
     // Open Recordings Folder

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/metadata.json
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "The Ultimate Internet Radio Receiver & Recorder for Cinnamon",
   "max-instances": 1,
-  "version": "1.11.0",
+  "version": "1.11.1",
   "uuid": "Radio3.0@claudiux",
   "name": "Radio3.0",
   "author": "claudiux",

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/Radio3.0@claudiux.pot
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/Radio3.0@claudiux.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-20 18:07+0200\n"
+"POT-Creation-Date: 2023-11-28 18:37+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -157,11 +157,11 @@ msgstr ""
 #. settings-schema.json->search-country->options
 #. settings-schema.json->search-codec->options
 #. settings-schema.json->search-order->options
-#: applet.js:616 applet.js:630 applet.js:4630 applet.js:4642
+#: applet.js:616 applet.js:630 applet.js:4693 applet.js:4705
 msgid "(Undefined)"
 msgstr ""
 
-#: applet.js:1022 applet.js:1751 applet.js:2151
+#: applet.js:1022 applet.js:1751 applet.js:2173
 msgid "Stop"
 msgstr ""
 
@@ -169,310 +169,315 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: applet.js:1989 applet.js:2019 applet.js:2065
+#: applet.js:1989 applet.js:2031 applet.js:2087
 msgid "Middle-Click: Stop Recording"
 msgstr ""
 
-#: applet.js:2015 applet.js:2061
+#: applet.js:2027 applet.js:2083
 msgid "Volume: %s%"
 msgstr ""
 
-#: applet.js:2021 applet.js:2067
+#: applet.js:2033 applet.js:2089
 msgid "Middle-click: ON/OFF"
 msgstr ""
 
-#: applet.js:2023 applet.js:2069
+#: applet.js:2035 applet.js:2091
 msgid "Click: Select another station"
 msgstr ""
 
-#: applet.js:2036
+#: applet.js:2048
 msgid "Click to select a station"
 msgstr ""
 
-#: applet.js:2071
+#: applet.js:2093
 msgid "Scroll wheel: volume change"
 msgstr ""
 
-#: applet.js:2127 applet.js:2486 applet.js:4288
+#: applet.js:2149 applet.js:2508 applet.js:4337
 msgid "Configure..."
 msgstr ""
 
-#: applet.js:2131 applet.js:2478
+#: applet.js:2153 applet.js:2500
 msgid "Search for new stations..."
 msgstr ""
 
-#: applet.js:2137 applet.js:2490 applet.js:4325
+#: applet.js:2159 applet.js:2512 applet.js:4374
 msgid "Sound Settings"
 msgstr ""
 
-#: applet.js:2200 applet.js:2247
+#: applet.js:2222 applet.js:2269
 msgid "Watch on YT"
 msgstr ""
 
-#: applet.js:2207
+#: applet.js:2229
 msgid "Try to download it from YT (unsafe)"
 msgstr ""
 
-#: applet.js:2238
+#: applet.js:2260
 #, javascript-format
 msgid "Infos on: %s"
 msgstr ""
 
-#: applet.js:2268
+#: applet.js:2290
 msgid "Recently Played Stations:"
 msgstr ""
 
-#: applet.js:2304
+#: applet.js:2326
 msgid "Visit the home page of this station"
 msgstr ""
 
-#: applet.js:2345
+#: applet.js:2367
 msgid "My Categories"
 msgstr ""
 
-#: applet.js:2414
+#: applet.js:2436
 msgid "My Radio Stations"
 msgstr ""
 
-#: applet.js:2598
+#: applet.js:2620
 msgid "Downloading..."
 msgstr ""
 
-#: applet.js:2600
+#: applet.js:2622
 msgid "Stop downloading"
 msgstr ""
 
-#: applet.js:2708
+#: applet.js:2730
 msgid "Download complete"
 msgstr ""
 
-#: applet.js:2710 applet.js:2719 applet.js:4090 applet.js:4099 applet.js:4108
-#: applet.js:4392
+#: applet.js:2732 applet.js:2741 applet.js:4139 applet.js:4148 applet.js:4157
+#: applet.js:4455
 msgid "Open the recordings folder"
 msgstr ""
 
-#: applet.js:2717 applet.js:4087 applet.js:4097 applet.js:4106
+#: applet.js:2739 applet.js:4136 applet.js:4146 applet.js:4155
 msgid "An error seems to have occurred during recording!"
 msgstr ""
 
-#: applet.js:2718 applet.js:4089 applet.js:4098 applet.js:4107
+#: applet.js:2740 applet.js:4138 applet.js:4147 applet.js:4156
 msgid "Please check this record."
 msgstr ""
 
-#: applet.js:2819 applet.js:2853
+#: applet.js:2847 applet.js:2881
 msgid "Record from now"
 msgstr ""
 
-#: applet.js:2837 applet.js:4536
+#: applet.js:2865 applet.js:4599
 msgid "Stop Current Recording"
 msgstr ""
 
-#: applet.js:2949
+#: applet.js:2977
 #, javascript-format
 msgid "Playing %s%s"
 msgstr ""
 
-#: applet.js:2998
+#: applet.js:3026
 msgid "Radio OFF"
 msgstr ""
 
-#: applet.js:3126
+#: applet.js:3154
 msgid "Unable to record anything!"
 msgstr ""
 
-#: applet.js:3126 applet.js:4412
+#: applet.js:3154 applet.js:4475
 msgid "Insufficient space"
 msgstr ""
 
-#: applet.js:3126
+#: applet.js:3154
 msgid "The limit you set has been reached."
 msgstr ""
 
-#: applet.js:3492
+#: applet.js:3536
 msgid "Please Log Out then Log In"
 msgstr ""
 
-#: applet.js:3492
+#: applet.js:3536
 msgid "to finalize yt-dlp update"
 msgstr ""
 
-#: applet.js:3578
+#: applet.js:3627
 msgid "Nothing to save."
 msgstr ""
 
-#: applet.js:3591
+#: applet.js:3640
 msgid "List of saved radio stations"
 msgstr ""
 
-#: applet.js:3609
+#: applet.js:3658
 msgid "This will replace all current radio stations."
 msgstr ""
 
-#: applet.js:3610
+#: applet.js:3659
 msgid "Are you sure you want to continue?"
 msgstr ""
 
-#: applet.js:3670 applet.js:3763
+#: applet.js:3719 applet.js:3812
 msgid "Update in progress"
 msgstr ""
 
-#: applet.js:3670 applet.js:3763
+#: applet.js:3719 applet.js:3812
 msgid "It may take a while ... Please wait."
 msgstr ""
 
-#: applet.js:3758 applet.js:3840
+#: applet.js:3807 applet.js:3889
 msgid "Update completed successfully"
 msgstr ""
 
-#: applet.js:3968 applet.js:4024
+#: applet.js:4017 applet.js:4073
 msgid "ERROR: Invalid YT video URL!"
 msgstr ""
 
-#: applet.js:3993
+#: applet.js:4042
 msgid "Unable to extract a single soundtrack"
 msgstr ""
 
-#: applet.js:3993
+#: applet.js:4042
 msgid "Maybe it's a playlist?"
 msgstr ""
 
-#: applet.js:4026
+#: applet.js:4075
 msgid "Close"
 msgstr ""
 
-#: applet.js:4247
+#: applet.js:4296
 msgid "About..."
 msgstr ""
 
-#: applet.js:4258
+#: applet.js:4307
 msgid "Radio3.0 web page..."
 msgstr ""
 
-#: applet.js:4269
+#: applet.js:4318
 msgid "Manual..."
 msgstr ""
 
-#: applet.js:4301
+#: applet.js:4350
 msgid "Schedule a background record..."
 msgstr ""
 
-#: applet.js:4313
+#: applet.js:4362
 msgid "Extract soundtrack from YouTube video..."
 msgstr ""
 
-#: applet.js:4334
+#: applet.js:4383
 msgid "Pulse Effects"
 msgstr ""
 
-#: applet.js:4343
+#: applet.js:4392
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
 
-#: applet.js:4356
+#: applet.js:4405
 msgid "Radio ON at startup"
 msgstr ""
 
-#: applet.js:4370
+#: applet.js:4419
 msgid "Display Station Logo"
 msgstr ""
 
-#: applet.js:4409
+#. settings-schema.json->dont-check-dependencies->description
+#: applet.js:4433
+msgid "Do not check about dependencies"
+msgstr ""
+
+#: applet.js:4472
 msgid "(auto)"
 msgstr ""
 
-#: applet.js:4409
+#: applet.js:4472
 msgid "(manual)"
 msgstr ""
 
-#: applet.js:4412 applet.js:4585
+#: applet.js:4475 applet.js:4648
 msgid "Stop Recording"
 msgstr ""
 
-#: applet.js:4412
+#: applet.js:4475
 msgid "Start Recording"
 msgstr ""
 
-#: applet.js:4433
+#: applet.js:4496
 msgid "Reload this applet"
 msgstr ""
 
-#: applet.js:4452
+#: applet.js:4515
 msgid "Cancel downloads from YT"
 msgstr ""
 
-#: applet.js:4586
+#: applet.js:4649
 msgid "Close without stopping recording"
 msgstr ""
 
-#: applet.js:4796
+#: applet.js:4859
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr ""
 
-#: applet.js:4808
+#: applet.js:4871
 msgid "Recording completed"
 msgstr ""
 
-#: applet.js:4902
+#: applet.js:4965
 msgid "This will import a new file containing radio stations."
 msgstr ""
 
-#: applet.js:4903
+#: applet.js:4966
 msgid "Do you want to continue?"
 msgstr ""
 
-#: applet.js:4974
+#: applet.js:5037
 msgid "No new radio in your list."
 msgstr ""
 
-#: applet.js:4976
+#: applet.js:5039
 msgid "One more radio in your list."
 msgstr ""
 
-#: applet.js:4978
+#: applet.js:5041
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr ""
 
-#: applet.js:5185
+#: applet.js:5248
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr ""
 
-#: applet.js:5187
+#: applet.js:5250
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr ""
 
-#: applet.js:5189
+#: applet.js:5252
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr ""
 
-#: applet.js:5390
+#: applet.js:5453
 #, javascript-format
 msgid "%s kbps"
 msgstr ""
 
-#: lib/checkDependencies.js:345
+#: lib/checkDependencies.js:384
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr ""
 
-#: lib/checkDependencies.js:346
+#: lib/checkDependencies.js:385
 msgid "All dependencies are installed"
 msgstr ""
 
-#: lib/checkDependencies.js:374
+#: lib/checkDependencies.js:413
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
 msgstr ""
 
-#: lib/checkDependencies.js:375
+#: lib/checkDependencies.js:414
 msgid "Please execute, in the just opened terminal, the commands:"
 msgstr ""
 
-#: lib/checkDependencies.js:376
+#: lib/checkDependencies.js:415
 msgid "Some dependencies are not installed!"
 msgstr ""
 
@@ -814,6 +819,10 @@ msgstr ""
 msgid "Favicon"
 msgstr ""
 
+#. settings-schema.json->radios->columns->title
+msgid "Artist/Title swap"
+msgstr ""
+
 #. settings-schema.json->stations-list-play-button->description
 #. settings-schema.json->import-list-play-button->description
 #. settings-schema.json->search-list-play-button->description
@@ -1042,10 +1051,6 @@ msgid ""
 "Default is (Undefined): The volume level remains unchanged.\n"
 "\n"
 "Please note that you can change the volume level scrolling on this applet icon, or using the slider in the context menu."
-msgstr ""
-
-#. settings-schema.json->dont-check-dependencies->description
-msgid "Do not check about dependencies"
 msgstr ""
 
 #. settings-schema.json->volume-step->description

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/po/fr.po
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/po/fr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Radio3.0@claudiux\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-20 18:07+0200\n"
-"PO-Revision-Date: 2023-06-20 18:08+0200\n"
+"POT-Creation-Date: 2023-11-28 18:37+0100\n"
+"PO-Revision-Date: 2023-11-28 18:39+0100\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
 "Language: fr_FR\n"
@@ -197,11 +197,11 @@ msgstr "%s octets = %s Go = %s Gio"
 #. settings-schema.json->search-country->options
 #. settings-schema.json->search-codec->options
 #. settings-schema.json->search-order->options
-#: applet.js:616 applet.js:630 applet.js:4630 applet.js:4642
+#: applet.js:616 applet.js:630 applet.js:4693 applet.js:4705
 msgid "(Undefined)"
 msgstr "(Indéfini)"
 
-#: applet.js:1022 applet.js:1751 applet.js:2151
+#: applet.js:1022 applet.js:1751 applet.js:2173
 msgid "Stop"
 msgstr "Arrêt"
 
@@ -209,301 +209,306 @@ msgstr "Arrêt"
 msgid "Start"
 msgstr "Marche"
 
-#: applet.js:1989 applet.js:2019 applet.js:2065
+#: applet.js:1989 applet.js:2031 applet.js:2087
 msgid "Middle-Click: Stop Recording"
 msgstr "Clic-molette : Arrêter l'enregistrement"
 
-#: applet.js:2015 applet.js:2061
+#: applet.js:2027 applet.js:2083
 msgid "Volume: %s%"
 msgstr "Volume : %s%"
 
-#: applet.js:2021 applet.js:2067
+#: applet.js:2033 applet.js:2089
 msgid "Middle-click: ON/OFF"
 msgstr "Clic-molette : Marche/Arrêt"
 
-#: applet.js:2023 applet.js:2069
+#: applet.js:2035 applet.js:2091
 msgid "Click: Select another station"
 msgstr "Clic : Choisir une autre station"
 
-#: applet.js:2036
+#: applet.js:2048
 msgid "Click to select a station"
 msgstr "Cliquer pour choisir une autre station"
 
-#: applet.js:2071
+#: applet.js:2093
 msgid "Scroll wheel: volume change"
 msgstr "Roule-molette : Modifier le volume"
 
-#: applet.js:2127 applet.js:2486 applet.js:4288
+#: applet.js:2149 applet.js:2508 applet.js:4337
 msgid "Configure..."
 msgstr "Configurer..."
 
-#: applet.js:2131 applet.js:2478
+#: applet.js:2153 applet.js:2500
 msgid "Search for new stations..."
 msgstr "Rechercher de nouvelles stations..."
 
-#: applet.js:2137 applet.js:2490 applet.js:4325
+#: applet.js:2159 applet.js:2512 applet.js:4374
 msgid "Sound Settings"
 msgstr "Paramètres du son"
 
-#: applet.js:2200 applet.js:2247
+#: applet.js:2222 applet.js:2269
 msgid "Watch on YT"
 msgstr "Voir sur YT"
 
-#: applet.js:2207
+#: applet.js:2229
 msgid "Try to download it from YT (unsafe)"
 msgstr "Essayer de télécharger depuis YT (peu sûr)"
 
-#: applet.js:2238
+#: applet.js:2260
 #, javascript-format
 msgid "Infos on: %s"
 msgstr "Infos sur : %s"
 
-#: applet.js:2268
+#: applet.js:2290
 msgid "Recently Played Stations:"
 msgstr "Stations récemment écoutées :"
 
-#: applet.js:2304
+#: applet.js:2326
 msgid "Visit the home page of this station"
 msgstr "Visiter le site web de cette station"
 
-#: applet.js:2345
+#: applet.js:2367
 msgid "My Categories"
 msgstr "Mes catégories"
 
-#: applet.js:2414
+#: applet.js:2436
 msgid "My Radio Stations"
 msgstr "Mes stations de radio"
 
-#: applet.js:2598
+#: applet.js:2620
 msgid "Downloading..."
 msgstr "Téléchargement..."
 
-#: applet.js:2600
+#: applet.js:2622
 msgid "Stop downloading"
 msgstr "Arrêter ce téléchargement"
 
-#: applet.js:2708
+#: applet.js:2730
 msgid "Download complete"
 msgstr "Enregistrement terminé"
 
-#: applet.js:2710 applet.js:2719 applet.js:4090 applet.js:4099 applet.js:4108
-#: applet.js:4392
+#: applet.js:2732 applet.js:2741 applet.js:4139 applet.js:4148 applet.js:4157
+#: applet.js:4455
 msgid "Open the recordings folder"
 msgstr "Ouvrir le dossier des enregistrements"
 
-#: applet.js:2717 applet.js:4087 applet.js:4097 applet.js:4106
+#: applet.js:2739 applet.js:4136 applet.js:4146 applet.js:4155
 msgid "An error seems to have occurred during recording!"
 msgstr "Une erreur semble survenue pendant l'enregistrement !"
 
-#: applet.js:2718 applet.js:4089 applet.js:4098 applet.js:4107
+#: applet.js:2740 applet.js:4138 applet.js:4147 applet.js:4156
 msgid "Please check this record."
 msgstr "Veuillez vérifier cet enregistrement."
 
-#: applet.js:2819 applet.js:2853
+#: applet.js:2847 applet.js:2881
 msgid "Record from now"
 msgstr "Enregistrer à partir de maintenant"
 
-#: applet.js:2837 applet.js:4536
+#: applet.js:2865 applet.js:4599
 msgid "Stop Current Recording"
 msgstr "Arrêter l'enregistrement actuel"
 
-#: applet.js:2949
+#: applet.js:2977
 #, javascript-format
 msgid "Playing %s%s"
 msgstr "À l'écoute de %s%s"
 
-#: applet.js:2998
+#: applet.js:3026
 msgid "Radio OFF"
 msgstr "Radio éteinte"
 
-#: applet.js:3126
+#: applet.js:3154
 msgid "Unable to record anything!"
 msgstr "Impossible d'enregistrer !"
 
-#: applet.js:3126 applet.js:4412
+#: applet.js:3154 applet.js:4475
 msgid "Insufficient space"
 msgstr "Espace insuffisant"
 
-#: applet.js:3126
+#: applet.js:3154
 msgid "The limit you set has been reached."
 msgstr "La limite que vous avez fixée a été atteinte."
 
-#: applet.js:3492
+#: applet.js:3536
 msgid "Please Log Out then Log In"
 msgstr "Veuillez vous déconnecter et vous reconnecter"
 
-#: applet.js:3492
+#: applet.js:3536
 msgid "to finalize yt-dlp update"
 msgstr "pour finaliser la mise à jour de yt-dlp"
 
-#: applet.js:3578
+#: applet.js:3627
 msgid "Nothing to save."
 msgstr "Rien à sauvegarder."
 
-#: applet.js:3591
+#: applet.js:3640
 msgid "List of saved radio stations"
 msgstr "Liste des stations sauvegardées"
 
-#: applet.js:3609
+#: applet.js:3658
 msgid "This will replace all current radio stations."
 msgstr "Cela va remplacer toutes vos stations actuelles."
 
-#: applet.js:3610
+#: applet.js:3659
 msgid "Are you sure you want to continue?"
 msgstr "Êtes-vous sûr(e) de vouloir continuer ?"
 
-#: applet.js:3670 applet.js:3763
+#: applet.js:3719 applet.js:3812
 msgid "Update in progress"
 msgstr "Mise à jour en cours"
 
-#: applet.js:3670 applet.js:3763
+#: applet.js:3719 applet.js:3812
 msgid "It may take a while ... Please wait."
 msgstr "Cela peut prendre du temps... Merci de patienter."
 
-#: applet.js:3758 applet.js:3840
+#: applet.js:3807 applet.js:3889
 msgid "Update completed successfully"
 msgstr "Mise à jour effectuée avec succès"
 
-#: applet.js:3968 applet.js:4024
+#: applet.js:4017 applet.js:4073
 msgid "ERROR: Invalid YT video URL!"
 msgstr "ERREUR : URL de la vidéo YT invalide !"
 
-#: applet.js:3993
+#: applet.js:4042
 msgid "Unable to extract a single soundtrack"
 msgstr "Impossible d'extraire une seule bande son"
 
-#: applet.js:3993
+#: applet.js:4042
 msgid "Maybe it's a playlist?"
 msgstr "S'agit-il d'une playlist ?"
 
-#: applet.js:4026
+#: applet.js:4075
 msgid "Close"
 msgstr "Fermer"
 
-#: applet.js:4247
+#: applet.js:4296
 msgid "About..."
 msgstr "À propos..."
 
-#: applet.js:4258
+#: applet.js:4307
 msgid "Radio3.0 web page..."
 msgstr "Page web de Radio3.0..."
 
-#: applet.js:4269
+#: applet.js:4318
 msgid "Manual..."
 msgstr "Manuel..."
 
-#: applet.js:4301
+#: applet.js:4350
 msgid "Schedule a background record..."
 msgstr "Planifier un enregistrement en arrière-plan..."
 
-#: applet.js:4313
+#: applet.js:4362
 msgid "Extract soundtrack from YouTube video..."
 msgstr "Extraire la bande son d'une vidéo YouTube..."
 
-#: applet.js:4334
+#: applet.js:4383
 msgid "Pulse Effects"
 msgstr "Pulse Effects"
 
-#: applet.js:4343
+#: applet.js:4392
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Supprimer '%s'"
 
-#: applet.js:4356
+#: applet.js:4405
 msgid "Radio ON at startup"
 msgstr "Allumer la radio au démarrage"
 
-#: applet.js:4370
+#: applet.js:4419
 msgid "Display Station Logo"
 msgstr "Afficher le logo de la station"
 
-#: applet.js:4409
+#. settings-schema.json->dont-check-dependencies->description
+#: applet.js:4433
+msgid "Do not check about dependencies"
+msgstr "Ne pas vérifier les dépendances"
+
+#: applet.js:4472
 msgid "(auto)"
 msgstr "(auto)"
 
-#: applet.js:4409
+#: applet.js:4472
 msgid "(manual)"
 msgstr "(manuel)"
 
-#: applet.js:4412 applet.js:4585
+#: applet.js:4475 applet.js:4648
 msgid "Stop Recording"
 msgstr "Arrêter l'enregistrement"
 
-#: applet.js:4412
+#: applet.js:4475
 msgid "Start Recording"
 msgstr "Démarrer l'enregistrement"
 
-#: applet.js:4433
+#: applet.js:4496
 msgid "Reload this applet"
 msgstr "Recharger cette applet"
 
-#: applet.js:4452
+#: applet.js:4515
 msgid "Cancel downloads from YT"
 msgstr "Abandon des téléchargements depuis YT"
 
-#: applet.js:4586
+#: applet.js:4649
 msgid "Close without stopping recording"
 msgstr "Fermer sans arrêter l'enregistrement"
 
-#: applet.js:4796
+#: applet.js:4859
 #, javascript-format
 msgid "Starting recording from %s:%s to %s:%s"
 msgstr "Démarrage de l'enregistrement de %s:%s à %s:%s"
 
-#: applet.js:4808
+#: applet.js:4871
 msgid "Recording completed"
 msgstr "Enregistrement terminé"
 
-#: applet.js:4902
+#: applet.js:4965
 msgid "This will import a new file containing radio stations."
 msgstr "Cela va importer un nouveau fichier contenant des stations de radio."
 
-#: applet.js:4903
+#: applet.js:4966
 msgid "Do you want to continue?"
 msgstr "Voulez-vous continuer ?"
 
-#: applet.js:4974
+#: applet.js:5037
 msgid "No new radio in your list."
 msgstr "Aucune nouvelle radio dans votre liste."
 
-#: applet.js:4976
+#: applet.js:5039
 msgid "One more radio in your list."
 msgstr "Une radio de plus dans votre liste."
 
-#: applet.js:4978
+#: applet.js:5041
 #, javascript-format
 msgid "%s more radios in your list."
 msgstr "%s radios de plus dans votre liste."
 
-#: applet.js:5185
+#: applet.js:5248
 msgid "There are no new stations to add to the Radio3.0 applet menu"
 msgstr ""
 "Il n'y a aucune nouvelle station à ajouter au menu de l'applet Radio3.0"
 
-#: applet.js:5187
+#: applet.js:5250
 msgid "A new station has been added to the Radio3.0 applet menu"
 msgstr "Une nouvelle station a été ajoutée au menu de l'applet Radio3.0"
 
-#: applet.js:5189
+#: applet.js:5252
 #, javascript-format
 msgid "%s new stations have been added to the Radio3.0 applet menu"
 msgstr "%s  nouvelles stations ont été ajoutées au menu de l'applet Radio3.0"
 
-#: applet.js:5390
+#: applet.js:5453
 #, javascript-format
 msgid "%s kbps"
 msgstr "%s kbit/s"
 
-#: lib/checkDependencies.js:345
+#: lib/checkDependencies.js:384
 #, javascript-format
 msgid "The applet %s is fully functional."
 msgstr "L'applet %s est pleinement fonctionnelle."
 
-#: lib/checkDependencies.js:346
+#: lib/checkDependencies.js:385
 msgid "All dependencies are installed"
 msgstr "Toutes les dépendances ont été installées"
 
-#: lib/checkDependencies.js:374
+#: lib/checkDependencies.js:413
 msgid ""
 "You appear to be missing some of the programs required for this applet to "
 "have all its features."
@@ -511,11 +516,11 @@ msgstr ""
 "Vous semblez ne pas disposer des programmes requis pour bénéficier de toutes "
 "les fonctionnalités de cette applet."
 
-#: lib/checkDependencies.js:375
+#: lib/checkDependencies.js:414
 msgid "Please execute, in the just opened terminal, the commands:"
 msgstr "Veuillez exécuter, dans le terminal qui s'est ouvert, les commandes :"
 
-#: lib/checkDependencies.js:376
+#: lib/checkDependencies.js:415
 msgid "Some dependencies are not installed!"
 msgstr "Certaines dépendances ne sont pas installées !"
 
@@ -863,6 +868,10 @@ msgstr "Mots-clés"
 msgid "Favicon"
 msgstr "Favicon"
 
+#. settings-schema.json->radios->columns->title
+msgid "Artist/Title swap"
+msgstr "Permuter Artiste/Titre"
+
 #. settings-schema.json->stations-list-play-button->description
 #. settings-schema.json->import-list-play-button->description
 #. settings-schema.json->search-list-play-button->description
@@ -1114,10 +1123,6 @@ msgstr ""
 "Veuillez noter que vous pouvez modifier le niveau de volume en roulant la "
 "molette sur l'icône de Radio3.0, ou en déplaçant le curseur situé dans le "
 "menu contextuel."
-
-#. settings-schema.json->dont-check-dependencies->description
-msgid "Do not check about dependencies"
-msgstr "Ne pas vérifier les dépendances"
 
 #. settings-schema.json->volume-step->description
 msgid "Volume step scrolling on icon"

--- a/Radio3.0@claudiux/files/Radio3.0@claudiux/settings-schema.json
+++ b/Radio3.0@claudiux/files/Radio3.0@claudiux/settings-schema.json
@@ -198,8 +198,7 @@
       "title": "Start-up",
       "keys": [
         "switch-on-last-station-at-start-up",
-        "volume-at-startup",
-        "dont-check-dependencies"
+        "volume-at-startup"
       ]
     },
     "sectionBehaviorVolumeStep": {
@@ -816,7 +815,7 @@
     "tooltip": "If set, then this will change the volume level starting a new radio, in percentage of the general volume level.\nDefault is (Undefined): The volume level remains unchanged.\n\nPlease note that you can change the volume level scrolling on this applet icon, or using the slider in the context menu."
   },
   "dont-check-dependencies": {
-    "type": "switch",
+    "type": "generic",
     "description": "Do not check about dependencies",
     "default": false
   },


### PR DESCRIPTION
Moves the "Do not check dependencies" option from the Settings Behavior tab to the context menu. This avoids error messages.