### PR TITLE
qredshift@quintao: hotfix: disable by default under Wayland

### DIFF
--- a/qredshift@quintao/files/qredshift@quintao/applet.js
+++ b/qredshift@quintao/files/qredshift@quintao/applet.js
@@ -11,6 +11,7 @@ const Mainloop = imports.mainloop;
 const Settings = imports.ui.settings;
 const Main = imports.ui.main;
 const Signals = imports.signals;
+const Meta = imports.gi.Meta;
 
 const Gettext = imports.gettext;
 const UUID = "qredshift@quintao";
@@ -825,7 +826,9 @@ class QRedshift extends Applet.TextIconApplet {
     
     on_applet_added_to_panel() {
         qLOG('QRedshift', 'ADDED TO PANEL');
-        if (this.opt.enableAtStartup === true)
+        if (Meta.is_wayland_compositor())
+            this.opt.enabled = false;
+        else if (this.opt.enableAtStartup === true)
             this.opt.enabled = true;
     }
     

--- a/qredshift@quintao/files/qredshift@quintao/settings-schema.json
+++ b/qredshift@quintao/files/qredshift@quintao/settings-schema.json
@@ -106,13 +106,14 @@
   "enabled": {
     "type": "checkbox",
     "default": false,
-    "description": "Enabled"
+    "description": "Enabled",
+    "tooltip": "Automatically disabled under Wayland due to redshift not being yet supported by Wayland"
   },
   "enableAtStartup": {
     "type": "checkbox",
     "default": false,
-    "description": "Activate QRedshift as soon as Cinnamon starts up",
-    "tooltip": "(even if it has previously been deactivated)"
+    "description": "Reactivate QRedshift as soon as Cinnamon starts up",
+    "tooltip": "Won't work under Wayland due to redshift not being yet supported by Wayland"
   },
   "autoUpdate": {
     "type": "checkbox",


### PR DESCRIPTION
Redshift is not supported yet by Wayland and running the applet while Cinnamon is running under Wayland may cause the system to completely freeze, even not initilizing successfuly. Some people also reported on Reddit having this same issue https://www.reddit.com/r/linuxmint/comments/195dsmu/blank_screen_on_experimental_wayland_session/

cc @raphaelquintao