### PR TITLE
placesCenter@scollins v2.3 - Allows to show entire path in Recent Documents tooltips

### DIFF
--- a/placesCenter@scollins/files/placesCenter@scollins/metadata.json
+++ b/placesCenter@scollins/files/placesCenter@scollins/metadata.json
@@ -4,7 +4,7 @@
     "description": "Provides an easy-to-read layout to access your places",
     "comments": "Places Center is a feature-rich, cross-platform Cinnamon applet that provides easy access to all of your most-used places. Feel free to contribute by submitting pull requests, bug reports and feature requests to my github repo.",
     "website": "https://github.com/linuxmint/cinnamon-spices-applets",
-    "version": "2.2",
+    "version": "2.3",
     "contributors": "Stephen Collins - Author,kehugter - Added configurability to middle click,claudiux - Improvements to the 'Recent' section.",
     "max-instances": -1,
     "author": "collinss"

--- a/placesCenter@scollins/files/placesCenter@scollins/po/bg.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/bg.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-20 20:18+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-15 02:01+0200\n"
 "PO-Revision-Date: 2017-12-20 20:20+0200\n"
 "Last-Translator: Peyu Yovev <spacy00001@gmail.com>\n"
 "Language-Team: \n"
@@ -18,43 +19,51 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applet.js:178
+#: applet.js:150
+msgid "(Right click to open folder)"
+msgstr ""
+
+#: applet.js:172
 msgid "Places"
 msgstr "Места"
 
-#: applet.js:291
+#: applet.js:287
 msgid "Search Home Folder"
 msgstr "Търси в домашната папка"
 
-#: applet.js:305
+#: applet.js:310
 msgid "SYSTEM"
 msgstr "СИСТЕМА"
 
-#: applet.js:314
+#: applet.js:319
 msgid "Search File System"
 msgstr "Търси във файловата система"
 
-#: applet.js:330
+#: applet.js:344
 msgid "RECENT DOCUMENTS"
 msgstr "ПОСЛЕДНИ ДОКУМЕНТИ"
 
-#: applet.js:344
+#: applet.js:358
 msgid "Clear"
 msgstr "Изчисти"
 
-#: applet.js:388
+#: applet.js:364
+msgid "Recent"
+msgstr ""
+
+#: applet.js:407
 msgid "Computer"
 msgstr "Компютър"
 
-#: applet.js:394
+#: applet.js:413
 msgid "File System"
 msgstr "Файлова система"
 
-#: applet.js:410
+#: applet.js:429
 msgid "Network"
 msgstr "Мрежа"
 
-#: applet.js:513
+#: applet.js:569
 msgid "Trash"
 msgstr "Кошче"
 
@@ -127,8 +136,41 @@ msgid "Skipping"
 msgstr "Пропускане"
 
 #: search.py:259
-msgid " - direcotry already searched"
+#, fuzzy
+msgid " - directory already searched"
 msgstr " - директорията е вече претърсена"
+
+#. metadata.json->name
+msgid "Places Center"
+msgstr "Централни места"
+
+#. metadata.json->description
+msgid "Provides an easy-to-read layout to access your places"
+msgstr "Доставя лесна за ползване подредба за достъп до вашите места"
+
+#. metadata.json->comments
+msgid ""
+"Places Center is a feature-rich, cross-platform Cinnamon applet that "
+"provides easy access to all of your most-used places. Feel free to "
+"contribute by submitting pull requests, bug reports and feature requests to "
+"my github repo."
+msgstr ""
+"Централни места е богат на функции, много платформен аплет за Cinnamon, "
+"който предоставя лесен достъп до най-използваните от вас места. Чувствайте "
+"се поканени да допринесете с pull request, искане за функции и отчет за "
+"грешки в моето github хранилище."
+
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Автор: Стивън Колинс"
+
+#. metadata.json->contributors
+msgid "kehugter - Added configurability to middle click"
+msgstr "Добавка на конфигурация при клик с колелцето: kehugter"
+
+#. metadata.json->contributors
+msgid "claudiux - Improvements to the 'Recent' section."
+msgstr ""
 
 #. settings-schema.json->generalPage->title
 msgid "General"
@@ -258,34 +300,43 @@ msgstr "Показвай мрежа"
 msgid "Show recent documents"
 msgstr "Показване на последните документи"
 
+#. settings-schema.json->recentSizeLimit->options
+msgid "5"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "10"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "15"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "20"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "25"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "30"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+#, fuzzy
+msgid "All Recent Documents"
+msgstr "Последни документи"
+
 #. settings-schema.json->recentSizeLimit->description
 msgid "Number to show"
 msgstr "Брой за показване"
 
-#. metadata.json->name
-msgid "Places Center"
-msgstr "Централни места"
-
-#. metadata.json->description
-msgid "Provides an easy-to-read layout to access your places"
-msgstr "Доставя лесна за ползване подредба за достъп до вашите места"
-
-#. metadata.json->comments
-msgid ""
-"Places Center is a feature-rich, cross-platform Cinnamon applet that "
-"provides easy access to all of your most-used places. Feel free to "
-"contribute by submitting pull requests, bug reports and feature requests to "
-"my github repo."
+#. settings-schema.json->recentShowUri->description
+msgid "Show complete path in tooltips"
 msgstr ""
-"Централни места е богат на функции, много платформен аплет за Cinnamon, "
-"който предоставя лесен достъп до най-използваните от вас места. Чувствайте "
-"се поканени да допринесете с pull request, искане за функции и отчет за "
-"грешки в моето github хранилище."
 
-#. metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Автор: Стивън Колинс"
-
-#. metadata.json->contributors
-msgid "kehugter - Added configurability to middle click"
-msgstr "Добавка на конфигурация при клик с колелцето: kehugter"
+#. settings-schema.json->btnPrivacy->description
+msgid "Privacy"
+msgstr ""

--- a/placesCenter@scollins/files/placesCenter@scollins/po/da.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/da.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-24 20:57+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-15 02:01+0200\n"
 "PO-Revision-Date: 2022-10-27 19:44+0200\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -18,47 +19,51 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:148
+#: applet.js:150
 msgid "(Right click to open folder)"
 msgstr "(Højreklik for at åbne mappen)"
 
-#: applet.js:170
+#: applet.js:172
 msgid "Places"
 msgstr "Steder"
 
-#: applet.js:284
+#: applet.js:287
 msgid "Search Home Folder"
 msgstr "Søg i mappen Hjem"
 
-#: applet.js:307
+#: applet.js:310
 msgid "SYSTEM"
 msgstr "SYSTEM"
 
-#: applet.js:316
+#: applet.js:319
 msgid "Search File System"
 msgstr "Søg i Filsystem"
 
-#: applet.js:341
+#: applet.js:344
 msgid "RECENT DOCUMENTS"
 msgstr "SENESTE DOKUMENTER"
 
-#: applet.js:355
+#: applet.js:358
 msgid "Clear"
 msgstr "Ryd"
 
-#: applet.js:398
+#: applet.js:364
+msgid "Recent"
+msgstr ""
+
+#: applet.js:407
 msgid "Computer"
 msgstr "Computer"
 
-#: applet.js:404
+#: applet.js:413
 msgid "File System"
 msgstr "Filsystem"
 
-#: applet.js:420
+#: applet.js:429
 msgid "Network"
 msgstr "Netværk"
 
-#: applet.js:560
+#: applet.js:569
 msgid "Trash"
 msgstr "Papirkurven"
 
@@ -161,6 +166,10 @@ msgstr "Stephen Collins - forfatter"
 #. metadata.json->contributors
 msgid "kehugter - Added configurability to middle click"
 msgstr "kehugter - Tilføjede konfigurering af midterklik"
+
+#. metadata.json->contributors
+msgid "claudiux - Improvements to the 'Recent' section."
+msgstr ""
 
 #. settings-schema.json->generalPage->title
 msgid "General"
@@ -320,6 +329,10 @@ msgstr "Alle seneste dokumenter"
 #. settings-schema.json->recentSizeLimit->description
 msgid "Number to show"
 msgstr "Antal der skal vises"
+
+#. settings-schema.json->recentShowUri->description
+msgid "Show complete path in tooltips"
+msgstr ""
 
 #. settings-schema.json->btnPrivacy->description
 msgid "Privacy"

--- a/placesCenter@scollins/files/placesCenter@scollins/po/de.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/de.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-24 20:57+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-15 02:01+0200\n"
 "PO-Revision-Date: 2021-02-24 21:50+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,47 +19,51 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applet.js:148
+#: applet.js:150
 msgid "(Right click to open folder)"
 msgstr "(Rechtsklick zum Öffnen des Ordners)"
 
-#: applet.js:170
+#: applet.js:172
 msgid "Places"
 msgstr "Orte"
 
-#: applet.js:284
+#: applet.js:287
 msgid "Search Home Folder"
 msgstr "Persönlichen Ordner durchsuchen"
 
-#: applet.js:307
+#: applet.js:310
 msgid "SYSTEM"
 msgstr "SYSTEM"
 
-#: applet.js:316
+#: applet.js:319
 msgid "Search File System"
 msgstr "Dateisystem durchsuchen"
 
-#: applet.js:341
+#: applet.js:344
 msgid "RECENT DOCUMENTS"
 msgstr "ZULETZT VERWENDETE DATEIEN"
 
-#: applet.js:355
+#: applet.js:358
 msgid "Clear"
 msgstr "Leeren"
 
-#: applet.js:398
+#: applet.js:364
+msgid "Recent"
+msgstr ""
+
+#: applet.js:407
 msgid "Computer"
 msgstr "Rechner"
 
