### PR TITLE
directory-menu@torchipeppo: Add execution to 'Open' functions

### DIFF
--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/metadata.json
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "directory-menu@torchipeppo",
     "name": "Directory Menu",
     "description": "Show a directory in a dropdown menu",
-    "version": "0.3",
+    "version": "0.4",
     "author": "torchipeppo",
     "max-instances": "-1"
 }

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/directory-menu@torchipeppo.pot
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/directory-menu@torchipeppo.pot
@@ -1,0 +1,46 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-02-04 13:42-0500\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. metadata.json->name
+msgid "Directory Menu"
+msgstr ""
+
+#. metadata.json->description
+msgid "Show a directory in a dropdown menu"
+msgstr ""
+
+#. settings-schema.json->starting-uri->description
+msgid "Base Directory"
+msgstr ""
+
+#. settings-schema.json->icon-name->description
+msgid "Icon (hover here for info!)"
+msgstr ""
+
+#. settings-schema.json->icon-name->tooltip
+msgid "Must be an icon name (no path), and should be symbolic."
+msgstr ""
+
+#. settings-schema.json->tooltip->description
+msgid "Tooltip text"
+msgstr ""
+
+#. settings-schema.json->show-hidden->description
+msgid "Include hidden files"
+msgstr ""

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/popup_menu.py
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/popup_menu.py
@@ -20,6 +20,7 @@ KNOWN ISSUES
 
 #!/usr/bin/python3
 
+import subprocess
 import sys
 import json
 
@@ -136,12 +137,17 @@ class Cassettone:
             "uri": uri,
             "timestamp": timestamp,
         }))
+        subprocess.run(['/usr/bin/xdg-open', uri], check=False)
 
     def open_terminal_at_path(self, path):
         print(json.dumps({
             "action": "open_terminal_at_path",
             "path": path,
         }))
+        terminal_preferences = Gio.Settings.new("org.cinnamon.desktop.default-applications.terminal")
+        argv = [terminal_preferences.get_string("exec")]
+        spawn_flags = GLib.SpawnFlags.SEARCH_PATH | GLib.SpawnFlags.STDOUT_TO_DEV_NULL | GLib.SpawnFlags.STDERR_TO_DEV_NULL
+        GLib.spawn_async(working_directory=path, argv=argv, flags=spawn_flags)
 
     def destroy_subitem_later(self, subItem):
         def g2():

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/settings-schema.json
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/settings-schema.json
@@ -1,27 +1,24 @@
 {
     "starting-uri": {
-       "type": "filechooser",
-       "default" : "~",
-       "description" : "Base Directory",
-       "select-dir": true
+        "type": "filechooser",
+        "default": "~",
+        "description": "Base Directory",
+        "select-dir": true
     },
-
     "icon-name": {
         "type": "iconfilechooser",
-        "default" : "folder-symbolic",
-        "description" : "Icon (hover here for info!)",
+        "default": "folder-symbolic",
+        "description": "Icon (hover here for info!)",
         "tooltip": "Must be an icon name (no path), and should be symbolic."
     },
-
     "tooltip": {
         "type": "entry",
-        "default" : "Directory Menu",
-        "description" : "Tooltip text"
+        "default": "Directory Menu",
+        "description": "Tooltip text"
     },
-
     "show-hidden": {
         "type": "switch",
-        "default" : false,
-        "description" : "Include hidden files"
+        "default": false,
+        "description": "Include hidden files"
     }
 }


### PR DESCRIPTION
Add translation template
Add a terminal option for non-Debian-based distros

This addresses the execution functionality of the applet.

cc @torchipeppo 