### PR TITLE
Fix color-picking when display scaling is used

### DIFF
--- a/color-picker@fmete/files/color-picker@fmete/cp.py
+++ b/color-picker@fmete/files/color-picker@fmete/cp.py
@@ -36,7 +36,8 @@ except ImportError:
 
 def getPixelColor(x, y):
   w = Gdk.get_default_root_window()
-  pb = Gdk.pixbuf_get_from_window(w, x, y, 1, 1)
+  scale_factor = w.get_scale_factor()
+  pb = Gdk.pixbuf_get_from_window(w, x // scale_factor, y // scale_factor, 1, 1)
   return pb.get_pixels()
 
 def mousePixel():


### PR DESCRIPTION
Fixes https://github.com/linuxmint/cinnamon-spices-applets/issues/4711

The provided fix allows the color picker to also work when display scaling is used. Previously when using the color picker with display scaling, it would report either #000000 or an incorrect color (when picking a color somewhere in the upper left color of the screen).

Tested locally with a multi-monitor setup with different resolutions for each monitor and with multiple different scaling settings.