### PR TITLE
[MonitorInputSource@klangman] Reset exitcode after menu update

### DIFF
--- a/MonitorInputSource@klangman/files/MonitorInputSource@klangman/applet.js
+++ b/MonitorInputSource@klangman/files/MonitorInputSource@klangman/applet.js
@@ -330,6 +330,7 @@ class InputSourceApp extends Applet.IconApplet {
             item.actor.set_reactive(false);
             this.menu.addMenuItem(item,0);
          }
+         this.exitCode = 0;
       } else {
          let pos = 0;
          for (let i=0 ; i<this.displays.length ; i++) {


### PR DESCRIPTION
Once the exitcode has been processed and the menu has been updated to show an error, reset the exitcode so that a refresh has a chance to succeed and populate the menu with new monitor input entries.