-#: applet.js:404
+#: applet.js:413
 msgid "File System"
 msgstr "Dateisystem"
 
-#: applet.js:420
+#: applet.js:429
 msgid "Network"
 msgstr "Netzwerk"
 
-#: applet.js:560
+#: applet.js:569
 msgid "Trash"
 msgstr "Papierkorb"
 
@@ -161,6 +166,10 @@ msgstr "Stephen Collins - Autor"
 #. metadata.json->contributors
 msgid "kehugter - Added configurability to middle click"
 msgstr "kehugter - Konfigurierbarkeit für Mittelklick hinzugefügt"
+
+#. metadata.json->contributors
+msgid "claudiux - Improvements to the 'Recent' section."
+msgstr ""
 
 #. settings-schema.json->generalPage->title
 msgid "General"
@@ -323,28 +332,10 @@ msgstr "Alle kürzlich verwendeten Dateien"
 msgid "Number to show"
 msgstr "Anzuzeigende Anzahl"
 
+#. settings-schema.json->recentShowUri->description
+msgid "Show complete path in tooltips"
+msgstr ""
+
 #. settings-schema.json->btnPrivacy->description
 msgid "Privacy"
 msgstr "Privatsphäre"
-
-#~ msgid "General Settings"
-#~ msgstr "Allgemeine Einstellungen"
-
-#~ msgid "Icon size"
-#~ msgstr "Symbolgröße"
-
-#~ msgid ""
-#~ "List of uris/file paths to be included. Entries may be separated by "
-#~ "either a comma(,) or by a new-line. You can set the name to be displayed "
-#~ "by adding :customName after the location."
-#~ msgstr ""
-#~ "Liste von URIs/Dateipfaden, welche eingefügt werden sollen. Einträge "
-#~ "können entweder durch ein Komma (,) oder durch eine neue Zeile getrennt "
-#~ "werden. Sie können den Namen, der angezeigt werden soll, durch Hinzufügen "
-#~ "von :ANZEIGENAME an das Pfadende festlegen."
-
-#~ msgid "User Section"
-#~ msgstr "Benutzer-Bereich"
-
-#~ msgid "System Section"
-#~ msgstr "System-Bereich"

--- a/placesCenter@scollins/files/placesCenter@scollins/po/es.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/es.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-24 20:57+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-15 02:01+0200\n"
 "PO-Revision-Date: 2023-11-20 17:59-0300\n"
 "Last-Translator: Germán Franco <dev.germanfr@gmail.com>\n"
 "Language-Team: \n"
@@ -18,47 +19,51 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4\n"
 
-#: applet.js:148
+#: applet.js:150
 msgid "(Right click to open folder)"
 msgstr "(Haga clic con el botón derecho para abrir la carpeta)"
 
-#: applet.js:170
+#: applet.js:172
 msgid "Places"
 msgstr "Lugares"
 
-#: applet.js:284
+#: applet.js:287
 msgid "Search Home Folder"
 msgstr "Buscar en la carpeta personal"
 
-#: applet.js:307
+#: applet.js:310
 msgid "SYSTEM"
 msgstr "SISTEMA"
 
-#: applet.js:316
+#: applet.js:319
 msgid "Search File System"
 msgstr "Buscar en el sistema de archivos"
 
-#: applet.js:341
+#: applet.js:344
 msgid "RECENT DOCUMENTS"
 msgstr "DOCUMENTOS RECIENTES"
 
-#: applet.js:355
+#: applet.js:358
 msgid "Clear"
 msgstr "Limpiar"
 
-#: applet.js:398
+#: applet.js:364
+msgid "Recent"
+msgstr ""
+
+#: applet.js:407
 msgid "Computer"
 msgstr "PC"
 
-#: applet.js:404
+#: applet.js:413
 msgid "File System"
 msgstr "Sistema de archivos"
 
-#: applet.js:420
+#: applet.js:429
 msgid "Network"
 msgstr "Red"
 
-#: applet.js:560
+#: applet.js:569
 msgid "Trash"
 msgstr "Papelera"
 
@@ -162,6 +167,10 @@ msgstr "Stephen Collins - Autor"
 #. metadata.json->contributors
 msgid "kehugter - Added configurability to middle click"
 msgstr "kehugter - Añadió la opción de configurar el click central"
+
+#. metadata.json->contributors
+msgid "claudiux - Improvements to the 'Recent' section."
+msgstr ""
 
 #. settings-schema.json->generalPage->title
 msgid "General"
@@ -322,6 +331,10 @@ msgstr "Documentos recientes"
 #. settings-schema.json->recentSizeLimit->description
 msgid "Number to show"
 msgstr "Número de entradas visibles"
+
+#. settings-schema.json->recentShowUri->description
+msgid "Show complete path in tooltips"
+msgstr ""
 
 #. settings-schema.json->btnPrivacy->description
 msgid "Privacy"

--- a/placesCenter@scollins/files/placesCenter@scollins/po/eu.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/eu.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-19 21:13-0700\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-15 02:01+0200\n"
 "PO-Revision-Date: 2022-12-12 16:33+0100\n"
 "Last-Translator: Inigo Gebara <igebara@disroot.org>\n"
 "Language-Team: \n"
@@ -18,43 +19,51 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:178
+#: applet.js:150
+msgid "(Right click to open folder)"
+msgstr ""
+
+#: applet.js:172
 msgid "Places"
 msgstr "Lekuak"
 
-#: applet.js:291
+#: applet.js:287
 msgid "Search Home Folder"
 msgstr "Bilatu karpeta nagusian"
 
-#: applet.js:305
+#: applet.js:310
 msgid "SYSTEM"
 msgstr "SISTEMA"
 
-#: applet.js:314
+#: applet.js:319
 msgid "Search File System"
 msgstr "Bilatu fitxategi-sisteman"
 
-#: applet.js:330
+#: applet.js:344
 msgid "RECENT DOCUMENTS"
 msgstr "DUELA GUTXIKO DOKUMENTUAK"
 
-#: applet.js:344
+#: applet.js:358
 msgid "Clear"
 msgstr "Garbitu"
 
-#: applet.js:388
+#: applet.js:364
+msgid "Recent"
+msgstr ""
+
+#: applet.js:407
 msgid "Computer"
 msgstr "Ordenagailua"
 
-#: applet.js:394
+#: applet.js:413
 msgid "File System"
 msgstr "Fitxategi-sistema"
 
-#: applet.js:410
+#: applet.js:429
 msgid "Network"
 msgstr "Sarea"
 
-#: applet.js:513
+#: applet.js:569
 msgid "Trash"
 msgstr "Zakarrontzia"
 
@@ -127,8 +136,41 @@ msgid "Skipping"
 msgstr "Saltatzen"
 
 #: search.py:259
-msgid " - direcotry already searched"
+#, fuzzy
+msgid " - directory already searched"
 msgstr " - dagoeneko bilatutako karpeta"
+
+#. metadata.json->name
+msgid "Places Center"
+msgstr "Lekuen Zentroa"
+
+#. metadata.json->description
+msgid "Provides an easy-to-read layout to access your places"
+msgstr "Zure lekuetara sarbidea, irakurtzeko erraza den diseinua eskaintzen du"
+
+#. metadata.json->comments
+msgid ""
+"Places Center is a feature-rich, cross-platform Cinnamon applet that "
+"provides easy access to all of your most-used places. Feel free to "
+"contribute by submitting pull requests, bug reports and feature requests to "
+"my github repo."
+msgstr ""
+"Lekuen Zentrua ezaugarriz aberatza den plataforma-arteko Cinnamon appleta "
+"da, zure leku erabilienetara sarbide erraza ematen duena. Aske sentitu Pull "
+"Request-ak bidali, akatsen txostenak bidaliz edo Github errepositorioan "
+"ekarpenak eginez."
+
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - Egilea"
+
+#. metadata.json->contributors
+msgid "kehugter - Added configurability to middle click"
+msgstr "kehugter - Erdiko klika konfiguratzeko gaitasuna gehitu dio"
+
+#. metadata.json->contributors
+msgid "claudiux - Improvements to the 'Recent' section."
+msgstr ""
 
 #. settings-schema.json->generalPage->title
 msgid "General"
@@ -258,34 +300,43 @@ msgstr "Erakutsi sarea"
 msgid "Show recent documents"
 msgstr "Erakutsi duela gutxiko dokumentuak"
 
+#. settings-schema.json->recentSizeLimit->options
+msgid "5"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "10"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "15"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "20"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "25"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "30"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+#, fuzzy
+msgid "All Recent Documents"
+msgstr "Duela gutxiko dokumentuak"
+
 #. settings-schema.json->recentSizeLimit->description
 msgid "Number to show"
 msgstr "Erakusteko zenbakia"
 
-#. metadata.json->name
-msgid "Places Center"
-msgstr "Lekuen Zentroa"
-
-#. metadata.json->description
-msgid "Provides an easy-to-read layout to access your places"
-msgstr "Zure lekuetara sarbidea, irakurtzeko erraza den diseinua eskaintzen du"
-
-#. metadata.json->comments
-msgid ""
-"Places Center is a feature-rich, cross-platform Cinnamon applet that "
-"provides easy access to all of your most-used places. Feel free to "
-"contribute by submitting pull requests, bug reports and feature requests to "
-"my github repo."
+#. settings-schema.json->recentShowUri->description
+msgid "Show complete path in tooltips"
 msgstr ""
-"Lekuen Zentrua ezaugarriz aberatza den plataforma-arteko Cinnamon appleta "
-"da, zure leku erabilienetara sarbide erraza ematen duena. Aske sentitu Pull "
-"Request-ak bidali, akatsen txostenak bidaliz edo Github errepositorioan "
-"ekarpenak eginez."
 
