### PR TITLE
[suspend@janax] Add  double-click and count-down options

### DIFF
--- a/suspend@janax/files/suspend@janax/README.md
+++ b/suspend@janax/files/suspend@janax/README.md
@@ -1,0 +1,9 @@
+Immediately suspends the computer (by default)
+
+## Features
+
+1. Suspend instantly on a single click or only suspend on a double-click to avoid accidentally suspending the computer.
+2. Optionally add a count-down timer (1-9 sec) giving you the chance to cancel the suspend operation. 
+3. A single click on the panel button during the count down will cancel the suspend operation.
+4. Choose between a full color or a symbolic panel icon for the applet.
+

--- a/suspend@janax/files/suspend@janax/applet.js
+++ b/suspend@janax/files/suspend@janax/applet.js
@@ -2,42 +2,135 @@ const Lang = imports.lang;
 const Applet = imports.ui.applet;
 const GLib = imports.gi.GLib;
 const Gettext = imports.gettext;
+const Settings = imports.ui.settings;
+const Mainloop = imports.mainloop;
+const St = imports.gi.St;
+const Cinnamon = imports.gi.Cinnamon;
+const Clutter = imports.gi.Clutter;
+const SignalManager = imports.misc.signalManager;
+
 const UUID = "suspend@janax";
 
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale")
 
 function _(str) {
-  return Gettext.dgettext(UUID, str);
+   return Gettext.dgettext(UUID, str);
 }
 
