### PR TITLE
[CassiaWindowList@klangman] Add hover-peek, no click activate, and fixes

### DIFF
--- a/CassiaWindowList@klangman/README.md
+++ b/CassiaWindowList@klangman/README.md
@@ -1,19 +1,21 @@
 This is a Cinnamon window list and panel launcher applet based on CobiWindowList with a number of additional features
 designed to give you more control over how your window-list operates.
 
-Recent new features (Aug-Dec 2023):
+Recent new features (Aug 2023 - Feb 2024):
 
-1.  Adjustable spacing between window-list buttons
-2.  Ability to disable the new window animation
-3.  Ability to change the icon saturation from grayscale (0%) to vivid (200%)
-4.  Ability to show windows from other workspaces
-5.  Restores custom group/ungroup application setting after reboot/cinnamon-restart
-6.  Hotkey option to assign a set of 1-9 hotkeys to all window-list buttons
-7.  Hotkey hints using the (`) grave key with any registered hotkey modifiers
-8.  Added a Left-Click option to start new application windows in Launcher mode
-9.  Ability to show a common set of pinned buttons on all workspaces
-10. Smart numeric hotkeys to assign a set of 1-9 hotkeys to a specific application
-11. A bunch of fixes
+1.  Hover peek: Option to show a full size preview when hovering buttons/thumbnails
+2.  No Click activate: Option to automatically switch focus to the button/Thumbnail last hovered
+3.  Adjustable spacing between window-list buttons
+4.  Ability to disable the new window animation
+5.  Ability to change the icon saturation from grayscale (0%) to vivid (200%)
+6.  Ability to show windows from other workspaces
+7.  Restores custom group/ungroup application setting after reboot/cinnamon-restart
+8.  Hotkey option to assign a set of 1-9 hotkeys to all window-list buttons
+9.  Hotkey hints using the (`) grave key with any registered hotkey modifiers
+10. Added a Left-Click option to start new application windows in Launcher mode
+11. Ability to show a common set of pinned buttons on all workspaces
+12. Smart numeric hotkeys to assign a set of 1-9 hotkeys to a specific application
+13. A bunch of fixes
 
 The design goals are to:
 
@@ -58,6 +60,6 @@ https://github.com/klangman/CassiaWindowList
 
 This is where I develop new features and test out any new ideas I have before pushing to cinnamon-spices.
 