-#. metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - Egilea"
-
-#. metadata.json->contributors
-msgid "kehugter - Added configurability to middle click"
-msgstr "kehugter - Erdiko klika konfiguratzeko gaitasuna gehitu dio"
+#. settings-schema.json->btnPrivacy->description
+msgid "Privacy"
+msgstr ""

--- a/placesCenter@scollins/files/placesCenter@scollins/po/fi.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/fi.po
@@ -6,59 +6,64 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-24 20:57+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-15 02:01+0200\n"
 "PO-Revision-Date: 2022-11-23 12:29+0200\n"
+"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: fi\n"
 
-#: applet.js:148
+#: applet.js:150
 msgid "(Right click to open folder)"
 msgstr "(hiiren oikea avaa kansion)"
 
-#: applet.js:170
+#: applet.js:172
 msgid "Places"
 msgstr "Sijainnit"
 
-#: applet.js:284
+#: applet.js:287
 msgid "Search Home Folder"
 msgstr "Haku Koti kansiosta"
 
-#: applet.js:307
+#: applet.js:310
 msgid "SYSTEM"
 msgstr "SYSTEM"
 
-#: applet.js:316
+#: applet.js:319
 msgid "Search File System"
 msgstr "Haku järjestelmästä"
 
-#: applet.js:341
+#: applet.js:344
 msgid "RECENT DOCUMENTS"
 msgstr "VIIMEAIKAISET"
 
-#: applet.js:355
+#: applet.js:358
 msgid "Clear"
 msgstr "Tyhjennä"
 
-#: applet.js:398
+#: applet.js:364
+msgid "Recent"
+msgstr ""
+
+#: applet.js:407
 msgid "Computer"
 msgstr "Tietokone"
 
-#: applet.js:404
+#: applet.js:413
 msgid "File System"
 msgstr "Tiedostojärjestelmä"
 
-#: applet.js:420
+#: applet.js:429
 msgid "Network"
 msgstr "Verkko"
 
-#: applet.js:560
+#: applet.js:569
 msgid "Trash"
 msgstr "Roskakori"
 
@@ -160,6 +165,10 @@ msgstr "Tekijä - Stephen Collins"
 #. metadata.json->contributors
 msgid "kehugter - Added configurability to middle click"
 msgstr "kehugter - Lisätty konfigurointi hiiren keskipainikkeeseen"
+
+#. metadata.json->contributors
+msgid "claudiux - Improvements to the 'Recent' section."
+msgstr ""
 
 #. settings-schema.json->generalPage->title
 msgid "General"
@@ -319,6 +328,10 @@ msgstr "Kaikki viimeisimmät asiakirjat"
 #. settings-schema.json->recentSizeLimit->description
 msgid "Number to show"
 msgstr "Näytettävä määrä"
+
+#. settings-schema.json->recentShowUri->description
+msgid "Show complete path in tooltips"
+msgstr ""
 
 #. settings-schema.json->btnPrivacy->description
 msgid "Privacy"

--- a/placesCenter@scollins/files/placesCenter@scollins/po/fr.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/fr.po
@@ -6,9 +6,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-24 20:57+0100\n"
-"PO-Revision-Date: 2023-04-26 21:31+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-15 02:01+0200\n"
+"PO-Revision-Date: 2024-04-15 02:04+0200\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -18,47 +19,51 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: applet.js:148
+#: applet.js:150
 msgid "(Right click to open folder)"
 msgstr "(Clic droit pour ouvrir son dossier)"
 
-#: applet.js:170
+#: applet.js:172
 msgid "Places"
 msgstr "Emplacements"
 
-#: applet.js:284
+#: applet.js:287
 msgid "Search Home Folder"
 msgstr "Rechercher dans mon dossier personnel"
 
-#: applet.js:307
+#: applet.js:310
 msgid "SYSTEM"
 msgstr "SYSTÈME"
 
-#: applet.js:316
+#: applet.js:319
 msgid "Search File System"
 msgstr "Rechercher dans le système de fichiers"
 
-#: applet.js:341
+#: applet.js:344
 msgid "RECENT DOCUMENTS"
 msgstr "DOCUMENTS RÉCENTS"
 
-#: applet.js:355
+#: applet.js:358
 msgid "Clear"
 msgstr "Effacer"
 
-#: applet.js:398
+#: applet.js:364
+msgid "Recent"
+msgstr "Récents"
+
+#: applet.js:407
 msgid "Computer"
 msgstr "Ordinateur"
 
-#: applet.js:404
+#: applet.js:413
 msgid "File System"
 msgstr "Système de fichiers"
 
-#: applet.js:420
+#: applet.js:429
 msgid "Network"
 msgstr "Réseau"
 
-#: applet.js:560
+#: applet.js:569
 msgid "Trash"
 msgstr "Corbeille"
 
@@ -163,6 +168,10 @@ msgstr "Stephen Collins - Auteur"
 #. metadata.json->contributors
 msgid "kehugter - Added configurability to middle click"
 msgstr "kehugter - Ajout de la configurabilité du clic central"
+
+#. metadata.json->contributors
+msgid "claudiux - Improvements to the 'Recent' section."
+msgstr "claudiux - Améliorations dans la section Documents Récents."
 
 #. settings-schema.json->generalPage->title
 msgid "General"
@@ -328,12 +337,10 @@ msgstr "Tous les documents récents"
 msgid "Number to show"
 msgstr "Nombre de documents récents à afficher"
 
+#. settings-schema.json->recentShowUri->description
+msgid "Show complete path in tooltips"
+msgstr "Afficher le chemin complet dans les infobulles"
+
 #. settings-schema.json->btnPrivacy->description
 msgid "Privacy"
 msgstr "Confidentialité"
-
-#~ msgid "Click to open the file."
-#~ msgstr "Clic gauche pour ouvrir le fichier."
-
-#~ msgid "Show help about recent documents"
-#~ msgstr "Afficher l'aide concernant les documents récents"

--- a/placesCenter@scollins/files/placesCenter@scollins/po/hr.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/hr.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Places Center 2.1\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-26 21:07+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-15 02:01+0200\n"
 "PO-Revision-Date: 2017-02-26 21:10+0100\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian <hr@li.org>\n"
@@ -16,197 +17,141 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: applet.js:250
-msgid "Clear"
-msgstr "Obriši"
+#: applet.js:150
+msgid "(Right click to open folder)"
+msgstr ""
 
-#: applet.js:306
+#: applet.js:172
 msgid "Places"
 msgstr "Lokacije"
 
-#: applet.js:408
+#: applet.js:287
 msgid "Search Home Folder"
 msgstr "Pretraži osobnu mapu"
 
-#: applet.js:422
+#: applet.js:310
 msgid "SYSTEM"
 msgstr "SUSTAV"
 
-#: applet.js:430
+#: applet.js:319
 msgid "Search File System"
 msgstr "Pretraži datotečni sustav"
 
-#: applet.js:445
+#: applet.js:344
 msgid "RECENT DOCUMENTS"
 msgstr "NEDAVNI DOKUMENTI"
 
-#: applet.js:494
+#: applet.js:358
+msgid "Clear"
+msgstr "Obriši"
+
+#: applet.js:364
+msgid "Recent"
+msgstr ""
+
+#: applet.js:407
 msgid "Computer"
 msgstr "Računalo"
 
-#: applet.js:500
+#: applet.js:413
 msgid "File System"
 msgstr "Datotečni sustav"
 
-#: applet.js:516
+#: applet.js:429
 msgid "Network"
 msgstr "Mreža"
 
-#: applet.js:612
+#: applet.js:569
 msgid "Trash"
 msgstr "Smeće"
 
