### PR TITLE
directory-menu@torchipeppo: Add support for Flatpak terminals

### DIFF
--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/metadata.json
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "directory-menu@torchipeppo",
     "name": "Directory Menu",
     "description": "Quickly navigate through directories on your system using a dropdown menu.",
-    "version": "0.5",
+    "version": "0.5.1",
     "author": "torchipeppo",
     "max-instances": "-1"
 }

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/popup_menu.py
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/popup_menu.py
@@ -157,7 +157,7 @@ class Cassettone:
             "path": path,
         }))
         terminal_preferences = Gio.Settings.new("org.cinnamon.desktop.default-applications.terminal")
-        argv = [terminal_preferences.get_string("exec")]
+        argv = terminal_preferences.get_string("exec").split()
         spawn_flags = GLib.SpawnFlags.SEARCH_PATH | GLib.SpawnFlags.STDOUT_TO_DEV_NULL | GLib.SpawnFlags.STDERR_TO_DEV_NULL
         GLib.spawn_async(working_directory=path, argv=argv, flags=spawn_flags)
 


### PR DESCRIPTION
cc @torchipeppo This adds support for terminals installed via Flatpak (e.g. [Black Box](https://flathub.org/apps/com.raggesilver.BlackBox))

Shout if you want to change the version too.