### PR TITLE
Fix "Main.Util undefined" error

### DIFF
--- a/ShutdownMenuWithIcons@LLOBERA/files/ShutdownMenuWithIcons@LLOBERA/ABOUT.txt
+++ b/ShutdownMenuWithIcons@LLOBERA/files/ShutdownMenuWithIcons@LLOBERA/ABOUT.txt
@@ -1,5 +1,5 @@
 Shutdown Menu With Icons Cinnamon Applet
-Developed by Nicolas LLOBERA - nllobera@gmail.com from the System Shutdown and Restart Applet by Shelley
-version: 2.2 (28-08-2013)
+Developed by Nicolas LLOBERA from the System Shutdown and Restart Applet by Shelley
+version: 2.3 (08-02-2024)
 License: GPLv3
-Copyright © 2013 Nicolas LLOBERA
+Copyright © 2024 Nicolas LLOBERA

--- a/ShutdownMenuWithIcons@LLOBERA/files/ShutdownMenuWithIcons@LLOBERA/RELEASE.txt
+++ b/ShutdownMenuWithIcons@LLOBERA/files/ShutdownMenuWithIcons@LLOBERA/RELEASE.txt
@@ -1,3 +1,7 @@
+v2.3 - 08-02-2024
+========
+Fix the "Main.Util is undefined" error
+
 v2.2 - 28-08-2013
 ========
 Add the "Switch users" menu

--- a/ShutdownMenuWithIcons@LLOBERA/files/ShutdownMenuWithIcons@LLOBERA/applet.js
+++ b/ShutdownMenuWithIcons@LLOBERA/files/ShutdownMenuWithIcons@LLOBERA/applet.js
@@ -1,8 +1,8 @@
 // Shutdown Menu With Icons Cinnamon Applet
-// Developed by Nicolas LLOBERA - nllobera@gmail.com from the System Shutdown and Restart Applet by Shelley
-// version: 2.2 (28-08-2013)
+// Developed by Nicolas LLOBERA from the System Shutdown and Restart Applet by Shelley
+// version: 2.3 (08-02-2024)
 // License: GPLv3
-// Copyright © 2013 Nicolas LLOBERA
+// Copyright © 2024 Nicolas LLOBERA
 
 const Gettext = imports.gettext;
 const Gio = imports.gi.Gio;

--- a/ShutdownMenuWithIcons@LLOBERA/files/ShutdownMenuWithIcons@LLOBERA/applet.js
+++ b/ShutdownMenuWithIcons@LLOBERA/files/ShutdownMenuWithIcons@LLOBERA/applet.js
@@ -4,20 +4,20 @@
 // License: GPLv3
 // Copyright © 2013 Nicolas LLOBERA
 
-const Applet = imports.ui.applet;
 const Gettext = imports.gettext;
-const UUID = "ShutdownMenuWithIcons@LLOBERA";
-const Gtk = imports.gi.Gtk;
 const Gio = imports.gi.Gio;
-const Main = imports.ui.main;
-const PopupMenu = imports.ui.popupMenu;
-const Settings = imports.ui.settings;
+const GLib = imports.gi.GLib;
+const Gtk = imports.gi.Gtk;
 const St = imports.gi.St;
 const Util = imports.misc.util;
-const GLib = imports.gi.GLib;
-const AppletUUID = "ShutdownMenuWithIcons@LLOBERA";
-const AppletDirectory = imports.ui.appletManager.appletMeta[AppletUUID].path;
+const Applet = imports.ui.applet;
+const PopupMenu = imports.ui.popupMenu;
+const Settings = imports.ui.settings;
 
+const UUID = "ShutdownMenuWithIcons@LLOBERA";
+const AppletUUID = "ShutdownMenuWithIcons@LLOBERA";
+
+const AppletDirectory = imports.ui.appletManager.appletMeta[AppletUUID].path;
 imports.searchPath.push(AppletDirectory);
 const PopupMenuExtension = imports.popupImageLeftMenuItem;
 
@@ -167,7 +167,7 @@ MyApplet.prototype = {
     },
     
     createMenuItem: function(displayName, iconName, command) {
-        let menuItem = new PopupMenuExtension.PopupImageLeftMenuItem(displayName, iconName, command);
+        var menuItem = new PopupMenuExtension.PopupImageLeftMenuItem(displayName, iconName, command);
         menuItem.connect("activate", function(actor, event) {
             // As application variable is not accessible here, 
             // the application variable is passed to the PopupImageLeftMenuItem ctor to be accessible throw the actor argument
@@ -188,12 +188,12 @@ MyApplet.prototype = {
         this._applet_context_menu.addMenuItem(this.settings_menu_item);
         
         this.help_menu_item = new Applet.MenuItem(_("Help"), Gtk.STOCK_HELP, function() {
-            Main.Util.spawnCommandLine("xdg-open " + AppletDirectory + "/README.txt");
+            Util.spawnCommandLine("xdg-open " + AppletDirectory + "/README.txt");
         });
         this._applet_context_menu.addMenuItem(this.help_menu_item);
         
         this.about_menu_item = new Applet.MenuItem(_("About"), Gtk.STOCK_ABOUT,  function() {
-            Main.Util.spawnCommandLine("xdg-open " + AppletDirectory + "/ABOUT.txt");
+            Util.spawnCommandLine("xdg-open " + AppletDirectory + "/ABOUT.txt");
         });
         this._applet_context_menu.addMenuItem(this.about_menu_item);
     },
@@ -205,6 +205,6 @@ MyApplet.prototype = {
 };
 
 function main(metadata, orientation, panel_height, instanceId) {
-    let myApplet = new MyApplet(metadata, orientation, panel_height, instanceId);
+    var myApplet = new MyApplet(metadata, orientation, panel_height, instanceId);
     return myApplet;      
 }

--- a/ShutdownMenuWithIcons@LLOBERA/files/ShutdownMenuWithIcons@LLOBERA/popupImageLeftMenuItem.js
+++ b/ShutdownMenuWithIcons@LLOBERA/files/ShutdownMenuWithIcons@LLOBERA/popupImageLeftMenuItem.js
@@ -1,6 +1,6 @@
 // Popup Image Left Menu Item for Cinnamon Applet
 // A Popup Menu Item with an icon to the left, the text to the right and a command associated to the menu
-// Developed by Nicolas LLOBERA <nllobera@gmail.com>
+// Developed by Nicolas LLOBERA
 // version: 1.1 (11-06-2013)
 // License: GPLv3
 // Copyright © 2013 Nicolas LLOBERA


### PR DESCRIPTION
While clicking for the first time on an item menu, the command is not executed and the following error is recorded on xsession-errors:
`JS ERROR: Exception in callback for signal: activate: TypeError: Main.Util is undefined`

fix #5444