-#. placesCenter@scollins->settings-schema.json->panelIcon->description
-msgid "Panel icon"
-msgstr "Ikona panela"
-
-#. placesCenter@scollins->settings-schema.json->panelIcon->tooltip
-msgid "Accepts icon name or direct path (supports symbolic icons)"
-msgstr "Upišite naziv ikone ili izravnu putanju (podržava simboličke ikone)"
-
-#. placesCenter@scollins->settings-schema.json->showComputer->description
-msgid "Show computer"
-msgstr "Prikaži računalo"
-
-#. placesCenter@scollins->settings-schema.json->showRoot->description
-msgid "Show file system"
-msgstr "Prikaži datotečni sustav"
-
-#. placesCenter@scollins->settings-schema.json->recentSection->title
-#. placesCenter@scollins->settings-schema.json->recentPage->title
-msgid "Recent documents"
-msgstr "Nedavni dokumenti"
-
-#. placesCenter@scollins->settings-schema.json->generalPage->title
-msgid "General"
-msgstr "Općenito"
-
-#. placesCenter@scollins->settings-schema.json->systemSection->title
-msgid "System section"
-msgstr "Mogućnosti sustava"
-
-#. placesCenter@scollins->settings-schema.json->userPage->title
-msgid "User"
-msgstr "Korisnik"
-
-#. placesCenter@scollins->settings-schema.json->menu->title
-msgid "Menu settings"
-msgstr "Postavke izbornika"
-
-#. placesCenter@scollins->settings-schema.json->userSection->title
-msgid "User section"
-msgstr "Korisnikove mogućnosti"
-
-#. placesCenter@scollins->settings-schema.json->systemPage->title
-msgid "System"
-msgstr "Sustav"
-
-#. placesCenter@scollins->settings-schema.json->panel->title
-msgid "Panel settings"
-msgstr "Postavke panela"
-
-#. placesCenter@scollins->settings-schema.json->keyOpen->description
-msgid "Menu shortcut key"
-msgstr "Prečac tipkovnice izbornika"
-
-#. placesCenter@scollins->settings-schema.json->middleClickPath->description
-msgid "Open on middle click"
-msgstr "Otvori pri srednjem kliku"
-
-#. placesCenter@scollins->settings-schema.json->middleClickPath->tooltip
-msgid "Leave blank to disable"
-msgstr "Ostavi prazno za onemgućavanje"
-
-#. placesCenter@scollins->settings-schema.json->iconSize->description
-msgid "Menu icon size"
-msgstr "Veličina ikone izbornika"
-
-#. placesCenter@scollins->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "pikseli"
-
-#. placesCenter@scollins->settings-schema.json->showTrash->description
-msgid "Show trash"
-msgstr "Prikaži smeće"
-
-#. placesCenter@scollins->settings-schema.json->showTrash->options
-msgid "Always"
-msgstr "Uvijek"
-
-#. placesCenter@scollins->settings-schema.json->showTrash->options
-msgid "Never"
-msgstr "Nikada"
-
-#. placesCenter@scollins->settings-schema.json->showTrash->options
-msgid "When not empty"
-msgstr "Kada nije prazno"
-
-#. placesCenter@scollins->settings-schema.json->showVolumes->description
-msgid "Show volumes"
-msgstr "Prikaži montirane uređaje"
-
-#. placesCenter@scollins->settings-schema.json->recentSizeLimit->description
-msgid "Number to show"
-msgstr "Broj prikazanih nedavnih dokumenata"
-
-#. placesCenter@scollins->settings-schema.json->userCustomPlaces->description
-#. placesCenter@scollins->settings-
-#. schema.json->systemCustomPlaces->description
-msgid "Custom places"
-msgstr "Prilagođene lokacije"
-
-#. placesCenter@scollins->settings-schema.json->userCustomPlaces->tooltip
-#. placesCenter@scollins->settings-schema.json->systemCustomPlaces->tooltip
-msgid ""
-"List of uris/file paths to be included. Entries may be separated by either a "
-"comma(,) or by a new-line. You can set the name to be displayed by adding :"
-"customName after the location."
+#: search.py:43
+msgid "Open..."
 msgstr ""
-"Popis uri-ja/putanja datoteka koje su uključene. Unosi mogu biti odvojeni "
-"ili zarezom (,) ili novim redkom. Možete postaviti naziv za prikaz "
-"dodavanjem :Prilagođeni-Naziv nakon lokacije."
 
-#. placesCenter@scollins->settings-schema.json->panelText->description
-msgid "Panel text"
-msgstr "Tekst panela"
+#: search.py:48
+msgid "Open Containing Folder..."
+msgstr ""
 
-#. placesCenter@scollins->settings-schema.json->showNetwork->description
-msgid "Show network"
-msgstr "Prikaži mrežu"
+#: search.py:85
+msgid "Search"
+msgstr ""
 
-#. placesCenter@scollins->settings-schema.json->onlyShowMounted->description
-msgid "Only show mounted drives"
-msgstr "Prikaži samo montirane uređaje"
+#: search.py:106
+msgid "Start in"
+msgstr ""
 
-#. placesCenter@scollins->settings-
-#. schema.json->showRecentDocuments->description
-msgid "Show recent documents"
-msgstr "Prikaži nedavne dokumente"
+#: search.py:107
+#, fuzzy
+msgid "Select a folder"
+msgstr "Pretraži osobnu mapu"
 
-#. placesCenter@scollins->settings-schema.json->showDesktop->description
-msgid "Show desktop"
-msgstr "Prikaži radnu površinu"
+#: search.py:113
+msgid "Follow symlinks"
+msgstr ""
 
-#. placesCenter@scollins->metadata.json->name
+#: search.py:117
+msgid "Search hidden"
+msgstr ""
+
+#: search.py:121
+msgid "Use regular expressions"
+msgstr ""
+
+#: search.py:125
+msgid "Stop"
+msgstr ""
+
+#: search.py:140
+msgid "File"
+msgstr ""
+
+#: search.py:156
+msgid "Path"
+msgstr ""
+
+#: search.py:184
+msgid "Searching..."
+msgstr ""
+
+#: search.py:198 search.py:199
+#, fuzzy
+msgid "Search Stopped"
+msgstr "Pretraži osobnu mapu"
+
+#: search.py:215
+msgid "Searching: "
+msgstr ""
+
+#: search.py:220
+msgid "Error: insufficient permissions to read folder "
+msgstr ""
+
+#: search.py:252
+#, fuzzy
+msgid "Search Completed"
+msgstr "Pretraži osobnu mapu"
+
+#: search.py:259
+msgid "Skipping"
+msgstr ""
+
+#: search.py:259
+msgid " - directory already searched"
+msgstr ""
+
+#. metadata.json->name
 msgid "Places Center"
 msgstr "Središte lokacija"
 
-#. placesCenter@scollins->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - Autor"
-
-#. placesCenter@scollins->metadata.json->contributors
-msgid "kehugter - Added configurability to middle click"
-msgstr "kehugter - Dodao prilagodljiv srednji klik"
-
-#. placesCenter@scollins->metadata.json->description
+#. metadata.json->description
 msgid "Provides an easy-to-read layout to access your places"
 msgstr "Omogućuje lako čitljiv raspored za pristup vašim lokacijama"
 
-#. placesCenter@scollins->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Places Center is a feature-rich, cross-platform Cinnamon applet that "
 "provides easy access to all of your most-used places. Feel free to "
@@ -218,17 +163,182 @@ msgstr ""
 "doprinijeti slanjem zahtjeva s novom značajkom, prijave grešaka i zahtjevom "
 "nove značajke na moj github repozitorij."
 
-#~ msgid "General Settings"
-#~ msgstr "Opće postavke"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - Autor"
 
-#~ msgid "User Section"
-#~ msgstr "Korisnikove mogućnosti"
+#. metadata.json->contributors
+msgid "kehugter - Added configurability to middle click"
+msgstr "kehugter - Dodao prilagodljiv srednji klik"
 
-#~ msgid "Icon size"
-#~ msgstr "Veličina ikone"
+#. metadata.json->contributors
+msgid "claudiux - Improvements to the 'Recent' section."
+msgstr ""
 
-#~ msgid "Recent Documents"
-#~ msgstr "Nedavni dokumenti"
+#. settings-schema.json->generalPage->title
+msgid "General"
+msgstr "Općenito"
 
-#~ msgid "System Section"
-#~ msgstr "Mogućnosti sustava"
+#. settings-schema.json->userPage->title
+msgid "User"
+msgstr "Korisnik"
+
+#. settings-schema.json->systemPage->title
+msgid "System"
+msgstr "Sustav"
+
+#. settings-schema.json->recentPage->title
+#. settings-schema.json->recentSection->title
+msgid "Recent documents"
+msgstr "Nedavni dokumenti"
+
+#. settings-schema.json->panel->title
+msgid "Panel settings"
+msgstr "Postavke panela"
+
+#. settings-schema.json->menu->title
+msgid "Menu settings"
+msgstr "Postavke izbornika"
+
+#. settings-schema.json->userSection->title
+msgid "User section"
+msgstr "Korisnikove mogućnosti"
+
+#. settings-schema.json->systemSection->title
+msgid "System section"
+msgstr "Mogućnosti sustava"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel icon"
+msgstr "Ikona panela"
+
+#. settings-schema.json->panelIcon->tooltip
+msgid "Accepts icon name or direct path (supports symbolic icons)"
+msgstr "Upišite naziv ikone ili izravnu putanju (podržava simboličke ikone)"
+
+#. settings-schema.json->panelText->description
+msgid "Panel text"
+msgstr "Tekst panela"
+
+#. settings-schema.json->keyOpen->description
+msgid "Menu shortcut key"
+msgstr "Prečac tipkovnice izbornika"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "pikseli"
+
+#. settings-schema.json->iconSize->description
+msgid "Menu icon size"
+msgstr "Veličina ikone izbornika"
+
+#. settings-schema.json->middleClickPath->description
+msgid "Open on middle click"
+msgstr "Otvori pri srednjem kliku"
+
+#. settings-schema.json->middleClickPath->tooltip
+msgid "Leave blank to disable"
+msgstr "Ostavi prazno za onemgućavanje"
+
+#. settings-schema.json->showDesktop->description
+msgid "Show desktop"
+msgstr "Prikaži radnu površinu"
+
+#. settings-schema.json->userCustomPlaces->description
+#. settings-schema.json->systemCustomPlaces->description
+msgid "Custom places"
+msgstr "Prilagođene lokacije"
+
+#. settings-schema.json->userCustomPlaces->tooltip
+#. settings-schema.json->systemCustomPlaces->tooltip
+#, fuzzy
+msgid ""
+"List of uris/file paths to be included. Entries may be separated by either a "
+"comma(,) or by a new-line. You can set the name to be displayed by adding :"
+"customName after the location. You can likewise set an icon name by adding :"
+"iconName after the custom name."
+msgstr ""
+"Popis uri-ja/putanja datoteka koje su uključene. Unosi mogu biti odvojeni "
+"ili zarezom (,) ili novim redkom. Možete postaviti naziv za prikaz "
+"dodavanjem :Prilagođeni-Naziv nakon lokacije."
+
+#. settings-schema.json->showTrash->description
+msgid "Show trash"
+msgstr "Prikaži smeće"
+
+#. settings-schema.json->showTrash->options
+msgid "Never"
+msgstr "Nikada"
+
+#. settings-schema.json->showTrash->options
+msgid "Always"
+msgstr "Uvijek"
+
+#. settings-schema.json->showTrash->options
+msgid "When not empty"
+msgstr "Kada nije prazno"
+
+#. settings-schema.json->showComputer->description
+msgid "Show computer"
+msgstr "Prikaži računalo"
+
+#. settings-schema.json->showRoot->description
+msgid "Show file system"
+msgstr "Prikaži datotečni sustav"
+
+#. settings-schema.json->showVolumes->description
+msgid "Show volumes"
+msgstr "Prikaži montirane uređaje"
+
+#. settings-schema.json->onlyShowMounted->description
+msgid "Only show mounted drives"
+msgstr "Prikaži samo montirane uređaje"
+
+#. settings-schema.json->showNetwork->description
+msgid "Show network"
+msgstr "Prikaži mrežu"
+
+#. settings-schema.json->showRecentDocuments->description
+msgid "Show recent documents"
+msgstr "Prikaži nedavne dokumente"
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "5"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "10"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "15"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "20"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "25"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "30"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+#, fuzzy
+msgid "All Recent Documents"
+msgstr "Nedavni dokumenti"
+
+#. settings-schema.json->recentSizeLimit->description
+msgid "Number to show"
+msgstr "Broj prikazanih nedavnih dokumenata"
+
+#. settings-schema.json->recentShowUri->description
+msgid "Show complete path in tooltips"
+msgstr ""
+
+#. settings-schema.json->btnPrivacy->description
+msgid "Privacy"
+msgstr ""

