### PR TITLE
[CassiaWindowList@klangman] Fix "All Buttons" hotkey with translations

### DIFF
--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/applet.js
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/applet.js
@@ -503,6 +503,17 @@ function getFirstLauncherApp() {
    return null;
 }
 
+// Is the passed in string equal to "all buttons" disregarding case and accepting English or a
+// translation. Since the default hotkey entry using "All Buttons" is not translatable, the hotkey
+// will still be English even when using a translation, so we should accept English or a translation.
+// Also ensures that the key sequence uses the "1" key as required by the "All Buttons" syntax.
+function isAllButtons(hotkey) {
+   let lower = hotkey.description.toLowerCase();
+   if ((lower == "all buttons" || lower ==  _("all buttons")) && hotkey.keyCombo.indexOf(">1")!=-1)
+      return true;
+   return false;
+}
+
 // Represents an item in the Thumbnail popup menu
 class ThumbnailMenuItem extends PopupMenu.PopupBaseMenuItem {
 
@@ -1383,7 +1394,7 @@ class WindowListButton {
                 let end = keyString.slice(keyString.lastIndexOf("+"))
                 text = text + "\n" + keyString.slice(0,keyString.lastIndexOf("+")) + end.toUpperCase();
              }
-          } else if (hotKeys[i].description.toLowerCase() == _("all buttons") ) {
+          } else if (isAllButtons(hotKeys[i])) {
              let childern = this._workspace.actor.get_children();
              let idx = childern.indexOf(this.actor);
              if (idx >= 0 && idx < 9) {
@@ -2627,7 +2638,7 @@ class WindowListButton {
       let hotKeys = this._applet._keyBindings;
       item = null;
       for (let i=0 ; i < hotKeys.length ; i++) {
-         if (hotKeys[i].enabled===true && hotKeys[i].description.endsWith(".desktop")!==true && hotKeys[i].description.toLowerCase() !== _("all buttons")) {
+         if (hotKeys[i].enabled===true && hotKeys[i].description.endsWith(".desktop")!==true && isAllButtons(hotKeys[i])!==true) {
             let idx = i;
             let keyString;
             if (hotKeys[i].keyCombo!==null) {
@@ -4138,7 +4149,7 @@ class WindowList extends Applet.Applet {
         } else {
            Main.activateWindow(workspace._keyBindingsWindows[idx]);
         }
-     } else if (this._keyBindings[idx].description.toLowerCase() ==  _("all buttons")) {
+     } else if (isAllButtons(this._keyBindings[idx])) {
         seqNum--;
         let numChildern = workspace.actor.get_n_children();
         if (seqNum < numChildern) {
@@ -4206,7 +4217,7 @@ class WindowList extends Applet.Applet {
         if (oldBindings.length > i) {
            [seqCombo,secondCombo] = getSmartNumericHotkey(oldBindings[i].keyCombo);
            if (oldBindings[i].enabled && (!keyBindings[i].enabled || keyBindings[i].keyCombo != oldBindings[i].keyCombo || (seqCombo && oldKeySequence != keySequence))) {
-              if (seqCombo && (oldKeySequence || oldBindings[i].description.toLowerCase() == _("all buttons"))) {
+              if (seqCombo && (oldKeySequence || isAllButtons(oldBindings[i]))) {
                  //log( `removing smart numeric hotkeys for ${oldBindings[i].description}` );
                  for( let num=1 ; num < 10 ; num++ ) {
                     Main.keybindingManager.removeHotKey("CassiaWL-" + i + "-" + num + this.instanceId);
@@ -4229,7 +4240,7 @@ class WindowList extends Applet.Applet {
         if (keyBindings[i].enabled && (oldBindings.length <= i || !oldBindings[i].enabled || keyBindings[i].keyCombo != oldBindings[i].keyCombo || (seqCombo && oldKeySequence != keySequence))) {
            let idx = i;
            // Register smart numeric hotkeys if applicable
-           if (seqCombo && (keySequence || keyBindings[i].description.toLowerCase() == _("all buttons"))) {
+           if (seqCombo && (keySequence || isAllButtons(keyBindings[i]))) {
               //log( `Registering smart numeric hotkeys for ${keyBindings[i].description}  i.e. ${seqCombo+1}` );
               for( let num=1 ; num < 10 ; num++ ) {
                  Main.keybindingManager.addHotKey("CassiaWL-" + i + "-" + num + this.instanceId, seqCombo+num, Lang.bind(this, function() {this._performHotkey(idx, num)} ));
@@ -4318,7 +4329,7 @@ class WindowList extends Applet.Applet {
            let first = keyCombo.slice(0,colons);
            let second = keyCombo.slice(colons+2)
            if (first.startsWith(modifiers) || second.startsWith(modifiers)) {
-              if (keyBindings[i].description.toLowerCase() == _("all buttons") && keyBindings[i].keyCombo.indexOf(modifiers+"1")!=-1) {
+              if (isAllButtons(keyBindings[i])) {
                  let children = workspace.actor.get_children();
                  for( let idx=0 ; idx < children.length && idx < 9 ; idx++ ){
                     children[idx]._delegate._updateNumberForHotkeyHelp((idx+1).toString());

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-12 10:09-0500\n"
+"POT-Creation-Date: 2023-12-17 23:49-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,29 +17,28 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: 4.0/applet.js:1386 4.0/applet.js:2630 4.0/applet.js:4141 4.0/applet.js:4209
-#: 4.0/applet.js:4232 4.0/applet.js:4321
+#: 4.0/applet.js:512
 msgid "all buttons"
 msgstr ""
 
-#: 4.0/applet.js:2359
+#: 4.0/applet.js:2370
 msgid "Applet Preferences"
 msgstr ""
 
-#: 4.0/applet.js:2363
+#: 4.0/applet.js:2374
 msgid "About..."
 msgstr ""
 
-#: 4.0/applet.js:2367
+#: 4.0/applet.js:2378
 msgid "Configure..."
 msgstr ""
 
-#: 4.0/applet.js:2371
+#: 4.0/applet.js:2382
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
 
-#: 4.0/applet.js:2373
+#: 4.0/applet.js:2384
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 
@@ -49,111 +48,111 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2382
+#: 4.0/applet.js:2393
 msgid "Open new window"
 msgstr ""
 
-#: 4.0/applet.js:2390
+#: 4.0/applet.js:2401
 msgid "Remove from panel"
 msgstr ""
 
-#: 4.0/applet.js:2392
+#: 4.0/applet.js:2403
 msgid "Remove from this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2398
+#: 4.0/applet.js:2409
 msgid "Pin to panel"
 msgstr ""
 
-#: 4.0/applet.js:2400
+#: 4.0/applet.js:2411
 msgid "Pin to this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2441
+#: 4.0/applet.js:2452
 msgid "Pin to other workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2462
+#: 4.0/applet.js:2473
 msgid "Pin to all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2480
+#: 4.0/applet.js:2491
 msgid "Pin to launcher"
 msgstr ""
 
-#: 4.0/applet.js:2498 4.0/applet.js:2684
+#: 4.0/applet.js:2509 4.0/applet.js:2695
 msgid "Add new Hotkey for"
 msgstr ""
 
-#: 4.0/applet.js:2512
+#: 4.0/applet.js:2523
 msgid "Recent files"
 msgstr ""
 
-#: 4.0/applet.js:2536
+#: 4.0/applet.js:2547
 msgid "Places"
 msgstr ""
 
-#: 4.0/applet.js:2578
+#: 4.0/applet.js:2589
 msgid "Only on this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2580
+#: 4.0/applet.js:2591
 msgid "Visible on all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2581
+#: 4.0/applet.js:2592
 msgid "Move to another workspace"
 msgstr ""
 
-#: 4.0/applet.js:2590
+#: 4.0/applet.js:2601
 msgid " (this workspace)"
 msgstr ""
 
-#: 4.0/applet.js:2603
+#: 4.0/applet.js:2614
 msgid "Move to another monitor"
 msgstr ""
 
-#: 4.0/applet.js:2611
+#: 4.0/applet.js:2622
 msgid "Monitor"
 msgstr ""
 
-#: 4.0/applet.js:2639
+#: 4.0/applet.js:2650
 msgid "unassigned"
 msgstr ""
 
-#: 4.0/applet.js:2650 4.0/applet.js:2681
+#: 4.0/applet.js:2661 4.0/applet.js:2692
 msgid "Assign window to a hotkey"
 msgstr ""
 
-#: 4.0/applet.js:2704
+#: 4.0/applet.js:2715
 msgid "Change application label contents"
 msgstr ""
 
-#: 4.0/applet.js:2707
+#: 4.0/applet.js:2718
 msgid "Remove custom setting"
 msgstr ""
 
-#: 4.0/applet.js:2714
+#: 4.0/applet.js:2725
 msgid "Use window title"
 msgstr ""
 
-#: 4.0/applet.js:2721
+#: 4.0/applet.js:2732
 msgid "Use application name"
 msgstr ""
 
-#: 4.0/applet.js:2728
+#: 4.0/applet.js:2739
 msgid "No label"
 msgstr ""
 
-#: 4.0/applet.js:2739
+#: 4.0/applet.js:2750
 msgid "Ungroup application windows"
 msgstr ""
 
-#: 4.0/applet.js:2748
+#: 4.0/applet.js:2759
 msgid "Group application windows"
 msgstr ""
 
-#: 4.0/applet.js:2761
+#: 4.0/applet.js:2772
 msgid "Automatic grouping/ungrouping"
 msgstr ""
 
@@ -163,31 +162,31 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2791
+#: 4.0/applet.js:2802
 msgid "Move titlebar on to screen"
 msgstr ""
 
-#: 4.0/applet.js:2796
+#: 4.0/applet.js:2807
 msgid "Restore"
 msgstr ""
 
-#: 4.0/applet.js:2800
+#: 4.0/applet.js:2811
 msgid "Minimize"
 msgstr ""
 
-#: 4.0/applet.js:2806
+#: 4.0/applet.js:2817
 msgid "Unmaximize"
 msgstr ""
 
-#: 4.0/applet.js:2813
+#: 4.0/applet.js:2824
 msgid "Close others"
 msgstr ""
 
-#: 4.0/applet.js:2824
+#: 4.0/applet.js:2835
 msgid "Close all"
 msgstr ""
 
-#: 4.0/applet.js:2833
+#: 4.0/applet.js:2844
 msgid "Close"
 msgstr ""
 


### PR DESCRIPTION
The "All Buttons" default hotkey entry uses an English "All Buttons" which can't be translated but the hard-coded "all buttons" string in the code is translated and therefore the default "All Buttons" entry would not work unless the description string was changed to a translation of "All Buttons". This fix allows both English and a translation to work.