### PR TITLE
[ssm@Severga] Improve net list update

### DIFF
--- a/ssm@Severga/files/ssm@Severga/applet.js
+++ b/ssm@Severga/files/ssm@Severga/applet.js
@@ -423,7 +423,6 @@ NetDataProvider.prototype = {
 	},
 	
 	_process_devices: function() {
-													global.log("UPDATE!!!");
 		this.currentReadings = [];
 		for (let i = 0, len = this.devices.length; i < len; i++) {
 			if (this.devices[i].state !== CONNECTED_STATE) continue;


### PR DESCRIPTION
It turned out that the applet's list of net interfaces is shown incorrectly after turning off and on some connections in Network Manager. The signals I was able to find and use do not cover all changes that happen and the list sometimes doesn't change automatically, except after reloading the applet. Instead of signals I decided to use periodical net interfaces look-up every 30 sec.

I understand that this is not an efficient solution, and if somebody can help me with the signals, I would appreciate it very much.