--- a/placesCenter@scollins/files/placesCenter@scollins/po/hu.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/hu.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-24 20:57+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-15 02:01+0200\n"
 "PO-Revision-Date: 2021-09-26 07:40+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -18,47 +19,51 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applet.js:148
+#: applet.js:150
 msgid "(Right click to open folder)"
 msgstr "(Jobb egérgomb a mappa megnyitásához)"
 
-#: applet.js:170
+#: applet.js:172
 msgid "Places"
 msgstr "Helyek"
 
-#: applet.js:284
+#: applet.js:287
 msgid "Search Home Folder"
 msgstr "Saját mappában keresés"
 
-#: applet.js:307
+#: applet.js:310
 msgid "SYSTEM"
 msgstr "RENDSZER"
 
-#: applet.js:316
+#: applet.js:319
 msgid "Search File System"
 msgstr "Fájlrendszerben keresés"
 
-#: applet.js:341
+#: applet.js:344
 msgid "RECENT DOCUMENTS"
 msgstr "MOSTANÁBAN MEGNYITOTT DOKUMENTUMOK"
 
-#: applet.js:355
+#: applet.js:358
 msgid "Clear"
 msgstr "Törlés"
 
-#: applet.js:398
+#: applet.js:364
+msgid "Recent"
+msgstr ""
+
+#: applet.js:407
 msgid "Computer"
 msgstr "Számítógép"
 
-#: applet.js:404
+#: applet.js:413
 msgid "File System"
 msgstr "Fájlrendszer"
 
-#: applet.js:420
+#: applet.js:429
 msgid "Network"
 msgstr "Hálózat"
 
-#: applet.js:560
+#: applet.js:569
 msgid "Trash"
 msgstr "Kuka"
 
@@ -131,7 +136,6 @@ msgid "Skipping"
 msgstr "Átugrás"
 
 #: search.py:259
-#| msgid " - direcotry already searched"
 msgid " - directory already searched"
 msgstr " - a mappa már része volt a keresésnek"
 
@@ -163,6 +167,10 @@ msgstr "Stephen Collins - Szerző"
 msgid "kehugter - Added configurability to middle click"
 msgstr ""
 "kehugter - Konfigurálási lehetőségeket adott hozzá a görgő kattintáshoz"
+
+#. metadata.json->contributors
+msgid "claudiux - Improvements to the 'Recent' section."
+msgstr ""
 
 #. settings-schema.json->generalPage->title
 msgid "General"
@@ -323,6 +331,10 @@ msgstr "Minden mostanában megnyitott dokumentum"
 #. settings-schema.json->recentSizeLimit->description
 msgid "Number to show"
 msgstr "Megjelenítendő darabszám"
+
+#. settings-schema.json->recentShowUri->description
+msgid "Show complete path in tooltips"
+msgstr ""
 
 #. settings-schema.json->btnPrivacy->description
 msgid "Privacy"

--- a/placesCenter@scollins/files/placesCenter@scollins/po/it.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/it.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-24 20:57+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-15 02:01+0200\n"
 "PO-Revision-Date: 2022-06-03 17:36+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -18,47 +19,51 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applet.js:148
+#: applet.js:150
 msgid "(Right click to open folder)"
 msgstr "(Fare clic con il tasto destro per aprire la cartella)"
 
-#: applet.js:170
+#: applet.js:172
 msgid "Places"
 msgstr "Posizioni"
 
-#: applet.js:284
+#: applet.js:287
 msgid "Search Home Folder"
 msgstr "Cerca nella cartella Home"
 
-#: applet.js:307
+#: applet.js:310
 msgid "SYSTEM"
 msgstr "SISTEMA"
 
-#: applet.js:316
+#: applet.js:319
 msgid "Search File System"
 msgstr "Cerca nel File System"
 
-#: applet.js:341
+#: applet.js:344
 msgid "RECENT DOCUMENTS"
 msgstr "DOCUMENTI RECENTI"
 
-#: applet.js:355
+#: applet.js:358
 msgid "Clear"
 msgstr "Pulisci"
 
-#: applet.js:398
+#: applet.js:364
+msgid "Recent"
+msgstr ""
+
+#: applet.js:407
 msgid "Computer"
 msgstr "Computer"
 
-#: applet.js:404
+#: applet.js:413
 msgid "File System"
 msgstr "File System"
 
-#: applet.js:420
+#: applet.js:429
 msgid "Network"
 msgstr "Rete"
 
-#: applet.js:560
+#: applet.js:569
 msgid "Trash"
 msgstr "Cestino"
 
@@ -161,6 +166,10 @@ msgstr "Stephen Collins - Autore"
 #. metadata.json->contributors
 msgid "kehugter - Added configurability to middle click"
 msgstr "kehugter - Aggiunta la configurabilità al clic centrale"
+
+#. metadata.json->contributors
+msgid "claudiux - Improvements to the 'Recent' section."
+msgstr ""
 
 #. settings-schema.json->generalPage->title
 msgid "General"
@@ -322,6 +331,10 @@ msgstr "Tutti i Documenti Recenti"
 #. settings-schema.json->recentSizeLimit->description
 msgid "Number to show"
 msgstr "Numero da mostrare"
+
+#. settings-schema.json->recentShowUri->description
+msgid "Show complete path in tooltips"
+msgstr ""
 
 #. settings-schema.json->btnPrivacy->description
 msgid "Privacy"

--- a/placesCenter@scollins/files/placesCenter@scollins/po/placesCenter@scollins.pot
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/placesCenter@scollins.pot
@@ -1,63 +1,67 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is put in the public domain.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-24 20:57+0100\n"
+"Project-Id-Version: placesCenter@scollins 2.3\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-15 02:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:148
+#: applet.js:150
 msgid "(Right click to open folder)"
 msgstr ""
 
-#: applet.js:170
+#: applet.js:172
 msgid "Places"
 msgstr ""
 
-#: applet.js:284
+#: applet.js:287
 msgid "Search Home Folder"
 msgstr ""
 
-#: applet.js:307
+#: applet.js:310
 msgid "SYSTEM"
 msgstr ""
 
-#: applet.js:316
+#: applet.js:319
 msgid "Search File System"
 msgstr ""
 
-#: applet.js:341
+#: applet.js:344
 msgid "RECENT DOCUMENTS"
 msgstr ""
 
-#: applet.js:355
+#: applet.js:358
 msgid "Clear"
 msgstr ""
 
-#: applet.js:398
+#: applet.js:364
+msgid "Recent"
+msgstr ""
+
+#: applet.js:407
 msgid "Computer"
 msgstr ""
 
-#: applet.js:404
+#: applet.js:413
 msgid "File System"
 msgstr ""
 
-#: applet.js:420
+#: applet.js:429
 msgid "Network"
 msgstr ""
 
-#: applet.js:560
+#: applet.js:569
 msgid "Trash"
 msgstr ""
 
@@ -157,6 +161,10 @@ msgstr ""
 msgid "kehugter - Added configurability to middle click"
 msgstr ""
 
+#. metadata.json->contributors
+msgid "claudiux - Improvements to the 'Recent' section."
+msgstr ""
+
 #. settings-schema.json->generalPage->title
 msgid "General"
 msgstr ""
@@ -234,10 +242,10 @@ msgstr ""
 #. settings-schema.json->userCustomPlaces->tooltip
 #. settings-schema.json->systemCustomPlaces->tooltip
 msgid ""
-"List of uris/file paths to be included. Entries may be separated by either a"
-" comma(,) or by a new-line. You can set the name to be displayed by adding "
-":customName after the location. You can likewise set an icon name by adding "
-":iconName after the custom name."
+"List of uris/file paths to be included. Entries may be separated by either a "
+"comma(,) or by a new-line. You can set the name to be displayed by adding :"
+"customName after the location. You can likewise set an icon name by adding :"
+"iconName after the custom name."
 msgstr ""
 
 #. settings-schema.json->showTrash->description
@@ -310,6 +318,10 @@ msgstr ""
 
 #. settings-schema.json->recentSizeLimit->description
 msgid "Number to show"
