### PR TITLE
directory-menu@torchipeppo: add a new setting to truncate long file names, and an Italian translation

### DIFF
--- a/directory-menu@torchipeppo/README.md
+++ b/directory-menu@torchipeppo/README.md
@@ -8,9 +8,10 @@ This is a re-creation of a built-in feature in XFCE.
 
 * View the selected directory as a compact list
 * **Arbitrarily deep navigation through subdirectories**
+* Fast navigation: just hover on a directory to open it
 * Open any file by clicking on it
 * "Open in Terminal" button for directories
-* Configurable setting for showing or hiding hidden files
+* Configurable settings for handling hidden files, limiting menu width, and customization
 
 ## Installation
 

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/applet.js
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/applet.js
@@ -37,6 +37,7 @@ class CassettoneApplet extends Applet.IconApplet {
         this.settings.bind("show-hidden", "show_hidden", null, null);
         this.settings.bind("icon-name", "icon_name", this.set_applet_icon_symbolic_name, null);
         this.settings.bind("tooltip", "tooltip_text", (newtext) => {this.set_applet_tooltip(_(newtext))}, null);
+        this.settings.bind("character-limit", "character_limit", null, null);
         this.starting_uri = this.normalize_tilde(this.starting_uri);
 
         this.set_applet_icon_symbolic_name(this.icon_name);
@@ -138,6 +139,7 @@ class CassettoneApplet extends Applet.IconApplet {
             "x": x,
             "y": y,
             "orientation": o,
+            "character_limit": this.character_limit,
         }
 
         Util.spawn_async(['python3', `${this.metadata.path}/popup_menu.py`, JSON.stringify(args)]);

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/metadata.json
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "directory-menu@torchipeppo",
     "name": "Directory Menu",
     "description": "Quickly navigate through directories on your system using a dropdown menu.",
-    "version": "0.4",
+    "version": "0.5",
     "author": "torchipeppo",
     "max-instances": "-1"
 }

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/it.po
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/it.po
@@ -3,64 +3,62 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: directory-menu@torchipeppo 0.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
 "POT-Creation-Date: 2024-02-10 15:22+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2024-02-10 15:22+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #. metadata.json->name
 msgid "Directory Menu"
-msgstr ""
+msgstr "Menù delle Cartelle"
 
 #. metadata.json->description
 msgid ""
 "Quickly navigate through directories on your system using a dropdown menu."
 msgstr ""
+"Naviga rapidamente attraverso le tue cartelle con un menù a tendina."
 
 #. settings-schema.json->starting-uri->description
 msgid "Base Directory"
-msgstr ""
+msgstr "Cartella principale"
 
 #. settings-schema.json->icon-name->description
 msgid "Icon (hover here for info!)"
-msgstr ""
+msgstr "Icona (tieni il mouse qui per info!)"
 
 #. settings-schema.json->icon-name->tooltip
 msgid "Must be an icon name (no path), and should be symbolic."
-msgstr ""
+msgstr "Deve essere il nome di un'icona (non un percorso), e l'icona dovrebbe essere simbolica."
 
 #. settings-schema.json->tooltip->description
 msgid "Tooltip text"
-msgstr ""
+msgstr "Didascalia"
 
 #. settings-schema.json->character-limit->description
 msgid "Character Limit (-1 to disable)"
-msgstr ""
+msgstr "Limite di caratteri (-1 per disattivare)"
 
 #. settings-schema.json->character-limit->tooltip
-msgid ""
-"(Approximately) Limit the number of characters of each entry.\n"
-"Useful if you think the menu is too wide."
-msgstr ""
+msgid "(Approximately) Limit the number of characters of each entry.\nUseful if you think the menu is too wide."
+msgstr "Limita (approssimativamente) il numero di caratteri di ciascuna riga.\nUtile se il menù risulta troppo largo."
 
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
-msgstr ""
+msgstr "Mostra i file nascosti"
 
 #. popup_menu.py:71
 msgid "Open Folder"
-msgstr ""
+msgstr "Apri cartella"
 
 #. popup_menu.py:76
 msgid "Open in Terminal"
-msgstr ""
+msgstr "Apri nel terminale"

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/popup_menu.py
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/popup_menu.py
@@ -111,6 +111,8 @@ class Cassettone:
 
     def add_to_menu_from_gioinfo(self, menu, info):
         display_text = info.display_name
+        if self.character_limit > -1 and len(display_text) > self.character_limit:
+            display_text = display_text[:self.character_limit] + "..."
 
         icon = Gio.content_type_get_icon(info.content_type)
         image = Gtk.Image.new_from_gicon(icon, Gtk.IconSize.MENU)
@@ -238,6 +240,7 @@ class Cassettone:
         self.x = args["x"]
         self.y = args["y"]
         self.orientation = args["orientation"]
+        self.character_limit = args["character_limit"]
 
         # https://github.com/linuxmint/xapp/blob/master/libxapp/xapp-status-icon.c#L222
         # would be nice to determine it somehow, but it might not be so important right now

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/settings-schema.json
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/settings-schema.json
@@ -16,6 +16,15 @@
         "default": "Directory Menu",
         "description": "Tooltip text"
     },
+    "character-limit": {
+        "type": "spinbutton",
+        "default" : -1,
+        "min": -1,
+        "max": 9999,
+        "step": 1,
+        "description" : "Character Limit (-1 to disable)",
+        "tooltip": "(Approximately) Limit the number of characters of each entry.\nUseful if you think the menu is too wide."
+    },
     "show-hidden": {
         "type": "switch",
         "default": false,


### PR DESCRIPTION
While using this applet I noticed I kept visiting a folder with files that need pretty long names, which made the menu exceedingly large and slowed down navigation to the next subdirectory.
So I just added a simple, completely optional functionality to truncate the displayed file names and thus limit the width of the menu. Maybe it'll be of use to someone else too.

While I was at it, I added an Italian translation too. I quickly switched my system language and all the strings appear to be in order.

A fabricated example of the new setting in action:
![image](https://github.com/linuxmint/cinnamon-spices-applets/assets/2371934/4d218288-f896-4078-a85c-c20c7df90056)
![image](https://github.com/linuxmint/cinnamon-spices-applets/assets/2371934/63150829-6690-4de1-90cf-58d6da89654e)
