### PR TITLE
[CassiaWindowList@klangman] Add option show windows from all workspaces

### DIFF
--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
@@ -47,7 +47,7 @@
     "general-settings" : {
       "type" : "section",
       "title" : "General window list settings",
-      "keys" : ["group-windows", "display-pinned", "synchronize-pinned", "trailing-pinned-behaviour", "show-windows-for-current-monitor", "show-tooltips", "hide-panel-apps"]
+      "keys" : ["group-windows", "display-pinned", "synchronize-pinned", "trailing-pinned-behaviour", "show-windows-for-current-monitor", "show-windows-for-all-workspaces", "show-tooltips", "hide-panel-apps"]
     },
     "general-mouse" : {
       "type" : "section",
@@ -225,6 +225,11 @@
     "default": false,
     "description": "Only show windows on the same monitor",
     "tooltip": "If enabled, this applet instance only manages windows\nthat are displayed on the same monitor"
+  },
+  "show-windows-for-all-workspaces": {
+    "type": "switch",
+    "default": false,
+    "description": "Include windows from all workspaces"
   },
   "show-tooltips": {
     "type": "switch",

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-18 10:25-0500\n"
+"POT-Creation-Date: 2023-12-03 13:17-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,29 +17,29 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: 4.0/applet.js:1330 4.0/applet.js:2515 4.0/applet.js:3992 4.0/applet.js:4060
-#: 4.0/applet.js:4083 4.0/applet.js:4172
+#: 4.0/applet.js:1326 4.0/applet.js:2518 4.0/applet.js:4013 4.0/applet.js:4081
+#: 4.0/applet.js:4104 4.0/applet.js:4193
 msgid "all buttons"
 msgstr ""
 
-#: 4.0/applet.js:2247
+#: 4.0/applet.js:2250
 msgid "Applet Preferences"
 msgstr ""
 
-#: 4.0/applet.js:2251
+#: 4.0/applet.js:2254
 msgid "About..."
 msgstr ""
 
-#: 4.0/applet.js:2255
+#: 4.0/applet.js:2258
 msgid "Configure..."
 msgstr ""
 
-#: 4.0/applet.js:2259
+#: 4.0/applet.js:2262
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
 
-#: 4.0/applet.js:2261
+#: 4.0/applet.js:2264
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 
@@ -49,107 +49,107 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2270
+#: 4.0/applet.js:2273
 msgid "Open new window"
 msgstr ""
 
-#: 4.0/applet.js:2278
+#: 4.0/applet.js:2281
 msgid "Remove from panel"
 msgstr ""
 
-#: 4.0/applet.js:2280
+#: 4.0/applet.js:2283
 msgid "Remove from this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2286
+#: 4.0/applet.js:2289
 msgid "Pin to panel"
 msgstr ""
 
-#: 4.0/applet.js:2288
+#: 4.0/applet.js:2291
 msgid "Pin to this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2329
+#: 4.0/applet.js:2332
 msgid "Pin to other workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2350
+#: 4.0/applet.js:2353
 msgid "Pin to all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2368
+#: 4.0/applet.js:2371
 msgid "Pin to launcher"
 msgstr ""
 
-#: 4.0/applet.js:2386 4.0/applet.js:2569
+#: 4.0/applet.js:2389 4.0/applet.js:2572
 msgid "Add new Hotkey for"
 msgstr ""
 
-#: 4.0/applet.js:2400
+#: 4.0/applet.js:2403
 msgid "Recent files"
 msgstr ""
 
-#: 4.0/applet.js:2424
+#: 4.0/applet.js:2427
 msgid "Places"
 msgstr ""
 
-#: 4.0/applet.js:2466
+#: 4.0/applet.js:2469
 msgid "Only on this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2468
+#: 4.0/applet.js:2471
 msgid "Visible on all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2469
+#: 4.0/applet.js:2472
 msgid "Move to another workspace"
 msgstr ""
 
-#: 4.0/applet.js:2488
+#: 4.0/applet.js:2491
 msgid "Move to another monitor"
 msgstr ""
 
-#: 4.0/applet.js:2496
+#: 4.0/applet.js:2499
 msgid "Monitor"
 msgstr ""
 
-#: 4.0/applet.js:2524
+#: 4.0/applet.js:2527
 msgid "unassigned"
 msgstr ""
 
-#: 4.0/applet.js:2535 4.0/applet.js:2566
+#: 4.0/applet.js:2538 4.0/applet.js:2569
 msgid "Assign window to a hotkey"
 msgstr ""
 
-#: 4.0/applet.js:2589
+#: 4.0/applet.js:2592
 msgid "Change application label contents"
 msgstr ""
 
-#: 4.0/applet.js:2592
+#: 4.0/applet.js:2595
 msgid "Remove custom setting"
 msgstr ""
 
-#: 4.0/applet.js:2599
+#: 4.0/applet.js:2602
 msgid "Use window title"
 msgstr ""
 
-#: 4.0/applet.js:2606
+#: 4.0/applet.js:2609
 msgid "Use application name"
 msgstr ""
 
-#: 4.0/applet.js:2613
+#: 4.0/applet.js:2616
 msgid "No label"
 msgstr ""
 
-#: 4.0/applet.js:2624
+#: 4.0/applet.js:2627
 msgid "Ungroup application windows"
 msgstr ""
 
-#: 4.0/applet.js:2633
+#: 4.0/applet.js:2636
 msgid "Group application windows"
 msgstr ""
 
-#: 4.0/applet.js:2646
+#: 4.0/applet.js:2649
 msgid "Automatic grouping/ungrouping"
 msgstr ""
 
@@ -159,31 +159,31 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2676
+#: 4.0/applet.js:2679
 msgid "Move titlebar on to screen"
 msgstr ""
 
-#: 4.0/applet.js:2681
+#: 4.0/applet.js:2684
 msgid "Restore"
 msgstr ""
 
-#: 4.0/applet.js:2685
+#: 4.0/applet.js:2688
 msgid "Minimize"
 msgstr ""
 
-#: 4.0/applet.js:2691
+#: 4.0/applet.js:2694
 msgid "Unmaximize"
 msgstr ""
 
-#: 4.0/applet.js:2698
+#: 4.0/applet.js:2701
 msgid "Close others"
 msgstr ""
 
-#: 4.0/applet.js:2709
+#: 4.0/applet.js:2712
 msgid "Close all"
 msgstr ""
 
-#: 4.0/applet.js:2718
+#: 4.0/applet.js:2721
 msgid "Close"
 msgstr ""
 
@@ -507,6 +507,10 @@ msgstr ""
 msgid ""
 "If enabled, this applet instance only manages windows\n"
 "that are displayed on the same monitor"
+msgstr ""
+
+#. 4.0->settings-schema.json->show-windows-for-all-workspaces->description
+msgid "Include windows from all workspaces"
 msgstr ""
 
 #. 4.0->settings-schema.json->show-tooltips->description


### PR DESCRIPTION
1. Added an option (General:Include windows from all workspaces) that will show windows from other workspaces on the current window list. Clicking on a window from another workspace will cause the current workspace to switch to that windows workspace. Rearranging the windows on one workspace will not affect the window arrangement on other workspaces window lists.

2. Window-list tooltips will now have bold window title text and smaller hotkey text to emphasize the window title and deemphasize the hotkey text.

3. Don't include transient windows in the window Thumbnails.This matches how the standard grouped-window-list handles thumbnail windows.

4. Fix focus tracking for windows with child transient windows that get the focus after its parent window had the focus.

5. Use Main.activateWindow() on window-list left clicks to match the transient window activation behaviour of other parts of cinnamon (i.e. Alt-TAB and the default window list applet)