+msgstr ""
+
+#. settings-schema.json->recentShowUri->description
+msgid "Show complete path in tooltips"
 msgstr ""
 
 #. settings-schema.json->btnPrivacy->description

--- a/placesCenter@scollins/files/placesCenter@scollins/po/sv.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/sv.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: placesCenter@scollins\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-24 20:57+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-15 02:01+0200\n"
 "PO-Revision-Date: 2022-10-29 15:32+0200\n"
 "Last-Translator: Åke Engelbrektson <eson@svenskasprakfiler.se>\n"
 "Language-Team: Svenska Språkfiler <contactform@svenskasprakfiler.se>\n"
@@ -18,47 +19,51 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: applet.js:148
+#: applet.js:150
 msgid "(Right click to open folder)"
 msgstr "(Högerklicka för att öppna mapp)"
 
-#: applet.js:170
+#: applet.js:172
 msgid "Places"
 msgstr "Platser"
 
-#: applet.js:284
+#: applet.js:287
 msgid "Search Home Folder"
 msgstr "Sök i hemkatalogen"
 
-#: applet.js:307
+#: applet.js:310
 msgid "SYSTEM"
 msgstr "SYSTEM"
 
-#: applet.js:316
+#: applet.js:319
 msgid "Search File System"
 msgstr "Sök i filsystemet"
 
-#: applet.js:341
+#: applet.js:344
 msgid "RECENT DOCUMENTS"
 msgstr "TIDIGARE DOKUMENT"
 
-#: applet.js:355
+#: applet.js:358
 msgid "Clear"
 msgstr "Rensa"
 
-#: applet.js:398
+#: applet.js:364
+msgid "Recent"
+msgstr ""
+
+#: applet.js:407
 msgid "Computer"
 msgstr "Dator"
 
-#: applet.js:404
+#: applet.js:413
 msgid "File System"
 msgstr "Filsystem"
 
-#: applet.js:420
+#: applet.js:429
 msgid "Network"
 msgstr "Nätverk"
 
-#: applet.js:560
+#: applet.js:569
 msgid "Trash"
 msgstr "Papperskorg"
 
@@ -161,6 +166,10 @@ msgstr "Stephen Collins - Author"
 #. metadata.json->contributors
 msgid "kehugter - Added configurability to middle click"
 msgstr "kehugter - Lade till konfigurerbart mushjulsklick"
+
+#. metadata.json->contributors
+msgid "claudiux - Improvements to the 'Recent' section."
+msgstr ""
 
 #. settings-schema.json->generalPage->title
 msgid "General"
@@ -321,27 +330,10 @@ msgstr "Alla tidigare dokument"
 msgid "Number to show"
 msgstr "Antal att visa"
 
+#. settings-schema.json->recentShowUri->description
+msgid "Show complete path in tooltips"
+msgstr ""
+
 #. settings-schema.json->btnPrivacy->description
 msgid "Privacy"
 msgstr "Sekretess"
-
-#~ msgid "General Settings"
-#~ msgstr "Allmänna inställningar"
-
-#~ msgid "Icon size"
-#~ msgstr "Ikonstorlek"
-
-#~ msgid ""
-#~ "List of uris/file paths to be included. Entries may be separated by "
-#~ "either a comma(,) or by a new-line. You can set the name to be displayed "
-#~ "by adding :customName after the location."
-#~ msgstr ""
-#~ "Lista över uri-/filsökvägar att inkludera. Posterna kan separeras med "
-#~ "antingen kommatecken eller med ny rad. Du kan ange namnet som skall "
-#~ "visas, genom att lägga till :AnpassatNamn efter platsen."
-
-#~ msgid "User Section"
-#~ msgstr "Användarsektion"
-
-#~ msgid "System Section"
-#~ msgstr "Systemsektion"

--- a/placesCenter@scollins/files/placesCenter@scollins/po/tr.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/tr.po
@@ -5,56 +5,65 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-19 21:13-0700\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-15 02:01+0200\n"
 "PO-Revision-Date: 2018-11-05 00:37+0300\n"
-"Language-Team: Linux Mint Türkiye <gokhanlnx@gmail.com>\n"
-"\"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.6\n"
 "Last-Translator: Gökhan GÖKKAYA <gokhanlnx@gmail.com>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language-Team: Linux Mint Türkiye <gokhanlnx@gmail.com>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"\"MIME-Version: 1.0\n"
+"X-Generator: Poedit 2.0.6\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applet.js:178
+#: applet.js:150
+msgid "(Right click to open folder)"
+msgstr ""
+
+#: applet.js:172
 msgid "Places"
 msgstr "Konumlar"
 
-#: applet.js:291
+#: applet.js:287
 msgid "Search Home Folder"
 msgstr "Ev Dizinini Ara"
 
-#: applet.js:305
+#: applet.js:310
 msgid "SYSTEM"
 msgstr "SİSTEM"
 
-#: applet.js:314
+#: applet.js:319
 msgid "Search File System"
 msgstr "Dosya Sistemi Ara"
 
-#: applet.js:330
+#: applet.js:344
 msgid "RECENT DOCUMENTS"
 msgstr "SON BELGELER"
 
-#: applet.js:344
+#: applet.js:358
 msgid "Clear"
 msgstr "Temizle"
 
-#: applet.js:388
+#: applet.js:364
+msgid "Recent"
+msgstr ""
+
+#: applet.js:407
 msgid "Computer"
 msgstr "Bilgiayar"
 
-#: applet.js:394
+#: applet.js:413
 msgid "File System"
 msgstr "Dosya Sistemi"
 
-#: applet.js:410
+#: applet.js:429
 msgid "Network"
 msgstr "Ağ"
 
-#: applet.js:513
+#: applet.js:569
 msgid "Trash"
 msgstr "Çöp"
 
@@ -127,8 +136,41 @@ msgid "Skipping"
 msgstr "Atlanıyor"
 
 #: search.py:259
-msgid " - direcotry already searched"
+#, fuzzy
+msgid " - directory already searched"
 msgstr " - dizin zaten arandı"
+
+#. metadata.json->name
+msgid "Places Center"
+msgstr "Konumlar Merkezi"
+
+#. metadata.json->description
+msgid "Provides an easy-to-read layout to access your places"
+msgstr "Konumlarınıza erişmek için kolay okunur bir düzen sağlar."
+
+#. metadata.json->comments
+msgid ""
+"Places Center is a feature-rich, cross-platform Cinnamon applet that "
+"provides easy access to all of your most-used places. Feel free to "
+"contribute by submitting pull requests, bug reports and feature requests to "
+"my github repo."
+msgstr ""
+"Konum Merkezi, en çok kullandığınız yerlere kolay erişim kolaylığı sağlayan, "
+"zengin özelliklere sahip, çapraz platformlu bir Cinnamon uygulamacığıdır. "
+"Github deposuna işleme talepleri, hata raporları ve özellik istekleri "
+"göndererek katkıda bulunmaktan çekinmeyin."
+
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - Yazar"
+
+#. metadata.json->contributors
+msgid "kehugter - Added configurability to middle click"
+msgstr "kehugter - Orta tıklama için yapılandırılabilirlik ekledi"
+
+#. metadata.json->contributors
+msgid "claudiux - Improvements to the 'Recent' section."
+msgstr ""
 
 #. settings-schema.json->generalPage->title
 msgid "General"
@@ -169,7 +211,8 @@ msgstr "Panel simgesi"
 
 #. settings-schema.json->panelIcon->tooltip
 msgid "Accepts icon name or direct path (supports symbolic icons)"
-msgstr "Simge adını veya doğrudan hedefini kabul eder (sembolik simgeleri destekler)"
+msgstr ""
+"Simge adını veya doğrudan hedefini kabul eder (sembolik simgeleri destekler)"
 
 #. settings-schema.json->panelText->description
 msgid "Panel text"
@@ -258,34 +301,43 @@ msgstr "Ağı göster"
 msgid "Show recent documents"
 msgstr "Son belgeleri göster"
 
+#. settings-schema.json->recentSizeLimit->options
+msgid "5"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "10"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "15"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "20"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "25"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "30"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+#, fuzzy
+msgid "All Recent Documents"
+msgstr "Son belgeler"
+
 #. settings-schema.json->recentSizeLimit->description
 msgid "Number to show"
 msgstr "Sayı göster"
 
-#. metadata.json->name
-msgid "Places Center"
-msgstr "Konumlar Merkezi"
-
-#. metadata.json->description
-msgid "Provides an easy-to-read layout to access your places"
-msgstr "Konumlarınıza erişmek için kolay okunur bir düzen sağlar."
-
-#. metadata.json->comments
-msgid ""
-"Places Center is a feature-rich, cross-platform Cinnamon applet that "
-"provides easy access to all of your most-used places. Feel free to "
-"contribute by submitting pull requests, bug reports and feature requests to "
-"my github repo."
+#. settings-schema.json->recentShowUri->description
+msgid "Show complete path in tooltips"
 msgstr ""
-"Konum Merkezi, en çok kullandığınız yerlere kolay erişim kolaylığı sağlayan, "
-"zengin özelliklere sahip, çapraz platformlu bir Cinnamon uygulamacığıdır. "
-"Github deposuna işleme talepleri, hata raporları ve özellik istekleri "
-"göndererek katkıda bulunmaktan çekinmeyin."
 
-#. metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - Yazar"
-
-#. metadata.json->contributors
-msgid "kehugter - Added configurability to middle click"
-msgstr "kehugter - Orta tıklama için yapılandırılabilirlik ekledi"
+#. settings-schema.json->btnPrivacy->description
+msgid "Privacy"
+msgstr ""

