### PR TITLE
gpumonitor@axel358: add setting to select GPU

### DIFF
--- a/gpumonitor@axel358/files/gpumonitor@axel358/settings-schema.json
+++ b/gpumonitor@axel358/files/gpumonitor@axel358/settings-schema.json
@@ -39,6 +39,15 @@
       "description": "Decimal places",
       "tooltip": "Number of decimal places to show"
    },
+   "select-gpu": {
+      "type": "combobox",
+      "default": "",
+      "description": "Select GPU (bus nr.)",
+      "options": {
+         "Loading...": ""
+      },
+      "tooltip": "Use 'lshw -C display' for more info"
+   },
    "font-size": {
       "type": "spinbutton",
       "default": 100,


### PR DESCRIPTION
@axel358

Add a setting to select a specific GPU to monitor in case there are multiple GPUs (including integrated graphics for example).

Uses `lshw -C display` to get a list of GPUs, but I am not sure how to get the full name of the GPU, so currently shows just the bus number which is passed on to radeontop.