### PR TITLE
[qredshift@quintao] v1.7.6 - Adds option 'Activate as soon as Cinnamon starts up'

### DIFF
--- a/qredshift@quintao/files/qredshift@quintao/applet.js
+++ b/qredshift@quintao/files/qredshift@quintao/applet.js
@@ -80,6 +80,7 @@ class QRedshift extends Applet.TextIconApplet {
         this.opt = {
             redshift_version: 0,
             enabled: true,
+            enableAtStartup: false,
             autoUpdate: false,
             autoUpdateInterval: 20,
             smoothTransition: true,
@@ -140,6 +141,7 @@ class QRedshift extends Applet.TextIconApplet {
         };
         
         this.settings.bind('enabled', 'enabled', this.onSettChange.bind(this));
+        this.settings.bind("enableAtStartup", "enableAtStartup");
         this.settings.bind('autoUpdate', 'autoUpdate', this.onSettChange.bind(this));
         this.settings.bind('autoUpdateInterval', 'autoUpdateInterval', this.onSettChange.bind(this));
         this.settings.bind('adjustmentMethod', 'adjustmentMethod', this.onSettChange.bind(this));
@@ -823,6 +825,8 @@ class QRedshift extends Applet.TextIconApplet {
     
     on_applet_added_to_panel() {
         qLOG('QRedshift', 'ADDED TO PANEL');
+        if (this.opt.enableAtStartup === true)
+            this.opt.enabled = true;
     }
     
     

--- a/qredshift@quintao/files/qredshift@quintao/metadata.json
+++ b/qredshift@quintao/files/qredshift@quintao/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "qredshift@quintao",
   "name": "QRedshift",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "It makes the color of your computer's display adapt to the time of day, warm at night and like sunlight during the day.",
   "multiversion": true,
   "max-instances": 1,

--- a/qredshift@quintao/files/qredshift@quintao/po/es.po
+++ b/qredshift@quintao/files/qredshift@quintao/po/es.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-16 04:01+0200\n"
-"PO-Revision-Date: 2023-11-20 17:09-0300\n"
+"POT-Creation-Date: 2024-01-01 03:02+0100\n"
+"PO-Revision-Date: 2023-12-31 23:17-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -18,111 +18,111 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4\n"
 
-#: applet.js:236
+#: applet.js:238
 msgid "Reload Applet"
 msgstr "Recargar Applet"
 
-#: applet.js:247
+#: applet.js:249
 msgid "Recompile Translations"
 msgstr "Recompilar traducciones"
 
-#: applet.js:299
+#: applet.js:301
 msgid "REDSHIFT NOT INSTALLED!"
 msgstr "¡REDHISFT NO ESTÁ INSTALADO!"
 
-#: applet.js:302
+#: applet.js:304
 msgid "Requires Redshift: yay -S redshift-minimal"
 msgstr "Requiere Redshift: yay -S redshift-minimal"
 
-#: applet.js:305
+#: applet.js:307
 msgid "Requires Redshift: sudo apt-get install redshift"
 msgstr "Requiere Redshift: sudo apt-get install redshift"
 
-#: applet.js:457 applet.js:486
+#: applet.js:459 applet.js:488
 msgid "should be removed."
 msgstr "debe ser eliminado."
 
-#: applet.js:479
+#: applet.js:481
 msgid "should be replaced by redshift-minimal"
 msgstr "debe sustituirse por redshift-minimal"
 
 #. settings-schema.json->enabled->description
-#: applet.js:649
+#: applet.js:651
 msgid "Enabled"
 msgstr "Habilitado"
 
-#: applet.js:657 applet.js:702
+#: applet.js:659 applet.js:704
 msgid "Temp:"
 msgstr "Temperatura:"
 
-#: applet.js:668 applet.js:713
+#: applet.js:670 applet.js:715
 msgid "Bright:"
 msgstr "Brillo:"
 
-#: applet.js:679 applet.js:1011
+#: applet.js:681 applet.js:1015
 msgid "Gamma:"
 msgstr "Gamma:"
 
 #. settings-schema.json->enabledNight->description
-#: applet.js:694
+#: applet.js:696
 msgid "Night Enabled"
 msgstr "Modo nocturno habilitado"
 
 #. settings-schema.json->iconLabel->description
-#: applet.js:756
+#: applet.js:758
 msgid "Show Label"
 msgstr "Mostrar etiqueta"
 
-#: applet.js:969 applet.js:994
+#: applet.js:973 applet.js:998
 msgid "Transition to day"
 msgstr "Transición al día"
 
-#: applet.js:970 applet.js:995
+#: applet.js:974 applet.js:999
 msgid "Transition to night"
 msgstr "Transición a la noche"
 
-#: applet.js:971 applet.js:996
+#: applet.js:975 applet.js:1000
 msgid "Night"
 msgstr "Noche"
 
-#: applet.js:972 applet.js:997
+#: applet.js:976 applet.js:1001
 msgid "Day"
 msgstr "Día"
 
-#: applet.js:986
+#: applet.js:990
 msgid "On"
 msgstr "Ecendido"
 
-#: applet.js:986 applet.js:988
+#: applet.js:990 applet.js:992
 msgid "Off"
 msgstr "Apagado"
 
-#: applet.js:1002
+#: applet.js:1006
 msgid "Day Temperature"
 msgstr "Temperatura diurna"
 
-#: applet.js:1003
+#: applet.js:1007
 msgid "Day Brightness"
 msgstr "Brillo diurno"
 
-#: applet.js:1005
+#: applet.js:1009
 msgid "Night Temperature"
 msgstr "Temperatura nocturna"
 
-#: applet.js:1006
+#: applet.js:1010
 msgid "Night Brightness"
 msgstr "Brillo nocturno"
 
 #. settings-schema.json->labelScrollAction->options
 #. settings-schema.json->dayTemp->description
 #. settings-schema.json->nightTemp->description
-#: applet.js:1008
+#: applet.js:1012
 msgid "Temperature"
 msgstr "Temperatura"
 
 #. settings-schema.json->dayBrightness->description
 #. settings-schema.json->nightBrightness->description
-#: applet.js:1009
+#: applet.js:1013
 msgid "Brightness"
 msgstr "Brillo"
 
@@ -173,6 +173,14 @@ msgstr "Atajos del teclado"
 #. settings-schema.json->location-section->title
 msgid "Location Settings"
 msgstr "Configuración de ubicación"
+
+#. settings-schema.json->enableAtStartup->description
+msgid "Activate QRedshift as soon as Cinnamon starts up"
+msgstr "Activar QRedshift en cuanto se inicie Cinnamon"
+
+#. settings-schema.json->enableAtStartup->tooltip
+msgid "(even if it has previously been deactivated)"
+msgstr "(aunque se haya desactivado previamente)"
 
 #. settings-schema.json->autoUpdate->description
 msgid "Auto Update"

--- a/qredshift@quintao/files/qredshift@quintao/po/fr.po
+++ b/qredshift@quintao/files/qredshift@quintao/po/fr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: qredshift@quintao\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-16 04:01+0200\n"
-"PO-Revision-Date: 2023-07-16 04:03+0200\n"
+"POT-Creation-Date: 2024-01-01 03:02+0100\n"
+"PO-Revision-Date: 2024-01-01 03:04+0100\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -18,111 +18,111 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:236
+#: applet.js:238
 msgid "Reload Applet"
 msgstr "Relancer cette applet"
 
-#: applet.js:247
+#: applet.js:249
 msgid "Recompile Translations"
 msgstr "Recompiler les traductions"
 
-#: applet.js:299
+#: applet.js:301
 msgid "REDSHIFT NOT INSTALLED!"
 msgstr "REDSHIFT N'EST PAS INSTALLÉ !"
 
-#: applet.js:302
+#: applet.js:304
 msgid "Requires Redshift: yay -S redshift-minimal"
 msgstr "Nécessite l'installation de Redshift : yay -S redshift-minimal"
 
-#: applet.js:305
+#: applet.js:307
 msgid "Requires Redshift: sudo apt-get install redshift"
 msgstr "Nécessite l'installation de Redshift : sudo apt-get install redshift"
 
-#: applet.js:457 applet.js:486
+#: applet.js:459 applet.js:488
 msgid "should be removed."
 msgstr "devrait être retiré."
 
-#: applet.js:479
+#: applet.js:481
 msgid "should be replaced by redshift-minimal"
 msgstr "doit être remplacé par redshift-minimal"
 
 #. settings-schema.json->enabled->description
-#: applet.js:649
+#: applet.js:651
 msgid "Enabled"
 msgstr "Activé"
 
-#: applet.js:657 applet.js:702
+#: applet.js:659 applet.js:704
 msgid "Temp:"
 msgstr "Temp. :"
 
-#: applet.js:668 applet.js:713
+#: applet.js:670 applet.js:715
 msgid "Bright:"
 msgstr "Brill. :"
 
-#: applet.js:679 applet.js:1011
+#: applet.js:681 applet.js:1015
 msgid "Gamma:"
 msgstr "Gamma :"
 
 #. settings-schema.json->enabledNight->description
-#: applet.js:694
+#: applet.js:696
 msgid "Night Enabled"
 msgstr "Activer les paramètres de nuit"
 
 #. settings-schema.json->iconLabel->description
-#: applet.js:756
+#: applet.js:758
 msgid "Show Label"
 msgstr "Afficher l'étiquette de cette applet"
 
-#: applet.js:969 applet.js:994
+#: applet.js:973 applet.js:998
 msgid "Transition to day"
 msgstr "Transition vers le jour"
 
-#: applet.js:970 applet.js:995
+#: applet.js:974 applet.js:999
 msgid "Transition to night"
 msgstr "Transition vers la nuit"
 
-#: applet.js:971 applet.js:996
+#: applet.js:975 applet.js:1000
 msgid "Night"
 msgstr "Nuit"
 
-#: applet.js:972 applet.js:997
+#: applet.js:976 applet.js:1001
 msgid "Day"
 msgstr "Jour"
 
-#: applet.js:986
+#: applet.js:990
 msgid "On"
 msgstr "Activé"
 
-#: applet.js:986 applet.js:988
+#: applet.js:990 applet.js:992
 msgid "Off"
 msgstr "Désactivé"
 
-#: applet.js:1002
+#: applet.js:1006
 msgid "Day Temperature"
 msgstr "Température de jour"
 
-#: applet.js:1003
+#: applet.js:1007
 msgid "Day Brightness"
 msgstr "Brillance de jour"
 
-#: applet.js:1005
+#: applet.js:1009
 msgid "Night Temperature"
 msgstr "Température de nuit"
 
-#: applet.js:1006
+#: applet.js:1010
 msgid "Night Brightness"
 msgstr "Brillance de nuit"
 
 #. settings-schema.json->labelScrollAction->options
 #. settings-schema.json->dayTemp->description
 #. settings-schema.json->nightTemp->description
-#: applet.js:1008
+#: applet.js:1012
 msgid "Temperature"
 msgstr "Température"
 
 #. settings-schema.json->dayBrightness->description
 #. settings-schema.json->nightBrightness->description
-#: applet.js:1009
+#: applet.js:1013
 msgid "Brightness"
 msgstr "Brillance"
 
@@ -174,6 +174,14 @@ msgstr "Raccourcis clavier"
 #. settings-schema.json->location-section->title
 msgid "Location Settings"
 msgstr "Paramètres de lieu"
+
+#. settings-schema.json->enableAtStartup->description
+msgid "Activate QRedshift as soon as Cinnamon starts up"
+msgstr "Activer QRedshift au démarrage de Cinnamon"
+
+#. settings-schema.json->enableAtStartup->tooltip
+msgid "(even if it has previously been deactivated)"
+msgstr "(même s'il a été précédemment désactivé)"
 
 #. settings-schema.json->autoUpdate->description
 msgid "Auto Update"

--- a/qredshift@quintao/files/qredshift@quintao/po/qredshift@quintao.pot
+++ b/qredshift@quintao/files/qredshift@quintao/po/qredshift@quintao.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-16 04:01+0200\n"
+"POT-Creation-Date: 2024-01-01 03:02+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,111 +17,111 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:236
+#: applet.js:238
 msgid "Reload Applet"
 msgstr ""
 
-#: applet.js:247
+#: applet.js:249
 msgid "Recompile Translations"
 msgstr ""
 
-#: applet.js:299
+#: applet.js:301
 msgid "REDSHIFT NOT INSTALLED!"
 msgstr ""
 
-#: applet.js:302
+#: applet.js:304
 msgid "Requires Redshift: yay -S redshift-minimal"
 msgstr ""
 
-#: applet.js:305
+#: applet.js:307
 msgid "Requires Redshift: sudo apt-get install redshift"
 msgstr ""
 
-#: applet.js:457 applet.js:486
+#: applet.js:459 applet.js:488
 msgid "should be removed."
 msgstr ""
 
-#: applet.js:479
+#: applet.js:481
 msgid "should be replaced by redshift-minimal"
 msgstr ""
 
 #. settings-schema.json->enabled->description
-#: applet.js:649
+#: applet.js:651
 msgid "Enabled"
 msgstr ""
 
-#: applet.js:657 applet.js:702
+#: applet.js:659 applet.js:704
 msgid "Temp:"
 msgstr ""
 
-#: applet.js:668 applet.js:713
+#: applet.js:670 applet.js:715
 msgid "Bright:"
 msgstr ""
 
-#: applet.js:679 applet.js:1011
+#: applet.js:681 applet.js:1015
 msgid "Gamma:"
 msgstr ""
 
 #. settings-schema.json->enabledNight->description
-#: applet.js:694
+#: applet.js:696
 msgid "Night Enabled"
 msgstr ""
 
 #. settings-schema.json->iconLabel->description
-#: applet.js:756
+#: applet.js:758
 msgid "Show Label"
 msgstr ""
 
-#: applet.js:969 applet.js:994
+#: applet.js:973 applet.js:998
 msgid "Transition to day"
 msgstr ""
 
-#: applet.js:970 applet.js:995
+#: applet.js:974 applet.js:999
 msgid "Transition to night"
 msgstr ""
 
-#: applet.js:971 applet.js:996
+#: applet.js:975 applet.js:1000
 msgid "Night"
 msgstr ""
 
-#: applet.js:972 applet.js:997
+#: applet.js:976 applet.js:1001
 msgid "Day"
 msgstr ""
 
-#: applet.js:986
+#: applet.js:990
 msgid "On"
 msgstr ""
 
-#: applet.js:986 applet.js:988
+#: applet.js:990 applet.js:992
 msgid "Off"
 msgstr ""
 
-#: applet.js:1002
+#: applet.js:1006
 msgid "Day Temperature"
 msgstr ""
 
-#: applet.js:1003
+#: applet.js:1007
 msgid "Day Brightness"
 msgstr ""
 
-#: applet.js:1005
+#: applet.js:1009
 msgid "Night Temperature"
 msgstr ""
 
-#: applet.js:1006
+#: applet.js:1010
 msgid "Night Brightness"
 msgstr ""
 
 #. settings-schema.json->labelScrollAction->options
 #. settings-schema.json->dayTemp->description
 #. settings-schema.json->nightTemp->description
-#: applet.js:1008
+#: applet.js:1012
 msgid "Temperature"
 msgstr ""
 
 #. settings-schema.json->dayBrightness->description
 #. settings-schema.json->nightBrightness->description
-#: applet.js:1009
+#: applet.js:1013
 msgid "Brightness"
 msgstr ""
 
@@ -169,6 +169,14 @@ msgstr ""
 
 #. settings-schema.json->location-section->title
 msgid "Location Settings"
+msgstr ""
+
+#. settings-schema.json->enableAtStartup->description
+msgid "Activate QRedshift as soon as Cinnamon starts up"
+msgstr ""
+
+#. settings-schema.json->enableAtStartup->tooltip
+msgid "(even if it has previously been deactivated)"
 msgstr ""
 
 #. settings-schema.json->autoUpdate->description

--- a/qredshift@quintao/files/qredshift@quintao/settings-schema.json
+++ b/qredshift@quintao/files/qredshift@quintao/settings-schema.json
@@ -2,7 +2,7 @@
   "layout": {
     "type": "layout",
     "pages": ["panel-options", "panel-location", "panel-shortcuts"],
-    
+
     "panel-options": {
       "type": "page",
       "title": "Settings",
@@ -27,9 +27,9 @@
         "info-section"
       ]
     },
-    
-    
-    
+
+
+
     "info-section": {
       "type": "section",
       "title": "Tips",
@@ -39,12 +39,13 @@
         "textInfo"
       ]
     },
-    
+
     "opt-section": {
       "type": "section",
       "title": "Options",
       "keys": [
         "enabled",
+        "enableAtStartup",
         "autoUpdate",
         "autoUpdateInterval",
         "adjustmentMethod",
@@ -53,7 +54,7 @@
         "symbolicIcon"
       ]
     },
-    
+
     "day-section": {
       "type": "section",
       "title": "Day Settings",
@@ -63,7 +64,7 @@
         "gammaMix"
       ]
     },
-    
+
     "night-section": {
       "type": "section",
       "title": "Night Settings",
@@ -78,7 +79,7 @@
         "nightBrightness"
       ]
     },