--- a/placesCenter@scollins/files/placesCenter@scollins/po/uk.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/uk.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-24 20:57+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-15 02:01+0200\n"
 "PO-Revision-Date: 2023-08-24 12:12+0300\n"
 "Last-Translator: DmytroVoytko <Dmytro.Voytko@gmail.com>\n"
 "Language-Team: \n"
@@ -17,47 +18,51 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.3.2\n"
 
-#: applet.js:148
+#: applet.js:150
 msgid "(Right click to open folder)"
 msgstr "(Клацніть правою кнопкою миші, щоб відкрити папку)"
 
-#: applet.js:170
+#: applet.js:172
 msgid "Places"
 msgstr "Місця"
 
-#: applet.js:284
+#: applet.js:287
 msgid "Search Home Folder"
 msgstr "Пошук у домашній папці"
 
-#: applet.js:307
+#: applet.js:310
 msgid "SYSTEM"
 msgstr "СИСТЕМА"
 
-#: applet.js:316
+#: applet.js:319
 msgid "Search File System"
 msgstr "Пошук у файловій системі"
 
-#: applet.js:341
+#: applet.js:344
 msgid "RECENT DOCUMENTS"
 msgstr "ОСТАННІ ДОКУМЕНТИ"
 
-#: applet.js:355
+#: applet.js:358
 msgid "Clear"
 msgstr "Очистити"
 
-#: applet.js:398
+#: applet.js:364
+msgid "Recent"
+msgstr ""
+
+#: applet.js:407
 msgid "Computer"
 msgstr "Комп'ютер"
 
-#: applet.js:404
+#: applet.js:413
 msgid "File System"
 msgstr "Файлова система"
 
-#: applet.js:420
+#: applet.js:429
 msgid "Network"
 msgstr "Мережа"
 
-#: applet.js:560
+#: applet.js:569
 msgid "Trash"
 msgstr "Смітник"
 
@@ -148,10 +153,11 @@ msgid ""
 "contribute by submitting pull requests, bug reports and feature requests to "
 "my github repo."
 msgstr ""
-"Центр місць (Places Center) – це багатофункціональний кросплатформенний аплет "
-"Cinnamon, який забезпечує легкий доступ до місць, які ви найчастіше використовуєте. "
-"Не вагайтеся зробити свій внесок, надсилаючи свої pull request, звіти про помилки та "
-"запити на нові функції до мого сховища на github."
+"Центр місць (Places Center) – це багатофункціональний кросплатформенний "
+"аплет Cinnamon, який забезпечує легкий доступ до місць, які ви найчастіше "
+"використовуєте. Не вагайтеся зробити свій внесок, надсилаючи свої pull "
+"request, звіти про помилки та запити на нові функції до мого сховища на "
+"github."
 
 #. metadata.json->contributors
 msgid "Stephen Collins - Author"
@@ -160,6 +166,10 @@ msgstr "Stephen Collins - Автор"
 #. metadata.json->contributors
 msgid "kehugter - Added configurability to middle click"
 msgstr "kehugter - Додав налаштування клацання середньою кнопкою миші"
+
+#. metadata.json->contributors
+msgid "claudiux - Improvements to the 'Recent' section."
+msgstr ""
 
 #. settings-schema.json->generalPage->title
 msgid "General"
@@ -245,9 +255,9 @@ msgid ""
 "iconName after the custom name."
 msgstr ""
 "«Список URIs/шляхів до файлів, які потрібно включити. Записи можна розділяти "
-"комою (,) або новим рядком. Ви можете встановити ім’я, яке відображатиметься, "
-"додавши :customName після розташування. Ви також можете встановити назву "
-"піктограми, додавши :iconName після настроюваної назви."
+"комою (,) або новим рядком. Ви можете встановити ім’я, яке "
+"відображатиметься, додавши :customName після розташування. Ви також можете "
+"встановити назву піктограми, додавши :iconName після настроюваної назви."
 
 #. settings-schema.json->showTrash->description
 msgid "Show trash"
@@ -320,6 +330,10 @@ msgstr "Усі останні документи"
 #. settings-schema.json->recentSizeLimit->description
 msgid "Number to show"
 msgstr "Кількість для показу"
+
+#. settings-schema.json->recentShowUri->description
+msgid "Show complete path in tooltips"
+msgstr ""
 
 #. settings-schema.json->btnPrivacy->description
 msgid "Privacy"

--- a/placesCenter@scollins/files/placesCenter@scollins/po/zh_CN.po
+++ b/placesCenter@scollins/files/placesCenter@scollins/po/zh_CN.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-02 21:02+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-15 02:01+0200\n"
 "PO-Revision-Date: 2017-05-02 21:02+0800\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,180 +19,138 @@ msgstr ""
 "X-Generator: Poedit 1.8.11\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: applet.js:250
-msgid "Clear"
-msgstr "清除"
+#: applet.js:150
+msgid "(Right click to open folder)"
+msgstr ""
 
-#: applet.js:306
+#: applet.js:172
 msgid "Places"
 msgstr "位置"
 
-#: applet.js:403
+#: applet.js:287
 msgid "Search Home Folder"
 msgstr "搜索主目录文件夹"
 
-#: applet.js:417
+#: applet.js:310
 msgid "SYSTEM"
 msgstr "系统"
 
-#: applet.js:425
+#: applet.js:319
 msgid "Search File System"
 msgstr "搜索文件系统"
 
-#: applet.js:440
+#: applet.js:344
 msgid "RECENT DOCUMENTS"
 msgstr "最近的文档"
 
-#: applet.js:489
+#: applet.js:358
+msgid "Clear"
+msgstr "清除"
+
+#: applet.js:364
+msgid "Recent"
+msgstr ""
+
+#: applet.js:407
 msgid "Computer"
 msgstr "计算机"
 
-#: applet.js:495
+#: applet.js:413
 msgid "File System"
 msgstr "文件系统"
 
-#: applet.js:511
+#: applet.js:429
 msgid "Network"
 msgstr "网络"
 
-#: applet.js:607
+#: applet.js:569
 msgid "Trash"
 msgstr "回收站"
 
-#. cinnamon-places-center->settings-schema.json->panelIcon->description
-msgid "Panel icon"
-msgstr "面板图标"
-
-#. cinnamon-places-center->settings-schema.json->panelIcon->tooltip
-msgid "Accepts icon name or direct path (supports symbolic icons)"
-msgstr "接受图标名称或直接路径（支持符号图标）"
-
-#. cinnamon-places-center->settings-schema.json->showRoot->description
-msgid "Show file system"
-msgstr "显示文件系统"
-
-#. cinnamon-places-center->settings-schema.json->middleClickPath->description
-msgid "Open on middle click"
-msgstr "中键点击时打开"
-
-#. cinnamon-places-center->settings-schema.json->middleClickPath->tooltip
-msgid "Leave blank to disable"
-msgstr "留空则禁用"
-
-#. cinnamon-places-center->settings-schema.json->recentSizeLimit->description
-msgid "Number to show"
-msgstr "要显示的数量"
-
-#. cinnamon-places-center->settings-schema.json->general->description
-msgid "General Settings"
-msgstr "常规设置"
-
-#. cinnamon-places-center->settings-schema.json->showComputer->description
-msgid "Show computer"
-msgstr "显示计算机"
-
-#. cinnamon-places-center->settings-schema.json->onlyShowMounted->description
-msgid "Only show mounted drives"
-msgstr "仅显示已挂载的驱动器"
-
-#. cinnamon-places-center->settings-schema.json->keyOpen->description
-msgid "Menu shortcut key"
-msgstr "菜单快捷键"
-
-#. cinnamon-places-center->settings-schema.json->userSection->title
-msgid "User section"
-msgstr "用户部分"
-
-#. cinnamon-places-center->settings-schema.json->showTrash->description
-msgid "Show trash"
-msgstr "显示回收站"
-
-#. cinnamon-places-center->settings-schema.json->showTrash->options
-msgid "Always"
-msgstr "总是"
-
-#. cinnamon-places-center->settings-schema.json->showTrash->options
-msgid "Never"
-msgstr "从不"
-
-#. cinnamon-places-center->settings-schema.json->showTrash->options
-msgid "When not empty"
-msgstr "当非空时"
-
-#. cinnamon-places-center->settings-schema.json->showNetwork->description
-msgid "Show network"
-msgstr "显示网络"
-
-#. cinnamon-places-center->settings-schema.json->iconSize->description
-msgid "Icon size"
-msgstr "图标大小"
-
-#. cinnamon-places-center->settings-schema.json->iconSize->units
-msgid "px"
-msgstr "px"
-
-#. cinnamon-places-center->settings-schema.json->showVolumes->description
-msgid "Show volumes"
-msgstr "显示卷"
-
-#. cinnamon-places-center->settings-schema.json->panelText->description
-msgid "Panel text"
-msgstr "面板文本"
-
-#. cinnamon-places-center->settings-
-#. schema.json->systemCustomPlaces->description
-#. cinnamon-places-center->settings-schema.json->userCustomPlaces->description
-msgid "Custom places"
-msgstr "自定义位置"
-
-#. cinnamon-places-center->settings-schema.json->systemCustomPlaces->tooltip
-#. cinnamon-places-center->settings-schema.json->userCustomPlaces->tooltip
-msgid ""
-"List of uris/file paths to be included. Entries may be separated by either a "
-"comma(,) or by a new-line. You can set the name to be displayed by adding :"
-"customName after the location."
+#: search.py:43
+msgid "Open..."
 msgstr ""
-"要包含uri/文件路径的列表。条目可以用逗号(,)或换行符隔开。您可以通过在位置后面"
-"添加 :自定义名称 设置要显示的名称。"
 
