### PR TITLE
ddcci-multi-monitor@tim-we: Added changing brightness on scrolling applet icon.

### DIFF
--- a/ddcci-multi-monitor@tim-we/files/ddcci-multi-monitor@tim-we/applet.js
+++ b/ddcci-multi-monitor@tim-we/files/ddcci-multi-monitor@tim-we/applet.js
@@ -119,7 +119,7 @@ class DDCMultiMonitor extends Applet.IconApplet {
         this.set_applet_icon_symbolic_name("display-brightness");
         this.set_applet_tooltip(DEFAULT_TOOLTIP);
         this.actor.connect('scroll-event', (...args) => this._onScrollEvent(...args));
-        this.lastTooltipTimeoutID = setTimeout(() => {}, 1);
+        this.lastTooltipTimeoutID = null;
 
         this.menu = new Applet.AppletPopupMenu(this, orientation);
         this.menuManager = new PopupMenu.PopupMenuManager(this);

--- a/ddcci-multi-monitor@tim-we/files/ddcci-multi-monitor@tim-we/applet.js
+++ b/ddcci-multi-monitor@tim-we/files/ddcci-multi-monitor@tim-we/applet.js
@@ -196,19 +196,6 @@ class DDCMultiMonitor extends Applet.IconApplet {
         }
     }
 
-    scrollBrightnessChange(mon) {
-        this.set_applet_tooltip("Brightness: " + mon.brightness + "%"); // Show a tooltip with the current brightness
-        this._applet_tooltip.show();
-        setTimeout(() => { // Waits before actually setting the brightness, to reduce weirdness when scrolling more than 1 step
-log("do");
-            monitor.setBrightness(monitor.brightness); 
-            setTimeout(() => { // Hide the tooltip
-                this._applet_tooltip.hide();
-                this.set_applet_tooltip(DEFAULT_TOOLTIP);
-            }, 1000);
-        }, 180);
-    }
-
     // Change the brightness when scrolling on the icon
     _onScrollEvent(actor, event) {
         let direction = event.get_scroll_direction();
@@ -223,7 +210,6 @@ log("do");
                 this.set_applet_tooltip("Brightness: " + monitor.brightness + "%"); 
                 this._applet_tooltip.show();
                 setTimeout(() => { // Wait before actually changing the brightness, to prevent weirdness when scrolling multiple steps
-log("do");
                     monitor.setBrightness(monitor.brightness); 
                     setTimeout(() => {
                         this._applet_tooltip.hide();
@@ -234,13 +220,12 @@ log("do");
             });
             
         }
-        else if (direction == Clutter.ScrollDirection.UP) { // Do the same thing for scrolling up
+        else if (direction == Clutter.ScrollDirection.UP) {
             this.monitors.forEach((monitor) => {
                 monitor.brightness = Math.min(100, monitor.brightness + BRIGHTNESS_ADJUSTMENT_STEP);
                 this.set_applet_tooltip("Brightness: " + monitor.brightness + "%");
                 this._applet_tooltip.show();
                 setTimeout(() => {
-log("do");
                     monitor.setBrightness(monitor.brightness); 
                     setTimeout(() => {
                         this._applet_tooltip.hide();


### PR DESCRIPTION
Added ability to scroll on the applet icon to change the brightness without having to actually open it and move the slider. (With a lot of inspiration and code taken from the built-in [sound@cinnamon.org](https://github.com/linuxmint/cinnamon/tree/8214ed15927d59e4a7054404c2c584eeb4ba4a05/files/usr/share/cinnamon/applets/sound%40cinnamon.org)) 
I haven't tested it on a multi-monitor setup, but I think it would just increase or decrease the brightness of all the monitors.

I also changed a few quirks of the applet, such as not showing the real brightness of the monitor when opened, just the last brightness it was set to by the applet.