-function MyApplet(orientation) {
-    this._init(orientation);
+class SuspendApplet extends Applet.Applet {
+
+   constructor(orientation, panelHeight, instanceId) {
+      super(orientation, panelHeight, instanceId);
+      this.setAllowedLayout(Applet.AllowedLayout.BOTH);
+      this.signalManager = new SignalManager.SignalManager(null);
+      this.settings = new Settings.AppletSettings(this, UUID, instanceId);
+
+      // Icon Box to contain the icon and the count down label
+      let iconSize = this.getPanelIconSize(St.IconType.FULLCOLOR);
+      this._iconBox = new St.Group({natural_width: iconSize, natural_height: iconSize, x_align: Clutter.ActorAlign.CENTER, y_align: Clutter.ActorAlign.CENTER});
+
+      // Create the icon and it's container
+      this.actor.add_actor(this._iconBox);
+      this._iconBin = new St.Bin();
+      this._iconBin._delegate = this;
+      this._iconBox.add_actor(this._iconBin);
+      /*
+      if( this.settings.getValue("fullcolor-icon") ){
+         this._icon = new St.Icon({ icon_name: "gnome-session-suspend",
+                                    icon_type: St.IconType.FULLCOLOR,
+                                    reactive: true, track_hover: true,
+                                    style_class: 'applet-icon',
+                                    icon_size: iconSize});
+      }else{
+         this._icon = new St.Icon({ icon_name: "weather-clear-night",
+                                    icon_type: St.IconType.SYMBOLIC,
+                                    reactive: true, track_hover: true,
+                                    style_class: 'applet-icon',
+                                    icon_size: iconSize});
+      }
+      this._iconBin.set_child(this._icon);
+      */
+      this._updateIcon();
+
+      // Create the count down number label and it's containers
+      this._labelNumberBox = new St.BoxLayout();
+      this._labelNumberBin = new St.Bin({important: true, style_class: "grouped-window-list-badge", x_align: St.Align.MIDDLE, y_align: St.Align.MIDDLE});
+      this._labelNumber = new St.Label({style_class: "grouped-window-list-number-label"});
+      this._iconBox.add_actor(this._labelNumberBox);
+      this._labelNumberBox.add_actor(this._labelNumberBin);
+      this._labelNumberBin.add_actor(this._labelNumber);
+
+      this._labelNumberBox.hide();
+      this.set_applet_tooltip(_("Suspend"));
+      this.signalManager.connect(this.settings, "changed::fullcolor-icon", this._updateIcon, this);
+   }
+
+   _updateIcon() {
+      let iconSize = this.getPanelIconSize(St.IconType.FULLCOLOR);
+      log( "Icon updating" );
+      if( this._icon ){
+         this._icon.destroy();
+         //this._iconBin.remove_child(this._icon);
+      }
+      if( this.settings.getValue("fullcolor-icon") ){
+         this._icon = new St.Icon({ icon_name: "gnome-session-suspend",
+                                    icon_type: St.IconType.FULLCOLOR,
+                                    reactive: true, track_hover: true,
+                                    style_class: 'applet-icon',
+                                    icon_size: iconSize});
+      }else{
+         this._icon = new St.Icon({ icon_name: "weather-clear-night",
+                                    icon_type: St.IconType.SYMBOLIC,
+                                    reactive: true, track_hover: true,
+                                    style_class: 'applet-icon',
+                                    icon_size: iconSize});
+      }
+      this._iconBin.set_child(this._icon);
+   }
+
+   on_panel_icon_size_changed() {
+      let iconSize = this.getPanelIconSize(St.IconType.FULLCOLOR);
+      this._icon.set_icon_size(iconSize);
+      this._iconBox.set_height(iconSize);
+      this._iconBox.set_width(iconSize);
+   }
+
+   on_applet_clicked(event) {
+      if( this._countDown ) {
+         Mainloop.source_remove(this._countDown);
+         this._labelNumberBox.hide();
+         this._countDown = null;
+      } else {
+         if( !this.settings.getValue("suspend-on-double-click") || event.get_click_count() === 2 ) {
+            if( this.settings.getValue("count-down") ) {
+               this.countDownTime = this.settings.getValue("count-down-duration");
+               this._labelNumber.set_text( this.countDownTime.toString() );
+               this._labelNumberBox.show();
+               let [width, height] = this._labelNumber.get_size();
+               let size = Math.max(width, height);
+               this._labelNumberBin.width = size;
+               this._labelNumberBin.height = size;
+               this._countDown = Mainloop.timeout_add(1000, Lang.bind(this, this._countDownUpdate));
+            } else {
+               GLib.spawn_command_line_async('systemctl suspend -i');
+            }
+         }
+      }
+   }
+
+   _countDownUpdate(){
+      if( this.countDownTime > 1 ){
+         this.countDownTime--;
+         this._labelNumber.set_text( this.countDownTime.toString() );
+         this._countDown = Mainloop.timeout_add(1000, Lang.bind(this, this._countDownUpdate));
+      } else {
+         this._labelNumberBox.hide();
+         this._countDown = null;
+         GLib.spawn_command_line_async('systemctl suspend -i');
+      }
+   }
 }
 
-MyApplet.prototype = {
-    __proto__: Applet.IconApplet.prototype,
-
-    _init: function(orientation) {        
-        Applet.IconApplet.prototype._init.call(this, orientation);
-        
-        try {
-            this.set_applet_icon_name("gnome-session-suspend");
-            this.set_applet_tooltip(_("suspend"));                                                
-        }
-        catch (e) {
-            global.logError(e);
-        }
-    },
-    
-    on_applet_clicked: function(event) {      
-        GLib.spawn_command_line_async('systemctl suspend -i');
-    }
-   
-};
-
-
-
-function main(metadata, orientation) {  
-    let myApplet = new MyApplet(orientation);
-    return myApplet;      
+function main(metadata, orientation, panelHeight, instanceId) {
+   return new SuspendApplet(orientation, panelHeight, instanceId);
 }

--- a/suspend@janax/files/suspend@janax/metadata.json
+++ b/suspend@janax/files/suspend@janax/metadata.json
@@ -1,5 +1,6 @@
 {
-    "description": "Immediately suspends the computer", 
-    "uuid": "suspend@janax", 
-    "name": "Suspend computer"
+    "description": "Immediately suspends the computer",
+    "uuid": "suspend@janax",
+    "name": "Suspend computer",
+    "max-instances": -1
 }

--- a/suspend@janax/files/suspend@janax/metadata.json
+++ b/suspend@janax/files/suspend@janax/metadata.json
@@ -2,5 +2,6 @@
     "description": "Immediately suspends the computer",
     "uuid": "suspend@janax",
     "name": "Suspend computer",
+    "version": 2.0,
     "max-instances": -1
 }

--- a/suspend@janax/files/suspend@janax/po/da.po
+++ b/suspend@janax/files/suspend@janax/po/da.po
@@ -6,26 +6,71 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-03 19:19+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-02-12 11:21-0500\n"
 "PO-Revision-Date: 2017-10-03 19:20+0200\n"
+"Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
+"Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: da\n"
 
-#: applet.js:25
-msgid "suspend"
+#: applet.js:64
+#, fuzzy
+msgid "Suspend"
 msgstr "Sæt i hviletilstand"
 
-#. suspend@janax->metadata.json->description
+#. metadata.json->description
 msgid "Immediately suspends the computer"
 msgstr "Sætter øjeblikkeligt computeren i hviletilstand"
 
-#. suspend@janax->metadata.json->name
+#. metadata.json->name
 msgid "Suspend computer"
 msgstr "Sæt computeren i hviletilstand"
+
+#. settings-schema.json->suspend-header->description
+#, fuzzy
+msgid "Suspend computer setting"
+msgstr "Sæt computeren i hviletilstand"
+
+#. settings-schema.json->suspend-on-double-click->description
+msgid "Double-click to suspend"
+msgstr ""
+
+#. settings-schema.json->suspend-on-double-click->tooltip
+msgid ""
+"When enabled, a double-click will suspend the computer, otherwise the "
+"computer will suspend on a single click."
+msgstr ""
+
+#. settings-schema.json->count-down->description
+msgid "Use a count down before suspending"
+msgstr ""
+
+#. settings-schema.json->count-down->tooltip
+msgid ""
+"When enabled, a count down will occurs before suspending the computer.\n"
+"Clicking again during the count down will cancel the suspend."
+msgstr ""
+
+#. settings-schema.json->count-down-duration->units
+msgid "seconds"
+msgstr ""
+
+#. settings-schema.json->count-down-duration->description
+msgid "Count down duration"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->description
+msgid "Use a full color icon"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->tooltip
+msgid ""
+"When enabled, a full color panel icon will be used, otherwise a symbol icon "
+"sill be used."
+msgstr ""

--- a/suspend@janax/files/suspend@janax/po/de.po
+++ b/suspend@janax/files/suspend@janax/po/de.po
@@ -6,26 +6,71 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-23 12:17+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-02-12 11:21-0500\n"
 "PO-Revision-Date: 2021-02-16 18:30+0100\n"
+"Last-Translator: \n"
 "Language-Team: \n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: de\n"
 
-#: applet.js:25
-msgid "suspend"
+#: applet.js:64
+#, fuzzy
+msgid "Suspend"
 msgstr "In Bereitschaft versetzen"
 
-#. suspend@janax->metadata.json->description
+#. metadata.json->description
 msgid "Immediately suspends the computer"
 msgstr "Versetzt den Rechner sofort in Bereitschaft"
 
-#. suspend@janax->metadata.json->name
+#. metadata.json->name
 msgid "Suspend computer"
 msgstr "Rechner-Bereitschaftsmodus"
+
+#. settings-schema.json->suspend-header->description
+#, fuzzy
+msgid "Suspend computer setting"
+msgstr "Rechner-Bereitschaftsmodus"
+
+#. settings-schema.json->suspend-on-double-click->description
+msgid "Double-click to suspend"
+msgstr ""
+
+#. settings-schema.json->suspend-on-double-click->tooltip
+msgid ""
+"When enabled, a double-click will suspend the computer, otherwise the "
+"computer will suspend on a single click."
+msgstr ""
+
+#. settings-schema.json->count-down->description
+msgid "Use a count down before suspending"
+msgstr ""
+
+#. settings-schema.json->count-down->tooltip
+msgid ""
+"When enabled, a count down will occurs before suspending the computer.\n"
+"Clicking again during the count down will cancel the suspend."
+msgstr ""
+
+#. settings-schema.json->count-down-duration->units
+msgid "seconds"
+msgstr ""
+
+#. settings-schema.json->count-down-duration->description
+msgid "Count down duration"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->description
+msgid "Use a full color icon"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->tooltip
+msgid ""
+"When enabled, a full color panel icon will be used, otherwise a symbol icon "
+"sill be used."
+msgstr ""

--- a/suspend@janax/files/suspend@janax/po/es.po
+++ b/suspend@janax/files/suspend@janax/po/es.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-23 12:17+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-02-12 11:21-0500\n"
 "PO-Revision-Date: 2021-12-28 11:27-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,14 +19,58 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:25
-msgid "suspend"
+#: applet.js:64
+#, fuzzy
+msgid "Suspend"
 msgstr "suspender"
 
-#. suspend@janax->metadata.json->description
+#. metadata.json->description
 msgid "Immediately suspends the computer"
 msgstr "Suspende inmediatamente el ordenador"
 
-#. suspend@janax->metadata.json->name
+#. metadata.json->name
 msgid "Suspend computer"
 msgstr "Suspender el computador"
+
+#. settings-schema.json->suspend-header->description
+#, fuzzy
+msgid "Suspend computer setting"
+msgstr "Suspender el computador"
+
+#. settings-schema.json->suspend-on-double-click->description
+msgid "Double-click to suspend"
+msgstr ""
+
+#. settings-schema.json->suspend-on-double-click->tooltip
+msgid ""
+"When enabled, a double-click will suspend the computer, otherwise the "
+"computer will suspend on a single click."
+msgstr ""
+
+#. settings-schema.json->count-down->description
+msgid "Use a count down before suspending"
+msgstr ""
+
+#. settings-schema.json->count-down->tooltip
+msgid ""
+"When enabled, a count down will occurs before suspending the computer.\n"
+"Clicking again during the count down will cancel the suspend."
+msgstr ""
+
+#. settings-schema.json->count-down-duration->units
+msgid "seconds"
+msgstr ""
+
+#. settings-schema.json->count-down-duration->description
+msgid "Count down duration"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->description
+msgid "Use a full color icon"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->tooltip
+msgid ""
+"When enabled, a full color panel icon will be used, otherwise a symbol icon "
+"sill be used."
+msgstr ""

--- a/suspend@janax/files/suspend@janax/po/fr.po
+++ b/suspend@janax/files/suspend@janax/po/fr.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-23 12:17+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-02-12 11:21-0500\n"
 "PO-Revision-Date: 2023-05-11 18:36+0200\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -18,14 +19,58 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:25
-msgid "suspend"
+#: applet.js:64
+#, fuzzy
+msgid "Suspend"
 msgstr "Suspendre toute activité de l'ordinateur"
 
-#. suspend@janax->metadata.json->description
+#. metadata.json->description
 msgid "Immediately suspends the computer"
 msgstr "Suspend immédiatement l'ordinateur"
 
-#. suspend@janax->metadata.json->name
+#. metadata.json->name
 msgid "Suspend computer"
 msgstr "Suspendre toute activité de l'ordinateur"
+
+#. settings-schema.json->suspend-header->description
+#, fuzzy
+msgid "Suspend computer setting"
+msgstr "Suspendre toute activité de l'ordinateur"
+
+#. settings-schema.json->suspend-on-double-click->description
+msgid "Double-click to suspend"
+msgstr ""
+
+#. settings-schema.json->suspend-on-double-click->tooltip
+msgid ""
+"When enabled, a double-click will suspend the computer, otherwise the "
+"computer will suspend on a single click."
+msgstr ""
+
+#. settings-schema.json->count-down->description
+msgid "Use a count down before suspending"
+msgstr ""
+
+#. settings-schema.json->count-down->tooltip
+msgid ""
+"When enabled, a count down will occurs before suspending the computer.\n"
+"Clicking again during the count down will cancel the suspend."
+msgstr ""
+
+#. settings-schema.json->count-down-duration->units
+msgid "seconds"
+msgstr ""
+
+#. settings-schema.json->count-down-duration->description
+msgid "Count down duration"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->description
+msgid "Use a full color icon"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->tooltip
+msgid ""
+"When enabled, a full color panel icon will be used, otherwise a symbol icon "
+"sill be used."
+msgstr ""

--- a/suspend@janax/files/suspend@janax/po/hr.po
+++ b/suspend@janax/files/suspend@janax/po/hr.po
@@ -6,26 +6,72 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: suspend@janax\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-08 14:01+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-02-12 11:21-0500\n"
 "PO-Revision-Date: 2017-05-08 14:04+0200\n"
+"Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: \n"
+"Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: gogo <trebelnik2@gmail.com>\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"Language: hr\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: applet.js:25
-msgid "suspend"
+#: applet.js:64
+#, fuzzy
+msgid "Suspend"
 msgstr "Suspendiraj"
 
-#. suspend@janax->metadata.json->description
+#. metadata.json->description
 msgid "Immediately suspends the computer"
 msgstr "Odmah suspendirajte računalo."
 
-#. suspend@janax->metadata.json->name
+#. metadata.json->name
 msgid "Suspend computer"
 msgstr "Suspendiraj računalo"
+
+#. settings-schema.json->suspend-header->description
+#, fuzzy
+msgid "Suspend computer setting"
+msgstr "Suspendiraj računalo"
+
+#. settings-schema.json->suspend-on-double-click->description
+msgid "Double-click to suspend"
+msgstr ""
+
+#. settings-schema.json->suspend-on-double-click->tooltip
+msgid ""
+"When enabled, a double-click will suspend the computer, otherwise the "
+"computer will suspend on a single click."
+msgstr ""
+
+#. settings-schema.json->count-down->description
+msgid "Use a count down before suspending"
+msgstr ""
+
+#. settings-schema.json->count-down->tooltip
+msgid ""
+"When enabled, a count down will occurs before suspending the computer.\n"
+"Clicking again during the count down will cancel the suspend."
+msgstr ""
+
+#. settings-schema.json->count-down-duration->units
+msgid "seconds"
+msgstr ""
+
+#. settings-schema.json->count-down-duration->description
+msgid "Count down duration"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->description
+msgid "Use a full color icon"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->tooltip
+msgid ""
+"When enabled, a full color panel icon will be used, otherwise a symbol icon "
+"sill be used."
+msgstr ""

--- a/suspend@janax/files/suspend@janax/po/hu.po
+++ b/suspend@janax/files/suspend@janax/po/hu.po
@@ -6,26 +6,71 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-23 12:17+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-02-12 11:21-0500\n"
 "PO-Revision-Date: 2020-09-21 15:52+0200\n"
+"Last-Translator: \n"
 "Language-Team: \n"
+"Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.4.1\n"
-"Last-Translator: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: hu\n"
 
-#: applet.js:25
-msgid "suspend"
+#: applet.js:64
+#, fuzzy
+msgid "Suspend"
 msgstr "felfüggeszt"
 
-#. suspend@janax->metadata.json->description
+#. metadata.json->description
 msgid "Immediately suspends the computer"
 msgstr "A számítógép azonnali felfüggesztése"
 
-#. suspend@janax->metadata.json->name
+#. metadata.json->name
 msgid "Suspend computer"
 msgstr "Számítógép felfüggesztése"
+
+#. settings-schema.json->suspend-header->description
+#, fuzzy
+msgid "Suspend computer setting"
+msgstr "Számítógép felfüggesztése"
+
+#. settings-schema.json->suspend-on-double-click->description
+msgid "Double-click to suspend"
+msgstr ""
+
+#. settings-schema.json->suspend-on-double-click->tooltip
+msgid ""
+"When enabled, a double-click will suspend the computer, otherwise the "
+"computer will suspend on a single click."
+msgstr ""
+
+#. settings-schema.json->count-down->description
+msgid "Use a count down before suspending"
+msgstr ""
+
+#. settings-schema.json->count-down->tooltip
+msgid ""
+"When enabled, a count down will occurs before suspending the computer.\n"
+"Clicking again during the count down will cancel the suspend."
+msgstr ""
+
+#. settings-schema.json->count-down-duration->units
+msgid "seconds"
+msgstr ""
+
+#. settings-schema.json->count-down-duration->description
+msgid "Count down duration"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->description
+msgid "Use a full color icon"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->tooltip
+msgid ""
+"When enabled, a full color panel icon will be used, otherwise a symbol icon "
+"sill be used."
+msgstr ""

--- a/suspend@janax/files/suspend@janax/po/it.po
+++ b/suspend@janax/files/suspend@janax/po/it.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-23 12:17+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-02-12 11:21-0500\n"
 "PO-Revision-Date: 2022-06-03 19:12+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -17,14 +18,58 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
 
-#: applet.js:25
-msgid "suspend"
+#: applet.js:64
+#, fuzzy
+msgid "Suspend"
 msgstr "sospendi"
 
-#. suspend@janax->metadata.json->description
+#. metadata.json->description
 msgid "Immediately suspends the computer"
 msgstr "Sospende immediatamente il computer"
 
-#. suspend@janax->metadata.json->name
+#. metadata.json->name
 msgid "Suspend computer"
 msgstr "Sospendi computer"
+
+#. settings-schema.json->suspend-header->description
+#, fuzzy
+msgid "Suspend computer setting"
+msgstr "Sospendi computer"
+
+#. settings-schema.json->suspend-on-double-click->description
+msgid "Double-click to suspend"
+msgstr ""
+
+#. settings-schema.json->suspend-on-double-click->tooltip
+msgid ""
+"When enabled, a double-click will suspend the computer, otherwise the "
+"computer will suspend on a single click."
+msgstr ""
+
+#. settings-schema.json->count-down->description
+msgid "Use a count down before suspending"
+msgstr ""
+
+#. settings-schema.json->count-down->tooltip
+msgid ""
+"When enabled, a count down will occurs before suspending the computer.\n"
+"Clicking again during the count down will cancel the suspend."
+msgstr ""
+
+#. settings-schema.json->count-down-duration->units
+msgid "seconds"
+msgstr ""
+
+#. settings-schema.json->count-down-duration->description
+msgid "Count down duration"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->description
+msgid "Use a full color icon"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->tooltip
+msgid ""
+"When enabled, a full color panel icon will be used, otherwise a symbol icon "
+"sill be used."
+msgstr ""

--- a/suspend@janax/files/suspend@janax/po/pt_BR.po
+++ b/suspend@janax/files/suspend@janax/po/pt_BR.po
@@ -6,26 +6,71 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-23 12:17+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-02-12 11:21-0500\n"
 "PO-Revision-Date: 2021-10-01 13:55-0300\n"
+"Last-Translator: Marcelo Aof\n"
 "Language-Team: \n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0\n"
-"Last-Translator: Marcelo Aof\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Language: pt_BR\n"
 
-#: applet.js:25
-msgid "suspend"
+#: applet.js:64
+#, fuzzy
+msgid "Suspend"
 msgstr "Suspender"
 
-#. suspend@janax->metadata.json->description
+#. metadata.json->description
 msgid "Immediately suspends the computer"
 msgstr "Suspende imediatamente o computador"
 
-#. suspend@janax->metadata.json->name
+#. metadata.json->name
 msgid "Suspend computer"
 msgstr "Suspender o computador"
+
+#. settings-schema.json->suspend-header->description
+#, fuzzy
+msgid "Suspend computer setting"
+msgstr "Suspender o computador"
+
+#. settings-schema.json->suspend-on-double-click->description
+msgid "Double-click to suspend"
+msgstr ""
+
+#. settings-schema.json->suspend-on-double-click->tooltip
+msgid ""
+"When enabled, a double-click will suspend the computer, otherwise the "
+"computer will suspend on a single click."
+msgstr ""
+
+#. settings-schema.json->count-down->description
+msgid "Use a count down before suspending"
+msgstr ""
+
+#. settings-schema.json->count-down->tooltip
+msgid ""
+"When enabled, a count down will occurs before suspending the computer.\n"
+"Clicking again during the count down will cancel the suspend."
+msgstr ""
+
+#. settings-schema.json->count-down-duration->units
+msgid "seconds"
+msgstr ""
+
+#. settings-schema.json->count-down-duration->description
+msgid "Count down duration"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->description
+msgid "Use a full color icon"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->tooltip
+msgid ""
+"When enabled, a full color panel icon will be used, otherwise a symbol icon "
+"sill be used."
+msgstr ""

--- a/suspend@janax/files/suspend@janax/po/ru.po
+++ b/suspend@janax/files/suspend@janax/po/ru.po
@@ -6,26 +6,72 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-02 19:51+0300\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-02-12 11:21-0500\n"
 "PO-Revision-Date: 2017-05-02 19:56+0300\n"
+"Last-Translator: \n"
 "Language-Team: \n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: \n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"Language: ru\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: applet.js:25
-msgid "suspend"
+#: applet.js:64
+#, fuzzy
+msgid "Suspend"
 msgstr "приостановить"
 
-#. suspend@janax->metadata.json->description
+#. metadata.json->description
 msgid "Immediately suspends the computer"
 msgstr "Немедленно приостанавливает работу компьютера"
 
-#. suspend@janax->metadata.json->name
+#. metadata.json->name
 msgid "Suspend computer"
 msgstr "Приостановить компьютер"
+
+#. settings-schema.json->suspend-header->description
+#, fuzzy
+msgid "Suspend computer setting"
+msgstr "Приостановить компьютер"
+
+#. settings-schema.json->suspend-on-double-click->description
+msgid "Double-click to suspend"
+msgstr ""
+
+#. settings-schema.json->suspend-on-double-click->tooltip
+msgid ""
+"When enabled, a double-click will suspend the computer, otherwise the "
+"computer will suspend on a single click."
+msgstr ""
+
+#. settings-schema.json->count-down->description
+msgid "Use a count down before suspending"
+msgstr ""
+
+#. settings-schema.json->count-down->tooltip
+msgid ""
+"When enabled, a count down will occurs before suspending the computer.\n"
+"Clicking again during the count down will cancel the suspend."
+msgstr ""
+
+#. settings-schema.json->count-down-duration->units
+msgid "seconds"
+msgstr ""
+
+#. settings-schema.json->count-down-duration->description
+msgid "Count down duration"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->description
+msgid "Use a full color icon"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->tooltip
+msgid ""
+"When enabled, a full color panel icon will be used, otherwise a symbol icon "
+"sill be used."
+msgstr ""

--- a/suspend@janax/files/suspend@janax/po/suspend@janax.pot
+++ b/suspend@janax/files/suspend@janax/po/suspend@janax.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is put in the public domain.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-12 10:50-0500\n"
+"Project-Id-Version: suspend@janax 2.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-02-12 11:21-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/suspend@janax/files/suspend@janax/po/suspend@janax.pot
+++ b/suspend@janax/files/suspend@janax/po/suspend@janax.pot
@@ -8,23 +8,65 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-23 12:17+0800\n"
+"POT-Creation-Date: 2024-02-12 10:50-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:25
-msgid "suspend"
+#: applet.js:64
+msgid "Suspend"
 msgstr ""
 
-#. suspend@janax->metadata.json->description
+#. metadata.json->description
 msgid "Immediately suspends the computer"
 msgstr ""
 
-#. suspend@janax->metadata.json->name
+#. metadata.json->name
 msgid "Suspend computer"
+msgstr ""
+
+#. settings-schema.json->suspend-header->description
+msgid "Suspend computer setting"
+msgstr ""
+
+#. settings-schema.json->suspend-on-double-click->description
+msgid "Double-click to suspend"
+msgstr ""
+
+#. settings-schema.json->suspend-on-double-click->tooltip
+msgid ""
+"When enabled, a double-click will suspend the computer, otherwise the "
+"computer will suspend on a single click."
+msgstr ""
+
+#. settings-schema.json->count-down->description
+msgid "Use a count down before suspending"
+msgstr ""
+
+#. settings-schema.json->count-down->tooltip
+msgid ""
+"When enabled, a count down will occurs before suspending the computer.\n"
+"Clicking again during the count down will cancel the suspend."
+msgstr ""
+
+#. settings-schema.json->count-down-duration->units
+msgid "seconds"
+msgstr ""
+
+#. settings-schema.json->count-down-duration->description
+msgid "Count down duration"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->description
+msgid "Use a full color icon"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->tooltip
+msgid ""
+"When enabled, a full color panel icon will be used, otherwise a symbol icon "
+"sill be used."
 msgstr ""

--- a/suspend@janax/files/suspend@janax/po/sv.po
+++ b/suspend@janax/files/suspend@janax/po/sv.po
@@ -6,26 +6,71 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: suspend@janax\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-30 05:48+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-02-12 11:21-0500\n"
 "PO-Revision-Date: 2017-05-30 05:51+0200\n"
+"Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: sv\n"
 
-#: applet.js:25
-msgid "suspend"
+#: applet.js:64
+#, fuzzy
+msgid "Suspend"
 msgstr "Viloläge"
 
-#. suspend@janax->metadata.json->description
+#. metadata.json->description
 msgid "Immediately suspends the computer"
 msgstr "Försätt datorn i omedelbart viloläge"
 
-#. suspend@janax->metadata.json->name
+#. metadata.json->name
 msgid "Suspend computer"
 msgstr "Försätt datorn i viloläge"
+
+#. settings-schema.json->suspend-header->description
+#, fuzzy
+msgid "Suspend computer setting"
+msgstr "Försätt datorn i viloläge"
+
+#. settings-schema.json->suspend-on-double-click->description
+msgid "Double-click to suspend"
+msgstr ""
+
+#. settings-schema.json->suspend-on-double-click->tooltip
+msgid ""
+"When enabled, a double-click will suspend the computer, otherwise the "
+"computer will suspend on a single click."
+msgstr ""
+
+#. settings-schema.json->count-down->description
+msgid "Use a count down before suspending"
+msgstr ""
+
+#. settings-schema.json->count-down->tooltip
+msgid ""
+"When enabled, a count down will occurs before suspending the computer.\n"
+"Clicking again during the count down will cancel the suspend."
+msgstr ""
+
+#. settings-schema.json->count-down-duration->units
+msgid "seconds"
+msgstr ""
+
+#. settings-schema.json->count-down-duration->description
+msgid "Count down duration"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->description
+msgid "Use a full color icon"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->tooltip
+msgid ""
+"When enabled, a full color panel icon will be used, otherwise a symbol icon "
+"sill be used."
+msgstr ""

--- a/suspend@janax/files/suspend@janax/po/zh_CN.po
+++ b/suspend@janax/files/suspend@janax/po/zh_CN.po
@@ -6,26 +6,71 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-23 12:17+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-02-12 11:21-0500\n"
 "PO-Revision-Date: 2017-04-23 12:18+0800\n"
+"Last-Translator: \n"
 "Language-Team: \n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.11\n"
-"Last-Translator: \n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"Language: zh_CN\n"
 
-#: applet.js:25
-msgid "suspend"
+#: applet.js:64
+#, fuzzy
+msgid "Suspend"
 msgstr "挂起"
 
-#. suspend@janax->metadata.json->description
+#. metadata.json->description
 msgid "Immediately suspends the computer"
 msgstr "立即挂起计算机"
 
-#. suspend@janax->metadata.json->name
+#. metadata.json->name
 msgid "Suspend computer"
 msgstr "挂起计算机"
+
+#. settings-schema.json->suspend-header->description
+#, fuzzy
+msgid "Suspend computer setting"
+msgstr "挂起计算机"
+
+#. settings-schema.json->suspend-on-double-click->description
+msgid "Double-click to suspend"
+msgstr ""
+
+#. settings-schema.json->suspend-on-double-click->tooltip
+msgid ""
+"When enabled, a double-click will suspend the computer, otherwise the "
+"computer will suspend on a single click."
+msgstr ""
+
+#. settings-schema.json->count-down->description
+msgid "Use a count down before suspending"
+msgstr ""
+
+#. settings-schema.json->count-down->tooltip
+msgid ""
+"When enabled, a count down will occurs before suspending the computer.\n"
+"Clicking again during the count down will cancel the suspend."
+msgstr ""
+
+#. settings-schema.json->count-down-duration->units
+msgid "seconds"
+msgstr ""
+
+#. settings-schema.json->count-down-duration->description
+msgid "Count down duration"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->description
+msgid "Use a full color icon"
+msgstr ""
+
+#. settings-schema.json->fullcolor-icon->tooltip
+msgid ""
+"When enabled, a full color panel icon will be used, otherwise a symbol icon "
+"sill be used."
+msgstr ""

--- a/suspend@janax/files/suspend@janax/settings-schema.json
+++ b/suspend@janax/files/suspend@janax/settings-schema.json
@@ -1,0 +1,34 @@
+{
+   "suspend-header": {
+      "type": "header",
+      "description": "Suspend computer setting"
+   },
+   "suspend-on-double-click": {
+      "type": "switch",
+      "default": 0,
+      "description": "Double-click to suspend",
+      "tooltip": "When enabled, a double-click will suspend the computer, otherwise the computer will suspend on a single click."
+   },
+   "count-down": {
+      "type": "switch",
+      "default": 0,
+      "description": "Use a count down before suspending",
+      "tooltip": "When enabled, a count down will occurs before suspending the computer.\nClicking again during the count down will cancel the suspend."
+   },
+   "count-down-duration": {
+    "type": "spinbutton",
+    "default": 5,
+    "min": 0,
+    "max": 9,
+    "units": "seconds",
+    "step": 1,
+    "description": "Count down duration",
+    "dependency" : "count-down"
+   },
+   "fullcolor-icon": {
+      "type": "switch",
+      "default": 1,
+      "description": "Use a full color icon",
+      "tooltip": "When enabled, a full color panel icon will be used, otherwise a symbol icon sill be used."
+   }
+}

--- a/suspend@janax/info.json
+++ b/suspend@janax/info.json
@@ -1,4 +1,4 @@
 {
-    "author": "none",
+    "author": "klangman",
     "original_author": "janax"
 }


### PR DESCRIPTION
I believe this applet has been abandoned, so I am offering the following changes. I could also submit this as a separate applet if you think that better given the extent of the changes?

1. Rewritten in Javascript EC6
2. Added an option to require a double-click to suspend (reducing accidental suspends).
3. Added a count-down option to allow the user some time to abort the suspend by clicking on the applet icon a second time. The count-down is displayed using a icon-overlay badge like the one used by the grouped-windowlist applet for showing the window count.
4. Added an option to configure the count-down duration
4. Added a README.md.
5. Made the applet allow multiple instances (mainly for people with multiple monitors).
6. Added an option to use a symbolic or full color icon on the panel.

By default it still instantly suspends with a single click.