### PR TITLE
directory-menu@torchipeppo: Change to TextIconApplet and other improvements

### DIFF
--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/applet.js
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/applet.js
@@ -36,6 +36,7 @@ class CassettoneApplet extends Applet.TextIconApplet {
         this.settings.bind("show-hidden", "show_hidden", null, null);
         this.settings.bind("icon-name", "icon_name", this.set_applet_icon_symbolic_name, null);
         this.settings.bind("label", "label", this.set_applet_label, null);
+        this.settings.bind("limit-characters", "limit_characters", null, null);
         this.settings.bind("character-limit", "character_limit", null, null);
         this.starting_uri = this.normalize_tilde(this.starting_uri);
 
@@ -140,7 +141,7 @@ class CassettoneApplet extends Applet.TextIconApplet {
             "x": x,
             "y": y,
             "orientation": o,
-            "character_limit": this.character_limit,
+            "character_limit": this.limit_characters ? this.character_limit : -1,
         }
 
         Util.spawn_async(['python3', `${this.metadata.path}/popup_menu.py`, JSON.stringify(args)]);

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/applet.js
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/applet.js
@@ -21,8 +21,22 @@ const Gio = imports.gi.Gio;
 const St = imports.gi.St;
 const Cinnamon = imports.gi.Cinnamon;
 const Settings = imports.ui.settings;
+const Gettext = imports.gettext;
+
+
 const UUID = "directory-menu@torchipeppo";
 
+Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
+
+function _(text) {
+	let locText = Gettext.dgettext(UUID, text);
+
+	if (locText == text) {
+		locText = window._(text);
+	}
+
+	return locText;
+}
 
 
 class CassettoneApplet extends Applet.TextIconApplet {

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/applet.js
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/applet.js
@@ -25,8 +25,7 @@ const UUID = "directory-menu@torchipeppo";
 
 
 
-class CassettoneApplet extends Applet.IconApplet {
-
+class CassettoneApplet extends Applet.TextIconApplet {
     constructor(metadata, orientation, panel_height, instance_id) {
         super(orientation, panel_height, instance_id);
 
@@ -36,12 +35,14 @@ class CassettoneApplet extends Applet.IconApplet {
         this.settings.bind("starting-uri", "starting_uri", this.normalize_tilde, this.starting_uri);
         this.settings.bind("show-hidden", "show_hidden", null, null);
         this.settings.bind("icon-name", "icon_name", this.set_applet_icon_symbolic_name, null);
-        this.settings.bind("tooltip", "tooltip_text", (newtext) => {this.set_applet_tooltip(_(newtext))}, null);
+        this.settings.bind("label", "label", this.set_applet_label, null);
         this.settings.bind("character-limit", "character_limit", null, null);
         this.starting_uri = this.normalize_tilde(this.starting_uri);
 
+        this.set_applet_tooltip(_("Directory Menu"));
         this.set_applet_icon_symbolic_name(this.icon_name);
-        this.set_applet_tooltip(_(this.tooltip_text));
+        this.set_applet_label(this.label)
+        this.set_show_label_in_vertical_panels(false);
 
         this.actor.connect('enter-event', Lang.bind(this, this.on_enter_event));
         this.actor.connect('button-release-event', Lang.bind(this, this.on_button_release_event));

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/de.po
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/de.po
@@ -8,27 +8,36 @@ msgstr ""
 "Project-Id-Version: directory-menu@torchipeppo 0.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-02-10 15:22+0100\n"
+"POT-Creation-Date: 2024-04-07 17:27-0100\n"
 "PO-Revision-Date: 2024-03-29 23:13+0100\n"
+"Last-Translator: Martin Posselt <nekomajin@gmx.de>\n"
 "Language-Team: \n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Martin Posselt <nekomajin@gmx.de>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: de\n"
 
 #. metadata.json->name
+#: applet.js:43
 msgid "Directory Menu"
 msgstr "Verzeichnis-Menü"
+
+#: popup_menu.py:71
+msgid "Open Folder"
+msgstr "Ordner öffnen"
+
+#: popup_menu.py:76
+msgid "Open in Terminal"
+msgstr "Im Terminal öffnen"
 
 #. metadata.json->description
 msgid ""
 "Quickly navigate through directories on your system using a dropdown menu."
 msgstr ""
-"Mithilfe eines Dropdown-Menüs schnell durch die Verzeichnisse auf dem "
-"System navigieren."
+"Mithilfe eines Dropdown-Menüs schnell durch die Verzeichnisse auf dem System "
+"navigieren."
 
 #. settings-schema.json->starting-uri->description
 msgid "Base Directory"
@@ -41,15 +50,19 @@ msgstr "Icon (für weitere Infos mit dem Mauszeiger berühren)"
 #. settings-schema.json->icon-name->tooltip
 msgid "Must be an icon name (no path), and should be symbolic."
 msgstr ""
-"Angabe eines Symbolnamens (kein Pfad). Es sollte ein symbolisches Icon "
-"sein."
+"Angabe eines Symbolnamens (kein Pfad). Es sollte ein symbolisches Icon sein."
 
-#. settings-schema.json->tooltip->description
-msgid "Tooltip text"
-msgstr "Tooltip-Text"
+#. settings-schema.json->label->description
+msgid "Panel Text"
+msgstr ""
+
+#. settings-schema.json->limit-characters->description
+msgid "Limit the Maximum Number of Characters on the Submenus"
+msgstr ""
 
 #. settings-schema.json->character-limit->description
-msgid "Character Limit (-1 to disable)"
+#, fuzzy
+msgid "Character Limit"
 msgstr "Zeichenbegrenzung (-1 zum Deaktivieren)"
 
 #. settings-schema.json->character-limit->tooltip
@@ -63,11 +76,3 @@ msgstr ""
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
 msgstr "Versteckte Dateien anzeigen"
-
-#. popup_menu.py:71
-msgid "Open Folder"
-msgstr "Ordner öffnen"
-
-#. popup_menu.py:76
-msgid "Open in Terminal"
-msgstr "Im Terminal öffnen"

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/directory-menu@torchipeppo.pot
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/directory-menu@torchipeppo.pot
@@ -1,15 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is put in the public domain.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: directory-menu@torchipeppo 0.5\n"
+"Project-Id-Version: directory-menu@torchipeppo 0.5.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-02-10 15:22+0100\n"
+"POT-Creation-Date: 2024-04-07 17:27-0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +18,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. metadata.json->name
+#: applet.js:43
 msgid "Directory Menu"
+msgstr ""
+
+#: popup_menu.py:71
+msgid "Open Folder"
+msgstr ""
+
+#: popup_menu.py:76
+msgid "Open in Terminal"
 msgstr ""
 
 #. metadata.json->description
@@ -39,12 +47,16 @@ msgstr ""
 msgid "Must be an icon name (no path), and should be symbolic."
 msgstr ""
 
-#. settings-schema.json->tooltip->description
-msgid "Tooltip text"
+#. settings-schema.json->label->description
+msgid "Panel Text"
+msgstr ""
+
+#. settings-schema.json->limit-characters->description
+msgid "Limit the Maximum Number of Characters on the Submenus"
 msgstr ""
 
 #. settings-schema.json->character-limit->description
-msgid "Character Limit (-1 to disable)"
+msgid "Character Limit"
 msgstr ""
 
 #. settings-schema.json->character-limit->tooltip
@@ -55,12 +67,4 @@ msgstr ""
 
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
-msgstr ""
-
-#. popup_menu.py:71
-msgid "Open Folder"
-msgstr ""
-
-#. popup_menu.py:76
-msgid "Open in Terminal"
 msgstr ""

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/es.po
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-02-10 15:22+0100\n"
+"POT-Creation-Date: 2024-04-07 17:27-0100\n"
 "PO-Revision-Date: 2024-02-10 12:34-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,8 +19,17 @@ msgstr ""
 "X-Generator: Poedit 3.4.2\n"
 
 #. metadata.json->name
+#: applet.js:43
 msgid "Directory Menu"
 msgstr "Menú del Directorio"
+
+#: popup_menu.py:71
+msgid "Open Folder"
+msgstr "Abrir carpeta"
+
+#: popup_menu.py:76
+msgid "Open in Terminal"
+msgstr "Abrir en el terminal"
 
 #. metadata.json->description
 msgid ""
@@ -41,12 +50,17 @@ msgstr "Icono (pase el ratón para obtener información)"
 msgid "Must be an icon name (no path), and should be symbolic."
 msgstr "Debe ser un nombre de icono (sin ruta), y debe ser simbólico."
 
-#. settings-schema.json->tooltip->description
-msgid "Tooltip text"
-msgstr "Texto de información sobre herramientas"
+#. settings-schema.json->label->description
+msgid "Panel Text"
+msgstr ""
+
+#. settings-schema.json->limit-characters->description
+msgid "Limit the Maximum Number of Characters on the Submenus"
+msgstr ""
 
 #. settings-schema.json->character-limit->description
-msgid "Character Limit (-1 to disable)"
+#, fuzzy
+msgid "Character Limit"
 msgstr "Límite de caracteres (-1 para desactivar)"
 
 #. settings-schema.json->character-limit->tooltip
@@ -60,11 +74,3 @@ msgstr ""
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
 msgstr "Incluir archivos ocultos"
-
-#. popup_menu.py:71
-msgid "Open Folder"
-msgstr "Abrir carpeta"
-
-#. popup_menu.py:76
-msgid "Open in Terminal"
-msgstr "Abrir en el terminal"

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/fr.po
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: directory-menu@torchipeppo 0.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-02-10 15:22+0100\n"
+"POT-Creation-Date: 2024-04-07 17:27-0100\n"
 "PO-Revision-Date: 2024-02-11 17:20+0100\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -20,15 +20,24 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #. metadata.json->name
+#: applet.js:43
 msgid "Directory Menu"
 msgstr "Menu de répertoires"
+
+#: popup_menu.py:71
+msgid "Open Folder"
+msgstr "Ouvrir le dossier"
+
+#: popup_menu.py:76
+msgid "Open in Terminal"
+msgstr "Ouvrir dans un terminal"
 
 #. metadata.json->description
 msgid ""
 "Quickly navigate through directories on your system using a dropdown menu."
 msgstr ""
-"Naviguez rapidement dans les répertoires de votre système à l'aide d'un "
-"menu déroulant."
+"Naviguez rapidement dans les répertoires de votre système à l'aide d'un menu "
+"déroulant."
 
 #. settings-schema.json->starting-uri->description
 msgid "Base Directory"
@@ -43,12 +52,17 @@ msgid "Must be an icon name (no path), and should be symbolic."
 msgstr ""
 "Il doit s'agir d'un nom d'icône (pas de chemin) et doit être symbolique."
 
-#. settings-schema.json->tooltip->description
-msgid "Tooltip text"
-msgstr "Texte de l'info-bulle"
+#. settings-schema.json->label->description
+msgid "Panel Text"
+msgstr ""
+
+#. settings-schema.json->limit-characters->description
+msgid "Limit the Maximum Number of Characters on the Submenus"
+msgstr ""
 
 #. settings-schema.json->character-limit->description
-msgid "Character Limit (-1 to disable)"
+#, fuzzy
+msgid "Character Limit"
 msgstr "Nombre maximal de caractères (-1 pour désactiver)"
 
 #. settings-schema.json->character-limit->tooltip
@@ -62,11 +76,3 @@ msgstr ""
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
 msgstr "Montrer également les fichiers cachés"
-
-#. popup_menu.py:71
-msgid "Open Folder"
-msgstr "Ouvrir le dossier"
-
-#. popup_menu.py:76
-msgid "Open in Terminal"
-msgstr "Ouvrir dans un terminal"

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/hu.po
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-02-10 15:22+0100\n"
+"POT-Creation-Date: 2024-04-07 17:27-0100\n"
 "PO-Revision-Date: 2024-02-13 18:12+0100\n"
 "Last-Translator: Vajda Örs <ors0092@gmail.com>\n"
 "Language-Team: \n"
@@ -20,8 +20,17 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #. metadata.json->name
+#: applet.js:43
 msgid "Directory Menu"
 msgstr "Könyvtár menü"
+
+#: popup_menu.py:71
+msgid "Open Folder"
+msgstr "Könyvtár megnyitása"
+
+#: popup_menu.py:76
+msgid "Open in Terminal"
+msgstr "Megnyitás terminálban"
 
 #. metadata.json->description
 msgid ""
@@ -43,12 +52,17 @@ msgid "Must be an icon name (no path), and should be symbolic."
 msgstr ""
 "Ikonnévnek kell lennie (nincs elérési út), és szimbolikusnak kell lennie."
 
-#. settings-schema.json->tooltip->description
-msgid "Tooltip text"
-msgstr "Eszköztipp szövege"
+#. settings-schema.json->label->description
+msgid "Panel Text"
+msgstr ""
+
+#. settings-schema.json->limit-characters->description
+msgid "Limit the Maximum Number of Characters on the Submenus"
+msgstr ""
 
 #. settings-schema.json->character-limit->description
-msgid "Character Limit (-1 to disable)"
+#, fuzzy
+msgid "Character Limit"
 msgstr "Karakter Limit (-1 a letiltáshoz)"
 
 #. settings-schema.json->character-limit->tooltip
@@ -62,11 +76,3 @@ msgstr ""
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
 msgstr "Tartalmazza a rejtett fájlokat is"
-
-#. popup_menu.py:71
-msgid "Open Folder"
-msgstr "Könyvtár megnyitása"
-
-#. popup_menu.py:76
-msgid "Open in Terminal"
-msgstr "Megnyitás terminálban"

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/it.po
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: directory-menu@torchipeppo 0.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-02-10 15:22+0100\n"
+"POT-Creation-Date: 2024-04-07 17:27-0100\n"
 "PO-Revision-Date: 2024-02-10 15:22+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,14 +18,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. metadata.json->name
+#: applet.js:43
 msgid "Directory Menu"
 msgstr "Menù delle Cartelle"
+
+#: popup_menu.py:71
+msgid "Open Folder"
+msgstr "Apri cartella"
+
+#: popup_menu.py:76
+msgid "Open in Terminal"
+msgstr "Apri nel terminale"
 
 #. metadata.json->description
 msgid ""
 "Quickly navigate through directories on your system using a dropdown menu."
-msgstr ""
-"Naviga rapidamente attraverso le tue cartelle con un menù a tendina."
+msgstr "Naviga rapidamente attraverso le tue cartelle con un menù a tendina."
 
 #. settings-schema.json->starting-uri->description
 msgid "Base Directory"
@@ -37,28 +45,31 @@ msgstr "Icona (tieni il mouse qui per info!)"
 
 #. settings-schema.json->icon-name->tooltip
 msgid "Must be an icon name (no path), and should be symbolic."
-msgstr "Deve essere il nome di un'icona (non un percorso), e l'icona dovrebbe essere simbolica."
+msgstr ""
+"Deve essere il nome di un'icona (non un percorso), e l'icona dovrebbe essere "
+"simbolica."
 
-#. settings-schema.json->tooltip->description
-msgid "Tooltip text"
-msgstr "Didascalia"
+#. settings-schema.json->label->description
+msgid "Panel Text"
+msgstr ""
+
+#. settings-schema.json->limit-characters->description
+msgid "Limit the Maximum Number of Characters on the Submenus"
+msgstr ""
 
 #. settings-schema.json->character-limit->description
-msgid "Character Limit (-1 to disable)"
+#, fuzzy
+msgid "Character Limit"
 msgstr "Limite di caratteri (-1 per disattivare)"
 
 #. settings-schema.json->character-limit->tooltip
-msgid "(Approximately) Limit the number of characters of each entry.\nUseful if you think the menu is too wide."
-msgstr "Limita (approssimativamente) il numero di caratteri di ciascuna riga.\nUtile se il menù risulta troppo largo."
+msgid ""
+"(Approximately) Limit the number of characters of each entry.\n"
+"Useful if you think the menu is too wide."
+msgstr ""
+"Limita (approssimativamente) il numero di caratteri di ciascuna riga.\n"
+"Utile se il menù risulta troppo largo."
 
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
 msgstr "Mostra i file nascosti"
-
-#. popup_menu.py:71
-msgid "Open Folder"
-msgstr "Apri cartella"
-
-#. popup_menu.py:76
-msgid "Open in Terminal"
-msgstr "Apri nel terminale"

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/pt.po
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/po/pt.po
@@ -6,9 +6,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-04 22:10+0000\n"
-"PO-Revision-Date: 2024-02-04 18:56-0500\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-04-07 17:27-0100\n"
+"PO-Revision-Date: 2024-04-07 17:36-0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: pt\n"
@@ -18,12 +19,24 @@ msgstr ""
 "X-Generator: Poedit 3.4.2\n"
 
 #. metadata.json->name
+#: applet.js:43
 msgid "Directory Menu"
 msgstr "Menu de Diretórios"
 
+#: popup_menu.py:71
+msgid "Open Folder"
+msgstr "Abrir pasta"
+
+#: popup_menu.py:76
+msgid "Open in Terminal"
+msgstr "Abrir no terminal"
+
 #. metadata.json->description
-msgid "Quickly navigate through directories on your system using a dropdown menu."
-msgstr "Navegue rapidamente através dos diretórios do seu sistema utilizando um menu dropdown."
+msgid ""
+"Quickly navigate through directories on your system using a dropdown menu."
+msgstr ""
+"Navegue rapidamente através dos diretórios do seu sistema utilizando um menu "
+"dropdown."
 
 #. settings-schema.json->starting-uri->description
 msgid "Base Directory"
@@ -37,18 +50,26 @@ msgstr "Ícone"
 msgid "Must be an icon name (no path), and should be symbolic."
 msgstr "Precisa ser o nome de um ícone."
 
-#. settings-schema.json->tooltip->description
-msgid "Tooltip text"
-msgstr "Texto da dica"
+#. settings-schema.json->label->description
+msgid "Panel Text"
+msgstr "Texto do Painel"
+
+#. settings-schema.json->limit-characters->description
+msgid "Limit the Maximum Number of Characters on the Submenus"
+msgstr "Limitar o Número Máximo de Caracteres nos Submenus"
+
+#. settings-schema.json->character-limit->description
+msgid "Character Limit"
+msgstr "Limite de Caracteres"
+
+#. settings-schema.json->character-limit->tooltip
+msgid ""
+"(Approximately) Limit the number of characters of each entry.\n"
+"Useful if you think the menu is too wide."
+msgstr ""
+"(Aproximadamente) O número de caracteres para cada entrada.\n"
+"Útil caso achar que o menu está muito largo."
 
 #. settings-schema.json->show-hidden->description
 msgid "Include hidden files"
 msgstr "Incluir ficheiros ocultos"
-
-#. popup_menu.py:71
-msgid "Open Folder"
-msgstr "Abrir pasta"
-
-#. popup_menu.py:76
-msgid "Open in Terminal"
-msgstr "Abrir no terminal"

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/settings-schema.json
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/settings-schema.json
@@ -11,10 +11,10 @@
         "description": "Icon (hover here for info!)",
         "tooltip": "Must be an icon name (no path), and should be symbolic."
     },
-    "tooltip": {
+    "label": {
         "type": "entry",
-        "default": "Directory Menu",
-        "description": "Tooltip text"
+        "default": "",
+        "description": "Panel Text"
     },
     "character-limit": {
         "type": "spinbutton",

--- a/directory-menu@torchipeppo/files/directory-menu@torchipeppo/settings-schema.json
+++ b/directory-menu@torchipeppo/files/directory-menu@torchipeppo/settings-schema.json
@@ -16,14 +16,20 @@
         "default": "",
         "description": "Panel Text"
     },
+    "limit-characters": {
+        "type": "switch",
+        "default": false,
+        "description": "Limit the Maximum Number of Characters on the Submenus"
+    },
     "character-limit": {
         "type": "spinbutton",
-        "default" : -1,
-        "min": -1,
+        "default": 50,
+        "min": 0,
         "max": 9999,
-        "step": 1,
-        "description" : "Character Limit (-1 to disable)",
-        "tooltip": "(Approximately) Limit the number of characters of each entry.\nUseful if you think the menu is too wide."
+        "step": 5,
+        "description": "Character Limit",
+        "tooltip": "(Approximately) Limit the number of characters of each entry.\nUseful if you think the menu is too wide.",
+        "dependency": "limit-characters"
     },
     "show-hidden": {
         "type": "switch",


### PR DESCRIPTION
Hi @torchipeppo 

I made some changes here:

1. Turned the applet from an IconApplet to a TextIconApplet this way it will be possible to display a text label in the front of the icon as shown in the image below:

![Captura de ecrã de 2024-04-07 17-38-14](https://github.com/linuxmint/cinnamon-spices-applets/assets/63073056/60ddfdc5-c9d6-4680-bace-a6ea5e9b1279)

![Captura de ecrã de 2024-04-07 17-38-54](https://github.com/linuxmint/cinnamon-spices-applets/assets/63073056/ae6cacae-fcec-4ab3-b43f-cd4937fdf3f7)

2. Updated the Character Limit setting to show a switch instead to enable the character limiting, and only when it is enabled that the user has to define the character limit (the logic on the Python script continues the same)

![Captura de ecrã de 2024-04-07 17-44-29](https://github.com/linuxmint/cinnamon-spices-applets/assets/63073056/578feb38-8e0e-4336-9dce-3a1c3a9bf1e1)

3. I also removed the tooltip text entry in favor of the panel text added in 1. and instead made it static for "Directory Menu" which is the title of the applet

Please tell me if you approve these changes.
