### PR TITLE
[kdecapplet@joejoetv] Version 2.1.1 - Small bug fix

### DIFF
--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/applet.js
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/applet.js
@@ -825,7 +825,7 @@ class KDEConnectApplet extends Applet.TextIconApplet {
             } else {
                 this.warn("KDE Connect DBus service not found on session bus!", CommonUtils.LogLevel.NORMAL);
     
-                this.serviceOnBus = true;
+                this.serviceOnBus = false;
 
                 // KDE Connect DBus service is not available
     
@@ -1062,7 +1062,7 @@ class KDEConnectApplet extends Applet.TextIconApplet {
 
             if (this.serviceOnBus == false) {
                 // Add menu item to tell the user, that KDE Connect is currently unavailable to the applet
-                let kdecNotFoundMenuItem = new PopupMenu.PopupMenuItem(_("KDE Connect not available"), {reactive: false});
+                let kdecNotFoundMenuItem = new PopupMenu.PopupMenuItem(_("KDE Connect not available, make sure it's installed and running."), {reactive: false});
                 kdecNotFoundMenuItem.actor.add_style_pseudo_class('insensitive');
                 this.popupMenu.addMenuItem(kdecNotFoundMenuItem);
                 this.set_applet_tooltip(_("KDE Connect not available, make sure it's installed and running."), false);

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/metadata.json
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/metadata.json
@@ -4,6 +4,6 @@
   "description": "Enables interacting with devices connected via KDE Connect",
   "comments": "KDE Connect Applet makes it easy to use the various features provided by KDE Connect to interact with connected devices, like sending files, sending SMS messages, browsing the storage of the device and more",
   "website": "https://github.com/linuxmint/cinnamon-spices-applets/tree/master/kdecapplet@joejoetv",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "contributors": "Johannes Schoeneberger - Author,Severga - Inspiration for the Applet"
 }

--- a/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/de.po
+++ b/kdecapplet@joejoetv/files/kdecapplet@joejoetv/po/de.po
@@ -29,7 +29,7 @@ msgstr "KDE Connect ist nicht verfügbar"
 #: applet.js:1068
 msgid "KDE Connect not available, make sure it's installed and running."
 msgstr ""
-"KDE Connect ist nicht verfügbar, stelle sicher, das es installiert ist und "
+"KDE Connect ist nicht verfügbar, stelle sicher, dass es installiert ist und "
 "ausgeführt wird"
 
 #: applet.js:1072 applet.js:1085 applet.js:1270


### PR DESCRIPTION
## Changes

- Fixed bug that prevented the applet from showing the correct error message to the user, if KDE Connect was not installed or running
- Fixed spelling error in german language file