### PR TITLE
[suspend@janax] Fix some issues with using the symbolic icon setting

### DIFF
--- a/suspend@janax/README.md
+++ b/suspend@janax/README.md
@@ -1,9 +1,10 @@
-Immediately suspends the computer (by default)
+Immediately suspends the computer (when using default configuration)
 
 ## Features
 
 1. Suspend instantly on a single click or only suspend on a double-click to avoid accidentally suspending the computer.
-2. Optionally add a count-down timer (1-9 sec) giving you the chance to cancel the suspend operation. 
+2. Optionally add a count-down timer giving you the chance to cancel the suspend operation (configurable: 1-9 sec).
 3. A single click on the panel button during the count down will cancel the suspend operation.
 4. Choose between a full color or a symbolic panel icon for the applet.
 
+Free icon from:  http://findicons.com/icon/86657/suspend?id=86657

--- a/suspend@janax/files/suspend@janax/applet.js
+++ b/suspend@janax/files/suspend@janax/applet.js
@@ -26,7 +26,7 @@ class SuspendApplet extends Applet.Applet {
       this.settings = new Settings.AppletSettings(this, UUID, instanceId);
 
       // Icon Box to contain the icon and the count down label
-      let iconSize = this.getPanelIconSize(St.IconType.FULLCOLOR);
+      let iconSize = this.getPanelIconSize( (this.settings.getValue("fullcolor-icon")) ? St.IconType.FULLCOLOR : St.IconType.SYMBOLIC);
       this._iconBox = new St.Group({natural_width: iconSize, natural_height: iconSize, x_align: Clutter.ActorAlign.CENTER, y_align: Clutter.ActorAlign.CENTER});
 
       // Create the icon and it's container
@@ -34,22 +34,6 @@ class SuspendApplet extends Applet.Applet {
       this._iconBin = new St.Bin();
       this._iconBin._delegate = this;
       this._iconBox.add_actor(this._iconBin);
-      /*
-      if( this.settings.getValue("fullcolor-icon") ){
-         this._icon = new St.Icon({ icon_name: "gnome-session-suspend",
-                                    icon_type: St.IconType.FULLCOLOR,
-                                    reactive: true, track_hover: true,
-                                    style_class: 'applet-icon',
-                                    icon_size: iconSize});
-      }else{
-         this._icon = new St.Icon({ icon_name: "weather-clear-night",
-                                    icon_type: St.IconType.SYMBOLIC,
-                                    reactive: true, track_hover: true,
-                                    style_class: 'applet-icon',
-                                    icon_size: iconSize});
-      }
-      this._iconBin.set_child(this._icon);
-      */
       this._updateIcon();
 
       // Create the count down number label and it's containers
@@ -66,33 +50,31 @@ class SuspendApplet extends Applet.Applet {
    }
 
    _updateIcon() {
-      let iconSize = this.getPanelIconSize(St.IconType.FULLCOLOR);
-      log( "Icon updating" );
       if( this._icon ){
          this._icon.destroy();
-         //this._iconBin.remove_child(this._icon);
       }
       if( this.settings.getValue("fullcolor-icon") ){
+         let iconSize = this.getPanelIconSize(St.IconType.FULLCOLOR);
          this._icon = new St.Icon({ icon_name: "gnome-session-suspend",
                                     icon_type: St.IconType.FULLCOLOR,
                                     reactive: true, track_hover: true,
                                     style_class: 'applet-icon',
                                     icon_size: iconSize});
       }else{
+      let iconSize = this.getPanelIconSize(St.IconType.SYMBOLIC);
          this._icon = new St.Icon({ icon_name: "weather-clear-night",
                                     icon_type: St.IconType.SYMBOLIC,
                                     reactive: true, track_hover: true,
-                                    style_class: 'applet-icon',
-                                    icon_size: iconSize});
+                                    style_class: 'applet-icon'});
       }
       this._iconBin.set_child(this._icon);
+      this.on_panel_icon_size_changed()
    }
 
    on_panel_icon_size_changed() {
-      let iconSize = this.getPanelIconSize(St.IconType.FULLCOLOR);
+      let iconSize = this.getPanelIconSize(this.settings.getValue("fullcolor-icon") ? St.IconType.FULLCOLOR : St.IconType.SYMBOLIC);
+      this._iconBox.set_size(iconSize, iconSize);
       this._icon.set_icon_size(iconSize);
-      this._iconBox.set_height(iconSize);
-      this._iconBox.set_width(iconSize);
    }
 
    on_applet_clicked(event) {

--- a/suspend@janax/files/suspend@janax/metadata.json
+++ b/suspend@janax/files/suspend@janax/metadata.json
@@ -2,6 +2,6 @@
     "description": "Immediately suspends the computer",
     "uuid": "suspend@janax",
     "name": "Suspend computer",
-    "version": 2.0,
+    "version": "2.0.1",
     "max-instances": -1
 }

--- a/suspend@janax/files/suspend@janax/settings-schema.json
+++ b/suspend@janax/files/suspend@janax/settings-schema.json
@@ -29,6 +29,6 @@
       "type": "switch",
       "default": 1,
       "description": "Use a full color icon",
-      "tooltip": "When enabled, a full color panel icon will be used, otherwise a symbol icon sill be used."
+      "tooltip": "When enabled, a full color panel icon will be used, otherwise a symbolic icon sill be used."
    }
 }


### PR DESCRIPTION
1. Set the icon size to the symbolic icon size defined in panel settings when the "Use full color icon" option is disabled.

2. Recenter the icon when changing the "Use full color icon" setting.

3. Remove a debugging message accidentally left in the code.

4. Fix a typo in a tooltip.

5. Move the README.md to the correct location.