-If you use use this applet please let me know by liking it here and on my Github repository, that way I will be 
+If you use this applet please let me know by liking it here and on my Github repository, that way I will be
 encouraged to continue working on the project.
 

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
@@ -18,7 +18,7 @@
     "preview-page" : {
       "type" : "page",
       "title" : "Thumbnails",
-      "sections" : ["preview-settings", "preview-mouse-section"] 
+      "sections" : ["preview-settings", "preview-mouse-section"]
     },
 
     "hotkey-page" : {
@@ -47,7 +47,7 @@
     "general-settings" : {
       "type" : "section",
       "title" : "General window list settings",
-      "keys" : ["group-windows", "display-pinned", "synchronize-pinned", "trailing-pinned-behaviour", "animate-icon", "show-windows-for-current-monitor", "show-windows-for-all-workspaces", "show-tooltips", "button-spacing"]
+      "keys" : ["group-windows", "display-pinned", "synchronize-pinned", "animate-icon", "show-windows-for-current-monitor", "show-windows-for-all-workspaces", "show-tooltips", "button-spacing", "hover-peek-windowlist", "no-click-activate"]
     },
     "general-mouse" : {
       "type" : "section",
@@ -57,7 +57,7 @@
     "preview-settings" : {
       "type" : "section",
       "title" : "Thumbnails menu settings",
-      "keys" : ["show-previews", "number-of-unshrunk-previews", "menu-all-windows-of-pool", "menu-all-windows-of-auto"]
+      "keys" : ["show-previews", "number-of-unshrunk-previews", "menu-all-windows-of-pool", "menu-all-windows-of-auto", "hover-peek-thumbnail", "no-click-activate-thumbnail"]
     },
     "preview-mouse-section" : {
       "type" : "section",
@@ -77,7 +77,7 @@
     "adv-other-settings" : {
       "type" : "section",
       "title" : "",
-      "keys" : ["backup-file-name", "hide-panel-apps", "icon-saturation", "saturation-application"]
+      "keys" : ["backup-file-name", "hide-panel-apps",  "trailing-pinned-behaviour", "fade-animation-time", "icon-saturation", "saturation-application"]
     }
   },
   "caption-type": {
@@ -140,6 +140,16 @@
     "description": "Add new window buttons ahead of trailing pinned buttons",
     "tooltip": "When enabled, new windows will be added to the left of any pinned buttons currently placed on the right of the window list, effectively this allows you to keep pinned buttons at the end of the window list"
   },
+  "fade-animation-time": {
+    "type": "spinbutton",
+    "default": 100,
+    "min": 0,
+    "max": 2000,
+    "units": "milliseconds",
+    "step": 20,
+    "description": "Fade animation effect duration",
+    "tooltip": "This defines the duration of the fade-in/out animation effect. It applies to the Thumbnail menus and the full size window previews"
+  },
   "label-width": {
     "type": "spinbutton",
     "default": 150,
@@ -159,11 +169,11 @@
     "type": "spinbutton",
     "default": 500,
     "min": 5,
-    "max": 10000,
+    "max": 2000,
     "units": "milliseconds",
-    "step": 1,
+    "step": 20,
     "dependency": "label-animation",
-    "description": "Label animation time"
+    "description": "Label animation duration"
   },
   "display-number": {
     "type": "combobox",
@@ -254,6 +264,20 @@
     "description": "Spacing between buttons",
     "tooltip": "This defines the spacing between the buttons, the value will be divided in half and added to the left of the icon and to the right of the label on horizontal panels or to the top and button of the icon on vertical panels"
   },
+  "hover-peek-windowlist": {
+    "type": "switch",
+    "default": 0,
+    "dependency" : "group-windows<4",
+    "description": "Show a full size window preview when hovering over a button",
+    "tooltip": "If enabled, a full size preview window will appear when the mouse pointer is hovering over a window-list button."
+  },
+  "no-click-activate": {
+    "type": "switch",
+    "default": 0,
+    "dependency" : "group-windows<4",
+    "description": "Automatic focus change when leaving the panel",
+    "tooltip": "If enabled, the current window for a window-list button will get the focus when the mouse pointer leaves the panel. Leaving the window-list with Ctrl or Shift held or while remaining on the panel will leave the focus unchanged. This option is typically used in conjunction with the preview hovering option above."
+  },
 
   "menu-show-on-hover": {
     "type": "switch",
@@ -298,9 +322,9 @@
     "type": "spinbutton",
     "default": 500,
     "min": 5,
-    "max": 10000,
+    "max": 2000,
     "units": "milliseconds",
-    "step": 1,
+    "step": 20,
     "description": "Hover time before showing menu",
     "dependency": "menu-show-on-hover",
     "tooltip": "The waiting time before the thumbnail menu appears when hovering over a button\n(Not used when moving directly to a different button in the list)"
@@ -309,9 +333,9 @@
     "type": "spinbutton",
     "default": 500,
     "min": 5,
-    "max": 10000,
+    "max": 2000,
     "units": "milliseconds",
-    "step": 1,
+    "step": 20,
     "description": "Time before closing after pointer leaves the menu",
     "tooltip": "The waiting time for the thumbnail menu to close when leaving a button\n(Not used when moving directly to a different button in the list)"
   },
@@ -405,6 +429,21 @@
     },
     "description": "Thumbnail window forward button action"
   },
