### PR TITLE
[Sensors@claudiux] v3.3.0 - Fixes #4986

### DIFF
--- a/Sensors@claudiux/files/Sensors@claudiux/CHANGELOG.md
+++ b/Sensors@claudiux/files/Sensors@claudiux/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v3.3.0~20240102
+  * Fixes #4986.
+  * From now on, the monospace font style is only used when size must be preserved.
+
 ### v3.2.1~20240102
   * Toggle menu after selecting Suspend option.
 

--- a/Sensors@claudiux/files/Sensors@claudiux/applet.js
+++ b/Sensors@claudiux/files/Sensors@claudiux/applet.js
@@ -115,8 +115,9 @@ class SensorsApplet extends Applet.TextApplet {
     this._variables();
 
     // Style class name:
+    let _monospace = (this.keep_size) ? "sensors-monospace" : "applet-label";
     let _border_type = (this.remove_border) ? "-noborder" : "";
-    this.actor.set_style_class_name("sensors-label%s".format(_border_type));
+    this.actor.set_style_class_name("%s sensors-label%s".format(_monospace, _border_type));
 
     // Initialize some properties:
     this.isRunning = false;
@@ -667,8 +668,9 @@ class SensorsApplet extends Applet.TextApplet {
     //~ this.check_disktemp_user_readable();
 
     var _appletLabel = "";
+    let _monospace = (this.keep_size) ? "sensors-monospace" : "applet-label";
     let _border_type = (this.remove_border) ? "-noborder" : "";
-    var _actor_style = "sensors-label%s sensors-size%s".format(_border_type, this.char_size);
+    var _actor_style = "%s sensors-label%s sensors-size%s".format(_monospace, _border_type, this.char_size);
 
     let vertical = (this._orientation == St.Side.LEFT || this._orientation == St.Side.RIGHT);
     let sep = (vertical) ? "\n" : this.separator;
@@ -703,9 +705,9 @@ class SensorsApplet extends Applet.TextApplet {
               1.0*t["crit_by_user"] : 1.0*this._get_crit_temp(this.data["temps"][t["sensor"]]);
 
             if (!isNaN(_temp_crit) && _temp_crit > 0 && _temp >= _temp_crit)
-              _actor_style = "sensors-critical%s sensors-size%s".format(_border_type, this.char_size);
+              _actor_style = "%s sensors-critical%s sensors-size%s".format(_monospace, _border_type, this.char_size);
             else if (!isNaN(_temp_max) && _temp_max > 0 && _temp >= _temp_max)
-              _actor_style = "sensors-high%s sensors-size%s".format(_border_type, this.char_size);
+              _actor_style = "%s sensors-high%s sensors-size%s".format(_monospace, _border_type, this.char_size);
 
             nbr_already_shown += 1;
           }
@@ -725,9 +727,9 @@ class SensorsApplet extends Applet.TextApplet {
           let _temp_max = disk["high"];
           let _temp_crit = disk["crit"];
           if (_temp >= _temp_crit)
-            _actor_style = "sensors-critical%s sensors-size%s".format(_border_type, this.char_size);
+            _actor_style = "%s sensors-critical%s sensors-size%s".format(_monospace, _border_type, this.char_size);
           else if (_temp >= _temp_max)
-            _actor_style = "sensors-high%s sensors-size%s".format(_border_type, this.char_size);
+            _actor_style = "%s sensors-high%s sensors-size%s".format(_monospace, _border_type, this.char_size);
 
           _shown_name = "";
           if (this.show_temp_name && !vertical)
@@ -768,7 +770,7 @@ class SensorsApplet extends Applet.TextApplet {
             1.0*f["min_by_user"] : 1.0*this._get_min_fan(this.data["fans"][f["sensor"]]);
 
           if (_fan < _fan_min)
-            _actor_style = "sensors-critical%s sensors-size%s".format(_border_type, this.char_size);
+            _actor_style = "%s sensors-critical%s sensors-size%s".format(_monospace, _border_type, this.char_size);
 
           nbr_already_shown += 1;
         }
@@ -807,7 +809,7 @@ class SensorsApplet extends Applet.TextApplet {
           let _voltage_min = (_min_defined_by_user && _min_defined_by_user.length > 0) ? 1.0*_min_defined_by_user : 1.0*this._get_min_voltage(this.data["voltages"][v["sensor"]]);
 
           if (_voltage >= _voltage_max || _voltage < _voltage_min)
-            _actor_style = "sensors-critical%s sensors-size%s".format(_border_type, this.char_size);
+            _actor_style = "%s sensors-critical%s sensors-size%s".format(_monospace, _border_type, this.char_size);
 
           nbr_already_shown += 1;
         }
@@ -836,7 +838,7 @@ class SensorsApplet extends Applet.TextApplet {
           let _intrusion_alarm = this._get_alarm_intrusion(this.data["intrusions"][i["sensor"]]);
 
           if (_intrusion_alarm)
-            _actor_style = "sensors-critical%s sensors-size%s".format(_border_type, this.char_size);
+            _actor_style = "%s sensors-critical%s sensors-size%s".format(_monospace, _border_type, this.char_size);
 
           nbr_already_shown += 1;
         }

--- a/Sensors@claudiux/files/Sensors@claudiux/metadata.json
+++ b/Sensors@claudiux/files/Sensors@claudiux/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "Sensors@claudiux",
     "name": "Sensors Monitor",
     "description": "Displays the values of many computer sensors concerning Temperatures (CPU - GPU - Power Supply), Fan Speed, Voltages, Intrusions. Notifies you with color changes when a value reaches or exceeds its limit.",
-    "version": "3.2.0",
+    "version": "3.3.0",
     "max-instances": 1,
     "cinnamon-version": ["3.8", "4.0", "4.2", "4.4", "4.6", "4.8", "5.0", "5.2", "5.4", "5.6", "5.8"]
 }

--- a/Sensors@claudiux/files/Sensors@claudiux/stylesheet.css
+++ b/Sensors@claudiux/files/Sensors@claudiux/stylesheet.css
@@ -1,3 +1,7 @@
+.sensors-monospace {
+    font-family: monospace;
+}
+
 .sensors-label {
     background: transparent;
     margin: 1px, 1px, 1px, 1px;
@@ -7,7 +11,6 @@
     border-color: rgba(127,127,127,0.5);
     text-align: center;
     vertical-align: middle;
-    font-family: monospace;
 }
 
 .sensors-high {
@@ -19,7 +22,6 @@
     border-color: rgba(255,141,0,0.5);
     text-align: center;
     vertical-align: middle;
-    font-family: monospace;
 }
 
 .sensors-critical {
@@ -31,7 +33,6 @@
     border-color: rgba(194,34,34,0.5);
     text-align: center;
     vertical-align: middle;
-    font-family: monospace;
 }
 
 .sensors-label-noborder {
@@ -41,7 +42,6 @@
     border: 0;
     text-align: center;
     vertical-align: middle;
-    font-family: monospace;
 }
 
 .sensors-high-noborder {
@@ -51,7 +51,6 @@
     border: 0;
     text-align: center;
     vertical-align: middle;
-    font-family: monospace;
 }
 
 .sensors-critical-noborder {
@@ -61,7 +60,6 @@
     border: 0;
     text-align: center;
     vertical-align: middle;
-    font-family: monospace;
 }
 
 .sensors-size80 {


### PR DESCRIPTION
Fixes #4986
From now on, the monospace font style is only used when size must be preserved.