### PR TITLE
download-and-upload-speed@cardsurf: Made some small fixes

### DIFF
--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/appletGui.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/appletGui.js
@@ -74,12 +74,12 @@ IconLabel.prototype = {
             let text = this.label.get_text();
             let fixed_width = this.label.get_width();
 
-            if (text) {
-                this.set_label_text(text);
-            }
-
             if (fixed_width) {
                 this.set_label_width(fixed_width);
+            }
+
+            if (text) {
+                this.set_label_text(text);
             }
 
             return false;

--- a/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/appletGui.js
+++ b/download-and-upload-speed@cardsurf/files/download-and-upload-speed@cardsurf/appletGui.js
@@ -68,14 +68,18 @@ IconLabel.prototype = {
 
     set_label_fixed_width: function(fixed_width_text) {
         Mainloop.timeout_add(1, Lang.bind(this, function() {
+            this.set_label_to_preferred_width();
+            this.set_label_text(fixed_width_text);
+
             let text = this.label.get_text();
+            let fixed_width = this.label.get_width();
 
             if (text) {
-                this.set_label_to_preferred_width();
-                this.set_label_text(fixed_width_text);
-                let fixed_width = this.label.get_width();
-                this.set_label_width(fixed_width);
                 this.set_label_text(text);
+            }
+
+            if (fixed_width) {
+                this.set_label_width(fixed_width);
             }
 
             return false;
@@ -231,10 +235,10 @@ GuiSpeed.prototype = {
     _get_fixed_width_text: function() {
         let text = "";
         if(this.decimal_places == AppletConstants.DecimalPlaces.AUTO) {
-            text = "99.9MB";
+            text = " 99.9MB";
         }
         else {
-            text = "999." + this.repeat_string("9", this.decimal_places) + "MB";
+            text = " 999." + this.repeat_string("9", this.decimal_places) + "MB";
         }
         return text;
     },


### PR DESCRIPTION
Don't set the values for only the **text** or the **fixed_width** values if each is null or undefined. Also added a space to the fixed width string to give a small margin between the text and the icon, this was making the bytes not being shown correctly because they were too close to the icon.

cc @cardsurf