+
+  "hover-peek-thumbnail": {
+    "type": "switch",
+    "default": false,
+    "description": "Show a full size window preview when hovering over a Thumbnail",
+    "tooltip": "If enabled, a full size preview window will appear when the mouse pointer is hovering over a Thumbnail menu item"
+  },
+  "no-click-activate-thumbnail": {
+    "type": "switch",
+    "default": 0,
+    "dependency" : "group-windows<4",
+    "description": "Automatic focus change when leaving the Thumbnail menu",
+    "tooltip": "If enabled, the window associated with the Thumbnail menu item will get the focus when the mouse pointer leaves the menu. Leaving the menu with Ctrl or Shift held or leaving from either end of the menu will leave the focus unchanged. This option is typically used in conjunction with the preview hovering option above."
+  },
+
   "grouped-mouse-action-btn1": {
     "type": "combobox",
     "default": 2,

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-18 09:58-0500\n"
+"POT-Creation-Date: 2024-02-06 10:21-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,28 +17,32 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: 4.0/applet.js:512
+#: 4.0/applet.js:516
 msgid "all buttons"
 msgstr ""
 
-#: 4.0/applet.js:2382
+#: 4.0/applet.js:2501
 msgid "Applet Preferences"
 msgstr ""
 
-#: 4.0/applet.js:2386
+#: 4.0/applet.js:2505
 msgid "About..."
 msgstr ""
 
-#: 4.0/applet.js:2390
+#: 4.0/applet.js:2509
 msgid "Configure..."
 msgstr ""
 
-#: 4.0/applet.js:2394
+#: 4.0/applet.js:2513
+msgid "Website"
+msgstr ""
+
+#: 4.0/applet.js:2517
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
 
-#: 4.0/applet.js:2396
+#: 4.0/applet.js:2519
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 
@@ -48,111 +52,111 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2405
+#: 4.0/applet.js:2528
 msgid "Open new window"
 msgstr ""
 
-#: 4.0/applet.js:2413
+#: 4.0/applet.js:2536
 msgid "Remove from panel"
 msgstr ""
 
-#: 4.0/applet.js:2415
+#: 4.0/applet.js:2538
 msgid "Remove from this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2421
+#: 4.0/applet.js:2544
 msgid "Pin to panel"
 msgstr ""
 
-#: 4.0/applet.js:2423
+#: 4.0/applet.js:2546
 msgid "Pin to this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2464
+#: 4.0/applet.js:2587
 msgid "Pin to other workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2485
+#: 4.0/applet.js:2608
 msgid "Pin to all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2503
+#: 4.0/applet.js:2626
 msgid "Pin to launcher"
 msgstr ""
 
-#: 4.0/applet.js:2521 4.0/applet.js:2707
+#: 4.0/applet.js:2644 4.0/applet.js:2830
 msgid "Add new Hotkey for"
 msgstr ""
 
-#: 4.0/applet.js:2535
+#: 4.0/applet.js:2658
 msgid "Recent files"
 msgstr ""
 
-#: 4.0/applet.js:2559
+#: 4.0/applet.js:2682
 msgid "Places"
 msgstr ""
 
-#: 4.0/applet.js:2601
+#: 4.0/applet.js:2724
 msgid "Only on this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2603
+#: 4.0/applet.js:2726
 msgid "Visible on all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2604
+#: 4.0/applet.js:2727
 msgid "Move to another workspace"
 msgstr ""
 
-#: 4.0/applet.js:2613
+#: 4.0/applet.js:2736
 msgid " (this workspace)"
 msgstr ""
 
-#: 4.0/applet.js:2626
+#: 4.0/applet.js:2749
 msgid "Move to another monitor"
 msgstr ""
 
-#: 4.0/applet.js:2634
+#: 4.0/applet.js:2757
 msgid "Monitor"
 msgstr ""
 
-#: 4.0/applet.js:2662
+#: 4.0/applet.js:2785
 msgid "unassigned"
 msgstr ""
 
-#: 4.0/applet.js:2673 4.0/applet.js:2704
+#: 4.0/applet.js:2796 4.0/applet.js:2827
 msgid "Assign window to a hotkey"
 msgstr ""
 
-#: 4.0/applet.js:2727
+#: 4.0/applet.js:2850
 msgid "Change application label contents"
 msgstr ""
 
-#: 4.0/applet.js:2730
+#: 4.0/applet.js:2853
 msgid "Remove custom setting"
 msgstr ""
 
-#: 4.0/applet.js:2737
+#: 4.0/applet.js:2860
 msgid "Use window title"
 msgstr ""
 
-#: 4.0/applet.js:2744
+#: 4.0/applet.js:2867
 msgid "Use application name"
 msgstr ""
 
-#: 4.0/applet.js:2751
+#: 4.0/applet.js:2874
 msgid "No label"
 msgstr ""
 
-#: 4.0/applet.js:2762
+#: 4.0/applet.js:2885
 msgid "Ungroup application windows"
 msgstr ""
 
-#: 4.0/applet.js:2771
+#: 4.0/applet.js:2894
 msgid "Group application windows"
 msgstr ""
 
-#: 4.0/applet.js:2784
+#: 4.0/applet.js:2907
 msgid "Automatic grouping/ungrouping"
 msgstr ""
 
@@ -162,31 +166,31 @@ msgstr ""
 #. 4.0->settings-schema.json->mouse-action-btn2->options
 #. 4.0->settings-schema.json->mouse-action-btn8->options
 #. 4.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2814
+#: 4.0/applet.js:2937
 msgid "Move titlebar on to screen"
 msgstr ""
 
-#: 4.0/applet.js:2819
+#: 4.0/applet.js:2942
 msgid "Restore"
 msgstr ""
 
-#: 4.0/applet.js:2823
+#: 4.0/applet.js:2946
 msgid "Minimize"
 msgstr ""
 
-#: 4.0/applet.js:2829
+#: 4.0/applet.js:2952
 msgid "Unmaximize"
 msgstr ""
 
-#: 4.0/applet.js:2836
+#: 4.0/applet.js:2959
 msgid "Close others"
 msgstr ""
 
-#: 4.0/applet.js:2847
+#: 4.0/applet.js:2970
 msgid "Close all"
 msgstr ""
 
-#: 4.0/applet.js:2856
+#: 4.0/applet.js:2979
 msgid "Close"
 msgstr ""
 
@@ -386,6 +390,23 @@ msgid ""
 "you to keep pinned buttons at the end of the window list"
 msgstr ""
 
+#. 4.0->settings-schema.json->fade-animation-time->units
+#. 4.0->settings-schema.json->label-animation-time->units
+#. 4.0->settings-schema.json->preview-timeout-show->units
+#. 4.0->settings-schema.json->preview-timeout-hide->units
+msgid "milliseconds"
+msgstr ""
+
+#. 4.0->settings-schema.json->fade-animation-time->description
+msgid "Fade animation effect duration"
+msgstr ""
+
+#. 4.0->settings-schema.json->fade-animation-time->tooltip
+msgid ""
+"This defines the duration of the fade-in/out animation effect. It applies to "
+"the Thumbnail menus and the full size window previews"
+msgstr ""
+
 #. 4.0->settings-schema.json->label-width->units
 #. 4.0->settings-schema.json->button-spacing->units
 msgid "pixels"
@@ -403,14 +424,8 @@ msgstr ""
 msgid "Animate label"
 msgstr ""
 
-#. 4.0->settings-schema.json->label-animation-time->units
-#. 4.0->settings-schema.json->preview-timeout-show->units
-#. 4.0->settings-schema.json->preview-timeout-hide->units
-msgid "milliseconds"
-msgstr ""
-
 #. 4.0->settings-schema.json->label-animation-time->description
-msgid "Label animation time"
+msgid "Label animation duration"
 msgstr ""
 
 #. 4.0->settings-schema.json->display-number->options
@@ -547,6 +562,29 @@ msgid ""
 "This defines the spacing between the buttons, the value will be divided in "
 "half and added to the left of the icon and to the right of the label on "
 "horizontal panels or to the top and button of the icon on vertical panels"
+msgstr ""
+
+#. 4.0->settings-schema.json->hover-peek-windowlist->description
+msgid "Show a full size window preview when hovering over a button"
+msgstr ""
+
+#. 4.0->settings-schema.json->hover-peek-windowlist->tooltip
+msgid ""
+"If enabled, a full size preview window will appear when the mouse pointer is "
+"hovering over a window-list button."
+msgstr ""
+
+#. 4.0->settings-schema.json->no-click-activate->description
+msgid "Automatic focus change when leaving the panel"
+msgstr ""
+
+#. 4.0->settings-schema.json->no-click-activate->tooltip
+msgid ""
+"If enabled, the current window for a window-list button will get the focus "
+"when the mouse pointer leaves the panel. Leaving the window-list with Ctrl "
+"or Shift held or while remaining on the panel will leave the focus "
+"unchanged. This option is typically used in conjunction with the preview "
+"hovering option above."
 msgstr ""
 
 #. 4.0->settings-schema.json->menu-show-on-hover->description
@@ -824,6 +862,29 @@ msgstr ""
 
 #. 4.0->settings-schema.json->preview-forward-click->description
 msgid "Thumbnail window forward button action"
+msgstr ""
+
+#. 4.0->settings-schema.json->hover-peek-thumbnail->description
+msgid "Show a full size window preview when hovering over a Thumbnail"
+msgstr ""
+
+#. 4.0->settings-schema.json->hover-peek-thumbnail->tooltip
+msgid ""
+"If enabled, a full size preview window will appear when the mouse pointer is "
+"hovering over a Thumbnail menu item"
+msgstr ""
+
+#. 4.0->settings-schema.json->no-click-activate-thumbnail->description
+msgid "Automatic focus change when leaving the Thumbnail menu"
+msgstr ""
+
+#. 4.0->settings-schema.json->no-click-activate-thumbnail->tooltip
+msgid ""
+"If enabled, the window associated with the Thumbnail menu item will get the "
+"focus when the mouse pointer leaves the menu. Leaving the menu with Ctrl or "
+"Shift held or leaving from either end of the menu will leave the focus "
+"unchanged. This option is typically used in conjunction with the preview "
+"hovering option above."
 msgstr ""
 
 #. 4.0->settings-schema.json->grouped-mouse-action-btn1->options


### PR DESCRIPTION
1. Added a new Window-list button & Thumbnail menu item options that will cause a full size window preview to appear when hovering over a window-list button or a Thumbnail menu item.

2. Added new options to automatically active windows when leaving the panel/menu (no click focus changing). This allows the user to activate a window by simply moving to mouse over a window-list button or a Thumbnail menu item and then moving back towards the middle of the screen. The action can be cancelled by holding the Ctrl or Shift keys before leaving the panel/menu, or by leaving the panel/menu by moving the pointer off either end of the window-list/menu. The config option to enable this feature for the window-list is in the General tab and the option for the Thumbnail menu is in the Thumbnail tab.

3. Added a fade-in/out effect when opening/closing the Thumbnail menu.

4. Add an option (advanced config tab) allowing the user to adjust the fade-in/out effect duration which is used when opening/closing the Thumbnail menu and when showing a hover peek full size preview.

5. Changed all the effect duration options to have a maximum of 2000ms (2sec) and to have a step change of 20ms for each click on the -/+ adjustment buttons. The old max of 10sec was unreasonably high and a step change of just 1ms was kind of useless.

6. Moved the "Add new window buttons ahead of trailing pinned buttons" option to the advanced config tab since I don't think it's commonly used and moving it makes space to add the new options listed above.

7. Update the icon when the icon signal is fired which will fix seeing a generic icon rather then the windows icon in some cases (i.e. Minecraft Java edition)

8. Don't animate window closing if there is no label to remove. This fixes a small delay when removing window-list buttons where the label was 0-length.

9. Fix a regression causing buttons without icons in some rare cases (i.e. x3270)

10. Added a "Website" option in the "Applet Preferences" sub-menu that will open the cinnamon spices page