### PR TITLE
[system-controls@rcalixte] v1.3.0

### DIFF
--- a/system-controls@rcalixte/CHANGELOG.md
+++ b/system-controls@rcalixte/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+### 1.3.0
+* Remove options that are unavailable when locks (disable-log-out, disable-switching-user, disable-lock-screen) are enabled, without having to restart the applet.
+* Add OSD when restarting Cinnamon.
+* Close the menu before activating any action.
+
 ### 1.2.2
 
 * Remove unavailable options in the Wayland session for now

--- a/system-controls@rcalixte/README.md
+++ b/system-controls@rcalixte/README.md
@@ -10,9 +10,9 @@ This is an applet that adds an icon in the panel that provides access to the
 following system controls functions:
 
 * Restart Cinnamon
-* Lock Screen
+* Lock Screen (when allowed)
 * Switch User (if enabled in system settings)
-* Log Out
+* Log Out (when allowed)
 * Suspend
 * Hibernate
 * Restart

--- a/system-controls@rcalixte/files/system-controls@rcalixte/metadata.json
+++ b/system-controls@rcalixte/files/system-controls@rcalixte/metadata.json
@@ -2,6 +2,6 @@
     "description": "A simple system controls applet to restart Cinnamon, lock the screen, switch users, log off, suspend, hibernate, reboot, or power off the computer",
     "uuid": "system-controls@rcalixte",
     "name": "System Controls",
-    "version": "1.2.2",
+    "version": "1.3.0",
     "max-instances": -1
 }


### PR DESCRIPTION
@rcalixte

Hi Rick,

I offer some changes for your system-controls@rcalixte applet:

* Remove options that are unavailable when locks (disable-log-out, disable-switching-user, disable-lock-screen) are enabled, without having to restart the applet.
* Add OSD when restarting Cinnamon.
* Close the menu before activating any action.

I hope you'll find it to your liking.

Regards
claudiux

