### PR TITLE
Little addition for those who do not want to miss CPU overheating

### DIFF
--- a/ssm@Severga/files/ssm@Severga/applet.js
+++ b/ssm@Severga/files/ssm@Severga/applet.js
@@ -58,6 +58,9 @@ SSMApplet.prototype = {
 			this._applet_tooltip.set_text(_("Required GTop package missing!"));
 		} else {
 			this._applet_tooltip._tooltip.set_style('text-align: left; font-family: monospace; font-size: 9pt');
+			this._applet_context_menu.addMenuItem(new Applet.MenuItem(_("Reset Peak Temperature"), "go-bottom-symbolic", () => {
+				this.maxTempEver = -283;
+			}));
 			this._applet_context_menu.addMenuItem(new Applet.MenuItem(_("Clear Cache"), "user-trash", () => {
 				let [success, argv] = GLib.shell_parse_argv("pkexec sh -c 'echo 1 >/proc/sys/vm/drop_caches'");
 				let flags = GLib.SpawnFlags.SEARCH_PATH | GLib.SpawnFlags.DO_NOT_REAP_CHILD;
@@ -103,6 +106,8 @@ SSMApplet.prototype = {
 			this.memDataProvider = new MemDataProvider();
 			this.netDataProvider = new NetDataProvider();
 			
+			this.maxTempEver = -283;
+			
 			this.timeoutR = 0;
 			this.timeout = Mainloop.timeout_add_seconds(1, () => this._update());
 			this.timeout2 = Mainloop.timeout_add_seconds(0.5, () => this._update2());
@@ -145,6 +150,7 @@ SSMApplet.prototype = {
 		} else {
 			this.currentTemp = -283;
 		}
+		if (this.currentTemp > this.maxTempEver) this.maxTempEver = this.currentTemp;
 		this.waitingForSensors = false;
 	},
 	
@@ -152,7 +158,7 @@ SSMApplet.prototype = {
 		let shortInfo, shortInfo2, longInfo, tooltip;
 		[shortInfo, longInfo] = this.cpuDataProvider.data();
 		this.cpuLabel.set_text(shortInfo);
-		tooltip = "<b>" + _("CPUs") + "</b>   " + (this.sensorsFailed || this.currentTemp == -283 ? "" : "(<i>" + this.currentTemp + "°C max</i>)") + "\n" + longInfo + "\n\n";
+		tooltip = "<b>" + _("CPUs") + "</b>   " + (this.sensorsFailed || this.currentTemp == -283 ? "" : "(<i>" + this.currentTemp + _("°C max; ") + this.maxTempEver + _("°C peak") + "</i>)") + "\n" + longInfo + "\n\n";
 		[shortInfo, longInfo] = this.memDataProvider.data();
 		this.memLabel.set_text(shortInfo);
 		tooltip += "<b>" + _("Memory") + "</b> (<i>" + (this.memDataProvider.memSize / 1000000000).toFixed(1) + _("GB") + (this.memDataProvider.swapSize ? "; " + (this.memDataProvider.swapSize / 1000000000).toFixed(1) + _("GB swap") : "") + "</i>)\n" + longInfo +"\n\n";

--- a/ssm@Severga/files/ssm@Severga/po/ru.po
+++ b/ssm@Severga/files/ssm@Severga/po/ru.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-03-08 19:56+0300\n"
-"PO-Revision-Date: 2023-03-08 20:40+0300\n"
+"PO-Revision-Date: 2023-12-02 12:24+0300\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -27,6 +27,10 @@ msgstr "Необходимый пакет \"GTop\" не найден!"
 msgid "Error!"
 msgstr "Ошибка!"
 
+#: applet.js:61
+msgid "Reset Peak Temperature"
+msgstr "Сбросить пиковое значение температуры"
+
 #: applet.js:62
 msgid "Clear Cache"
 msgstr "Очистить кэш"
@@ -34,6 +38,14 @@ msgstr "Очистить кэш"
 #: applet.js:156
 msgid "CPUs"
 msgstr "ЦП"
+
+#: applet.js:161
+msgid "°C max; "
+msgstr "°C макс.; "
+
+#: applet.js:161
+msgid "°C peak"
+msgstr "°C пик"
 
 #: applet.js:159
 msgid "Memory"

--- a/ssm@Severga/files/ssm@Severga/po/ssm@Severga.pot
+++ b/ssm@Severga/files/ssm@Severga/po/ssm@Severga.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-08 19:56+0300\n"
+"POT-Creation-Date: 2023-12-02 12:12+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,95 +17,107 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:33 applet.js:59
+#: applet.js:32 applet.js:58
 msgid "Required GTop package missing!"
 msgstr ""
 
-#: applet.js:57
+#: applet.js:56
 msgid "Error!"
 msgstr ""
 
-#: applet.js:62
+#: applet.js:61
+msgid "Reset Peak Temperature"
+msgstr ""
+
+#: applet.js:64
 msgid "Clear Cache"
 msgstr ""
 
-#: applet.js:156
+#: applet.js:161
 msgid "CPUs"
 msgstr ""
 
-#: applet.js:159
+#: applet.js:161
+msgid "°C max; "
+msgstr ""
+
+#: applet.js:161
+msgid "°C peak"
+msgstr ""
+
+#: applet.js:164
 msgid "Memory"
 msgstr ""
 
-#: applet.js:159
+#: applet.js:164
 msgid "GB"
 msgstr ""
 
-#: applet.js:159
+#: applet.js:164
 msgid "GB swap"
 msgstr ""
 
-#: applet.js:162
+#: applet.js:167
 msgid "Network"
 msgstr ""
 
-#: applet.js:316
+#: applet.js:321
 msgid "Core "
 msgstr ""
 
-#: applet.js:361
+#: applet.js:366
 msgid "Used:   "
 msgstr ""
 
-#: applet.js:362
+#: applet.js:367
 msgid "Cache:  "
 msgstr ""
 
-#: applet.js:363
+#: applet.js:368
 msgid "Buffer: "
 msgstr ""
 
-#: applet.js:367
+#: applet.js:372
 msgid "Swap:   "
 msgstr ""
 
-#: applet.js:437
+#: applet.js:442
 msgid "Up:      "
 msgstr ""
 
-#: applet.js:437 applet.js:438
+#: applet.js:442 applet.js:443
 msgid "B/s"
 msgstr ""
 
-#: applet.js:438
+#: applet.js:443
 msgid "Down:    "
 msgstr ""
 
-#: applet.js:439
+#: applet.js:444
 msgid "Data:    "
 msgstr ""
 
-#: applet.js:439
+#: applet.js:444
 msgid "B"
 msgstr ""
 
-#: applet.js:443
+#: applet.js:448
 msgid "no interfaces to show"
 msgstr ""
 
-#: applet.js:448
+#: applet.js:453
 msgid "k"
 msgstr ""
 
-#: applet.js:448
+#: applet.js:453
 msgid "M"
 msgstr ""
 
-#: applet.js:448
+#: applet.js:453
 msgid "G"
 msgstr ""
 
-#: applet.js:448
+#: applet.js:453
 msgid "T"
 msgstr ""
 


### PR DESCRIPTION
This addition is useful for those who want to know the peak temperature that has happened while their absence or using a full-screen application (game). Your applet's tooltip will show the peak temperature that has happened after (re)loading the applet or resetting the peak temperature (in the applet's context menu).