-    
+
     "keybind-section": {
       "type": "section",
       "title": "Key Bindings",
@@ -92,7 +93,7 @@
         "keyGammaDown"
       ]
     },
-    
+
     "location-section": {
       "type": "section",
       "title": "Location Settings",
@@ -101,11 +102,17 @@
       ]
     }
   },
-  
+
   "enabled": {
     "type": "checkbox",
     "default": false,
     "description": "Enabled"
+  },
+  "enableAtStartup": {
+    "type": "checkbox",
+    "default": false,
+    "description": "Activate QRedshift as soon as Cinnamon starts up",
+    "tooltip": "(even if it has previously been deactivated)"
   },
   "autoUpdate": {
     "type": "checkbox",
@@ -158,19 +165,19 @@
     "default": false,
     "description": "Use symbolic icon"
   },
-  
+
   "keyToggle": {
     "type": "keybinding",
     "description": "On/Off",
     "default": ""
   },
-  
+
   "keyBrightnessUp": {
     "type": "keybinding",
     "description": "Increase brightness level",
     "default": ""
   },
-  
+
   "keyBrightnessDown": {
     "type": "keybinding",
     "description": "Decrease brightness level",
@@ -182,19 +189,19 @@
     "description": "Increase temperature level",
     "default": ""
   },
-  
+
   "keyTempDown": {
     "type": "keybinding",
     "description": "Decrease temperature level",
     "default": ""
   },
-  
+
   "keyGammaUp": {
     "type": "keybinding",
     "description": "Increase gamma level",
     "default": ""
   },
-  
+
   "keyGammaDown": {
     "type": "keybinding",
     "description": "Decrease gamma level",
@@ -228,7 +235,7 @@
     "step": 0.01,
     "description": "Gamma"
   },
-  
+
   "enabledNight": {
     "type": "checkbox",
     "default": false,
@@ -296,7 +303,7 @@
     "step": 1,
     "description": "Brightness"
   },
-  
+
   "locationRemote": {
     "type": "checkbox",
     "default": true,


### PR DESCRIPTION
@raphaelquintao 
This PR adds an option "Activate QRedshift as soon as Cinnamon starts up".
This way, QRedshift can be activated even if it was previously deactivated.