### PR TITLE
Reloading Cinnamon Menu to get correct dimentions

### DIFF
--- a/rswitcher@nixdev.com/files/rswitcher@nixdev.com/rswitcher
+++ b/rswitcher@nixdev.com/files/rswitcher@nixdev.com/rswitcher
@@ -129,3 +129,6 @@ fi
 
 # Run the xrandr function to create the new settings.
 create_resolution
+
+# Reload start menu to get correct dimentions
+dbus-send --session --dest=org.Cinnamon.LookingGlass --type=method_call /org/Cinnamon/LookingGlass org.Cinnamon.LookingGlass.ReloadExtension string:'menu@cinnamon.org' string:'APPLET'


### PR DESCRIPTION
Added a reload of the Cinnamon menu applet after we change the resolution / scaling. 
This is so we get the correct scaling of the menu.