-#. cinnamon-places-center->settings-schema.json->recent->description
-msgid "Recent Documents"
-msgstr "最近的文档"
+#: search.py:48
+msgid "Open Containing Folder..."
+msgstr ""
 
-#. cinnamon-places-center->settings-schema.json->systemSection->title
-msgid "System section"
-msgstr "系统部分"
+#: search.py:85
+msgid "Search"
+msgstr ""
 
-#. cinnamon-places-center->settings-schema.json->showDesktop->description
-msgid "Show desktop"
-msgstr "显示桌面"
+#: search.py:106
+msgid "Start in"
+msgstr ""
 
-#. cinnamon-places-center->settings-
-#. schema.json->showRecentDocuments->description
-msgid "Show recent documents"
-msgstr "显示最近的文本"
+#: search.py:107
+#, fuzzy
+msgid "Select a folder"
+msgstr "搜索主目录文件夹"
 
-#. cinnamon-places-center->settings-schema.json->userPage->title
-msgid "User"
-msgstr "用户"
+#: search.py:113
+msgid "Follow symlinks"
+msgstr ""
 
-#. cinnamon-places-center->settings-schema.json->iconSize->description
-msgid "Menu icon size"
-msgstr "菜单图标大小"
+#: search.py:117
+msgid "Search hidden"
+msgstr ""
 
-#. cinnamon-places-center->metadata.json->description
+#: search.py:121
+msgid "Use regular expressions"
+msgstr ""
+
+#: search.py:125
+msgid "Stop"
+msgstr ""
+
+#: search.py:140
+msgid "File"
+msgstr ""
+
+#: search.py:156
+msgid "Path"
+msgstr ""
+
+#: search.py:184
+msgid "Searching..."
+msgstr ""
+
+#: search.py:198 search.py:199
+#, fuzzy
+msgid "Search Stopped"
+msgstr "搜索主目录文件夹"
+
+#: search.py:215
+msgid "Searching: "
+msgstr ""
+
+#: search.py:220
+msgid "Error: insufficient permissions to read folder "
+msgstr ""
+
+#: search.py:252
+#, fuzzy
+msgid "Search Completed"
+msgstr "搜索主目录文件夹"
+
+#: search.py:259
+msgid "Skipping"
+msgstr ""
+
+#: search.py:259
+msgid " - directory already searched"
+msgstr ""
+
+#. metadata.json->name
+msgid "Places Center"
+msgstr "位置中心"
+
+#. metadata.json->description
 msgid "Provides an easy-to-read layout to access your places"
 msgstr "提供一个易于阅读的布局以访问您的位置"
 
-#. cinnamon-places-center->metadata.json->contributors
-msgid "Stephen Collins - Author"
-msgstr "Stephen Collins - 作者"
-
-#. cinnamon-places-center->metadata.json->contributors
-msgid "kehugter - Added configurability to middle click"
-msgstr "kehugter - 增加了中键点击的可配置性"
-
-#. cinnamon-places-center->metadata.json->comments
+#. metadata.json->comments
 msgid ""
 "Places Center is a feature-rich, cross-platform Cinnamon applet that "
 "provides easy access to all of your most-used places. Feel free to "
@@ -201,12 +160,186 @@ msgstr ""
 "位置中心是一个功能丰富、跨平台的 Cinnamon 小程序，可以轻松访问所有您最常用的"
 "位置。请随意通过提交拉取请求、错误报告和功能请求贡献到我的 github 仓库。"
 
-#. cinnamon-places-center->metadata.json->name
-msgid "Places Center"
-msgstr "位置中心"
+#. metadata.json->contributors
+msgid "Stephen Collins - Author"
+msgstr "Stephen Collins - 作者"
 
-#~ msgid "User Section"
-#~ msgstr "用户部分"
+#. metadata.json->contributors
+msgid "kehugter - Added configurability to middle click"
+msgstr "kehugter - 增加了中键点击的可配置性"
 
-#~ msgid "System Section"
-#~ msgstr "系统部分"
+#. metadata.json->contributors
+msgid "claudiux - Improvements to the 'Recent' section."
+msgstr ""
+
+#. settings-schema.json->generalPage->title
+#, fuzzy
+msgid "General"
+msgstr "常规设置"
+
+#. settings-schema.json->userPage->title
+msgid "User"
+msgstr "用户"
+
+#. settings-schema.json->systemPage->title
+#, fuzzy
+msgid "System"
+msgstr "文件系统"
+
+#. settings-schema.json->recentPage->title
+#. settings-schema.json->recentSection->title
+#, fuzzy
+msgid "Recent documents"
+msgstr "最近的文档"
+
+#. settings-schema.json->panel->title
+#, fuzzy
+msgid "Panel settings"
+msgstr "常规设置"
+
+#. settings-schema.json->menu->title
+#, fuzzy
+msgid "Menu settings"
+msgstr "常规设置"
+
+#. settings-schema.json->userSection->title
+msgid "User section"
+msgstr "用户部分"
+
+#. settings-schema.json->systemSection->title
+msgid "System section"
+msgstr "系统部分"
+
+#. settings-schema.json->panelIcon->description
+msgid "Panel icon"
+msgstr "面板图标"
+
+#. settings-schema.json->panelIcon->tooltip
+msgid "Accepts icon name or direct path (supports symbolic icons)"
+msgstr "接受图标名称或直接路径（支持符号图标）"
+
+#. settings-schema.json->panelText->description
+msgid "Panel text"
+msgstr "面板文本"
+
+#. settings-schema.json->keyOpen->description
+msgid "Menu shortcut key"
+msgstr "菜单快捷键"
+
+#. settings-schema.json->iconSize->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->iconSize->description
+msgid "Menu icon size"
+msgstr "菜单图标大小"
+
+#. settings-schema.json->middleClickPath->description
+msgid "Open on middle click"
+msgstr "中键点击时打开"
+
+#. settings-schema.json->middleClickPath->tooltip
+msgid "Leave blank to disable"
+msgstr "留空则禁用"
+
+#. settings-schema.json->showDesktop->description
+msgid "Show desktop"
+msgstr "显示桌面"
+
+#. settings-schema.json->userCustomPlaces->description
+#. settings-schema.json->systemCustomPlaces->description
+msgid "Custom places"
+msgstr "自定义位置"
+
+#. settings-schema.json->userCustomPlaces->tooltip
+#. settings-schema.json->systemCustomPlaces->tooltip
+#, fuzzy
+msgid ""
+"List of uris/file paths to be included. Entries may be separated by either a "
+"comma(,) or by a new-line. You can set the name to be displayed by adding :"
+"customName after the location. You can likewise set an icon name by adding :"
+"iconName after the custom name."
+msgstr ""
+"要包含uri/文件路径的列表。条目可以用逗号(,)或换行符隔开。您可以通过在位置后面"
+"添加 :自定义名称 设置要显示的名称。"
+
+#. settings-schema.json->showTrash->description
+msgid "Show trash"
+msgstr "显示回收站"
+
+#. settings-schema.json->showTrash->options
+msgid "Never"
+msgstr "从不"
+
+#. settings-schema.json->showTrash->options
+msgid "Always"
+msgstr "总是"
+
+#. settings-schema.json->showTrash->options
+msgid "When not empty"
+msgstr "当非空时"
+
+#. settings-schema.json->showComputer->description
+msgid "Show computer"
+msgstr "显示计算机"
+
+#. settings-schema.json->showRoot->description
+msgid "Show file system"
+msgstr "显示文件系统"
+
+#. settings-schema.json->showVolumes->description
+msgid "Show volumes"
+msgstr "显示卷"
+
+#. settings-schema.json->onlyShowMounted->description
+msgid "Only show mounted drives"
+msgstr "仅显示已挂载的驱动器"
+
+#. settings-schema.json->showNetwork->description
+msgid "Show network"
+msgstr "显示网络"
+
+#. settings-schema.json->showRecentDocuments->description
+msgid "Show recent documents"
+msgstr "显示最近的文本"
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "5"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "10"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "15"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "20"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "25"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+msgid "30"
+msgstr ""
+
+#. settings-schema.json->recentSizeLimit->options
+#, fuzzy
+msgid "All Recent Documents"
+msgstr "最近的文档"
+
+#. settings-schema.json->recentSizeLimit->description
+msgid "Number to show"
+msgstr "要显示的数量"
+
+#. settings-schema.json->recentShowUri->description
+msgid "Show complete path in tooltips"
+msgstr ""
+
+#. settings-schema.json->btnPrivacy->description
+msgid "Privacy"
+msgstr ""

--- a/placesCenter@scollins/files/placesCenter@scollins/settings-schema.json
+++ b/placesCenter@scollins/files/placesCenter@scollins/settings-schema.json
@@ -45,7 +45,7 @@
         "recentSection": {
             "type": "section",
             "title": "Recent documents",
-            "keys": ["showRecentDocuments", "recentSizeLimit", "btnPrivacy"]
+            "keys": ["showRecentDocuments", "recentSizeLimit", "recentShowUri", "btnPrivacy"]
         }
     },
 
@@ -172,6 +172,12 @@
         "description": "Number to show",
         "indent": true,
         "dependency": "showRecentDocuments"
+    },
+
+    "recentShowUri": {
+        "type": "checkbox",
+        "description": "Show complete path in tooltips",
+        "default": true
     },
 
     "btnPrivacy": {


### PR DESCRIPTION
@collinss 
Hi Stephen,
This PR is to show the uri of each recent document in its tooltip.
This is useful when several documents have the same name (like `applet.js` - which applet is it?).
I hope you find these changes satisfactory.

Regards
claudiux