### PR TITLE
weather@mockturtl Update 3.4.2

### DIFF
--- a/weather@mockturtl/CHANGELOG.md
+++ b/weather@mockturtl/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.4.2
+
+* Fix [#5419]https://github.com/linuxmint/cinnamon-spices-applets/issues/5419
+* Fix [#5680]https://github.com/linuxmint/cinnamon-spices-applets/issues/5680
+
 ## 3.4.1
 
 Changes:

--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -9652,7 +9652,6 @@ const IOErrorEnumNames = {
     [imports.gi.Gio.IOErrorEnum.PROXY_AUTH_FAILED]: "PROXY_AUTH_FAILED",
     [imports.gi.Gio.IOErrorEnum.PROXY_NEED_AUTH]: "PROXY_NEED_AUTH",
     [imports.gi.Gio.IOErrorEnum.PROXY_NOT_ALLOWED]: "PROXY_NOT_ALLOWED",
-    [imports.gi.Gio.IOErrorEnum.BROKEN_PIPE]: "BROKEN_PIPE",
     [imports.gi.Gio.IOErrorEnum.CONNECTION_CLOSED]: "CONNECTION_CLOSED",
     [imports.gi.Gio.IOErrorEnum.NOT_CONNECTED]: "NOT_CONNECTED",
     [imports.gi.Gio.IOErrorEnum.MESSAGE_TOO_LARGE]: "MESSAGE_TOO_LARGE",
@@ -9781,7 +9780,6 @@ class Event {
     }
 }
 Event.eventStore = [];
-
 
 ;// CONCATENATED MODULE: ./src/3_8/lib/notification_service.ts
 
@@ -10051,12 +10049,16 @@ class Soup3 {
             else {
                 AddHeadersToMessage(message, headers);
                 const finalCancellable = cancellable !== null && cancellable !== void 0 ? cancellable : Cancellable.new();
-                const timeout = utils_setTimeout(() => finalCancellable.cancel(), REQUEST_TIMEOUT_SECONDS * 1000);
+                let timeout = null;
+                if (cancellable == null) {
+                    timeout = utils_setTimeout(() => finalCancellable.cancel(), REQUEST_TIMEOUT_SECONDS * 1000);
+                }
                 this._httpSession.send_and_read_async(message, PRIORITY_DEFAULT, finalCancellable, (session, result) => {
                     var _a;
                     const headers = {};
                     let res = null;
-                    clearTimeout(timeout);
+                    if (timeout != null)
+                        clearTimeout(timeout);
                     try {
                         res = this._httpSession.send_and_read_finish(result);
                         message.get_response_headers().foreach((name, value) => {
@@ -10106,7 +10108,13 @@ class Soup2 {
             else {
                 AddHeadersToMessage(message, headers);
                 const finalCancellable = cancellable !== null && cancellable !== void 0 ? cancellable : Cancellable.new();
+                let timeout = null;
+                if (cancellable == null) {
+                    timeout = utils_setTimeout(() => finalCancellable.cancel(), REQUEST_TIMEOUT_SECONDS * 1000);
+                }
                 this._httpSession.send_async(message, cancellable, async (session, result) => {
+                    if (timeout != null)
+                        clearTimeout(timeout);
                     const headers = {};
                     let res = null;
                     try {

--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -10,163 +10,165 @@ var weatherApplet;
  SunCalc is a JavaScript library for calculating sun/moon position and light phases.
  https://github.com/mourner/suncalc
 */
-
 (function () {
-  'use strict';
+  'use strict'; // shortcuts for easier to read formulas
 
-  // shortcuts for easier to read formulas
   var PI = Math.PI,
-    sin = Math.sin,
-    cos = Math.cos,
-    tan = Math.tan,
-    asin = Math.asin,
-    atan = Math.atan2,
-    acos = Math.acos,
-    rad = PI / 180;
-
-  // sun calculations are based on http://aa.quae.nl/en/reken/zonpositie.html formulas
-
+      sin = Math.sin,
+      cos = Math.cos,
+      tan = Math.tan,
+      asin = Math.asin,
+      atan = Math.atan2,
+      acos = Math.acos,
+      rad = PI / 180; // sun calculations are based on http://aa.quae.nl/en/reken/zonpositie.html formulas
   // date/time constants and conversions
 
   var dayMs = 1000 * 60 * 60 * 24,
-    J1970 = 2440588,
-    J2000 = 2451545;
+      J1970 = 2440588,
+      J2000 = 2451545;
+
   function toJulian(date) {
     return date.valueOf() / dayMs - 0.5 + J1970;
   }
+
   function fromJulian(j) {
     return new Date((j + 0.5 - J1970) * dayMs);
   }
+
   function toDays(date) {
     return toJulian(date) - J2000;
-  }
+  } // general calculations for position
 
-  // general calculations for position
 
   var e = rad * 23.4397; // obliquity of the Earth
 
   function rightAscension(l, b) {
     return atan(sin(l) * cos(e) - tan(b) * sin(e), cos(l));
   }
+
   function declination(l, b) {
     return asin(sin(b) * cos(e) + cos(b) * sin(e) * sin(l));
   }
+
   function azimuth(H, phi, dec) {
     return atan(sin(H), cos(H) * sin(phi) - tan(dec) * cos(phi));
   }
+
   function altitude(H, phi, dec) {
     return asin(sin(phi) * sin(dec) + cos(phi) * cos(dec) * cos(H));
   }
+
   function siderealTime(d, lw) {
     return rad * (280.16 + 360.9856235 * d) - lw;
   }
-  function astroRefraction(h) {
-    if (h < 0)
-      // the following formula works for positive altitudes only.
-      h = 0; // if h = -0.08901179 a div/0 would occur.
 
+  function astroRefraction(h) {
+    if (h < 0) // the following formula works for positive altitudes only.
+      h = 0; // if h = -0.08901179 a div/0 would occur.
     // formula 16.4 of "Astronomical Algorithms" 2nd edition by Jean Meeus (Willmann-Bell, Richmond) 1998.
     // 1.02 / tan(h + 10.26 / (h + 5.10)) h in degrees, result in arc minutes -> converted to rad:
-    return 0.0002967 / Math.tan(h + 0.00312536 / (h + 0.08901179));
-  }
 
-  // general sun calculations
+    return 0.0002967 / Math.tan(h + 0.00312536 / (h + 0.08901179));
+  } // general sun calculations
+
 
   function solarMeanAnomaly(d) {
     return rad * (357.5291 + 0.98560028 * d);
   }
+
   function eclipticLongitude(M) {
     var C = rad * (1.9148 * sin(M) + 0.02 * sin(2 * M) + 0.0003 * sin(3 * M)),
-      // equation of center
-      P = rad * 102.9372; // perihelion of the Earth
+        // equation of center
+    P = rad * 102.9372; // perihelion of the Earth
 
     return M + C + P + PI;
   }
+
   function sunCoords(d) {
     var M = solarMeanAnomaly(d),
-      L = eclipticLongitude(M);
+        L = eclipticLongitude(M);
     return {
       dec: declination(L, 0),
       ra: rightAscension(L, 0)
     };
   }
-  var SunCalc = {};
 
-  // calculates sun position for a given date and latitude/longitude
+  var SunCalc = {}; // calculates sun position for a given date and latitude/longitude
 
   SunCalc.getPosition = function (date, lat, lng) {
     var lw = rad * -lng,
-      phi = rad * lat,
-      d = toDays(date),
-      c = sunCoords(d),
-      H = siderealTime(d, lw) - c.ra;
+        phi = rad * lat,
+        d = toDays(date),
+        c = sunCoords(d),
+        H = siderealTime(d, lw) - c.ra;
     return {
       azimuth: azimuth(H, phi, c.dec),
       altitude: altitude(H, phi, c.dec)
     };
-  };
+  }; // sun times configuration (angle, morning name, evening name)
 
-  // sun times configuration (angle, morning name, evening name)
 
-  var times = SunCalc.times = [[-0.833, 'sunrise', 'sunset'], [-0.3, 'sunriseEnd', 'sunsetStart'], [-6, 'dawn', 'dusk'], [-12, 'nauticalDawn', 'nauticalDusk'], [-18, 'nightEnd', 'night'], [6, 'goldenHourEnd', 'goldenHour']];
-
-  // adds a custom time to the times config
+  var times = SunCalc.times = [[-0.833, 'sunrise', 'sunset'], [-0.3, 'sunriseEnd', 'sunsetStart'], [-6, 'dawn', 'dusk'], [-12, 'nauticalDawn', 'nauticalDusk'], [-18, 'nightEnd', 'night'], [6, 'goldenHourEnd', 'goldenHour']]; // adds a custom time to the times config
 
   SunCalc.addTime = function (angle, riseName, setName) {
     times.push([angle, riseName, setName]);
-  };
+  }; // calculations for sun times
 
-  // calculations for sun times
 
   var J0 = 0.0009;
+
   function julianCycle(d, lw) {
     return Math.round(d - J0 - lw / (2 * PI));
   }
+
   function approxTransit(Ht, lw, n) {
     return J0 + (Ht + lw) / (2 * PI) + n;
   }
+
   function solarTransitJ(ds, M, L) {
     return J2000 + ds + 0.0053 * sin(M) - 0.0069 * sin(2 * L);
   }
+
   function hourAngle(h, phi, d) {
     return acos((sin(h) - sin(phi) * sin(d)) / (cos(phi) * cos(d)));
   }
+
   function observerAngle(height) {
     return -2.076 * Math.sqrt(height) / 60;
-  }
+  } // returns set time for the given sun altitude
 
-  // returns set time for the given sun altitude
+
   function getSetJ(h, lw, phi, dec, n, M, L) {
     var w = hourAngle(h, phi, dec),
-      a = approxTransit(w, lw, n);
+        a = approxTransit(w, lw, n);
     return solarTransitJ(a, M, L);
-  }
-
-  // calculates sun times for a given date, latitude/longitude, and, optionally,
+  } // calculates sun times for a given date, latitude/longitude, and, optionally,
   // the observer height (in meters) relative to the horizon
+
 
   SunCalc.getTimes = function (date, lat, lng, height) {
     height = height || 0;
     var lw = rad * -lng,
-      phi = rad * lat,
-      dh = observerAngle(height),
-      d = toDays(date),
-      n = julianCycle(d, lw),
-      ds = approxTransit(0, lw, n),
-      M = solarMeanAnomaly(ds),
-      L = eclipticLongitude(M),
-      dec = declination(L, 0),
-      Jnoon = solarTransitJ(ds, M, L),
-      i,
-      len,
-      time,
-      h0,
-      Jset,
-      Jrise;
+        phi = rad * lat,
+        dh = observerAngle(height),
+        d = toDays(date),
+        n = julianCycle(d, lw),
+        ds = approxTransit(0, lw, n),
+        M = solarMeanAnomaly(ds),
+        L = eclipticLongitude(M),
+        dec = declination(L, 0),
+        Jnoon = solarTransitJ(ds, M, L),
+        i,
+        len,
+        time,
+        h0,
+        Jset,
+        Jrise;
     var result = {
       solarNoon: fromJulian(Jnoon),
       nadir: fromJulian(Jnoon - 0.5)
     };
+
     for (i = 0, len = times.length; i < len; i += 1) {
       time = times[i];
       h0 = (time[0] + dh) * rad;
@@ -175,26 +177,24 @@ var weatherApplet;
       result[time[1]] = fromJulian(Jrise);
       result[time[2]] = fromJulian(Jset);
     }
-    return result;
-  };
 
-  // moon calculations, based on http://aa.quae.nl/en/reken/hemelpositie.html formulas
+    return result;
+  }; // moon calculations, based on http://aa.quae.nl/en/reken/hemelpositie.html formulas
+
 
   function moonCoords(d) {
     // geocentric ecliptic coordinates of the moon
-
     var L = rad * (218.316 + 13.176396 * d),
-      // ecliptic longitude
-      M = rad * (134.963 + 13.064993 * d),
-      // mean anomaly
-      F = rad * (93.272 + 13.229350 * d),
-      // mean distance
-
-      l = L + rad * 6.289 * sin(M),
-      // longitude
-      b = rad * 5.128 * sin(F),
-      // latitude
-      dt = 385001 - 20905 * cos(M); // distance to the moon in km
+        // ecliptic longitude
+    M = rad * (134.963 + 13.064993 * d),
+        // mean anomaly
+    F = rad * (93.272 + 13.229350 * d),
+        // mean distance
+    l = L + rad * 6.289 * sin(M),
+        // longitude
+    b = rad * 5.128 * sin(F),
+        // latitude
+    dt = 385001 - 20905 * cos(M); // distance to the moon in km
 
     return {
       ra: rightAscension(l, b),
@@ -202,15 +202,16 @@ var weatherApplet;
       dist: dt
     };
   }
+
   SunCalc.getMoonPosition = function (date, lat, lng) {
     var lw = rad * -lng,
-      phi = rad * lat,
-      d = toDays(date),
-      c = moonCoords(d),
-      H = siderealTime(d, lw) - c.ra,
-      h = altitude(H, phi, c.dec),
-      // formula 14.1 of "Astronomical Algorithms" 2nd edition by Jean Meeus (Willmann-Bell, Richmond) 1998.
-      pa = atan(sin(H), tan(phi) * cos(c.dec) - sin(c.dec) * cos(H));
+        phi = rad * lat,
+        d = toDays(date),
+        c = moonCoords(d),
+        H = siderealTime(d, lw) - c.ra,
+        h = altitude(H, phi, c.dec),
+        // formula 14.1 of "Astronomical Algorithms" 2nd edition by Jean Meeus (Willmann-Bell, Richmond) 1998.
+    pa = atan(sin(H), tan(phi) * cos(c.dec) - sin(c.dec) * cos(H));
     h = h + astroRefraction(h); // altitude correction for refraction
 
     return {
@@ -219,54 +220,51 @@ var weatherApplet;
       distance: c.dist,
       parallacticAngle: pa
     };
-  };
-
-  // calculations for illumination parameters of the moon,
+  }; // calculations for illumination parameters of the moon,
   // based on http://idlastro.gsfc.nasa.gov/ftp/pro/astro/mphase.pro formulas and
   // Chapter 48 of "Astronomical Algorithms" 2nd edition by Jean Meeus (Willmann-Bell, Richmond) 1998.
 
+
   SunCalc.getMoonIllumination = function (date) {
     var d = toDays(date || new Date()),
-      s = sunCoords(d),
-      m = moonCoords(d),
-      sdist = 149598000,
-      // distance from Earth to Sun in km
-
-      phi = acos(sin(s.dec) * sin(m.dec) + cos(s.dec) * cos(m.dec) * cos(s.ra - m.ra)),
-      inc = atan(sdist * sin(phi), m.dist - sdist * cos(phi)),
-      angle = atan(cos(s.dec) * sin(s.ra - m.ra), sin(s.dec) * cos(m.dec) - cos(s.dec) * sin(m.dec) * cos(s.ra - m.ra));
+        s = sunCoords(d),
+        m = moonCoords(d),
+        sdist = 149598000,
+        // distance from Earth to Sun in km
+    phi = acos(sin(s.dec) * sin(m.dec) + cos(s.dec) * cos(m.dec) * cos(s.ra - m.ra)),
+        inc = atan(sdist * sin(phi), m.dist - sdist * cos(phi)),
+        angle = atan(cos(s.dec) * sin(s.ra - m.ra), sin(s.dec) * cos(m.dec) - cos(s.dec) * sin(m.dec) * cos(s.ra - m.ra));
     return {
       fraction: (1 + cos(inc)) / 2,
       phase: 0.5 + 0.5 * inc * (angle < 0 ? -1 : 1) / Math.PI,
       angle: angle
     };
   };
+
   function hoursLater(date, h) {
     return new Date(date.valueOf() + h * dayMs / 24);
-  }
+  } // calculations for moon rise/set times are based on http://www.stargazing.net/kepler/moonrise.html article
 
-  // calculations for moon rise/set times are based on http://www.stargazing.net/kepler/moonrise.html article
 
   SunCalc.getMoonTimes = function (date, lat, lng, inUTC) {
     var t = new Date(date);
     if (inUTC) t.setUTCHours(0, 0, 0, 0);else t.setHours(0, 0, 0, 0);
     var hc = 0.133 * rad,
-      h0 = SunCalc.getMoonPosition(t, lat, lng).altitude - hc,
-      h1,
-      h2,
-      rise,
-      set,
-      a,
-      b,
-      xe,
-      ye,
-      d,
-      roots,
-      x1,
-      x2,
-      dx;
+        h0 = SunCalc.getMoonPosition(t, lat, lng).altitude - hc,
+        h1,
+        h2,
+        rise,
+        set,
+        a,
+        b,
+        xe,
+        ye,
+        d,
+        roots,
+        x1,
+        x2,
+        dx; // go in 2-hour chunks, each time seeing if a 3-point quadratic curve crosses zero (which means rise or set)
 
-    // go in 2-hour chunks, each time seeing if a 3-point quadratic curve crosses zero (which means rise or set)
     for (var i = 1; i <= 24; i += 2) {
       h1 = SunCalc.getMoonPosition(hoursLater(t, i), lat, lng).altitude - hc;
       h2 = SunCalc.getMoonPosition(hoursLater(t, i + 1), lat, lng).altitude - hc;
@@ -276,6 +274,7 @@ var weatherApplet;
       ye = (a * xe + b) * xe + h1;
       d = b * b - 4 * a * h1;
       roots = 0;
+
       if (d >= 0) {
         dx = Math.sqrt(d) / (Math.abs(a) * 2);
         x1 = xe - dx;
@@ -284,23 +283,26 @@ var weatherApplet;
         if (Math.abs(x2) <= 1) roots++;
         if (x1 < -1) x1 = x2;
       }
+
       if (roots === 1) {
         if (h0 < 0) rise = i + x1;else set = i + x1;
       } else if (roots === 2) {
         rise = i + (ye < 0 ? x2 : x1);
         set = i + (ye < 0 ? x1 : x2);
       }
+
       if (rise && set) break;
       h0 = h2;
     }
+
     var result = {};
     if (rise) result.rise = hoursLater(t, rise);
     if (set) result.set = hoursLater(t, set);
     if (!rise && !set) result[ye > 0 ? 'alwaysUp' : 'alwaysDown'] = true;
     return result;
-  };
+  }; // export as Node module / AMD module / browser variable
 
-  // export as Node module / AMD module / browser variable
+
   if (true) module.exports = SunCalc;else {}
 })();
 
@@ -509,150 +511,155 @@ const distanceUnitLocales = {
  * @private
  */
 class LuxonError extends Error {}
-
 /**
  * @private
  */
+
+
 class InvalidDateTimeError extends LuxonError {
   constructor(reason) {
     super(`Invalid DateTime: ${reason.toMessage()}`);
   }
-}
 
+}
 /**
  * @private
  */
+
 class InvalidIntervalError extends LuxonError {
   constructor(reason) {
     super(`Invalid Interval: ${reason.toMessage()}`);
   }
-}
 
+}
 /**
  * @private
  */
+
 class InvalidDurationError extends LuxonError {
   constructor(reason) {
     super(`Invalid Duration: ${reason.toMessage()}`);
   }
+
 }
-
 /**
  * @private
  */
+
 class ConflictingSpecificationError extends LuxonError {}
-
 /**
  * @private
  */
+
 class InvalidUnitError extends LuxonError {
   constructor(unit) {
     super(`Invalid unit ${unit}`);
   }
+
 }
-
 /**
  * @private
  */
+
 class InvalidArgumentError extends LuxonError {}
-
 /**
  * @private
  */
+
 class ZoneIsAbstractError extends LuxonError {
   constructor() {
     super("Zone is an abstract class");
   }
+
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/formats.js
 /**
  * @private
  */
-
-var n = "numeric",
-  s = "short",
-  l = "long";
-var DATE_SHORT = {
+const n = "numeric",
+      s = "short",
+      l = "long";
+const DATE_SHORT = {
   year: n,
   month: n,
   day: n
 };
-var DATE_MED = {
+const DATE_MED = {
   year: n,
   month: s,
   day: n
 };
-var DATE_MED_WITH_WEEKDAY = {
+const DATE_MED_WITH_WEEKDAY = {
   year: n,
   month: s,
   day: n,
   weekday: s
 };
-var DATE_FULL = {
+const DATE_FULL = {
   year: n,
   month: l,
   day: n
 };
-var DATE_HUGE = {
+const DATE_HUGE = {
   year: n,
   month: l,
   day: n,
   weekday: l
 };
-var TIME_SIMPLE = {
+const TIME_SIMPLE = {
   hour: n,
   minute: n
 };
-var TIME_WITH_SECONDS = {
+const TIME_WITH_SECONDS = {
   hour: n,
   minute: n,
   second: n
 };
-var TIME_WITH_SHORT_OFFSET = {
+const TIME_WITH_SHORT_OFFSET = {
   hour: n,
   minute: n,
   second: n,
   timeZoneName: s
 };
-var TIME_WITH_LONG_OFFSET = {
+const TIME_WITH_LONG_OFFSET = {
   hour: n,
   minute: n,
   second: n,
   timeZoneName: l
 };
-var TIME_24_SIMPLE = {
+const TIME_24_SIMPLE = {
   hour: n,
   minute: n,
   hourCycle: "h23"
 };
-var TIME_24_WITH_SECONDS = {
+const TIME_24_WITH_SECONDS = {
   hour: n,
   minute: n,
   second: n,
   hourCycle: "h23"
 };
-var TIME_24_WITH_SHORT_OFFSET = {
+const TIME_24_WITH_SHORT_OFFSET = {
   hour: n,
   minute: n,
   second: n,
   hourCycle: "h23",
   timeZoneName: s
 };
-var TIME_24_WITH_LONG_OFFSET = {
+const TIME_24_WITH_LONG_OFFSET = {
   hour: n,
   minute: n,
   second: n,
   hourCycle: "h23",
   timeZoneName: l
 };
-var DATETIME_SHORT = {
+const DATETIME_SHORT = {
   year: n,
   month: n,
   day: n,
   hour: n,
   minute: n
 };
-var DATETIME_SHORT_WITH_SECONDS = {
+const DATETIME_SHORT_WITH_SECONDS = {
   year: n,
   month: n,
   day: n,
@@ -660,14 +667,14 @@ var DATETIME_SHORT_WITH_SECONDS = {
   minute: n,
   second: n
 };
-var DATETIME_MED = {
+const DATETIME_MED = {
   year: n,
   month: s,
   day: n,
   hour: n,
   minute: n
 };
-var DATETIME_MED_WITH_SECONDS = {
+const DATETIME_MED_WITH_SECONDS = {
   year: n,
   month: s,
   day: n,
@@ -675,7 +682,7 @@ var DATETIME_MED_WITH_SECONDS = {
   minute: n,
   second: n
 };
-var DATETIME_MED_WITH_WEEKDAY = {
+const DATETIME_MED_WITH_WEEKDAY = {
   year: n,
   month: s,
   day: n,
@@ -683,7 +690,7 @@ var DATETIME_MED_WITH_WEEKDAY = {
   hour: n,
   minute: n
 };
-var DATETIME_FULL = {
+const DATETIME_FULL = {
   year: n,
   month: l,
   day: n,
@@ -691,7 +698,7 @@ var DATETIME_FULL = {
   minute: n,
   timeZoneName: s
 };
-var DATETIME_FULL_WITH_SECONDS = {
+const DATETIME_FULL_WITH_SECONDS = {
   year: n,
   month: l,
   day: n,
@@ -700,7 +707,7 @@ var DATETIME_FULL_WITH_SECONDS = {
   second: n,
   timeZoneName: s
 };
-var DATETIME_HUGE = {
+const DATETIME_HUGE = {
   year: n,
   month: l,
   day: n,
@@ -709,7 +716,7 @@ var DATETIME_HUGE = {
   minute: n,
   timeZoneName: l
 };
-var DATETIME_HUGE_WITH_SECONDS = {
+const DATETIME_HUGE_WITH_SECONDS = {
   year: n,
   month: l,
   day: n,
@@ -721,10 +728,10 @@ var DATETIME_HUGE_WITH_SECONDS = {
 };
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/zone.js
 
-
 /**
  * @interface
  */
+
 class Zone {
   /**
    * The type of zone
@@ -734,28 +741,30 @@ class Zone {
   get type() {
     throw new ZoneIsAbstractError();
   }
-
   /**
    * The name of this zone.
    * @abstract
    * @type {string}
    */
+
+
   get name() {
     throw new ZoneIsAbstractError();
   }
+
   get ianaName() {
     return this.name;
   }
-
   /**
    * Returns whether the offset is known to be fixed for the whole year.
    * @abstract
    * @type {boolean}
    */
+
+
   get isUniversal() {
     throw new ZoneIsAbstractError();
   }
-
   /**
    * Returns the offset's common name (such as EST) at the specified timestamp
    * @abstract
@@ -765,10 +774,11 @@ class Zone {
    * @param {string} opts.locale - What locale to return the offset name in.
    * @return {string}
    */
+
+
   offsetName(ts, opts) {
     throw new ZoneIsAbstractError();
   }
-
   /**
    * Returns the offset's value as a string
    * @abstract
@@ -777,48 +787,54 @@ class Zone {
    *                          Accepts 'narrow', 'short', or 'techie'. Returning '+6', '+06:00', or '+0600' respectively
    * @return {string}
    */
+
+
   formatOffset(ts, format) {
     throw new ZoneIsAbstractError();
   }
-
   /**
    * Return the offset in minutes for this zone at the specified timestamp.
    * @abstract
    * @param {number} ts - Epoch milliseconds for which to compute the offset
    * @return {number}
    */
+
+
   offset(ts) {
     throw new ZoneIsAbstractError();
   }
-
   /**
    * Return whether this Zone is equal to another zone
    * @abstract
    * @param {Zone} otherZone - the zone to compare
    * @return {boolean}
    */
+
+
   equals(otherZone) {
     throw new ZoneIsAbstractError();
   }
-
   /**
    * Return whether this Zone is valid.
    * @abstract
    * @type {boolean}
    */
+
+
   get isValid() {
     throw new ZoneIsAbstractError();
   }
+
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/zones/systemZone.js
 
 
-var singleton = null;
-
+let singleton = null;
 /**
  * Represents the local zone for this JavaScript environment.
  * @implements {Zone}
  */
+
 class SystemZone extends Zone {
   /**
    * Get a singleton instance of the local zone
@@ -828,61 +844,78 @@ class SystemZone extends Zone {
     if (singleton === null) {
       singleton = new SystemZone();
     }
+
     return singleton;
   }
-
   /** @override **/
+
+
   get type() {
     return "system";
   }
-
   /** @override **/
+
+
   get name() {
     return new Intl.DateTimeFormat().resolvedOptions().timeZone;
   }
-
   /** @override **/
+
+
   get isUniversal() {
     return false;
   }
-
   /** @override **/
+
+
   offsetName(ts, _ref) {
-    var format = _ref.format,
-      locale = _ref.locale;
+    let format = _ref.format,
+        locale = _ref.locale;
     return parseZoneInfo(ts, format, locale);
   }
-
   /** @override **/
+
+
   formatOffset(ts, format) {
     return formatOffset(this.offset(ts), format);
   }
-
   /** @override **/
+
+
   offset(ts) {
     return -new Date(ts).getTimezoneOffset();
   }
-
   /** @override **/
+
+
   equals(otherZone) {
     return otherZone.type === "system";
   }
-
   /** @override **/
+
+
   get isValid() {
     return true;
   }
+
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/zones/IANAZone.js
 function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-function _iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
+
+function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
-var dtfCache = {};
+
+let dtfCache = {};
+
 function makeDTF(zone) {
   if (!dtfCache[zone]) {
     dtfCache[zone] = new Intl.DateTimeFormat("en-US", {
@@ -897,9 +930,11 @@ function makeDTF(zone) {
       era: "short"
     });
   }
+
   return dtfCache[zone];
 }
-var typeToPos = {
+
+const typeToPos = {
   year: 0,
   month: 1,
   day: 2,
@@ -908,40 +943,48 @@ var typeToPos = {
   minute: 5,
   second: 6
 };
+
 function hackyOffset(dtf, date) {
-  var formatted = dtf.format(date).replace(/\u200E/g, ""),
-    parsed = /(\d+)\/(\d+)\/(\d+) (AD|BC),? (\d+):(\d+):(\d+)/.exec(formatted),
-    _parsed = _slicedToArray(parsed, 8),
-    fMonth = _parsed[1],
-    fDay = _parsed[2],
-    fYear = _parsed[3],
-    fadOrBc = _parsed[4],
-    fHour = _parsed[5],
-    fMinute = _parsed[6],
-    fSecond = _parsed[7];
+  const formatted = dtf.format(date).replace(/\u200E/g, ""),
+        parsed = /(\d+)\/(\d+)\/(\d+) (AD|BC),? (\d+):(\d+):(\d+)/.exec(formatted),
+        _parsed = _slicedToArray(parsed, 8),
+        fMonth = _parsed[1],
+        fDay = _parsed[2],
+        fYear = _parsed[3],
+        fadOrBc = _parsed[4],
+        fHour = _parsed[5],
+        fMinute = _parsed[6],
+        fSecond = _parsed[7];
+
   return [fYear, fMonth, fDay, fadOrBc, fHour, fMinute, fSecond];
 }
+
 function partsOffset(dtf, date) {
-  var formatted = dtf.formatToParts(date);
-  var filled = [];
-  for (var i = 0; i < formatted.length; i++) {
-    var _formatted$i = formatted[i],
-      type = _formatted$i.type,
-      value = _formatted$i.value;
-    var pos = typeToPos[type];
+  const formatted = dtf.formatToParts(date);
+  const filled = [];
+
+  for (let i = 0; i < formatted.length; i++) {
+    const _formatted$i = formatted[i],
+          type = _formatted$i.type,
+          value = _formatted$i.value;
+    const pos = typeToPos[type];
+
     if (type === "era") {
       filled[pos] = value;
     } else if (!isUndefined(pos)) {
       filled[pos] = parseInt(value, 10);
     }
   }
+
   return filled;
 }
-var ianaZoneCache = {};
+
+let ianaZoneCache = {};
 /**
  * A zone identified by an IANA identifier, like America/New_York
  * @implements {Zone}
  */
+
 class IANAZone extends Zone {
   /**
    * @param {string} name - Zone name
@@ -951,18 +994,19 @@ class IANAZone extends Zone {
     if (!ianaZoneCache[name]) {
       ianaZoneCache[name] = new IANAZone(name);
     }
+
     return ianaZoneCache[name];
   }
-
   /**
    * Reset local caches. Should only be necessary in testing scenarios.
    * @return {void}
    */
+
+
   static resetCache() {
     ianaZoneCache = {};
     dtfCache = {};
   }
-
   /**
    * Returns whether the provided string is a valid specifier. This only checks the string's format, not that the specifier identifies a known zone; see isValidZone for that.
    * @param {string} s - The string to check validity on
@@ -971,10 +1015,11 @@ class IANAZone extends Zone {
    * @deprecated This method returns false for some valid IANA names. Use isValidZone instead.
    * @return {boolean}
    */
+
+
   static isValidSpecifier(s) {
     return this.isValidZone(s);
   }
-
   /**
    * Returns whether the provided string identifies a real zone
    * @param {string} zone - The string to check
@@ -983,10 +1028,13 @@ class IANAZone extends Zone {
    * @example IANAZone.isValidZone("Sport~~blorp") //=> false
    * @return {boolean}
    */
+
+
   static isValidZone(zone) {
     if (!zone) {
       return false;
     }
+
     try {
       new Intl.DateTimeFormat("en-US", {
         timeZone: zone
@@ -996,62 +1044,73 @@ class IANAZone extends Zone {
       return false;
     }
   }
+
   constructor(name) {
     super();
     /** @private **/
+
     this.zoneName = name;
     /** @private **/
+
     this.valid = IANAZone.isValidZone(name);
   }
-
   /** @override **/
+
+
   get type() {
     return "iana";
   }
-
   /** @override **/
+
+
   get name() {
     return this.zoneName;
   }
-
   /** @override **/
+
+
   get isUniversal() {
     return false;
   }
-
   /** @override **/
+
+
   offsetName(ts, _ref) {
-    var format = _ref.format,
-      locale = _ref.locale;
+    let format = _ref.format,
+        locale = _ref.locale;
     return parseZoneInfo(ts, format, locale, this.name);
   }
-
   /** @override **/
+
+
   formatOffset(ts, format) {
     return formatOffset(this.offset(ts), format);
   }
-
   /** @override **/
+
+
   offset(ts) {
-    var date = new Date(ts);
+    const date = new Date(ts);
     if (isNaN(date)) return NaN;
-    var dtf = makeDTF(this.name);
-    var _ref2 = dtf.formatToParts ? partsOffset(dtf, date) : hackyOffset(dtf, date),
-      _ref3 = _slicedToArray(_ref2, 7),
-      year = _ref3[0],
-      month = _ref3[1],
-      day = _ref3[2],
-      adOrBc = _ref3[3],
-      hour = _ref3[4],
-      minute = _ref3[5],
-      second = _ref3[6];
+    const dtf = makeDTF(this.name);
+
+    let _ref2 = dtf.formatToParts ? partsOffset(dtf, date) : hackyOffset(dtf, date),
+        _ref3 = _slicedToArray(_ref2, 7),
+        year = _ref3[0],
+        month = _ref3[1],
+        day = _ref3[2],
+        adOrBc = _ref3[3],
+        hour = _ref3[4],
+        minute = _ref3[5],
+        second = _ref3[6];
+
     if (adOrBc === "BC") {
       year = -Math.abs(year) + 1;
-    }
+    } // because we're using hour12 and https://bugs.chromium.org/p/chromium/issues/detail?id=1025564&can=2&q=%2224%3A00%22%20datetimeformat
 
-    // because we're using hour12 and https://bugs.chromium.org/p/chromium/issues/detail?id=1025564&can=2&q=%2224%3A00%22%20datetimeformat
-    var adjustedHour = hour === 24 ? 0 : hour;
-    var asUTC = objToLocalTS({
+
+    const adjustedHour = hour === 24 ? 0 : hour;
+    const asUTC = objToLocalTS({
       year,
       month,
       day,
@@ -1060,93 +1119,124 @@ class IANAZone extends Zone {
       second,
       millisecond: 0
     });
-    var asTS = +date;
-    var over = asTS % 1000;
+    let asTS = +date;
+    const over = asTS % 1000;
     asTS -= over >= 0 ? over : 1000 + over;
     return (asUTC - asTS) / (60 * 1000);
   }
-
   /** @override **/
+
+
   equals(otherZone) {
     return otherZone.type === "iana" && otherZone.name === this.name;
   }
-
   /** @override **/
+
+
   get isValid() {
     return this.valid;
   }
+
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/locale.js
-var _excluded = ["base"],
-  _excluded2 = ["padTo", "floor"];
+const _excluded = ["base"],
+      _excluded2 = ["padTo", "floor"];
+
 function locale_slicedToArray(arr, i) { return locale_arrayWithHoles(arr) || locale_iterableToArrayLimit(arr, i) || locale_unsupportedIterableToArray(arr, i) || locale_nonIterableRest(); }
+
 function locale_nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
 function locale_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return locale_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return locale_arrayLikeToArray(o, minLen); }
+
 function locale_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-function locale_iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
+
+function locale_iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
 function locale_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
-function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == typeof i ? i : i + ""; }
-function _toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
-function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } } return target; }
+
+function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
 
 
 
 
 
+ // todo - remap caching
 
-// todo - remap caching
+let intlLFCache = {};
 
-var intlLFCache = {};
 function getCachedLF(locString) {
-  var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-  var key = JSON.stringify([locString, opts]);
-  var dtf = intlLFCache[key];
+  let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  const key = JSON.stringify([locString, opts]);
+  let dtf = intlLFCache[key];
+
   if (!dtf) {
     dtf = new Intl.ListFormat(locString, opts);
     intlLFCache[key] = dtf;
   }
+
   return dtf;
 }
-var intlDTCache = {};
+
+let intlDTCache = {};
+
 function getCachedDTF(locString) {
-  var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-  var key = JSON.stringify([locString, opts]);
-  var dtf = intlDTCache[key];
+  let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  const key = JSON.stringify([locString, opts]);
+  let dtf = intlDTCache[key];
+
   if (!dtf) {
     dtf = new Intl.DateTimeFormat(locString, opts);
     intlDTCache[key] = dtf;
   }
+
   return dtf;
 }
-var intlNumCache = {};
+
+let intlNumCache = {};
+
 function getCachedINF(locString) {
-  var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-  var key = JSON.stringify([locString, opts]);
-  var inf = intlNumCache[key];
+  let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  const key = JSON.stringify([locString, opts]);
+  let inf = intlNumCache[key];
+
   if (!inf) {
     inf = new Intl.NumberFormat(locString, opts);
     intlNumCache[key] = inf;
   }
+
   return inf;
 }
-var intlRelCache = {};
+
+let intlRelCache = {};
+
 function getCachedRTF(locString) {
-  var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-  var base = opts.base,
-    cacheKeyOpts = _objectWithoutProperties(opts, _excluded); // exclude `base` from the options
-  var key = JSON.stringify([locString, cacheKeyOpts]);
-  var inf = intlRelCache[key];
+  let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+  const base = opts.base,
+        cacheKeyOpts = _objectWithoutProperties(opts, _excluded); // exclude `base` from the options
+
+
+  const key = JSON.stringify([locString, cacheKeyOpts]);
+  let inf = intlRelCache[key];
+
   if (!inf) {
     inf = new Intl.RelativeTimeFormat(locString, opts);
     intlRelCache[key] = inf;
   }
+
   return inf;
 }
-var sysLocaleCache = null;
+
+let sysLocaleCache = null;
+
 function systemLocale() {
   if (sysLocaleCache) {
     return sysLocaleCache;
@@ -1155,65 +1245,79 @@ function systemLocale() {
     return sysLocaleCache;
   }
 }
+
 function parseLocaleString(localeStr) {
   // I really want to avoid writing a BCP 47 parser
   // see, e.g. https://github.com/wooorm/bcp-47
   // Instead, we'll do this:
-
   // a) if the string has no -u extensions, just leave it alone
   // b) if it does, use Intl to resolve everything
   // c) if Intl fails, try again without the -u
+  const uIndex = localeStr.indexOf("-u-");
 
-  var uIndex = localeStr.indexOf("-u-");
   if (uIndex === -1) {
     return [localeStr];
   } else {
-    var options;
-    var smaller = localeStr.substring(0, uIndex);
+    let options;
+    const smaller = localeStr.substring(0, uIndex);
+
     try {
       options = getCachedDTF(localeStr).resolvedOptions();
     } catch (e) {
       options = getCachedDTF(smaller).resolvedOptions();
     }
-    var _options = options,
-      numberingSystem = _options.numberingSystem,
-      calendar = _options.calendar;
-    // return the smaller one so that we can append the calendar and numbering overrides to it
+
+    const _options = options,
+          numberingSystem = _options.numberingSystem,
+          calendar = _options.calendar; // return the smaller one so that we can append the calendar and numbering overrides to it
+
     return [smaller, numberingSystem, calendar];
   }
 }
+
 function intlConfigString(localeStr, numberingSystem, outputCalendar) {
   if (outputCalendar || numberingSystem) {
     localeStr += "-u";
+
     if (outputCalendar) {
       localeStr += `-ca-${outputCalendar}`;
     }
+
     if (numberingSystem) {
       localeStr += `-nu-${numberingSystem}`;
     }
+
     return localeStr;
   } else {
     return localeStr;
   }
 }
+
 function mapMonths(f) {
-  var ms = [];
-  for (var i = 1; i <= 12; i++) {
-    var dt = DateTime.utc(2016, i, 1);
+  const ms = [];
+
+  for (let i = 1; i <= 12; i++) {
+    const dt = DateTime.utc(2016, i, 1);
     ms.push(f(dt));
   }
+
   return ms;
 }
+
 function mapWeekdays(f) {
-  var ms = [];
-  for (var i = 1; i <= 7; i++) {
-    var dt = DateTime.utc(2016, 11, 13 + i);
+  const ms = [];
+
+  for (let i = 1; i <= 7; i++) {
+    const dt = DateTime.utc(2016, 11, 13 + i);
     ms.push(f(dt));
   }
+
   return ms;
 }
+
 function listStuff(loc, length, defaultOK, englishFn, intlFn) {
-  var mode = loc.listingMode(defaultOK);
+  const mode = loc.listingMode(defaultOK);
+
   if (mode === "error") {
     return null;
   } else if (mode === "en") {
@@ -1222,6 +1326,7 @@ function listStuff(loc, length, defaultOK, englishFn, intlFn) {
     return intlFn(length);
   }
 }
+
 function supportsFastNumbers(loc) {
   if (loc.numberingSystem && loc.numberingSystem !== "latn") {
     return false;
@@ -1229,46 +1334,52 @@ function supportsFastNumbers(loc) {
     return loc.numberingSystem === "latn" || !loc.locale || loc.locale.startsWith("en") || new Intl.DateTimeFormat(loc.intl).resolvedOptions().numberingSystem === "latn";
   }
 }
-
 /**
  * @private
  */
+
 
 class PolyNumberFormatter {
   constructor(intl, forceSimple, opts) {
     this.padTo = opts.padTo || 0;
     this.floor = opts.floor || false;
-    var padTo = opts.padTo,
-      floor = opts.floor,
-      otherOpts = _objectWithoutProperties(opts, _excluded2);
+
+    const padTo = opts.padTo,
+          floor = opts.floor,
+          otherOpts = _objectWithoutProperties(opts, _excluded2);
+
     if (!forceSimple || Object.keys(otherOpts).length > 0) {
-      var intlOpts = _objectSpread({
+      const intlOpts = _objectSpread({
         useGrouping: false
       }, opts);
+
       if (opts.padTo > 0) intlOpts.minimumIntegerDigits = opts.padTo;
       this.inf = getCachedINF(intl, intlOpts);
     }
   }
+
   format(i) {
     if (this.inf) {
-      var fixed = this.floor ? Math.floor(i) : i;
+      const fixed = this.floor ? Math.floor(i) : i;
       return this.inf.format(fixed);
     } else {
       // to match the browser's numberformatter defaults
-      var _fixed = this.floor ? Math.floor(i) : roundTo(i, 3);
-      return padStart(_fixed, this.padTo);
+      const fixed = this.floor ? Math.floor(i) : roundTo(i, 3);
+      return padStart(fixed, this.padTo);
     }
   }
-}
 
+}
 /**
  * @private
  */
 
+
 class PolyDateFormatter {
   constructor(dt, intl, opts) {
     this.opts = opts;
-    var z = undefined;
+    let z = undefined;
+
     if (dt.zone.isUniversal) {
       // UTC-8 or Etc/UTC-8 are not part of tzdata, only Etc/GMT+8 and the like.
       // That is why fixed-offset TZ is set to that unless it is:
@@ -1276,8 +1387,9 @@ class PolyDateFormatter {
       // 2. Unsupported by the browser:
       //    - some do not support Etc/
       //    - < Etc/GMT-14, > Etc/GMT+12, and 30-minute or 45-minute offsets are not part of tzdata
-      var gmtOffset = -1 * (dt.offset / 60);
-      var offsetZ = gmtOffset >= 0 ? `Etc/GMT+${gmtOffset}` : `Etc/GMT${gmtOffset}`;
+      const gmtOffset = -1 * (dt.offset / 60);
+      const offsetZ = gmtOffset >= 0 ? `Etc/GMT+${gmtOffset}` : `Etc/GMT${gmtOffset}`;
+
       if (dt.offset !== 0 && IANAZone.create(offsetZ).valid) {
         z = offsetZ;
         this.dt = dt;
@@ -1290,6 +1402,7 @@ class PolyDateFormatter {
         // the time and tell the formatter to show it to us in UTC, so that the time is right
         // and the bad zone doesn't show up.
         z = "UTC";
+
         if (opts.timeZoneName) {
           this.dt = dt;
         } else {
@@ -1302,33 +1415,42 @@ class PolyDateFormatter {
       this.dt = dt;
       z = dt.zone.name;
     }
-    var intlOpts = _objectSpread({}, this.opts);
+
+    const intlOpts = _objectSpread({}, this.opts);
+
     intlOpts.timeZone = intlOpts.timeZone || z;
     this.dtf = getCachedDTF(intl, intlOpts);
   }
+
   format() {
     return this.dtf.format(this.dt.toJSDate());
   }
+
   formatToParts() {
     return this.dtf.formatToParts(this.dt.toJSDate());
   }
+
   resolvedOptions() {
     return this.dtf.resolvedOptions();
   }
-}
 
+}
 /**
  * @private
  */
+
+
 class PolyRelFormatter {
   constructor(intl, isEnglish, opts) {
     this.opts = _objectSpread({
       style: "long"
     }, opts);
+
     if (!isEnglish && hasRelative()) {
       this.rtf = getCachedRTF(intl, opts);
     }
   }
+
   format(count, unit) {
     if (this.rtf) {
       return this.rtf.format(count, unit);
@@ -1336,6 +1458,7 @@ class PolyRelFormatter {
       return formatRelativeTime(unit, count, this.opts.numeric, this.opts.style !== "long");
     }
   }
+
   formatToParts(count, unit) {
     if (this.rtf) {
       return this.rtf.formatToParts(count, unit);
@@ -1343,44 +1466,51 @@ class PolyRelFormatter {
       return [];
     }
   }
-}
 
+}
 /**
  * @private
  */
+
 
 class Locale {
   static fromOpts(opts) {
     return Locale.create(opts.locale, opts.numberingSystem, opts.outputCalendar, opts.defaultToEN);
   }
+
   static create(locale, numberingSystem, outputCalendar) {
-    var defaultToEN = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
-    var specifiedLocale = locale || Settings.defaultLocale;
-    // the system locale is useful for human readable strings but annoying for parsing/formatting known formats
-    var localeR = specifiedLocale || (defaultToEN ? "en-US" : systemLocale());
-    var numberingSystemR = numberingSystem || Settings.defaultNumberingSystem;
-    var outputCalendarR = outputCalendar || Settings.defaultOutputCalendar;
+    let defaultToEN = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
+    const specifiedLocale = locale || Settings.defaultLocale; // the system locale is useful for human readable strings but annoying for parsing/formatting known formats
+
+    const localeR = specifiedLocale || (defaultToEN ? "en-US" : systemLocale());
+    const numberingSystemR = numberingSystem || Settings.defaultNumberingSystem;
+    const outputCalendarR = outputCalendar || Settings.defaultOutputCalendar;
     return new Locale(localeR, numberingSystemR, outputCalendarR, specifiedLocale);
   }
+
   static resetCache() {
     sysLocaleCache = null;
     intlDTCache = {};
     intlNumCache = {};
     intlRelCache = {};
   }
+
   static fromObject() {
-    var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-      locale = _ref.locale,
-      numberingSystem = _ref.numberingSystem,
-      outputCalendar = _ref.outputCalendar;
+    let _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+        locale = _ref.locale,
+        numberingSystem = _ref.numberingSystem,
+        outputCalendar = _ref.outputCalendar;
+
     return Locale.create(locale, numberingSystem, outputCalendar);
   }
+
   constructor(locale, numbering, outputCalendar, specifiedLocale) {
-    var _parseLocaleString = parseLocaleString(locale),
-      _parseLocaleString2 = locale_slicedToArray(_parseLocaleString, 3),
-      parsedLocale = _parseLocaleString2[0],
-      parsedNumberingSystem = _parseLocaleString2[1],
-      parsedOutputCalendar = _parseLocaleString2[2];
+    const _parseLocaleString = parseLocaleString(locale),
+          _parseLocaleString2 = locale_slicedToArray(_parseLocaleString, 3),
+          parsedLocale = _parseLocaleString2[0],
+          parsedNumberingSystem = _parseLocaleString2[1],
+          parsedOutputCalendar = _parseLocaleString2[2];
+
     this.locale = parsedLocale;
     this.numberingSystem = numbering || parsedNumberingSystem || null;
     this.outputCalendar = outputCalendar || parsedOutputCalendar || null;
@@ -1398,17 +1528,21 @@ class Locale {
     this.specifiedLocale = specifiedLocale;
     this.fastNumbersCached = null;
   }
+
   get fastNumbers() {
     if (this.fastNumbersCached == null) {
       this.fastNumbersCached = supportsFastNumbers(this);
     }
+
     return this.fastNumbersCached;
   }
+
   listingMode() {
-    var isActuallyEn = this.isEnglish();
-    var hasNoWeirdness = (this.numberingSystem === null || this.numberingSystem === "latn") && (this.outputCalendar === null || this.outputCalendar === "gregory");
+    const isActuallyEn = this.isEnglish();
+    const hasNoWeirdness = (this.numberingSystem === null || this.numberingSystem === "latn") && (this.outputCalendar === null || this.outputCalendar === "gregory");
     return isActuallyEn && hasNoWeirdness ? "en" : "intl";
   }
+
   clone(alts) {
     if (!alts || Object.getOwnPropertyNames(alts).length === 0) {
       return this;
@@ -1416,124 +1550,143 @@ class Locale {
       return Locale.create(alts.locale || this.specifiedLocale, alts.numberingSystem || this.numberingSystem, alts.outputCalendar || this.outputCalendar, alts.defaultToEN || false);
     }
   }
+
   redefaultToEN() {
-    var alts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    let alts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     return this.clone(_objectSpread(_objectSpread({}, alts), {}, {
       defaultToEN: true
     }));
   }
+
   redefaultToSystem() {
-    var alts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    let alts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     return this.clone(_objectSpread(_objectSpread({}, alts), {}, {
       defaultToEN: false
     }));
   }
+
   months(length) {
-    var format = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
-    var defaultOK = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
+    let format = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+    let defaultOK = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
     return listStuff(this, length, defaultOK, months, () => {
-      var intl = format ? {
-          month: length,
-          day: "numeric"
-        } : {
-          month: length
-        },
-        formatStr = format ? "format" : "standalone";
+      const intl = format ? {
+        month: length,
+        day: "numeric"
+      } : {
+        month: length
+      },
+            formatStr = format ? "format" : "standalone";
+
       if (!this.monthsCache[formatStr][length]) {
         this.monthsCache[formatStr][length] = mapMonths(dt => this.extract(dt, intl, "month"));
       }
+
       return this.monthsCache[formatStr][length];
     });
   }
+
   weekdays(length) {
-    var format = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
-    var defaultOK = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
+    let format = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+    let defaultOK = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
     return listStuff(this, length, defaultOK, weekdays, () => {
-      var intl = format ? {
-          weekday: length,
-          year: "numeric",
-          month: "long",
-          day: "numeric"
-        } : {
-          weekday: length
-        },
-        formatStr = format ? "format" : "standalone";
+      const intl = format ? {
+        weekday: length,
+        year: "numeric",
+        month: "long",
+        day: "numeric"
+      } : {
+        weekday: length
+      },
+            formatStr = format ? "format" : "standalone";
+
       if (!this.weekdaysCache[formatStr][length]) {
         this.weekdaysCache[formatStr][length] = mapWeekdays(dt => this.extract(dt, intl, "weekday"));
       }
+
       return this.weekdaysCache[formatStr][length];
     });
   }
+
   meridiems() {
-    var defaultOK = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
+    let defaultOK = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
     return listStuff(this, undefined, defaultOK, () => meridiems, () => {
       // In theory there could be aribitrary day periods. We're gonna assume there are exactly two
       // for AM and PM. This is probably wrong, but it's makes parsing way easier.
       if (!this.meridiemCache) {
-        var intl = {
+        const intl = {
           hour: "numeric",
           hourCycle: "h12"
         };
         this.meridiemCache = [DateTime.utc(2016, 11, 13, 9), DateTime.utc(2016, 11, 13, 19)].map(dt => this.extract(dt, intl, "dayperiod"));
       }
+
       return this.meridiemCache;
     });
   }
-  eras(length) {
-    var defaultOK = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
-    return listStuff(this, length, defaultOK, eras, () => {
-      var intl = {
-        era: length
-      };
 
-      // This is problematic. Different calendars are going to define eras totally differently. What I need is the minimum set of dates
+  eras(length) {
+    let defaultOK = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
+    return listStuff(this, length, defaultOK, eras, () => {
+      const intl = {
+        era: length
+      }; // This is problematic. Different calendars are going to define eras totally differently. What I need is the minimum set of dates
       // to definitely enumerate them.
+
       if (!this.eraCache[length]) {
         this.eraCache[length] = [DateTime.utc(-40, 1, 1), DateTime.utc(2017, 1, 1)].map(dt => this.extract(dt, intl, "era"));
       }
+
       return this.eraCache[length];
     });
   }
+
   extract(dt, intlOpts, field) {
-    var df = this.dtFormatter(dt, intlOpts),
-      results = df.formatToParts(),
-      matching = results.find(m => m.type.toLowerCase() === field);
+    const df = this.dtFormatter(dt, intlOpts),
+          results = df.formatToParts(),
+          matching = results.find(m => m.type.toLowerCase() === field);
     return matching ? matching.value : null;
   }
+
   numberFormatter() {
-    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     // this forcesimple option is never used (the only caller short-circuits on it, but it seems safer to leave)
     // (in contrast, the rest of the condition is used heavily)
     return new PolyNumberFormatter(this.intl, opts.forceSimple || this.fastNumbers, opts);
   }
+
   dtFormatter(dt) {
-    var intlOpts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    let intlOpts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     return new PolyDateFormatter(dt, this.intl, intlOpts);
   }
+
   relFormatter() {
-    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     return new PolyRelFormatter(this.intl, this.isEnglish(), opts);
   }
+
   listFormatter() {
-    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     return getCachedLF(this.intl, opts);
   }
+
   isEnglish() {
     return this.locale === "en" || this.locale.toLowerCase() === "en-us" || new Intl.DateTimeFormat(this.intl).resolvedOptions().locale.startsWith("en-us");
   }
+
   equals(other) {
     return this.locale === other.locale && this.numberingSystem === other.numberingSystem && this.outputCalendar === other.outputCalendar;
   }
+
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/zones/fixedOffsetZone.js
 
 
-var fixedOffsetZone_singleton = null;
-
+let fixedOffsetZone_singleton = null;
 /**
  * A zone with a fixed offset (meaning no DST)
  * @implements {Zone}
  */
+
 class FixedOffsetZone extends Zone {
   /**
    * Get a singleton instance of UTC
@@ -1543,18 +1696,19 @@ class FixedOffsetZone extends Zone {
     if (fixedOffsetZone_singleton === null) {
       fixedOffsetZone_singleton = new FixedOffsetZone(0);
     }
+
     return fixedOffsetZone_singleton;
   }
-
   /**
    * Get an instance with a specified offset
    * @param {number} offset - The offset in minutes
    * @return {FixedOffsetZone}
    */
+
+
   static instance(offset) {
     return offset === 0 ? FixedOffsetZone.utcInstance : new FixedOffsetZone(offset);
   }
-
   /**
    * Get an instance of FixedOffsetZone from a UTC offset string, like "UTC+6"
    * @param {string} s - The offset string to parse
@@ -1563,30 +1717,39 @@ class FixedOffsetZone extends Zone {
    * @example FixedOffsetZone.parseSpecifier("UTC-6:00")
    * @return {FixedOffsetZone}
    */
+
+
   static parseSpecifier(s) {
     if (s) {
-      var r = s.match(/^utc(?:([+-]\d{1,2})(?::(\d{2}))?)?$/i);
+      const r = s.match(/^utc(?:([+-]\d{1,2})(?::(\d{2}))?)?$/i);
+
       if (r) {
         return new FixedOffsetZone(signedOffset(r[1], r[2]));
       }
     }
+
     return null;
   }
+
   constructor(offset) {
     super();
     /** @private **/
+
     this.fixed = offset;
   }
-
   /** @override **/
+
+
   get type() {
     return "fixed";
   }
-
   /** @override **/
+
+
   get name() {
     return this.fixed === 0 ? "UTC" : `UTC${formatOffset(this.fixed, "narrow")}`;
   }
+
   get ianaName() {
     if (this.fixed === 0) {
       return "Etc/UTC";
@@ -1594,90 +1757,107 @@ class FixedOffsetZone extends Zone {
       return `Etc/GMT${formatOffset(-this.fixed, "narrow")}`;
     }
   }
-
   /** @override **/
+
+
   offsetName() {
     return this.name;
   }
-
   /** @override **/
+
+
   formatOffset(ts, format) {
     return formatOffset(this.fixed, format);
   }
-
   /** @override **/
+
+
   get isUniversal() {
     return true;
   }
-
   /** @override **/
+
+
   offset() {
     return this.fixed;
   }
-
   /** @override **/
+
+
   equals(otherZone) {
     return otherZone.type === "fixed" && otherZone.fixed === this.fixed;
   }
-
   /** @override **/
+
+
   get isValid() {
     return true;
   }
+
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/zones/invalidZone.js
-
 
 /**
  * A zone that failed to parse. You should never need to instantiate this.
  * @implements {Zone}
  */
+
 class InvalidZone extends Zone {
   constructor(zoneName) {
     super();
     /**  @private */
+
     this.zoneName = zoneName;
   }
-
   /** @override **/
+
+
   get type() {
     return "invalid";
   }
-
   /** @override **/
+
+
   get name() {
     return this.zoneName;
   }
-
   /** @override **/
+
+
   get isUniversal() {
     return false;
   }
-
   /** @override **/
+
+
   offsetName() {
     return null;
   }
-
   /** @override **/
+
+
   formatOffset() {
     return "";
   }
-
   /** @override **/
+
+
   offset() {
     return NaN;
   }
-
   /** @override **/
+
+
   equals() {
     return false;
   }
-
   /** @override **/
+
+
   get isValid() {
     return false;
   }
+
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/zoneUtil.js
 /**
@@ -1689,15 +1869,15 @@ class InvalidZone extends Zone {
 
 
 
-
 function normalizeZone(input, defaultZone) {
-  var offset;
+  let offset;
+
   if (isUndefined(input) || input === null) {
     return defaultZone;
   } else if (input instanceof Zone) {
     return input;
   } else if (isString(input)) {
-    var lowered = input.toLowerCase();
+    const lowered = input.toLowerCase();
     if (lowered === "default") return defaultZone;else if (lowered === "local" || lowered === "system") return SystemZone.instance;else if (lowered === "utc" || lowered === "gmt") return FixedOffsetZone.utcInstance;else return FixedOffsetZone.parseSpecifier(lowered) || IANAZone.create(input);
   } else if (isNumber(input)) {
     return FixedOffsetZone.instance(input);
@@ -1714,17 +1894,19 @@ function normalizeZone(input, defaultZone) {
 
 
 
-var now = () => Date.now(),
-  defaultZone = "system",
-  defaultLocale = null,
-  defaultNumberingSystem = null,
-  defaultOutputCalendar = null,
-  twoDigitCutoffYear = 60,
-  throwOnInvalid;
 
+let now = () => Date.now(),
+    defaultZone = "system",
+    defaultLocale = null,
+    defaultNumberingSystem = null,
+    defaultOutputCalendar = null,
+    twoDigitCutoffYear = 60,
+    throwOnInvalid;
 /**
  * Settings contains static getters and setters that control Luxon's overall behavior. Luxon is a simple library with few options, but the ones it does have live here.
  */
+
+
 class Settings {
   /**
    * Get the callback for returning the current timestamp.
@@ -1733,7 +1915,6 @@ class Settings {
   static get now() {
     return now;
   }
-
   /**
    * Set the callback for returning the current timestamp.
    * The function should return a number, which will be interpreted as an Epoch millisecond count
@@ -1741,84 +1922,94 @@ class Settings {
    * @example Settings.now = () => Date.now() + 3000 // pretend it is 3 seconds in the future
    * @example Settings.now = () => 0 // always pretend it's Jan 1, 1970 at midnight in UTC time
    */
+
+
   static set now(n) {
     now = n;
   }
-
   /**
    * Set the default time zone to create DateTimes in. Does not affect existing instances.
    * Use the value "system" to reset this value to the system's time zone.
    * @type {string}
    */
+
+
   static set defaultZone(zone) {
     defaultZone = zone;
   }
-
   /**
    * Get the default time zone object currently used to create DateTimes. Does not affect existing instances.
    * The default value is the system's time zone (the one set on the machine that runs this code).
    * @type {Zone}
    */
+
+
   static get defaultZone() {
     return normalizeZone(defaultZone, SystemZone.instance);
   }
-
   /**
    * Get the default locale to create DateTimes with. Does not affect existing instances.
    * @type {string}
    */
+
+
   static get defaultLocale() {
     return defaultLocale;
   }
-
   /**
    * Set the default locale to create DateTimes with. Does not affect existing instances.
    * @type {string}
    */
+
+
   static set defaultLocale(locale) {
     defaultLocale = locale;
   }
-
   /**
    * Get the default numbering system to create DateTimes with. Does not affect existing instances.
    * @type {string}
    */
+
+
   static get defaultNumberingSystem() {
     return defaultNumberingSystem;
   }
-
   /**
    * Set the default numbering system to create DateTimes with. Does not affect existing instances.
    * @type {string}
    */
+
+
   static set defaultNumberingSystem(numberingSystem) {
     defaultNumberingSystem = numberingSystem;
   }
-
   /**
    * Get the default output calendar to create DateTimes with. Does not affect existing instances.
    * @type {string}
    */
+
+
   static get defaultOutputCalendar() {
     return defaultOutputCalendar;
   }
-
   /**
    * Set the default output calendar to create DateTimes with. Does not affect existing instances.
    * @type {string}
    */
+
+
   static set defaultOutputCalendar(outputCalendar) {
     defaultOutputCalendar = outputCalendar;
   }
-
   /**
    * Get the cutoff year after which a string encoding a year as two digits is interpreted to occur in the current century.
    * @type {number}
    */
+
+
   static get twoDigitCutoffYear() {
     return twoDigitCutoffYear;
   }
-
   /**
    * Set the cutoff year after which a string encoding a year as two digits is interpreted to occur in the current century.
    * @type {number}
@@ -1827,41 +2018,48 @@ class Settings {
    * @example Settings.twoDigitCutoffYear = 1950 // interpretted as 50
    * @example Settings.twoDigitCutoffYear = 2050 // ALSO interpretted as 50
    */
+
+
   static set twoDigitCutoffYear(cutoffYear) {
     twoDigitCutoffYear = cutoffYear % 100;
   }
-
   /**
    * Get whether Luxon will throw when it encounters invalid DateTimes, Durations, or Intervals
    * @type {boolean}
    */
+
+
   static get throwOnInvalid() {
     return throwOnInvalid;
   }
-
   /**
    * Set whether Luxon will throw when it encounters invalid DateTimes, Durations, or Intervals
    * @type {boolean}
    */
+
+
   static set throwOnInvalid(t) {
     throwOnInvalid = t;
   }
-
   /**
    * Reset Luxon's global caches. Should only be necessary in testing scenarios.
    * @return {void}
    */
+
+
   static resetCaches() {
     Locale.resetCache();
     IANAZone.resetCache();
   }
+
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/util.js
-function util_ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
-function util_objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? util_ownKeys(Object(t), !0).forEach(function (r) { util_defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : util_ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function util_defineProperty(obj, key, value) { key = util_toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function util_toPropertyKey(t) { var i = util_toPrimitive(t, "string"); return "symbol" == typeof i ? i : i + ""; }
-function util_toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
+function util_ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
+
+function util_objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? util_ownKeys(Object(source), !0).forEach(function (key) { util_defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : util_ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
+
+function util_defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 /*
   This is just a junk drawer, containing anything used across multiple classes.
   Because Luxon is small(ish), this should stay small and we won't worry about splitting
@@ -1869,12 +2067,9 @@ function util_toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var 
 */
 
 
-
-
 /**
  * @private
  */
-
 // TYPES
 
 function isUndefined(o) {
@@ -1891,9 +2086,7 @@ function isString(o) {
 }
 function isDate(o) {
   return Object.prototype.toString.call(o) === "[object Date]";
-}
-
-// CAPABILITIES
+} // CAPABILITIES
 
 function hasRelative() {
   try {
@@ -1901,9 +2094,7 @@ function hasRelative() {
   } catch (e) {
     return false;
   }
-}
-
-// OBJECTS AND ARRAYS
+} // OBJECTS AND ARRAYS
 
 function maybeArray(thing) {
   return Array.isArray(thing) ? thing : [thing];
@@ -1912,8 +2103,10 @@ function bestBy(arr, by, compare) {
   if (arr.length === 0) {
     return undefined;
   }
+
   return arr.reduce((best, next) => {
-    var pair = [by(next), next];
+    const pair = [by(next), next];
+
     if (!best) {
       return pair;
     } else if (compare(best[0], pair[0]) === best[0]) {
@@ -1931,27 +2124,26 @@ function util_pick(obj, keys) {
 }
 function util_hasOwnProperty(obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
-}
-
-// NUMBERS AND STRINGS
+} // NUMBERS AND STRINGS
 
 function integerBetween(thing, bottom, top) {
   return isInteger(thing) && thing >= bottom && thing <= top;
-}
+} // x % n but takes the sign of n instead of x
 
-// x % n but takes the sign of n instead of x
 function floorMod(x, n) {
   return x - n * Math.floor(x / n);
 }
 function padStart(input) {
-  var n = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 2;
-  var isNeg = input < 0;
-  var padded;
+  let n = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 2;
+  const isNeg = input < 0;
+  let padded;
+
   if (isNeg) {
     padded = "-" + ("" + -input).padStart(n, "0");
   } else {
     padded = ("" + input).padStart(n, "0");
   }
+
   return padded;
 }
 function parseInteger(string) {
@@ -1973,18 +2165,16 @@ function parseMillis(fraction) {
   if (isUndefined(fraction) || fraction === null || fraction === "") {
     return undefined;
   } else {
-    var f = parseFloat("0." + fraction) * 1000;
+    const f = parseFloat("0." + fraction) * 1000;
     return Math.floor(f);
   }
 }
 function roundTo(number, digits) {
-  var towardZero = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
-  var factor = 10 ** digits,
-    rounder = towardZero ? Math.trunc : Math.round;
+  let towardZero = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
+  const factor = 10 ** digits,
+        rounder = towardZero ? Math.trunc : Math.round;
   return rounder(number * factor) / factor;
-}
-
-// DATE BASICS
+} // DATE BASICS
 
 function isLeapYear(year) {
   return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
@@ -1993,103 +2183,107 @@ function daysInYear(year) {
   return isLeapYear(year) ? 366 : 365;
 }
 function daysInMonth(year, month) {
-  var modMonth = floorMod(month - 1, 12) + 1,
-    modYear = year + (month - modMonth) / 12;
+  const modMonth = floorMod(month - 1, 12) + 1,
+        modYear = year + (month - modMonth) / 12;
+
   if (modMonth === 2) {
     return isLeapYear(modYear) ? 29 : 28;
   } else {
     return [31, null, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][modMonth - 1];
   }
-}
+} // covert a calendar object to a local timestamp (epoch, but with the offset baked in)
 
-// covert a calendar object to a local timestamp (epoch, but with the offset baked in)
 function objToLocalTS(obj) {
-  var d = Date.UTC(obj.year, obj.month - 1, obj.day, obj.hour, obj.minute, obj.second, obj.millisecond);
+  let d = Date.UTC(obj.year, obj.month - 1, obj.day, obj.hour, obj.minute, obj.second, obj.millisecond); // for legacy reasons, years between 0 and 99 are interpreted as 19XX; revert that
 
-  // for legacy reasons, years between 0 and 99 are interpreted as 19XX; revert that
   if (obj.year < 100 && obj.year >= 0) {
     d = new Date(d);
     d.setUTCFullYear(d.getUTCFullYear() - 1900);
   }
+
   return +d;
 }
 function weeksInWeekYear(weekYear) {
-  var p1 = (weekYear + Math.floor(weekYear / 4) - Math.floor(weekYear / 100) + Math.floor(weekYear / 400)) % 7,
-    last = weekYear - 1,
-    p2 = (last + Math.floor(last / 4) - Math.floor(last / 100) + Math.floor(last / 400)) % 7;
+  const p1 = (weekYear + Math.floor(weekYear / 4) - Math.floor(weekYear / 100) + Math.floor(weekYear / 400)) % 7,
+        last = weekYear - 1,
+        p2 = (last + Math.floor(last / 4) - Math.floor(last / 100) + Math.floor(last / 400)) % 7;
   return p1 === 4 || p2 === 3 ? 53 : 52;
 }
 function untruncateYear(year) {
   if (year > 99) {
     return year;
   } else return year > Settings.twoDigitCutoffYear ? 1900 + year : 2000 + year;
-}
-
-// PARSING
+} // PARSING
 
 function parseZoneInfo(ts, offsetFormat, locale) {
-  var timeZone = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : null;
-  var date = new Date(ts),
-    intlOpts = {
-      hourCycle: "h23",
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit"
-    };
+  let timeZone = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : null;
+  const date = new Date(ts),
+        intlOpts = {
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit"
+  };
+
   if (timeZone) {
     intlOpts.timeZone = timeZone;
   }
-  var modified = util_objectSpread({
+
+  const modified = util_objectSpread({
     timeZoneName: offsetFormat
   }, intlOpts);
-  var parsed = new Intl.DateTimeFormat(locale, modified).formatToParts(date).find(m => m.type.toLowerCase() === "timezonename");
+
+  const parsed = new Intl.DateTimeFormat(locale, modified).formatToParts(date).find(m => m.type.toLowerCase() === "timezonename");
   return parsed ? parsed.value : null;
-}
+} // signedOffset('-5', '30') -> -330
 
-// signedOffset('-5', '30') -> -330
 function signedOffset(offHourStr, offMinuteStr) {
-  var offHour = parseInt(offHourStr, 10);
+  let offHour = parseInt(offHourStr, 10); // don't || this because we want to preserve -0
 
-  // don't || this because we want to preserve -0
   if (Number.isNaN(offHour)) {
     offHour = 0;
   }
-  var offMin = parseInt(offMinuteStr, 10) || 0,
-    offMinSigned = offHour < 0 || Object.is(offHour, -0) ? -offMin : offMin;
-  return offHour * 60 + offMinSigned;
-}
 
-// COERCION
+  const offMin = parseInt(offMinuteStr, 10) || 0,
+        offMinSigned = offHour < 0 || Object.is(offHour, -0) ? -offMin : offMin;
+  return offHour * 60 + offMinSigned;
+} // COERCION
 
 function asNumber(value) {
-  var numericValue = Number(value);
+  const numericValue = Number(value);
   if (typeof value === "boolean" || value === "" || Number.isNaN(numericValue)) throw new InvalidArgumentError(`Invalid unit value ${value}`);
   return numericValue;
 }
 function normalizeObject(obj, normalizer) {
-  var normalized = {};
-  for (var u in obj) {
+  const normalized = {};
+
+  for (const u in obj) {
     if (util_hasOwnProperty(obj, u)) {
-      var v = obj[u];
+      const v = obj[u];
       if (v === undefined || v === null) continue;
       normalized[normalizer(u)] = asNumber(v);
     }
   }
+
   return normalized;
 }
 function formatOffset(offset, format) {
-  var hours = Math.trunc(Math.abs(offset / 60)),
-    minutes = Math.trunc(Math.abs(offset % 60)),
-    sign = offset >= 0 ? "+" : "-";
+  const hours = Math.trunc(Math.abs(offset / 60)),
+        minutes = Math.trunc(Math.abs(offset % 60)),
+        sign = offset >= 0 ? "+" : "-";
+
   switch (format) {
     case "short":
       return `${sign}${padStart(hours, 2)}:${padStart(minutes, 2)}`;
+
     case "narrow":
       return `${sign}${hours}${minutes > 0 ? `:${minutes}` : ""}`;
+
     case "techie":
       return `${sign}${padStart(hours, 2)}${padStart(minutes, 2)}`;
+
     default:
       throw new RangeError(`Value format ${format} is out of range for property format`);
   }
@@ -2100,62 +2294,75 @@ function timeObject(obj) {
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/english.js
 
 
+
 function stringify(obj) {
   return JSON.stringify(obj, Object.keys(obj).sort());
 }
-
 /**
  * @private
  */
 
-var monthsLong = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
-var monthsShort = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-var monthsNarrow = ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"];
+
+const monthsLong = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+const monthsShort = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const monthsNarrow = ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"];
 function months(length) {
   switch (length) {
     case "narrow":
       return [...monthsNarrow];
+
     case "short":
       return [...monthsShort];
+
     case "long":
       return [...monthsLong];
+
     case "numeric":
       return ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"];
+
     case "2-digit":
       return ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"];
+
     default:
       return null;
   }
 }
-var weekdaysLong = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
-var weekdaysShort = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-var weekdaysNarrow = ["M", "T", "W", "T", "F", "S", "S"];
+const weekdaysLong = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+const weekdaysShort = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const weekdaysNarrow = ["M", "T", "W", "T", "F", "S", "S"];
 function weekdays(length) {
   switch (length) {
     case "narrow":
       return [...weekdaysNarrow];
+
     case "short":
       return [...weekdaysShort];
+
     case "long":
       return [...weekdaysLong];
+
     case "numeric":
       return ["1", "2", "3", "4", "5", "6", "7"];
+
     default:
       return null;
   }
 }
-var meridiems = ["AM", "PM"];
-var erasLong = ["Before Christ", "Anno Domini"];
-var erasShort = ["BC", "AD"];
-var erasNarrow = ["B", "A"];
+const meridiems = ["AM", "PM"];
+const erasLong = ["Before Christ", "Anno Domini"];
+const erasShort = ["BC", "AD"];
+const erasNarrow = ["B", "A"];
 function eras(length) {
   switch (length) {
     case "narrow":
       return [...erasNarrow];
+
     case "short":
       return [...erasShort];
+
     case "long":
       return [...erasLong];
+
     default:
       return null;
   }
@@ -2173,9 +2380,9 @@ function eraForDateTime(dt, length) {
   return eras(length)[dt.year < 0 ? 0 : 1];
 }
 function formatRelativeTime(unit, count) {
-  var numeric = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : "always";
-  var narrow = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
-  var units = {
+  let numeric = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : "always";
+  let narrow = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
+  const units = {
     years: ["year", "yr."],
     quarters: ["quarter", "qtr."],
     months: ["month", "mo."],
@@ -2185,100 +2392,138 @@ function formatRelativeTime(unit, count) {
     minutes: ["minute", "min."],
     seconds: ["second", "sec."]
   };
-  var lastable = ["hours", "minutes", "seconds"].indexOf(unit) === -1;
+  const lastable = ["hours", "minutes", "seconds"].indexOf(unit) === -1;
+
   if (numeric === "auto" && lastable) {
-    var isDay = unit === "days";
+    const isDay = unit === "days";
+
     switch (count) {
       case 1:
         return isDay ? "tomorrow" : `next ${units[unit][0]}`;
+
       case -1:
         return isDay ? "yesterday" : `last ${units[unit][0]}`;
+
       case 0:
         return isDay ? "today" : `this ${units[unit][0]}`;
+
       default: // fall through
+
     }
   }
-  var isInPast = Object.is(count, -0) || count < 0,
-    fmtValue = Math.abs(count),
-    singular = fmtValue === 1,
-    lilUnits = units[unit],
-    fmtUnit = narrow ? singular ? lilUnits[1] : lilUnits[2] || lilUnits[1] : singular ? units[unit][0] : unit;
+
+  const isInPast = Object.is(count, -0) || count < 0,
+        fmtValue = Math.abs(count),
+        singular = fmtValue === 1,
+        lilUnits = units[unit],
+        fmtUnit = narrow ? singular ? lilUnits[1] : lilUnits[2] || lilUnits[1] : singular ? units[unit][0] : unit;
   return isInPast ? `${fmtValue} ${fmtUnit} ago` : `in ${fmtValue} ${fmtUnit}`;
 }
 function formatString(knownFormat) {
   // these all have the offsets removed because we don't have access to them
   // without all the intl stuff this is backfilling
-  var filtered = pick(knownFormat, ["weekday", "era", "year", "month", "day", "hour", "minute", "second", "timeZoneName", "hourCycle"]),
-    key = stringify(filtered),
-    dateTimeHuge = "EEEE, LLLL d, yyyy, h:mm a";
+  const filtered = pick(knownFormat, ["weekday", "era", "year", "month", "day", "hour", "minute", "second", "timeZoneName", "hourCycle"]),
+        key = stringify(filtered),
+        dateTimeHuge = "EEEE, LLLL d, yyyy, h:mm a";
+
   switch (key) {
     case stringify(Formats.DATE_SHORT):
       return "M/d/yyyy";
+
     case stringify(Formats.DATE_MED):
       return "LLL d, yyyy";
+
     case stringify(Formats.DATE_MED_WITH_WEEKDAY):
       return "EEE, LLL d, yyyy";
+
     case stringify(Formats.DATE_FULL):
       return "LLLL d, yyyy";
+
     case stringify(Formats.DATE_HUGE):
       return "EEEE, LLLL d, yyyy";
+
     case stringify(Formats.TIME_SIMPLE):
       return "h:mm a";
+
     case stringify(Formats.TIME_WITH_SECONDS):
       return "h:mm:ss a";
+
     case stringify(Formats.TIME_WITH_SHORT_OFFSET):
       return "h:mm a";
+
     case stringify(Formats.TIME_WITH_LONG_OFFSET):
       return "h:mm a";
+
     case stringify(Formats.TIME_24_SIMPLE):
       return "HH:mm";
+
     case stringify(Formats.TIME_24_WITH_SECONDS):
       return "HH:mm:ss";
+
     case stringify(Formats.TIME_24_WITH_SHORT_OFFSET):
       return "HH:mm";
+
     case stringify(Formats.TIME_24_WITH_LONG_OFFSET):
       return "HH:mm";
+
     case stringify(Formats.DATETIME_SHORT):
       return "M/d/yyyy, h:mm a";
+
     case stringify(Formats.DATETIME_MED):
       return "LLL d, yyyy, h:mm a";
+
     case stringify(Formats.DATETIME_FULL):
       return "LLLL d, yyyy, h:mm a";
+
     case stringify(Formats.DATETIME_HUGE):
       return dateTimeHuge;
+
     case stringify(Formats.DATETIME_SHORT_WITH_SECONDS):
       return "M/d/yyyy, h:mm:ss a";
+
     case stringify(Formats.DATETIME_MED_WITH_SECONDS):
       return "LLL d, yyyy, h:mm:ss a";
+
     case stringify(Formats.DATETIME_MED_WITH_WEEKDAY):
       return "EEE, d LLL yyyy, h:mm a";
+
     case stringify(Formats.DATETIME_FULL_WITH_SECONDS):
       return "LLLL d, yyyy, h:mm:ss a";
+
     case stringify(Formats.DATETIME_HUGE_WITH_SECONDS):
       return "EEEE, LLLL d, yyyy, h:mm:ss a";
+
     default:
       return dateTimeHuge;
   }
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/formatter.js
-function formatter_ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
-function formatter_objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? formatter_ownKeys(Object(t), !0).forEach(function (r) { formatter_defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : formatter_ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function formatter_defineProperty(obj, key, value) { key = formatter_toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function formatter_toPropertyKey(t) { var i = formatter_toPrimitive(t, "string"); return "symbol" == typeof i ? i : i + ""; }
-function formatter_toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
+function formatter_ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
+
+function formatter_objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? formatter_ownKeys(Object(source), !0).forEach(function (key) { formatter_defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : formatter_ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
+
+function formatter_defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = formatter_unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
+
 function formatter_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return formatter_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return formatter_arrayLikeToArray(o, minLen); }
+
 function formatter_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
 
 
 
+
+
 function stringifyTokens(splits, tokenToString) {
-  var s = "";
+  let s = "";
+
   var _iterator = _createForOfIteratorHelper(splits),
-    _step;
+      _step;
+
   try {
     for (_iterator.s(); !(_step = _iterator.n()).done;) {
-      var token = _step.value;
+      const token = _step.value;
+
       if (token.literal) {
         s += token.val;
       } else {
@@ -2290,9 +2535,11 @@ function stringifyTokens(splits, tokenToString) {
   } finally {
     _iterator.f();
   }
+
   return s;
 }
-var macroTokenToFormatOpts = {
+
+const macroTokenToFormatOpts = {
   D: DATE_SHORT,
   DD: DATE_MED,
   DDD: DATE_FULL,
@@ -2314,23 +2561,25 @@ var macroTokenToFormatOpts = {
   FFF: DATETIME_FULL_WITH_SECONDS,
   FFFF: DATETIME_HUGE_WITH_SECONDS
 };
-
 /**
  * @private
  */
 
 class Formatter {
   static create(locale) {
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     return new Formatter(locale, opts);
   }
+
   static parseFormat(fmt) {
-    var current = null,
-      currentFull = "",
-      bracketed = false;
-    var splits = [];
-    for (var i = 0; i < fmt.length; i++) {
-      var c = fmt.charAt(i);
+    let current = null,
+        currentFull = "",
+        bracketed = false;
+    const splits = [];
+
+    for (let i = 0; i < fmt.length; i++) {
+      const c = fmt.charAt(i);
+
       if (c === "'") {
         if (currentFull.length > 0) {
           splits.push({
@@ -2338,6 +2587,7 @@ class Formatter {
             val: currentFull
           });
         }
+
         current = null;
         currentFull = "";
         bracketed = !bracketed;
@@ -2352,350 +2602,438 @@ class Formatter {
             val: currentFull
           });
         }
+
         currentFull = c;
         current = c;
       }
     }
+
     if (currentFull.length > 0) {
       splits.push({
         literal: bracketed,
         val: currentFull
       });
     }
+
     return splits;
   }
+
   static macroTokenToFormatOpts(token) {
     return macroTokenToFormatOpts[token];
   }
+
   constructor(locale, formatOpts) {
     this.opts = formatOpts;
     this.loc = locale;
     this.systemLoc = null;
   }
+
   formatWithSystemDefault(dt, opts) {
     if (this.systemLoc === null) {
       this.systemLoc = this.loc.redefaultToSystem();
     }
-    var df = this.systemLoc.dtFormatter(dt, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
+
+    const df = this.systemLoc.dtFormatter(dt, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
     return df.format();
   }
+
   formatDateTime(dt) {
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    var df = this.loc.dtFormatter(dt, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    const df = this.loc.dtFormatter(dt, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
     return df.format();
   }
+
   formatDateTimeParts(dt) {
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    var df = this.loc.dtFormatter(dt, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    const df = this.loc.dtFormatter(dt, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
     return df.formatToParts();
   }
+
   formatInterval(interval) {
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    var df = this.loc.dtFormatter(interval.start, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    const df = this.loc.dtFormatter(interval.start, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
     return df.dtf.formatRange(interval.start.toJSDate(), interval.end.toJSDate());
   }
+
   resolvedOptions(dt) {
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    var df = this.loc.dtFormatter(dt, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    const df = this.loc.dtFormatter(dt, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
     return df.resolvedOptions();
   }
+
   num(n) {
-    var p = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
+    let p = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
+
     // we get some perf out of doing this here, annoyingly
     if (this.opts.forceSimple) {
       return padStart(n, p);
     }
-    var opts = formatter_objectSpread({}, this.opts);
+
+    const opts = formatter_objectSpread({}, this.opts);
+
     if (p > 0) {
       opts.padTo = p;
     }
+
     return this.loc.numberFormatter(opts).format(n);
   }
+
   formatDateTimeFromString(dt, fmt) {
-    var knownEnglish = this.loc.listingMode() === "en",
-      useDateTimeFormatter = this.loc.outputCalendar && this.loc.outputCalendar !== "gregory",
-      string = (opts, extract) => this.loc.extract(dt, opts, extract),
-      formatOffset = opts => {
-        if (dt.isOffsetFixed && dt.offset === 0 && opts.allowZ) {
-          return "Z";
-        }
-        return dt.isValid ? dt.zone.formatOffset(dt.ts, opts.format) : "";
-      },
-      meridiem = () => knownEnglish ? meridiemForDateTime(dt) : string({
-        hour: "numeric",
-        hourCycle: "h12"
-      }, "dayperiod"),
-      month = (length, standalone) => knownEnglish ? monthForDateTime(dt, length) : string(standalone ? {
-        month: length
-      } : {
-        month: length,
-        day: "numeric"
-      }, "month"),
-      weekday = (length, standalone) => knownEnglish ? weekdayForDateTime(dt, length) : string(standalone ? {
-        weekday: length
-      } : {
-        weekday: length,
-        month: "long",
-        day: "numeric"
-      }, "weekday"),
-      maybeMacro = token => {
-        var formatOpts = Formatter.macroTokenToFormatOpts(token);
-        if (formatOpts) {
-          return this.formatWithSystemDefault(dt, formatOpts);
-        } else {
-          return token;
-        }
-      },
-      era = length => knownEnglish ? eraForDateTime(dt, length) : string({
-        era: length
-      }, "era"),
-      tokenToString = token => {
-        // Where possible: http://cldr.unicode.org/translation/date-time-1/date-time#TOC-Standalone-vs.-Format-Styles
-        switch (token) {
-          // ms
-          case "S":
-            return this.num(dt.millisecond);
-          case "u":
-          // falls through
-          case "SSS":
-            return this.num(dt.millisecond, 3);
-          // seconds
-          case "s":
-            return this.num(dt.second);
-          case "ss":
-            return this.num(dt.second, 2);
-          // fractional seconds
-          case "uu":
-            return this.num(Math.floor(dt.millisecond / 10), 2);
-          case "uuu":
-            return this.num(Math.floor(dt.millisecond / 100));
-          // minutes
-          case "m":
-            return this.num(dt.minute);
-          case "mm":
-            return this.num(dt.minute, 2);
-          // hours
-          case "h":
-            return this.num(dt.hour % 12 === 0 ? 12 : dt.hour % 12);
-          case "hh":
-            return this.num(dt.hour % 12 === 0 ? 12 : dt.hour % 12, 2);
-          case "H":
-            return this.num(dt.hour);
-          case "HH":
-            return this.num(dt.hour, 2);
-          // offset
-          case "Z":
-            // like +6
-            return formatOffset({
-              format: "narrow",
-              allowZ: this.opts.allowZ
-            });
-          case "ZZ":
-            // like +06:00
-            return formatOffset({
-              format: "short",
-              allowZ: this.opts.allowZ
-            });
-          case "ZZZ":
-            // like +0600
-            return formatOffset({
-              format: "techie",
-              allowZ: this.opts.allowZ
-            });
-          case "ZZZZ":
-            // like EST
-            return dt.zone.offsetName(dt.ts, {
-              format: "short",
-              locale: this.loc.locale
-            });
-          case "ZZZZZ":
-            // like Eastern Standard Time
-            return dt.zone.offsetName(dt.ts, {
-              format: "long",
-              locale: this.loc.locale
-            });
-          // zone
-          case "z":
-            // like America/New_York
-            return dt.zoneName;
-          // meridiems
-          case "a":
-            return meridiem();
-          // dates
-          case "d":
-            return useDateTimeFormatter ? string({
-              day: "numeric"
-            }, "day") : this.num(dt.day);
-          case "dd":
-            return useDateTimeFormatter ? string({
-              day: "2-digit"
-            }, "day") : this.num(dt.day, 2);
-          // weekdays - standalone
-          case "c":
-            // like 1
-            return this.num(dt.weekday);
-          case "ccc":
-            // like 'Tues'
-            return weekday("short", true);
-          case "cccc":
-            // like 'Tuesday'
-            return weekday("long", true);
-          case "ccccc":
-            // like 'T'
-            return weekday("narrow", true);
-          // weekdays - format
-          case "E":
-            // like 1
-            return this.num(dt.weekday);
-          case "EEE":
-            // like 'Tues'
-            return weekday("short", false);
-          case "EEEE":
-            // like 'Tuesday'
-            return weekday("long", false);
-          case "EEEEE":
-            // like 'T'
-            return weekday("narrow", false);
-          // months - standalone
-          case "L":
-            // like 1
-            return useDateTimeFormatter ? string({
-              month: "numeric",
-              day: "numeric"
-            }, "month") : this.num(dt.month);
-          case "LL":
-            // like 01, doesn't seem to work
-            return useDateTimeFormatter ? string({
-              month: "2-digit",
-              day: "numeric"
-            }, "month") : this.num(dt.month, 2);
-          case "LLL":
-            // like Jan
-            return month("short", true);
-          case "LLLL":
-            // like January
-            return month("long", true);
-          case "LLLLL":
-            // like J
-            return month("narrow", true);
-          // months - format
-          case "M":
-            // like 1
-            return useDateTimeFormatter ? string({
-              month: "numeric"
-            }, "month") : this.num(dt.month);
-          case "MM":
-            // like 01
-            return useDateTimeFormatter ? string({
-              month: "2-digit"
-            }, "month") : this.num(dt.month, 2);
-          case "MMM":
-            // like Jan
-            return month("short", false);
-          case "MMMM":
-            // like January
-            return month("long", false);
-          case "MMMMM":
-            // like J
-            return month("narrow", false);
-          // years
-          case "y":
-            // like 2014
-            return useDateTimeFormatter ? string({
-              year: "numeric"
-            }, "year") : this.num(dt.year);
-          case "yy":
-            // like 14
-            return useDateTimeFormatter ? string({
-              year: "2-digit"
-            }, "year") : this.num(dt.year.toString().slice(-2), 2);
-          case "yyyy":
-            // like 0012
-            return useDateTimeFormatter ? string({
-              year: "numeric"
-            }, "year") : this.num(dt.year, 4);
-          case "yyyyyy":
-            // like 000012
-            return useDateTimeFormatter ? string({
-              year: "numeric"
-            }, "year") : this.num(dt.year, 6);
-          // eras
-          case "G":
-            // like AD
-            return era("short");
-          case "GG":
-            // like Anno Domini
-            return era("long");
-          case "GGGGG":
-            return era("narrow");
-          case "kk":
-            return this.num(dt.weekYear.toString().slice(-2), 2);
-          case "kkkk":
-            return this.num(dt.weekYear, 4);
-          case "W":
-            return this.num(dt.weekNumber);
-          case "WW":
-            return this.num(dt.weekNumber, 2);
-          case "o":
-            return this.num(dt.ordinal);
-          case "ooo":
-            return this.num(dt.ordinal, 3);
-          case "q":
-            // like 1
-            return this.num(dt.quarter);
-          case "qq":
-            // like 01
-            return this.num(dt.quarter, 2);
-          case "X":
-            return this.num(Math.floor(dt.ts / 1000));
-          case "x":
-            return this.num(dt.ts);
-          default:
-            return maybeMacro(token);
-        }
-      };
+    const knownEnglish = this.loc.listingMode() === "en",
+          useDateTimeFormatter = this.loc.outputCalendar && this.loc.outputCalendar !== "gregory",
+          string = (opts, extract) => this.loc.extract(dt, opts, extract),
+          formatOffset = opts => {
+      if (dt.isOffsetFixed && dt.offset === 0 && opts.allowZ) {
+        return "Z";
+      }
+
+      return dt.isValid ? dt.zone.formatOffset(dt.ts, opts.format) : "";
+    },
+          meridiem = () => knownEnglish ? meridiemForDateTime(dt) : string({
+      hour: "numeric",
+      hourCycle: "h12"
+    }, "dayperiod"),
+          month = (length, standalone) => knownEnglish ? monthForDateTime(dt, length) : string(standalone ? {
+      month: length
+    } : {
+      month: length,
+      day: "numeric"
+    }, "month"),
+          weekday = (length, standalone) => knownEnglish ? weekdayForDateTime(dt, length) : string(standalone ? {
+      weekday: length
+    } : {
+      weekday: length,
+      month: "long",
+      day: "numeric"
+    }, "weekday"),
+          maybeMacro = token => {
+      const formatOpts = Formatter.macroTokenToFormatOpts(token);
+
+      if (formatOpts) {
+        return this.formatWithSystemDefault(dt, formatOpts);
+      } else {
+        return token;
+      }
+    },
+          era = length => knownEnglish ? eraForDateTime(dt, length) : string({
+      era: length
+    }, "era"),
+          tokenToString = token => {
+      // Where possible: http://cldr.unicode.org/translation/date-time-1/date-time#TOC-Standalone-vs.-Format-Styles
+      switch (token) {
+        // ms
+        case "S":
+          return this.num(dt.millisecond);
+
+        case "u": // falls through
+
+        case "SSS":
+          return this.num(dt.millisecond, 3);
+        // seconds
+
+        case "s":
+          return this.num(dt.second);
+
+        case "ss":
+          return this.num(dt.second, 2);
+        // fractional seconds
+
+        case "uu":
+          return this.num(Math.floor(dt.millisecond / 10), 2);
+
+        case "uuu":
+          return this.num(Math.floor(dt.millisecond / 100));
+        // minutes
+
+        case "m":
+          return this.num(dt.minute);
+
+        case "mm":
+          return this.num(dt.minute, 2);
+        // hours
+
+        case "h":
+          return this.num(dt.hour % 12 === 0 ? 12 : dt.hour % 12);
+
+        case "hh":
+          return this.num(dt.hour % 12 === 0 ? 12 : dt.hour % 12, 2);
+
+        case "H":
+          return this.num(dt.hour);
+
+        case "HH":
+          return this.num(dt.hour, 2);
+        // offset
+
+        case "Z":
+          // like +6
+          return formatOffset({
+            format: "narrow",
+            allowZ: this.opts.allowZ
+          });
+
+        case "ZZ":
+          // like +06:00
+          return formatOffset({
+            format: "short",
+            allowZ: this.opts.allowZ
+          });
+
+        case "ZZZ":
+          // like +0600
+          return formatOffset({
+            format: "techie",
+            allowZ: this.opts.allowZ
+          });
+
+        case "ZZZZ":
+          // like EST
+          return dt.zone.offsetName(dt.ts, {
+            format: "short",
+            locale: this.loc.locale
+          });
+
+        case "ZZZZZ":
+          // like Eastern Standard Time
+          return dt.zone.offsetName(dt.ts, {
+            format: "long",
+            locale: this.loc.locale
+          });
+        // zone
+
+        case "z":
+          // like America/New_York
+          return dt.zoneName;
+        // meridiems
+
+        case "a":
+          return meridiem();
+        // dates
+
+        case "d":
+          return useDateTimeFormatter ? string({
+            day: "numeric"
+          }, "day") : this.num(dt.day);
+
+        case "dd":
+          return useDateTimeFormatter ? string({
+            day: "2-digit"
+          }, "day") : this.num(dt.day, 2);
+        // weekdays - standalone
+
+        case "c":
+          // like 1
+          return this.num(dt.weekday);
+
+        case "ccc":
+          // like 'Tues'
+          return weekday("short", true);
+
+        case "cccc":
+          // like 'Tuesday'
+          return weekday("long", true);
+
+        case "ccccc":
+          // like 'T'
+          return weekday("narrow", true);
+        // weekdays - format
+
+        case "E":
+          // like 1
+          return this.num(dt.weekday);
+
+        case "EEE":
+          // like 'Tues'
+          return weekday("short", false);
+
+        case "EEEE":
+          // like 'Tuesday'
+          return weekday("long", false);
+
+        case "EEEEE":
+          // like 'T'
+          return weekday("narrow", false);
+        // months - standalone
+
+        case "L":
+          // like 1
+          return useDateTimeFormatter ? string({
+            month: "numeric",
+            day: "numeric"
+          }, "month") : this.num(dt.month);
+
+        case "LL":
+          // like 01, doesn't seem to work
+          return useDateTimeFormatter ? string({
+            month: "2-digit",
+            day: "numeric"
+          }, "month") : this.num(dt.month, 2);
+
+        case "LLL":
+          // like Jan
+          return month("short", true);
+
+        case "LLLL":
+          // like January
+          return month("long", true);
+
+        case "LLLLL":
+          // like J
+          return month("narrow", true);
+        // months - format
+
+        case "M":
+          // like 1
+          return useDateTimeFormatter ? string({
+            month: "numeric"
+          }, "month") : this.num(dt.month);
+
+        case "MM":
+          // like 01
+          return useDateTimeFormatter ? string({
+            month: "2-digit"
+          }, "month") : this.num(dt.month, 2);
+
+        case "MMM":
+          // like Jan
+          return month("short", false);
+
+        case "MMMM":
+          // like January
+          return month("long", false);
+
+        case "MMMMM":
+          // like J
+          return month("narrow", false);
+        // years
+
+        case "y":
+          // like 2014
+          return useDateTimeFormatter ? string({
+            year: "numeric"
+          }, "year") : this.num(dt.year);
+
+        case "yy":
+          // like 14
+          return useDateTimeFormatter ? string({
+            year: "2-digit"
+          }, "year") : this.num(dt.year.toString().slice(-2), 2);
+
+        case "yyyy":
+          // like 0012
+          return useDateTimeFormatter ? string({
+            year: "numeric"
+          }, "year") : this.num(dt.year, 4);
+
+        case "yyyyyy":
+          // like 000012
+          return useDateTimeFormatter ? string({
+            year: "numeric"
+          }, "year") : this.num(dt.year, 6);
+        // eras
+
+        case "G":
+          // like AD
+          return era("short");
+
+        case "GG":
+          // like Anno Domini
+          return era("long");
+
+        case "GGGGG":
+          return era("narrow");
+
+        case "kk":
+          return this.num(dt.weekYear.toString().slice(-2), 2);
+
+        case "kkkk":
+          return this.num(dt.weekYear, 4);
+
+        case "W":
+          return this.num(dt.weekNumber);
+
+        case "WW":
+          return this.num(dt.weekNumber, 2);
+
+        case "o":
+          return this.num(dt.ordinal);
+
+        case "ooo":
+          return this.num(dt.ordinal, 3);
+
+        case "q":
+          // like 1
+          return this.num(dt.quarter);
+
+        case "qq":
+          // like 01
+          return this.num(dt.quarter, 2);
+
+        case "X":
+          return this.num(Math.floor(dt.ts / 1000));
+
+        case "x":
+          return this.num(dt.ts);
+
+        default:
+          return maybeMacro(token);
+      }
+    };
+
     return stringifyTokens(Formatter.parseFormat(fmt), tokenToString);
   }
+
   formatDurationFromString(dur, fmt) {
-    var tokenToField = token => {
-        switch (token[0]) {
-          case "S":
-            return "millisecond";
-          case "s":
-            return "second";
-          case "m":
-            return "minute";
-          case "h":
-            return "hour";
-          case "d":
-            return "day";
-          case "w":
-            return "week";
-          case "M":
-            return "month";
-          case "y":
-            return "year";
-          default:
-            return null;
-        }
-      },
-      tokenToString = lildur => token => {
-        var mapped = tokenToField(token);
-        if (mapped) {
-          return this.num(lildur.get(mapped), token.length);
-        } else {
-          return token;
-        }
-      },
-      tokens = Formatter.parseFormat(fmt),
-      realTokens = tokens.reduce((found, _ref) => {
-        var literal = _ref.literal,
+    const tokenToField = token => {
+      switch (token[0]) {
+        case "S":
+          return "millisecond";
+
+        case "s":
+          return "second";
+
+        case "m":
+          return "minute";
+
+        case "h":
+          return "hour";
+
+        case "d":
+          return "day";
+
+        case "w":
+          return "week";
+
+        case "M":
+          return "month";
+
+        case "y":
+          return "year";
+
+        default:
+          return null;
+      }
+    },
+          tokenToString = lildur => token => {
+      const mapped = tokenToField(token);
+
+      if (mapped) {
+        return this.num(lildur.get(mapped), token.length);
+      } else {
+        return token;
+      }
+    },
+          tokens = Formatter.parseFormat(fmt),
+          realTokens = tokens.reduce((found, _ref) => {
+      let literal = _ref.literal,
           val = _ref.val;
-        return literal ? found : found.concat(val);
-      }, []),
-      collapsed = dur.shiftTo(...realTokens.map(tokenToField).filter(t => t));
+      return literal ? found : found.concat(val);
+    }, []),
+          collapsed = dur.shiftTo(...realTokens.map(tokenToField).filter(t => t));
+
     return stringifyTokens(tokens, tokenToString(collapsed));
   }
+
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/invalid.js
 class Invalid {
@@ -2703,6 +3041,7 @@ class Invalid {
     this.reason = reason;
     this.explanation = explanation;
   }
+
   toMessage() {
     if (this.explanation) {
       return `${this.reason}: ${this.explanation}`;
@@ -2710,18 +3049,25 @@ class Invalid {
       return this.reason;
     }
   }
+
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/regexParser.js
-function regexParser_ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
-function regexParser_objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? regexParser_ownKeys(Object(t), !0).forEach(function (r) { regexParser_defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : regexParser_ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function regexParser_defineProperty(obj, key, value) { key = regexParser_toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function regexParser_toPropertyKey(t) { var i = regexParser_toPrimitive(t, "string"); return "symbol" == typeof i ? i : i + ""; }
-function regexParser_toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
+function regexParser_ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
+
+function regexParser_objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? regexParser_ownKeys(Object(source), !0).forEach(function (key) { regexParser_defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : regexParser_ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
+
+function regexParser_defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 function regexParser_slicedToArray(arr, i) { return regexParser_arrayWithHoles(arr) || regexParser_iterableToArrayLimit(arr, i) || regexParser_unsupportedIterableToArray(arr, i) || regexParser_nonIterableRest(); }
+
 function regexParser_nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
 function regexParser_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return regexParser_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return regexParser_arrayLikeToArray(o, minLen); }
+
 function regexParser_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-function regexParser_iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
+
+function regexParser_iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
 function regexParser_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
@@ -2738,91 +3084,111 @@ function regexParser_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
  * Some extractions are super dumb and simpleParse and fromStrings help DRY them.
  */
 
-var ianaRegex = /[A-Za-z_+-]{1,256}(?::?\/[A-Za-z0-9_+-]{1,256}(?:\/[A-Za-z0-9_+-]{1,256})?)?/;
+const ianaRegex = /[A-Za-z_+-]{1,256}(?::?\/[A-Za-z0-9_+-]{1,256}(?:\/[A-Za-z0-9_+-]{1,256})?)?/;
+
 function combineRegexes() {
   for (var _len = arguments.length, regexes = new Array(_len), _key = 0; _key < _len; _key++) {
     regexes[_key] = arguments[_key];
   }
-  var full = regexes.reduce((f, r) => f + r.source, "");
+
+  const full = regexes.reduce((f, r) => f + r.source, "");
   return RegExp(`^${full}$`);
 }
+
 function combineExtractors() {
   for (var _len2 = arguments.length, extractors = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
     extractors[_key2] = arguments[_key2];
   }
+
   return m => extractors.reduce((_ref, ex) => {
-    var _ref2 = regexParser_slicedToArray(_ref, 3),
-      mergedVals = _ref2[0],
-      mergedZone = _ref2[1],
-      cursor = _ref2[2];
-    var _ex = ex(m, cursor),
-      _ex2 = regexParser_slicedToArray(_ex, 3),
-      val = _ex2[0],
-      zone = _ex2[1],
-      next = _ex2[2];
+    let _ref2 = regexParser_slicedToArray(_ref, 3),
+        mergedVals = _ref2[0],
+        mergedZone = _ref2[1],
+        cursor = _ref2[2];
+
+    const _ex = ex(m, cursor),
+          _ex2 = regexParser_slicedToArray(_ex, 3),
+          val = _ex2[0],
+          zone = _ex2[1],
+          next = _ex2[2];
+
     return [regexParser_objectSpread(regexParser_objectSpread({}, mergedVals), val), zone || mergedZone, next];
   }, [{}, null, 1]).slice(0, 2);
 }
+
 function parse(s) {
   if (s == null) {
     return [null, null];
   }
+
   for (var _len3 = arguments.length, patterns = new Array(_len3 > 1 ? _len3 - 1 : 0), _key3 = 1; _key3 < _len3; _key3++) {
     patterns[_key3 - 1] = arguments[_key3];
   }
-  for (var _i = 0, _patterns = patterns; _i < _patterns.length; _i++) {
-    var _patterns$_i = regexParser_slicedToArray(_patterns[_i], 2),
-      regex = _patterns$_i[0],
-      extractor = _patterns$_i[1];
-    var m = regex.exec(s);
+
+  for (var _i2 = 0, _patterns = patterns; _i2 < _patterns.length; _i2++) {
+    const _patterns$_i = regexParser_slicedToArray(_patterns[_i2], 2),
+          regex = _patterns$_i[0],
+          extractor = _patterns$_i[1];
+
+    const m = regex.exec(s);
+
     if (m) {
       return extractor(m);
     }
   }
+
   return [null, null];
 }
+
 function simpleParse() {
   for (var _len4 = arguments.length, keys = new Array(_len4), _key4 = 0; _key4 < _len4; _key4++) {
     keys[_key4] = arguments[_key4];
   }
+
   return (match, cursor) => {
-    var ret = {};
-    var i;
+    const ret = {};
+    let i;
+
     for (i = 0; i < keys.length; i++) {
       ret[keys[i]] = parseInteger(match[cursor + i]);
     }
+
     return [ret, null, cursor + i];
   };
-}
+} // ISO and SQL parsing
 
-// ISO and SQL parsing
-var offsetRegex = /(?:(Z)|([+-]\d\d)(?::?(\d\d))?)/;
-var isoExtendedZone = `(?:${offsetRegex.source}?(?:\\[(${ianaRegex.source})\\])?)?`;
-var isoTimeBaseRegex = /(\d\d)(?::?(\d\d)(?::?(\d\d)(?:[.,](\d{1,30}))?)?)?/;
-var isoTimeRegex = RegExp(`${isoTimeBaseRegex.source}${isoExtendedZone}`);
-var isoTimeExtensionRegex = RegExp(`(?:T${isoTimeRegex.source})?`);
-var isoYmdRegex = /([+-]\d{6}|\d{4})(?:-?(\d\d)(?:-?(\d\d))?)?/;
-var isoWeekRegex = /(\d{4})-?W(\d\d)(?:-?(\d))?/;
-var isoOrdinalRegex = /(\d{4})-?(\d{3})/;
-var extractISOWeekData = simpleParse("weekYear", "weekNumber", "weekDay");
-var extractISOOrdinalData = simpleParse("year", "ordinal");
-var sqlYmdRegex = /(\d{4})-(\d\d)-(\d\d)/; // dumbed-down version of the ISO one
-var sqlTimeRegex = RegExp(`${isoTimeBaseRegex.source} ?(?:${offsetRegex.source}|(${ianaRegex.source}))?`);
-var sqlTimeExtensionRegex = RegExp(`(?: ${sqlTimeRegex.source})?`);
+
+const offsetRegex = /(?:(Z)|([+-]\d\d)(?::?(\d\d))?)/;
+const isoExtendedZone = `(?:${offsetRegex.source}?(?:\\[(${ianaRegex.source})\\])?)?`;
+const isoTimeBaseRegex = /(\d\d)(?::?(\d\d)(?::?(\d\d)(?:[.,](\d{1,30}))?)?)?/;
+const isoTimeRegex = RegExp(`${isoTimeBaseRegex.source}${isoExtendedZone}`);
+const isoTimeExtensionRegex = RegExp(`(?:T${isoTimeRegex.source})?`);
+const isoYmdRegex = /([+-]\d{6}|\d{4})(?:-?(\d\d)(?:-?(\d\d))?)?/;
+const isoWeekRegex = /(\d{4})-?W(\d\d)(?:-?(\d))?/;
+const isoOrdinalRegex = /(\d{4})-?(\d{3})/;
+const extractISOWeekData = simpleParse("weekYear", "weekNumber", "weekDay");
+const extractISOOrdinalData = simpleParse("year", "ordinal");
+const sqlYmdRegex = /(\d{4})-(\d\d)-(\d\d)/; // dumbed-down version of the ISO one
+
+const sqlTimeRegex = RegExp(`${isoTimeBaseRegex.source} ?(?:${offsetRegex.source}|(${ianaRegex.source}))?`);
+const sqlTimeExtensionRegex = RegExp(`(?: ${sqlTimeRegex.source})?`);
+
 function regexParser_int(match, pos, fallback) {
-  var m = match[pos];
+  const m = match[pos];
   return isUndefined(m) ? fallback : parseInteger(m);
 }
+
 function extractISOYmd(match, cursor) {
-  var item = {
+  const item = {
     year: regexParser_int(match, cursor),
     month: regexParser_int(match, cursor + 1, 1),
     day: regexParser_int(match, cursor + 2, 1)
   };
   return [item, null, cursor + 3];
 }
+
 function extractISOTime(match, cursor) {
-  var item = {
+  const item = {
     hours: regexParser_int(match, cursor, 0),
     minutes: regexParser_int(match, cursor + 1, 0),
     seconds: regexParser_int(match, cursor + 2, 0),
@@ -2830,41 +3196,44 @@ function extractISOTime(match, cursor) {
   };
   return [item, null, cursor + 4];
 }
+
 function extractISOOffset(match, cursor) {
-  var local = !match[cursor] && !match[cursor + 1],
-    fullOffset = signedOffset(match[cursor + 1], match[cursor + 2]),
-    zone = local ? null : FixedOffsetZone.instance(fullOffset);
+  const local = !match[cursor] && !match[cursor + 1],
+        fullOffset = signedOffset(match[cursor + 1], match[cursor + 2]),
+        zone = local ? null : FixedOffsetZone.instance(fullOffset);
   return [{}, zone, cursor + 3];
 }
+
 function extractIANAZone(match, cursor) {
-  var zone = match[cursor] ? IANAZone.create(match[cursor]) : null;
+  const zone = match[cursor] ? IANAZone.create(match[cursor]) : null;
   return [{}, zone, cursor + 1];
-}
+} // ISO time parsing
 
-// ISO time parsing
 
-var isoTimeOnly = RegExp(`^T?${isoTimeBaseRegex.source}$`);
+const isoTimeOnly = RegExp(`^T?${isoTimeBaseRegex.source}$`); // ISO duration parsing
 
-// ISO duration parsing
+const isoDuration = /^-?P(?:(?:(-?\d{1,20}(?:\.\d{1,20})?)Y)?(?:(-?\d{1,20}(?:\.\d{1,20})?)M)?(?:(-?\d{1,20}(?:\.\d{1,20})?)W)?(?:(-?\d{1,20}(?:\.\d{1,20})?)D)?(?:T(?:(-?\d{1,20}(?:\.\d{1,20})?)H)?(?:(-?\d{1,20}(?:\.\d{1,20})?)M)?(?:(-?\d{1,20})(?:[.,](-?\d{1,20}))?S)?)?)$/;
 
-var isoDuration = /^-?P(?:(?:(-?\d{1,20}(?:\.\d{1,20})?)Y)?(?:(-?\d{1,20}(?:\.\d{1,20})?)M)?(?:(-?\d{1,20}(?:\.\d{1,20})?)W)?(?:(-?\d{1,20}(?:\.\d{1,20})?)D)?(?:T(?:(-?\d{1,20}(?:\.\d{1,20})?)H)?(?:(-?\d{1,20}(?:\.\d{1,20})?)M)?(?:(-?\d{1,20})(?:[.,](-?\d{1,20}))?S)?)?)$/;
 function extractISODuration(match) {
-  var _match = regexParser_slicedToArray(match, 9),
-    s = _match[0],
-    yearStr = _match[1],
-    monthStr = _match[2],
-    weekStr = _match[3],
-    dayStr = _match[4],
-    hourStr = _match[5],
-    minuteStr = _match[6],
-    secondStr = _match[7],
-    millisecondsStr = _match[8];
-  var hasNegativePrefix = s[0] === "-";
-  var negativeSeconds = secondStr && secondStr[0] === "-";
-  var maybeNegate = function maybeNegate(num) {
-    var force = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+  const _match = regexParser_slicedToArray(match, 9),
+        s = _match[0],
+        yearStr = _match[1],
+        monthStr = _match[2],
+        weekStr = _match[3],
+        dayStr = _match[4],
+        hourStr = _match[5],
+        minuteStr = _match[6],
+        secondStr = _match[7],
+        millisecondsStr = _match[8];
+
+  const hasNegativePrefix = s[0] === "-";
+  const negativeSeconds = secondStr && secondStr[0] === "-";
+
+  const maybeNegate = function maybeNegate(num) {
+    let force = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
     return num !== undefined && (force || num && hasNegativePrefix) ? -num : num;
   };
+
   return [{
     years: maybeNegate(parseFloating(yearStr)),
     months: maybeNegate(parseFloating(monthStr)),
@@ -2875,12 +3244,12 @@ function extractISODuration(match) {
     seconds: maybeNegate(parseFloating(secondStr), secondStr === "-0"),
     milliseconds: maybeNegate(parseMillis(millisecondsStr), negativeSeconds)
   }];
-}
-
-// These are a little braindead. EDT *should* tell us that we're in, say, America/New_York
+} // These are a little braindead. EDT *should* tell us that we're in, say, America/New_York
 // and not just that we're in -240 *right now*. But since I don't think these are used that often
 // I'm just going to ignore that
-var obsOffsets = {
+
+
+const obsOffsets = {
   GMT: 0,
   EDT: -4 * 60,
   EST: -5 * 60,
@@ -2891,8 +3260,9 @@ var obsOffsets = {
   PDT: -7 * 60,
   PST: -8 * 60
 };
+
 function fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr) {
-  var result = {
+  const result = {
     year: yearStr.length === 2 ? untruncateYear(parseInteger(yearStr)) : parseInteger(yearStr),
     month: monthsShort.indexOf(monthStr) + 1,
     day: parseInteger(dayStr),
@@ -2900,29 +3270,34 @@ function fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, 
     minute: parseInteger(minuteStr)
   };
   if (secondStr) result.second = parseInteger(secondStr);
+
   if (weekdayStr) {
     result.weekday = weekdayStr.length > 3 ? weekdaysLong.indexOf(weekdayStr) + 1 : weekdaysShort.indexOf(weekdayStr) + 1;
   }
-  return result;
-}
 
-// RFC 2822/5322
-var rfc2822 = /^(?:(Mon|Tue|Wed|Thu|Fri|Sat|Sun),\s)?(\d{1,2})\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(\d{2,4})\s(\d\d):(\d\d)(?::(\d\d))?\s(?:(UT|GMT|[ECMP][SD]T)|([Zz])|(?:([+-]\d\d)(\d\d)))$/;
+  return result;
+} // RFC 2822/5322
+
+
+const rfc2822 = /^(?:(Mon|Tue|Wed|Thu|Fri|Sat|Sun),\s)?(\d{1,2})\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(\d{2,4})\s(\d\d):(\d\d)(?::(\d\d))?\s(?:(UT|GMT|[ECMP][SD]T)|([Zz])|(?:([+-]\d\d)(\d\d)))$/;
+
 function extractRFC2822(match) {
-  var _match2 = regexParser_slicedToArray(match, 12),
-    weekdayStr = _match2[1],
-    dayStr = _match2[2],
-    monthStr = _match2[3],
-    yearStr = _match2[4],
-    hourStr = _match2[5],
-    minuteStr = _match2[6],
-    secondStr = _match2[7],
-    obsOffset = _match2[8],
-    milOffset = _match2[9],
-    offHourStr = _match2[10],
-    offMinuteStr = _match2[11],
-    result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
-  var offset;
+  const _match2 = regexParser_slicedToArray(match, 12),
+        weekdayStr = _match2[1],
+        dayStr = _match2[2],
+        monthStr = _match2[3],
+        yearStr = _match2[4],
+        hourStr = _match2[5],
+        minuteStr = _match2[6],
+        secondStr = _match2[7],
+        obsOffset = _match2[8],
+        milOffset = _match2[9],
+        offHourStr = _match2[10],
+        offMinuteStr = _match2[11],
+        result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
+
+  let offset;
+
   if (obsOffset) {
     offset = obsOffsets[obsOffset];
   } else if (milOffset) {
@@ -2930,51 +3305,56 @@ function extractRFC2822(match) {
   } else {
     offset = signedOffset(offHourStr, offMinuteStr);
   }
+
   return [result, new FixedOffsetZone(offset)];
 }
+
 function preprocessRFC2822(s) {
   // Remove comments and folding whitespace and replace multiple-spaces with a single space
   return s.replace(/\([^)]*\)|[\n\t]/g, " ").replace(/(\s\s+)/g, " ").trim();
-}
+} // http date
 
-// http date
 
-var rfc1123 = /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (\d\d) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d\d):(\d\d):(\d\d) GMT$/,
-  rfc850 = /^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), (\d\d)-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(\d\d) (\d\d):(\d\d):(\d\d) GMT$/,
-  ascii = /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ( \d|\d\d) (\d\d):(\d\d):(\d\d) (\d{4})$/;
+const rfc1123 = /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (\d\d) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d\d):(\d\d):(\d\d) GMT$/,
+      rfc850 = /^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), (\d\d)-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(\d\d) (\d\d):(\d\d):(\d\d) GMT$/,
+      ascii = /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ( \d|\d\d) (\d\d):(\d\d):(\d\d) (\d{4})$/;
+
 function extractRFC1123Or850(match) {
-  var _match3 = regexParser_slicedToArray(match, 8),
-    weekdayStr = _match3[1],
-    dayStr = _match3[2],
-    monthStr = _match3[3],
-    yearStr = _match3[4],
-    hourStr = _match3[5],
-    minuteStr = _match3[6],
-    secondStr = _match3[7],
-    result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
-  return [result, FixedOffsetZone.utcInstance];
-}
-function extractASCII(match) {
-  var _match4 = regexParser_slicedToArray(match, 8),
-    weekdayStr = _match4[1],
-    monthStr = _match4[2],
-    dayStr = _match4[3],
-    hourStr = _match4[4],
-    minuteStr = _match4[5],
-    secondStr = _match4[6],
-    yearStr = _match4[7],
-    result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
-  return [result, FixedOffsetZone.utcInstance];
-}
-var isoYmdWithTimeExtensionRegex = combineRegexes(isoYmdRegex, isoTimeExtensionRegex);
-var isoWeekWithTimeExtensionRegex = combineRegexes(isoWeekRegex, isoTimeExtensionRegex);
-var isoOrdinalWithTimeExtensionRegex = combineRegexes(isoOrdinalRegex, isoTimeExtensionRegex);
-var isoTimeCombinedRegex = combineRegexes(isoTimeRegex);
-var extractISOYmdTimeAndOffset = combineExtractors(extractISOYmd, extractISOTime, extractISOOffset, extractIANAZone);
-var extractISOWeekTimeAndOffset = combineExtractors(extractISOWeekData, extractISOTime, extractISOOffset, extractIANAZone);
-var extractISOOrdinalDateAndTime = combineExtractors(extractISOOrdinalData, extractISOTime, extractISOOffset, extractIANAZone);
-var extractISOTimeAndOffset = combineExtractors(extractISOTime, extractISOOffset, extractIANAZone);
+  const _match3 = regexParser_slicedToArray(match, 8),
+        weekdayStr = _match3[1],
+        dayStr = _match3[2],
+        monthStr = _match3[3],
+        yearStr = _match3[4],
+        hourStr = _match3[5],
+        minuteStr = _match3[6],
+        secondStr = _match3[7],
+        result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
 
+  return [result, FixedOffsetZone.utcInstance];
+}
+
+function extractASCII(match) {
+  const _match4 = regexParser_slicedToArray(match, 8),
+        weekdayStr = _match4[1],
+        monthStr = _match4[2],
+        dayStr = _match4[3],
+        hourStr = _match4[4],
+        minuteStr = _match4[5],
+        secondStr = _match4[6],
+        yearStr = _match4[7],
+        result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
+
+  return [result, FixedOffsetZone.utcInstance];
+}
+
+const isoYmdWithTimeExtensionRegex = combineRegexes(isoYmdRegex, isoTimeExtensionRegex);
+const isoWeekWithTimeExtensionRegex = combineRegexes(isoWeekRegex, isoTimeExtensionRegex);
+const isoOrdinalWithTimeExtensionRegex = combineRegexes(isoOrdinalRegex, isoTimeExtensionRegex);
+const isoTimeCombinedRegex = combineRegexes(isoTimeRegex);
+const extractISOYmdTimeAndOffset = combineExtractors(extractISOYmd, extractISOTime, extractISOOffset, extractIANAZone);
+const extractISOWeekTimeAndOffset = combineExtractors(extractISOWeekData, extractISOTime, extractISOOffset, extractIANAZone);
+const extractISOOrdinalDateAndTime = combineExtractors(extractISOOrdinalData, extractISOTime, extractISOOffset, extractIANAZone);
+const extractISOTimeAndOffset = combineExtractors(extractISOTime, extractISOOffset, extractIANAZone);
 /*
  * @private
  */
@@ -2991,28 +3371,36 @@ function parseHTTPDate(s) {
 function parseISODuration(s) {
   return parse(s, [isoDuration, extractISODuration]);
 }
-var extractISOTimeOnly = combineExtractors(extractISOTime);
+const extractISOTimeOnly = combineExtractors(extractISOTime);
 function parseISOTimeOnly(s) {
   return parse(s, [isoTimeOnly, extractISOTimeOnly]);
 }
-var sqlYmdWithTimeExtensionRegex = combineRegexes(sqlYmdRegex, sqlTimeExtensionRegex);
-var sqlTimeCombinedRegex = combineRegexes(sqlTimeRegex);
-var extractISOTimeOffsetAndIANAZone = combineExtractors(extractISOTime, extractISOOffset, extractIANAZone);
+const sqlYmdWithTimeExtensionRegex = combineRegexes(sqlYmdRegex, sqlTimeExtensionRegex);
+const sqlTimeCombinedRegex = combineRegexes(sqlTimeRegex);
+const extractISOTimeOffsetAndIANAZone = combineExtractors(extractISOTime, extractISOOffset, extractIANAZone);
 function parseSQL(s) {
   return parse(s, [sqlYmdWithTimeExtensionRegex, extractISOYmdTimeAndOffset], [sqlTimeCombinedRegex, extractISOTimeOffsetAndIANAZone]);
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/duration.js
+function duration_createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = duration_unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e2) { throw _e2; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e3) { didErr = true; err = _e3; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
+
 function duration_slicedToArray(arr, i) { return duration_arrayWithHoles(arr) || duration_iterableToArrayLimit(arr, i) || duration_unsupportedIterableToArray(arr, i) || duration_nonIterableRest(); }
+
 function duration_nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
 function duration_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return duration_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return duration_arrayLikeToArray(o, minLen); }
+
 function duration_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-function duration_iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
+
+function duration_iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
 function duration_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-function duration_ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
-function duration_objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? duration_ownKeys(Object(t), !0).forEach(function (r) { duration_defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : duration_ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function duration_defineProperty(obj, key, value) { key = duration_toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function duration_toPropertyKey(t) { var i = duration_toPrimitive(t, "string"); return "symbol" == typeof i ? i : i + ""; }
-function duration_toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
+
+function duration_ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
+
+function duration_objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? duration_ownKeys(Object(source), !0).forEach(function (key) { duration_defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : duration_ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
+
+function duration_defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 
 
@@ -3020,106 +3408,104 @@ function duration_toPrimitive(t, r) { if ("object" != typeof t || !t) return t; 
 
 
 
-var INVALID = "Invalid Duration";
 
-// unit conversion constants
-var lowOrderMatrix = {
-    weeks: {
-      days: 7,
-      hours: 7 * 24,
-      minutes: 7 * 24 * 60,
-      seconds: 7 * 24 * 60 * 60,
-      milliseconds: 7 * 24 * 60 * 60 * 1000
-    },
-    days: {
-      hours: 24,
-      minutes: 24 * 60,
-      seconds: 24 * 60 * 60,
-      milliseconds: 24 * 60 * 60 * 1000
-    },
-    hours: {
-      minutes: 60,
-      seconds: 60 * 60,
-      milliseconds: 60 * 60 * 1000
-    },
-    minutes: {
-      seconds: 60,
-      milliseconds: 60 * 1000
-    },
-    seconds: {
-      milliseconds: 1000
-    }
+const INVALID = "Invalid Duration"; // unit conversion constants
+
+const lowOrderMatrix = {
+  weeks: {
+    days: 7,
+    hours: 7 * 24,
+    minutes: 7 * 24 * 60,
+    seconds: 7 * 24 * 60 * 60,
+    milliseconds: 7 * 24 * 60 * 60 * 1000
   },
-  casualMatrix = duration_objectSpread({
-    years: {
-      quarters: 4,
-      months: 12,
-      weeks: 52,
-      days: 365,
-      hours: 365 * 24,
-      minutes: 365 * 24 * 60,
-      seconds: 365 * 24 * 60 * 60,
-      milliseconds: 365 * 24 * 60 * 60 * 1000
-    },
-    quarters: {
-      months: 3,
-      weeks: 13,
-      days: 91,
-      hours: 91 * 24,
-      minutes: 91 * 24 * 60,
-      seconds: 91 * 24 * 60 * 60,
-      milliseconds: 91 * 24 * 60 * 60 * 1000
-    },
-    months: {
-      weeks: 4,
-      days: 30,
-      hours: 30 * 24,
-      minutes: 30 * 24 * 60,
-      seconds: 30 * 24 * 60 * 60,
-      milliseconds: 30 * 24 * 60 * 60 * 1000
-    }
-  }, lowOrderMatrix),
-  daysInYearAccurate = 146097.0 / 400,
-  daysInMonthAccurate = 146097.0 / 4800,
-  accurateMatrix = duration_objectSpread({
-    years: {
-      quarters: 4,
-      months: 12,
-      weeks: daysInYearAccurate / 7,
-      days: daysInYearAccurate,
-      hours: daysInYearAccurate * 24,
-      minutes: daysInYearAccurate * 24 * 60,
-      seconds: daysInYearAccurate * 24 * 60 * 60,
-      milliseconds: daysInYearAccurate * 24 * 60 * 60 * 1000
-    },
-    quarters: {
-      months: 3,
-      weeks: daysInYearAccurate / 28,
-      days: daysInYearAccurate / 4,
-      hours: daysInYearAccurate * 24 / 4,
-      minutes: daysInYearAccurate * 24 * 60 / 4,
-      seconds: daysInYearAccurate * 24 * 60 * 60 / 4,
-      milliseconds: daysInYearAccurate * 24 * 60 * 60 * 1000 / 4
-    },
-    months: {
-      weeks: daysInMonthAccurate / 7,
-      days: daysInMonthAccurate,
-      hours: daysInMonthAccurate * 24,
-      minutes: daysInMonthAccurate * 24 * 60,
-      seconds: daysInMonthAccurate * 24 * 60 * 60,
-      milliseconds: daysInMonthAccurate * 24 * 60 * 60 * 1000
-    }
-  }, lowOrderMatrix);
+  days: {
+    hours: 24,
+    minutes: 24 * 60,
+    seconds: 24 * 60 * 60,
+    milliseconds: 24 * 60 * 60 * 1000
+  },
+  hours: {
+    minutes: 60,
+    seconds: 60 * 60,
+    milliseconds: 60 * 60 * 1000
+  },
+  minutes: {
+    seconds: 60,
+    milliseconds: 60 * 1000
+  },
+  seconds: {
+    milliseconds: 1000
+  }
+},
+      casualMatrix = duration_objectSpread({
+  years: {
+    quarters: 4,
+    months: 12,
+    weeks: 52,
+    days: 365,
+    hours: 365 * 24,
+    minutes: 365 * 24 * 60,
+    seconds: 365 * 24 * 60 * 60,
+    milliseconds: 365 * 24 * 60 * 60 * 1000
+  },
+  quarters: {
+    months: 3,
+    weeks: 13,
+    days: 91,
+    hours: 91 * 24,
+    minutes: 91 * 24 * 60,
+    seconds: 91 * 24 * 60 * 60,
+    milliseconds: 91 * 24 * 60 * 60 * 1000
+  },
+  months: {
+    weeks: 4,
+    days: 30,
+    hours: 30 * 24,
+    minutes: 30 * 24 * 60,
+    seconds: 30 * 24 * 60 * 60,
+    milliseconds: 30 * 24 * 60 * 60 * 1000
+  }
+}, lowOrderMatrix),
+      daysInYearAccurate = 146097.0 / 400,
+      daysInMonthAccurate = 146097.0 / 4800,
+      accurateMatrix = duration_objectSpread({
+  years: {
+    quarters: 4,
+    months: 12,
+    weeks: daysInYearAccurate / 7,
+    days: daysInYearAccurate,
+    hours: daysInYearAccurate * 24,
+    minutes: daysInYearAccurate * 24 * 60,
+    seconds: daysInYearAccurate * 24 * 60 * 60,
+    milliseconds: daysInYearAccurate * 24 * 60 * 60 * 1000
+  },
+  quarters: {
+    months: 3,
+    weeks: daysInYearAccurate / 28,
+    days: daysInYearAccurate / 4,
+    hours: daysInYearAccurate * 24 / 4,
+    minutes: daysInYearAccurate * 24 * 60 / 4,
+    seconds: daysInYearAccurate * 24 * 60 * 60 / 4,
+    milliseconds: daysInYearAccurate * 24 * 60 * 60 * 1000 / 4
+  },
+  months: {
+    weeks: daysInMonthAccurate / 7,
+    days: daysInMonthAccurate,
+    hours: daysInMonthAccurate * 24,
+    minutes: daysInMonthAccurate * 24 * 60,
+    seconds: daysInMonthAccurate * 24 * 60 * 60,
+    milliseconds: daysInMonthAccurate * 24 * 60 * 60 * 1000
+  }
+}, lowOrderMatrix); // units ordered by size
 
-// units ordered by size
-var orderedUnits = ["years", "quarters", "months", "weeks", "days", "hours", "minutes", "seconds", "milliseconds"];
-var reverseUnits = orderedUnits.slice(0).reverse();
+const orderedUnits = ["years", "quarters", "months", "weeks", "days", "hours", "minutes", "seconds", "milliseconds"];
+const reverseUnits = orderedUnits.slice(0).reverse(); // clone really means "create another instance just like this one, but with these changes"
 
-// clone really means "create another instance just like this one, but with these changes"
 function clone(dur, alts) {
-  var clear = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
+  let clear = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
   // deep merge for vals
-  var conf = {
+  const conf = {
     values: clear ? alts.values : duration_objectSpread(duration_objectSpread({}, dur.values), alts.values || {}),
     loc: dur.loc.clone(alts.loc),
     conversionAccuracy: alts.conversionAccuracy || dur.conversionAccuracy,
@@ -3127,49 +3513,53 @@ function clone(dur, alts) {
   };
   return new Duration(conf);
 }
+
 function antiTrunc(n) {
   return n < 0 ? Math.floor(n) : Math.ceil(n);
-}
+} // NB: mutates parameters
 
-// NB: mutates parameters
+
 function convert(matrix, fromMap, fromUnit, toMap, toUnit) {
-  var conv = matrix[toUnit][fromUnit],
-    raw = fromMap[fromUnit] / conv,
-    sameSign = Math.sign(raw) === Math.sign(toMap[toUnit]),
-    // ok, so this is wild, but see the matrix in the tests
-    added = !sameSign && toMap[toUnit] !== 0 && Math.abs(raw) <= 1 ? antiTrunc(raw) : Math.trunc(raw);
+  const conv = matrix[toUnit][fromUnit],
+        raw = fromMap[fromUnit] / conv,
+        sameSign = Math.sign(raw) === Math.sign(toMap[toUnit]),
+        // ok, so this is wild, but see the matrix in the tests
+  added = !sameSign && toMap[toUnit] !== 0 && Math.abs(raw) <= 1 ? antiTrunc(raw) : Math.trunc(raw);
   toMap[toUnit] += added;
   fromMap[fromUnit] -= added * conv;
-}
+} // NB: mutates parameters
 
-// NB: mutates parameters
+
 function normalizeValues(matrix, vals) {
   reverseUnits.reduce((previous, current) => {
     if (!isUndefined(vals[current])) {
       if (previous) {
         convert(matrix, vals, previous, vals, current);
       }
+
       return current;
     } else {
       return previous;
     }
   }, null);
-}
+} // Remove all properties with a value of 0 from an object
 
-// Remove all properties with a value of 0 from an object
+
 function removeZeroes(vals) {
-  var newVals = {};
+  const newVals = {};
+
   for (var _i = 0, _Object$entries = Object.entries(vals); _i < _Object$entries.length; _i++) {
-    var _Object$entries$_i = duration_slicedToArray(_Object$entries[_i], 2),
-      key = _Object$entries$_i[0],
-      value = _Object$entries$_i[1];
+    const _Object$entries$_i = duration_slicedToArray(_Object$entries[_i], 2),
+          key = _Object$entries$_i[0],
+          value = _Object$entries$_i[1];
+
     if (value !== 0) {
       newVals[key] = value;
     }
   }
+
   return newVals;
 }
-
 /**
  * A Duration object represents a period of time, like "2 months" or "1 day, 1 hour". Conceptually, it's just a map of units to their quantities, accompanied by some additional configuration and methods for creating, parsing, interrogating, transforming, and formatting them. They can be used on their own or in conjunction with other Luxon types; for example, you can use {@link DateTime#plus} to add a Duration object to a DateTime, producing another DateTime.
  *
@@ -3183,43 +3573,51 @@ function removeZeroes(vals) {
  *
  * There's are more methods documented below. In addition, for more information on subtler topics like internationalization and validity, see the external documentation.
  */
+
+
 class Duration {
   /**
    * @private
    */
   constructor(config) {
-    var accurate = config.conversionAccuracy === "longterm" || false;
-    var matrix = accurate ? accurateMatrix : casualMatrix;
+    const accurate = config.conversionAccuracy === "longterm" || false;
+    let matrix = accurate ? accurateMatrix : casualMatrix;
+
     if (config.matrix) {
       matrix = config.matrix;
     }
-
     /**
      * @access private
      */
+
+
     this.values = config.values;
     /**
      * @access private
      */
+
     this.loc = config.loc || Locale.create();
     /**
      * @access private
      */
+
     this.conversionAccuracy = accurate ? "longterm" : "casual";
     /**
      * @access private
      */
+
     this.invalid = config.invalid || null;
     /**
      * @access private
      */
+
     this.matrix = matrix;
     /**
      * @access private
      */
+
     this.isLuxonDuration = true;
   }
-
   /**
    * Create Duration from a number of milliseconds.
    * @param {number} count of milliseconds
@@ -3229,12 +3627,13 @@ class Duration {
    * @param {string} [opts.conversionAccuracy='casual'] - the conversion system to use
    * @return {Duration}
    */
+
+
   static fromMillis(count, opts) {
     return Duration.fromObject({
       milliseconds: count
     }, opts);
   }
-
   /**
    * Create a Duration from a JavaScript object with keys like 'years' and 'hours'.
    * If this object is empty then a zero milliseconds duration is returned.
@@ -3255,11 +3654,15 @@ class Duration {
    * @param {string} [opts.matrix=Object] - the custom conversion system to use
    * @return {Duration}
    */
+
+
   static fromObject(obj) {
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
     if (obj == null || typeof obj !== "object") {
       throw new InvalidArgumentError(`Duration.fromObject: argument expected to be an object, got ${obj === null ? "null" : typeof obj}`);
     }
+
     return new Duration({
       values: normalizeObject(obj, Duration.normalizeUnit),
       loc: Locale.fromObject(opts),
@@ -3267,7 +3670,6 @@ class Duration {
       matrix: opts.matrix
     });
   }
-
   /**
    * Create a Duration from DurationLike.
    *
@@ -3278,6 +3680,8 @@ class Duration {
    * - Duration instance
    * @return {Duration}
    */
+
+
   static fromDurationLike(durationLike) {
     if (isNumber(durationLike)) {
       return Duration.fromMillis(durationLike);
@@ -3289,7 +3693,6 @@ class Duration {
       throw new InvalidArgumentError(`Unknown duration argument ${durationLike} of type ${typeof durationLike}`);
     }
   }
-
   /**
    * Create a Duration from an ISO 8601 duration string.
    * @param {string} text - text to parse
@@ -3304,17 +3707,19 @@ class Duration {
    * @example Duration.fromISO('P5Y3M').toObject() //=> { years: 5, months: 3 }
    * @return {Duration}
    */
+
+
   static fromISO(text, opts) {
-    var _parseISODuration = parseISODuration(text),
-      _parseISODuration2 = duration_slicedToArray(_parseISODuration, 1),
-      parsed = _parseISODuration2[0];
+    const _parseISODuration = parseISODuration(text),
+          _parseISODuration2 = duration_slicedToArray(_parseISODuration, 1),
+          parsed = _parseISODuration2[0];
+
     if (parsed) {
       return Duration.fromObject(parsed, opts);
     } else {
       return Duration.invalid("unparsable", `the input "${text}" can't be parsed as ISO 8601`);
     }
   }
-
   /**
    * Create a Duration from an ISO 8601 time string.
    * @param {string} text - text to parse
@@ -3331,29 +3736,36 @@ class Duration {
    * @example Duration.fromISOTime('T1100').toObject() //=> { hours: 11, minutes: 0, seconds: 0 }
    * @return {Duration}
    */
+
+
   static fromISOTime(text, opts) {
-    var _parseISOTimeOnly = parseISOTimeOnly(text),
-      _parseISOTimeOnly2 = duration_slicedToArray(_parseISOTimeOnly, 1),
-      parsed = _parseISOTimeOnly2[0];
+    const _parseISOTimeOnly = parseISOTimeOnly(text),
+          _parseISOTimeOnly2 = duration_slicedToArray(_parseISOTimeOnly, 1),
+          parsed = _parseISOTimeOnly2[0];
+
     if (parsed) {
       return Duration.fromObject(parsed, opts);
     } else {
       return Duration.invalid("unparsable", `the input "${text}" can't be parsed as ISO 8601`);
     }
   }
-
   /**
    * Create an invalid Duration.
    * @param {string} reason - simple string of why this datetime is invalid. Should not contain parameters or anything else data-dependent
    * @param {string} [explanation=null] - longer explanation, may include parameters and other useful debugging information
    * @return {Duration}
    */
+
+
   static invalid(reason) {
-    var explanation = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
+    let explanation = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
+
     if (!reason) {
       throw new InvalidArgumentError("need to specify a reason the Duration is invalid");
     }
-    var invalid = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
+
+    const invalid = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
+
     if (Settings.throwOnInvalid) {
       throw new InvalidDurationError(invalid);
     } else {
@@ -3362,12 +3774,13 @@ class Duration {
       });
     }
   }
-
   /**
    * @private
    */
+
+
   static normalizeUnit(unit) {
-    var normalized = {
+    const normalized = {
       year: "years",
       years: "years",
       quarter: "quarters",
@@ -3390,33 +3803,35 @@ class Duration {
     if (!normalized) throw new InvalidUnitError(unit);
     return normalized;
   }
-
   /**
    * Check if an object is a Duration. Works across context boundaries
    * @param {object} o
    * @return {boolean}
    */
+
+
   static isDuration(o) {
     return o && o.isLuxonDuration || false;
   }
-
   /**
    * Get  the locale of a Duration, such 'en-GB'
    * @type {string}
    */
+
+
   get locale() {
     return this.isValid ? this.loc.locale : null;
   }
-
   /**
    * Get the numbering system of a Duration, such 'beng'. The numbering system is used when formatting the Duration
    *
    * @type {string}
    */
+
+
   get numberingSystem() {
     return this.isValid ? this.loc.numberingSystem : null;
   }
-
   /**
    * Returns a string representation of this Duration formatted according to the specified format string. You may use these tokens:
    * * `S` for milliseconds
@@ -3439,15 +3854,18 @@ class Duration {
    * @example Duration.fromObject({ years: 1, days: 6, seconds: 2 }).toFormat("M S") //=> "12 518402000"
    * @return {string}
    */
+
+
   toFormat(fmt) {
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
     // reverse-compat since 1.2; we always round down now, never up, and we do it by default
-    var fmtOpts = duration_objectSpread(duration_objectSpread({}, opts), {}, {
+    const fmtOpts = duration_objectSpread(duration_objectSpread({}, opts), {}, {
       floor: opts.round !== false && opts.floor !== false
     });
+
     return this.isValid ? Formatter.create(this.loc, fmtOpts).formatDurationFromString(this, fmt) : INVALID;
   }
-
   /**
    * Returns a string representation of a Duration with all units included.
    * To modify its behavior use the `listStyle` and any Intl.NumberFormat option, though `unitDisplay` is especially relevant.
@@ -3461,13 +3879,17 @@ class Duration {
    * dur.toHuman({ unitDisplay: "short" }) //=> '1 day, 5 hr, 6 min'
    * ```
    */
+
+
   toHuman() {
-    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-    var l = orderedUnits.map(unit => {
-      var val = this.values[unit];
+    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    const l = orderedUnits.map(unit => {
+      const val = this.values[unit];
+
       if (isUndefined(val)) {
         return null;
       }
+
       return this.loc.numberFormatter(duration_objectSpread(duration_objectSpread({
         style: "unit",
         unitDisplay: "long"
@@ -3480,17 +3902,17 @@ class Duration {
       style: opts.listStyle || "narrow"
     }, opts)).format(l);
   }
-
   /**
    * Returns a JavaScript object with this Duration's values.
    * @example Duration.fromObject({ years: 1, days: 6, seconds: 2 }).toObject() //=> { years: 1, days: 6, seconds: 2 }
    * @return {Object}
    */
+
+
   toObject() {
     if (!this.isValid) return {};
     return duration_objectSpread({}, this.values);
   }
-
   /**
    * Returns an ISO 8601-compliant string representation of this Duration.
    * @see https://en.wikipedia.org/wiki/ISO_8601#Durations
@@ -3501,10 +3923,12 @@ class Duration {
    * @example Duration.fromObject({ milliseconds: 6 }).toISO() //=> 'PT0.006S'
    * @return {string}
    */
+
+
   toISO() {
     // we could use the formatter, but this is an easier way to get the minimum string
     if (!this.isValid) return null;
-    var s = "P";
+    let s = "P";
     if (this.years !== 0) s += this.years + "Y";
     if (this.months !== 0 || this.quarters !== 0) s += this.months + this.quarters * 3 + "M";
     if (this.weeks !== 0) s += this.weeks + "W";
@@ -3512,14 +3936,12 @@ class Duration {
     if (this.hours !== 0 || this.minutes !== 0 || this.seconds !== 0 || this.milliseconds !== 0) s += "T";
     if (this.hours !== 0) s += this.hours + "H";
     if (this.minutes !== 0) s += this.minutes + "M";
-    if (this.seconds !== 0 || this.milliseconds !== 0)
-      // this will handle "floating point madness" by removing extra decimal places
+    if (this.seconds !== 0 || this.milliseconds !== 0) // this will handle "floating point madness" by removing extra decimal places
       // https://stackoverflow.com/questions/588004/is-floating-point-math-broken
       s += roundTo(this.seconds + this.milliseconds / 1000, 3) + "S";
     if (s === "P") s += "T0S";
     return s;
   }
-
   /**
    * Returns an ISO 8601-compliant string representation of this Duration, formatted as a time of day.
    * Note that this will return null if the duration is invalid, negative, or equal to or greater than 24 hours.
@@ -3536,10 +3958,12 @@ class Duration {
    * @example Duration.fromObject({ hours: 11 }).toISOTime({ format: 'basic' }) //=> '110000.000'
    * @return {string}
    */
+
+
   toISOTime() {
-    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     if (!this.isValid) return null;
-    var millis = this.toMillis();
+    const millis = this.toMillis();
     if (millis < 0 || millis >= 86400000) return null;
     opts = duration_objectSpread({
       suppressMilliseconds: false,
@@ -3547,84 +3971,106 @@ class Duration {
       includePrefix: false,
       format: "extended"
     }, opts);
-    var value = this.shiftTo("hours", "minutes", "seconds", "milliseconds");
-    var fmt = opts.format === "basic" ? "hhmm" : "hh:mm";
+    const value = this.shiftTo("hours", "minutes", "seconds", "milliseconds");
+    let fmt = opts.format === "basic" ? "hhmm" : "hh:mm";
+
     if (!opts.suppressSeconds || value.seconds !== 0 || value.milliseconds !== 0) {
       fmt += opts.format === "basic" ? "ss" : ":ss";
+
       if (!opts.suppressMilliseconds || value.milliseconds !== 0) {
         fmt += ".SSS";
       }
     }
-    var str = value.toFormat(fmt);
+
+    let str = value.toFormat(fmt);
+
     if (opts.includePrefix) {
       str = "T" + str;
     }
+
     return str;
   }
-
   /**
    * Returns an ISO 8601 representation of this Duration appropriate for use in JSON.
    * @return {string}
    */
+
+
   toJSON() {
     return this.toISO();
   }
-
   /**
    * Returns an ISO 8601 representation of this Duration appropriate for use in debugging.
    * @return {string}
    */
+
+
   toString() {
     return this.toISO();
   }
-
   /**
    * Returns an milliseconds value of this Duration.
    * @return {number}
    */
+
+
   toMillis() {
     return this.as("milliseconds");
   }
-
   /**
    * Returns an milliseconds value of this Duration. Alias of {@link toMillis}
    * @return {number}
    */
+
+
   valueOf() {
     return this.toMillis();
   }
-
   /**
    * Make this Duration longer by the specified amount. Return a newly-constructed Duration.
    * @param {Duration|Object|number} duration - The amount to add. Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
    * @return {Duration}
    */
+
+
   plus(duration) {
     if (!this.isValid) return this;
-    var dur = Duration.fromDurationLike(duration),
-      result = {};
-    for (var _i2 = 0, _orderedUnits = orderedUnits; _i2 < _orderedUnits.length; _i2++) {
-      var k = _orderedUnits[_i2];
-      if (util_hasOwnProperty(dur.values, k) || util_hasOwnProperty(this.values, k)) {
-        result[k] = dur.get(k) + this.get(k);
+    const dur = Duration.fromDurationLike(duration),
+          result = {};
+
+    var _iterator = duration_createForOfIteratorHelper(orderedUnits),
+        _step;
+
+    try {
+      for (_iterator.s(); !(_step = _iterator.n()).done;) {
+        const k = _step.value;
+
+        if (util_hasOwnProperty(dur.values, k) || util_hasOwnProperty(this.values, k)) {
+          result[k] = dur.get(k) + this.get(k);
+        }
       }
+    } catch (err) {
+      _iterator.e(err);
+    } finally {
+      _iterator.f();
     }
+
     return clone(this, {
       values: result
     }, true);
   }
-
   /**
    * Make this Duration shorter by the specified amount. Return a newly-constructed Duration.
    * @param {Duration|Object|number} duration - The amount to subtract. Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
    * @return {Duration}
    */
+
+
   minus(duration) {
     if (!this.isValid) return this;
-    var dur = Duration.fromDurationLike(duration);
+    const dur = Duration.fromDurationLike(duration);
     return this.plus(dur.negate());
   }
-
   /**
    * Scale this Duration by the specified amount. Return a newly-constructed Duration.
    * @param {function} fn - The function to apply to each unit. Arity is 1 or 2: the value of the unit and, optionally, the unit name. Must return a number.
@@ -3632,18 +4078,21 @@ class Duration {
    * @example Duration.fromObject({ hours: 1, minutes: 30 }).mapUnits((x, u) => u === "hours" ? x * 2 : x) //=> { hours: 2, minutes: 30 }
    * @return {Duration}
    */
+
+
   mapUnits(fn) {
     if (!this.isValid) return this;
-    var result = {};
-    for (var _i3 = 0, _Object$keys = Object.keys(this.values); _i3 < _Object$keys.length; _i3++) {
-      var k = _Object$keys[_i3];
+    const result = {};
+
+    for (var _i2 = 0, _Object$keys = Object.keys(this.values); _i2 < _Object$keys.length; _i2++) {
+      const k = _Object$keys[_i2];
       result[k] = asNumber(fn(this.values[k], k));
     }
+
     return clone(this, {
       values: result
     }, true);
   }
-
   /**
    * Get the value of unit.
    * @param {string} unit - a unit such as 'minute' or 'day'
@@ -3652,10 +4101,11 @@ class Duration {
    * @example Duration.fromObject({years: 2, days: 3}).get('days') //=> 3
    * @return {number}
    */
+
+
   get(unit) {
     return this[Duration.normalizeUnit(unit)];
   }
-
   /**
    * "Set" the values of specified units. Return a newly-constructed Duration.
    * @param {Object} values - a mapping of units to numbers
@@ -3663,37 +4113,42 @@ class Duration {
    * @example dur.set({ hours: 8, minutes: 30 })
    * @return {Duration}
    */
+
+
   set(values) {
     if (!this.isValid) return this;
-    var mixed = duration_objectSpread(duration_objectSpread({}, this.values), normalizeObject(values, Duration.normalizeUnit));
+
+    const mixed = duration_objectSpread(duration_objectSpread({}, this.values), normalizeObject(values, Duration.normalizeUnit));
+
     return clone(this, {
       values: mixed
     });
   }
-
   /**
    * "Set" the locale and/or numberingSystem.  Returns a newly-constructed Duration.
    * @example dur.reconfigure({ locale: 'en-GB' })
    * @return {Duration}
    */
+
+
   reconfigure() {
-    var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-      locale = _ref.locale,
-      numberingSystem = _ref.numberingSystem,
-      conversionAccuracy = _ref.conversionAccuracy,
-      matrix = _ref.matrix;
-    var loc = this.loc.clone({
+    let _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+        locale = _ref.locale,
+        numberingSystem = _ref.numberingSystem,
+        conversionAccuracy = _ref.conversionAccuracy,
+        matrix = _ref.matrix;
+
+    const loc = this.loc.clone({
       locale,
       numberingSystem
     });
-    var opts = {
+    const opts = {
       loc,
       matrix,
       conversionAccuracy
     };
     return clone(this, opts);
   }
-
   /**
    * Return the length of the duration in the specified unit.
    * @param {string} unit - a unit such as 'minutes' or 'days'
@@ -3702,258 +4157,315 @@ class Duration {
    * @example Duration.fromObject({hours: 60}).as('days') //=> 2.5
    * @return {number}
    */
+
+
   as(unit) {
     return this.isValid ? this.shiftTo(unit).get(unit) : NaN;
   }
-
   /**
    * Reduce this Duration to its canonical representation in its current units.
    * @example Duration.fromObject({ years: 2, days: 5000 }).normalize().toObject() //=> { years: 15, days: 255 }
    * @example Duration.fromObject({ hours: 12, minutes: -45 }).normalize().toObject() //=> { hours: 11, minutes: 15 }
    * @return {Duration}
    */
+
+
   normalize() {
     if (!this.isValid) return this;
-    var vals = this.toObject();
+    const vals = this.toObject();
     normalizeValues(this.matrix, vals);
     return clone(this, {
       values: vals
     }, true);
   }
-
   /**
    * Rescale units to its largest representation
    * @example Duration.fromObject({ milliseconds: 90000 }).rescale().toObject() //=> { minutes: 1, seconds: 30 }
    * @return {Duration}
    */
+
+
   rescale() {
     if (!this.isValid) return this;
-    var vals = removeZeroes(this.normalize().shiftToAll().toObject());
+    const vals = removeZeroes(this.normalize().shiftToAll().toObject());
     return clone(this, {
       values: vals
     }, true);
   }
-
   /**
    * Convert this Duration into its representation in a different set of units.
    * @example Duration.fromObject({ hours: 1, seconds: 30 }).shiftTo('minutes', 'milliseconds').toObject() //=> { minutes: 60, milliseconds: 30000 }
    * @return {Duration}
    */
+
+
   shiftTo() {
     for (var _len = arguments.length, units = new Array(_len), _key = 0; _key < _len; _key++) {
       units[_key] = arguments[_key];
     }
+
     if (!this.isValid) return this;
+
     if (units.length === 0) {
       return this;
     }
+
     units = units.map(u => Duration.normalizeUnit(u));
-    var built = {},
-      accumulated = {},
-      vals = this.toObject();
-    var lastUnit;
-    for (var _i4 = 0, _orderedUnits2 = orderedUnits; _i4 < _orderedUnits2.length; _i4++) {
-      var k = _orderedUnits2[_i4];
-      if (units.indexOf(k) >= 0) {
-        lastUnit = k;
-        var own = 0;
+    const built = {},
+          accumulated = {},
+          vals = this.toObject();
+    let lastUnit;
 
-        // anything we haven't boiled down yet should get boiled to this unit
-        for (var ak in accumulated) {
-          own += this.matrix[ak][k] * accumulated[ak];
-          accumulated[ak] = 0;
-        }
+    var _iterator2 = duration_createForOfIteratorHelper(orderedUnits),
+        _step2;
 
-        // plus anything that's already in this unit
-        if (isNumber(vals[k])) {
-          own += vals[k];
-        }
-        var i = Math.trunc(own);
-        built[k] = i;
-        accumulated[k] = (own * 1000 - i * 1000) / 1000;
+    try {
+      for (_iterator2.s(); !(_step2 = _iterator2.n()).done;) {
+        const k = _step2.value;
 
-        // plus anything further down the chain that should be rolled up in to this
-        for (var down in vals) {
-          if (orderedUnits.indexOf(down) > orderedUnits.indexOf(k)) {
-            convert(this.matrix, vals, down, built, k);
+        if (units.indexOf(k) >= 0) {
+          lastUnit = k;
+          let own = 0; // anything we haven't boiled down yet should get boiled to this unit
+
+          for (const ak in accumulated) {
+            own += this.matrix[ak][k] * accumulated[ak];
+            accumulated[ak] = 0;
+          } // plus anything that's already in this unit
+
+
+          if (isNumber(vals[k])) {
+            own += vals[k];
           }
+
+          const i = Math.trunc(own);
+          built[k] = i;
+          accumulated[k] = (own * 1000 - i * 1000) / 1000; // plus anything further down the chain that should be rolled up in to this
+
+          for (const down in vals) {
+            if (orderedUnits.indexOf(down) > orderedUnits.indexOf(k)) {
+              convert(this.matrix, vals, down, built, k);
+            }
+          } // otherwise, keep it in the wings to boil it later
+
+        } else if (isNumber(vals[k])) {
+          accumulated[k] = vals[k];
         }
-        // otherwise, keep it in the wings to boil it later
-      } else if (isNumber(vals[k])) {
-        accumulated[k] = vals[k];
-      }
+      } // anything leftover becomes the decimal for the last unit
+      // lastUnit must be defined since units is not empty
+
+    } catch (err) {
+      _iterator2.e(err);
+    } finally {
+      _iterator2.f();
     }
 
-    // anything leftover becomes the decimal for the last unit
-    // lastUnit must be defined since units is not empty
-    for (var key in accumulated) {
+    for (const key in accumulated) {
       if (accumulated[key] !== 0) {
         built[lastUnit] += key === lastUnit ? accumulated[key] : accumulated[key] / this.matrix[lastUnit][key];
       }
     }
+
     return clone(this, {
       values: built
     }, true).normalize();
   }
-
   /**
    * Shift this Duration to all available units.
    * Same as shiftTo("years", "months", "weeks", "days", "hours", "minutes", "seconds", "milliseconds")
    * @return {Duration}
    */
+
+
   shiftToAll() {
     if (!this.isValid) return this;
     return this.shiftTo("years", "months", "weeks", "days", "hours", "minutes", "seconds", "milliseconds");
   }
-
   /**
    * Return the negative of this Duration.
    * @example Duration.fromObject({ hours: 1, seconds: 30 }).negate().toObject() //=> { hours: -1, seconds: -30 }
    * @return {Duration}
    */
+
+
   negate() {
     if (!this.isValid) return this;
-    var negated = {};
-    for (var _i5 = 0, _Object$keys2 = Object.keys(this.values); _i5 < _Object$keys2.length; _i5++) {
-      var k = _Object$keys2[_i5];
+    const negated = {};
+
+    for (var _i3 = 0, _Object$keys2 = Object.keys(this.values); _i3 < _Object$keys2.length; _i3++) {
+      const k = _Object$keys2[_i3];
       negated[k] = this.values[k] === 0 ? 0 : -this.values[k];
     }
+
     return clone(this, {
       values: negated
     }, true);
   }
-
   /**
    * Get the years.
    * @type {number}
    */
+
+
   get years() {
     return this.isValid ? this.values.years || 0 : NaN;
   }
-
   /**
    * Get the quarters.
    * @type {number}
    */
+
+
   get quarters() {
     return this.isValid ? this.values.quarters || 0 : NaN;
   }
-
   /**
    * Get the months.
    * @type {number}
    */
+
+
   get months() {
     return this.isValid ? this.values.months || 0 : NaN;
   }
-
   /**
    * Get the weeks
    * @type {number}
    */
+
+
   get weeks() {
     return this.isValid ? this.values.weeks || 0 : NaN;
   }
-
   /**
    * Get the days.
    * @type {number}
    */
+
+
   get days() {
     return this.isValid ? this.values.days || 0 : NaN;
   }
-
   /**
    * Get the hours.
    * @type {number}
    */
+
+
   get hours() {
     return this.isValid ? this.values.hours || 0 : NaN;
   }
-
   /**
    * Get the minutes.
    * @type {number}
    */
+
+
   get minutes() {
     return this.isValid ? this.values.minutes || 0 : NaN;
   }
-
   /**
    * Get the seconds.
    * @return {number}
    */
+
+
   get seconds() {
     return this.isValid ? this.values.seconds || 0 : NaN;
   }
-
   /**
    * Get the milliseconds.
    * @return {number}
    */
+
+
   get milliseconds() {
     return this.isValid ? this.values.milliseconds || 0 : NaN;
   }
-
   /**
    * Returns whether the Duration is invalid. Invalid durations are returned by diff operations
    * on invalid DateTimes or Intervals.
    * @return {boolean}
    */
+
+
   get isValid() {
     return this.invalid === null;
   }
-
   /**
    * Returns an error code if this Duration became invalid, or null if the Duration is valid
    * @return {string}
    */
+
+
   get invalidReason() {
     return this.invalid ? this.invalid.reason : null;
   }
-
   /**
    * Returns an explanation of why this Duration became invalid, or null if the Duration is valid
    * @type {string}
    */
+
+
   get invalidExplanation() {
     return this.invalid ? this.invalid.explanation : null;
   }
-
   /**
    * Equality check
    * Two Durations are equal iff they have the same units and the same values for each unit.
    * @param {Duration} other
    * @return {boolean}
    */
+
+
   equals(other) {
     if (!this.isValid || !other.isValid) {
       return false;
     }
+
     if (!this.loc.equals(other.loc)) {
       return false;
     }
+
     function eq(v1, v2) {
       // Consider 0 and undefined as equal
       if (v1 === undefined || v1 === 0) return v2 === undefined || v2 === 0;
       return v1 === v2;
     }
-    for (var _i6 = 0, _orderedUnits3 = orderedUnits; _i6 < _orderedUnits3.length; _i6++) {
-      var u = _orderedUnits3[_i6];
-      if (!eq(this.values[u], other.values[u])) {
-        return false;
+
+    var _iterator3 = duration_createForOfIteratorHelper(orderedUnits),
+        _step3;
+
+    try {
+      for (_iterator3.s(); !(_step3 = _iterator3.n()).done;) {
+        const u = _step3.value;
+
+        if (!eq(this.values[u], other.values[u])) {
+          return false;
+        }
       }
+    } catch (err) {
+      _iterator3.e(err);
+    } finally {
+      _iterator3.f();
     }
+
     return true;
   }
+
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/interval.js
-function interval_createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = interval_unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
+function interval_createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = interval_unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e2) { throw _e2; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e3) { didErr = true; err = _e3; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
+
 function interval_slicedToArray(arr, i) { return interval_arrayWithHoles(arr) || interval_iterableToArrayLimit(arr, i) || interval_unsupportedIterableToArray(arr, i) || interval_nonIterableRest(); }
+
 function interval_nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
 function interval_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return interval_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return interval_arrayLikeToArray(o, minLen); }
+
 function interval_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-function interval_iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
+
+function interval_iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
 function interval_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
@@ -3962,9 +4474,9 @@ function interval_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
 
-var interval_INVALID = "Invalid Interval";
 
-// checks if the start is equal to or before the end
+const interval_INVALID = "Invalid Interval"; // checks if the start is equal to or before the end
+
 function validateStartEnd(start, end) {
   if (!start || !start.isValid) {
     return Interval.invalid("missing or invalid start");
@@ -3976,7 +4488,6 @@ function validateStartEnd(start, end) {
     return null;
   }
 }
-
 /**
  * An Interval object represents a half-open interval of time, where each endpoint is a {@link DateTime}. Conceptually, it's a container for those two endpoints, accompanied by methods for creating, parsing, interrogating, comparing, transforming, and formatting them.
  *
@@ -3989,6 +4500,8 @@ function validateStartEnd(start, end) {
  * * **Comparison** To compare this Interval to another one, use {@link Interval#equals}, {@link Interval#overlaps}, {@link Interval#abutsStart}, {@link Interval#abutsEnd}, {@link Interval#engulfs}
  * * **Output** To convert the Interval into other representations, see {@link Interval#toString}, {@link Interval#toLocaleString}, {@link Interval#toISO}, {@link Interval#toISODate}, {@link Interval#toISOTime}, {@link Interval#toFormat}, and {@link Interval#toDuration}.
  */
+
+
 class Interval {
   /**
    * @private
@@ -4001,29 +4514,36 @@ class Interval {
     /**
      * @access private
      */
+
     this.e = config.end;
     /**
      * @access private
      */
+
     this.invalid = config.invalid || null;
     /**
      * @access private
      */
+
     this.isLuxonInterval = true;
   }
-
   /**
    * Create an invalid Interval.
    * @param {string} reason - simple string of why this Interval is invalid. Should not contain parameters or anything else data-dependent
    * @param {string} [explanation=null] - longer explanation, may include parameters and other useful debugging information
    * @return {Interval}
    */
+
+
   static invalid(reason) {
-    var explanation = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
+    let explanation = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
+
     if (!reason) {
       throw new InvalidArgumentError("need to specify a reason the Interval is invalid");
     }
-    var invalid = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
+
+    const invalid = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
+
     if (Settings.throwOnInvalid) {
       throw new InvalidIntervalError(invalid);
     } else {
@@ -4032,17 +4552,19 @@ class Interval {
       });
     }
   }
-
   /**
    * Create an Interval from a start DateTime and an end DateTime. Inclusive of the start but not the end.
    * @param {DateTime|Date|Object} start
    * @param {DateTime|Date|Object} end
    * @return {Interval}
    */
+
+
   static fromDateTimes(start, end) {
-    var builtStart = friendlyDateTime(start),
-      builtEnd = friendlyDateTime(end);
-    var validateError = validateStartEnd(builtStart, builtEnd);
+    const builtStart = friendlyDateTime(start),
+          builtEnd = friendlyDateTime(end);
+    const validateError = validateStartEnd(builtStart, builtEnd);
+
     if (validateError == null) {
       return new Interval({
         start: builtStart,
@@ -4052,31 +4574,32 @@ class Interval {
       return validateError;
     }
   }
-
   /**
    * Create an Interval from a start DateTime and a Duration to extend to.
    * @param {DateTime|Date|Object} start
    * @param {Duration|Object|number} duration - the length of the Interval.
    * @return {Interval}
    */
+
+
   static after(start, duration) {
-    var dur = Duration.fromDurationLike(duration),
-      dt = friendlyDateTime(start);
+    const dur = Duration.fromDurationLike(duration),
+          dt = friendlyDateTime(start);
     return Interval.fromDateTimes(dt, dt.plus(dur));
   }
-
   /**
    * Create an Interval from an end DateTime and a Duration to extend backwards to.
    * @param {DateTime|Date|Object} end
    * @param {Duration|Object|number} duration - the length of the Interval.
    * @return {Interval}
    */
+
+
   static before(end, duration) {
-    var dur = Duration.fromDurationLike(duration),
-      dt = friendlyDateTime(end);
+    const dur = Duration.fromDurationLike(duration),
+          dt = friendlyDateTime(end);
     return Interval.fromDateTimes(dt.minus(dur), dt);
   }
-
   /**
    * Create an Interval from an ISO 8601 string.
    * Accepts `<start>/<end>`, `<start>/<duration>`, and `<duration>/<end>` formats.
@@ -4085,103 +4608,120 @@ class Interval {
    * @see https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
    * @return {Interval}
    */
+
+
   static fromISO(text, opts) {
-    var _split = (text || "").split("/", 2),
-      _split2 = interval_slicedToArray(_split, 2),
-      s = _split2[0],
-      e = _split2[1];
+    const _split = (text || "").split("/", 2),
+          _split2 = interval_slicedToArray(_split, 2),
+          s = _split2[0],
+          e = _split2[1];
+
     if (s && e) {
-      var start, startIsValid;
+      let start, startIsValid;
+
       try {
         start = DateTime.fromISO(s, opts);
         startIsValid = start.isValid;
       } catch (e) {
         startIsValid = false;
       }
-      var end, endIsValid;
+
+      let end, endIsValid;
+
       try {
         end = DateTime.fromISO(e, opts);
         endIsValid = end.isValid;
       } catch (e) {
         endIsValid = false;
       }
+
       if (startIsValid && endIsValid) {
         return Interval.fromDateTimes(start, end);
       }
+
       if (startIsValid) {
-        var dur = Duration.fromISO(e, opts);
+        const dur = Duration.fromISO(e, opts);
+
         if (dur.isValid) {
           return Interval.after(start, dur);
         }
       } else if (endIsValid) {
-        var _dur = Duration.fromISO(s, opts);
-        if (_dur.isValid) {
-          return Interval.before(end, _dur);
+        const dur = Duration.fromISO(s, opts);
+
+        if (dur.isValid) {
+          return Interval.before(end, dur);
         }
       }
     }
+
     return Interval.invalid("unparsable", `the input "${text}" can't be parsed as ISO 8601`);
   }
-
   /**
    * Check if an object is an Interval. Works across context boundaries
    * @param {object} o
    * @return {boolean}
    */
+
+
   static isInterval(o) {
     return o && o.isLuxonInterval || false;
   }
-
   /**
    * Returns the start of the Interval
    * @type {DateTime}
    */
+
+
   get start() {
     return this.isValid ? this.s : null;
   }
-
   /**
    * Returns the end of the Interval
    * @type {DateTime}
    */
+
+
   get end() {
     return this.isValid ? this.e : null;
   }
-
   /**
    * Returns whether this Interval's end is at least its start, meaning that the Interval isn't 'backwards'.
    * @type {boolean}
    */
+
+
   get isValid() {
     return this.invalidReason === null;
   }
-
   /**
    * Returns an error code if this Interval is invalid, or null if the Interval is valid
    * @type {string}
    */
+
+
   get invalidReason() {
     return this.invalid ? this.invalid.reason : null;
   }
-
   /**
    * Returns an explanation of why this Interval became invalid, or null if the Interval is valid
    * @type {string}
    */
+
+
   get invalidExplanation() {
     return this.invalid ? this.invalid.explanation : null;
   }
-
   /**
    * Returns the length of the Interval in the specified unit.
    * @param {string} unit - the unit (such as 'hours' or 'days') to return the length in.
    * @return {number}
    */
+
+
   length() {
-    var unit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "milliseconds";
+    let unit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "milliseconds";
     return this.isValid ? this.toDuration(...[unit]).get(unit) : NaN;
   }
-
   /**
    * Returns the count of minutes, hours, days, months, or years included in the Interval, even in part.
    * Unlike {@link Interval#length} this counts sections of the calendar, not periods of time, e.g. specifying 'day'
@@ -4189,61 +4729,67 @@ class Interval {
    * @param {string} [unit='milliseconds'] - the unit of time to count.
    * @return {number}
    */
+
+
   count() {
-    var unit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "milliseconds";
+    let unit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "milliseconds";
     if (!this.isValid) return NaN;
-    var start = this.start.startOf(unit),
-      end = this.end.startOf(unit);
+    const start = this.start.startOf(unit),
+          end = this.end.startOf(unit);
     return Math.floor(end.diff(start, unit).get(unit)) + 1;
   }
-
   /**
    * Returns whether this Interval's start and end are both in the same unit of time
    * @param {string} unit - the unit of time to check sameness on
    * @return {boolean}
    */
+
+
   hasSame(unit) {
     return this.isValid ? this.isEmpty() || this.e.minus(1).hasSame(this.s, unit) : false;
   }
-
   /**
    * Return whether this Interval has the same start and end DateTimes.
    * @return {boolean}
    */
+
+
   isEmpty() {
     return this.s.valueOf() === this.e.valueOf();
   }
-
   /**
    * Return whether this Interval's start is after the specified DateTime.
    * @param {DateTime} dateTime
    * @return {boolean}
    */
+
+
   isAfter(dateTime) {
     if (!this.isValid) return false;
     return this.s > dateTime;
   }
-
   /**
    * Return whether this Interval's end is before the specified DateTime.
    * @param {DateTime} dateTime
    * @return {boolean}
    */
+
+
   isBefore(dateTime) {
     if (!this.isValid) return false;
     return this.e <= dateTime;
   }
-
   /**
    * Return whether this Interval contains the specified DateTime.
    * @param {DateTime} dateTime
    * @return {boolean}
    */
+
+
   contains(dateTime) {
     if (!this.isValid) return false;
     return this.s <= dateTime && this.e > dateTime;
   }
-
   /**
    * "Sets" the start and/or end dates. Returns a newly-constructed Interval.
    * @param {Object} values - the values to set
@@ -4251,124 +4797,143 @@ class Interval {
    * @param {DateTime} values.end - the ending DateTime
    * @return {Interval}
    */
+
+
   set() {
-    var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-      start = _ref.start,
-      end = _ref.end;
+    let _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+        start = _ref.start,
+        end = _ref.end;
+
     if (!this.isValid) return this;
     return Interval.fromDateTimes(start || this.s, end || this.e);
   }
-
   /**
    * Split this Interval at each of the specified DateTimes
    * @param {...DateTime} dateTimes - the unit of time to count.
    * @return {Array}
    */
+
+
   splitAt() {
     if (!this.isValid) return [];
+
     for (var _len = arguments.length, dateTimes = new Array(_len), _key = 0; _key < _len; _key++) {
       dateTimes[_key] = arguments[_key];
     }
-    var sorted = dateTimes.map(friendlyDateTime).filter(d => this.contains(d)).sort(),
-      results = [];
-    var s = this.s,
-      i = 0;
+
+    const sorted = dateTimes.map(friendlyDateTime).filter(d => this.contains(d)).sort(),
+          results = [];
+    let s = this.s,
+        i = 0;
+
     while (s < this.e) {
-      var added = sorted[i] || this.e,
-        next = +added > +this.e ? this.e : added;
+      const added = sorted[i] || this.e,
+            next = +added > +this.e ? this.e : added;
       results.push(Interval.fromDateTimes(s, next));
       s = next;
       i += 1;
     }
+
     return results;
   }
-
   /**
    * Split this Interval into smaller Intervals, each of the specified length.
    * Left over time is grouped into a smaller interval
    * @param {Duration|Object|number} duration - The length of each resulting interval.
    * @return {Array}
    */
+
+
   splitBy(duration) {
-    var dur = Duration.fromDurationLike(duration);
+    const dur = Duration.fromDurationLike(duration);
+
     if (!this.isValid || !dur.isValid || dur.as("milliseconds") === 0) {
       return [];
     }
-    var s = this.s,
-      idx = 1,
-      next;
-    var results = [];
+
+    let s = this.s,
+        idx = 1,
+        next;
+    const results = [];
+
     while (s < this.e) {
-      var added = this.start.plus(dur.mapUnits(x => x * idx));
+      const added = this.start.plus(dur.mapUnits(x => x * idx));
       next = +added > +this.e ? this.e : added;
       results.push(Interval.fromDateTimes(s, next));
       s = next;
       idx += 1;
     }
+
     return results;
   }
-
   /**
    * Split this Interval into the specified number of smaller intervals.
    * @param {number} numberOfParts - The number of Intervals to divide the Interval into.
    * @return {Array}
    */
+
+
   divideEqually(numberOfParts) {
     if (!this.isValid) return [];
     return this.splitBy(this.length() / numberOfParts).slice(0, numberOfParts);
   }
-
   /**
    * Return whether this Interval overlaps with the specified Interval
    * @param {Interval} other
    * @return {boolean}
    */
+
+
   overlaps(other) {
     return this.e > other.s && this.s < other.e;
   }
-
   /**
    * Return whether this Interval's end is adjacent to the specified Interval's start.
    * @param {Interval} other
    * @return {boolean}
    */
+
+
   abutsStart(other) {
     if (!this.isValid) return false;
     return +this.e === +other.s;
   }
-
   /**
    * Return whether this Interval's start is adjacent to the specified Interval's end.
    * @param {Interval} other
    * @return {boolean}
    */
+
+
   abutsEnd(other) {
     if (!this.isValid) return false;
     return +other.e === +this.s;
   }
-
   /**
    * Return whether this Interval engulfs the start and end of the specified Interval.
    * @param {Interval} other
    * @return {boolean}
    */
+
+
   engulfs(other) {
     if (!this.isValid) return false;
     return this.s <= other.s && this.e >= other.e;
   }
-
   /**
    * Return whether this Interval has the same start and end as the specified Interval.
    * @param {Interval} other
    * @return {boolean}
    */
+
+
   equals(other) {
     if (!this.isValid || !other.isValid) {
       return false;
     }
+
     return this.s.equals(other.s) && this.e.equals(other.e);
   }
-
   /**
    * Return an Interval representing the intersection of this Interval and the specified Interval.
    * Specifically, the resulting Interval has the maximum start time and the minimum end time of the two Intervals.
@@ -4376,88 +4941,101 @@ class Interval {
    * @param {Interval} other
    * @return {Interval}
    */
+
+
   intersection(other) {
     if (!this.isValid) return this;
-    var s = this.s > other.s ? this.s : other.s,
-      e = this.e < other.e ? this.e : other.e;
+    const s = this.s > other.s ? this.s : other.s,
+          e = this.e < other.e ? this.e : other.e;
+
     if (s >= e) {
       return null;
     } else {
       return Interval.fromDateTimes(s, e);
     }
   }
-
   /**
    * Return an Interval representing the union of this Interval and the specified Interval.
    * Specifically, the resulting Interval has the minimum start time and the maximum end time of the two Intervals.
    * @param {Interval} other
    * @return {Interval}
    */
+
+
   union(other) {
     if (!this.isValid) return this;
-    var s = this.s < other.s ? this.s : other.s,
-      e = this.e > other.e ? this.e : other.e;
+    const s = this.s < other.s ? this.s : other.s,
+          e = this.e > other.e ? this.e : other.e;
     return Interval.fromDateTimes(s, e);
   }
-
   /**
    * Merge an array of Intervals into a equivalent minimal set of Intervals.
    * Combines overlapping and adjacent Intervals.
    * @param {Array} intervals
    * @return {Array}
    */
+
+
   static merge(intervals) {
-    var _intervals$sort$reduc = intervals.sort((a, b) => a.s - b.s).reduce((_ref2, item) => {
-        var _ref3 = interval_slicedToArray(_ref2, 2),
+    const _intervals$sort$reduc = intervals.sort((a, b) => a.s - b.s).reduce((_ref2, item) => {
+      let _ref3 = interval_slicedToArray(_ref2, 2),
           sofar = _ref3[0],
           current = _ref3[1];
-        if (!current) {
-          return [sofar, item];
-        } else if (current.overlaps(item) || current.abutsStart(item)) {
-          return [sofar, current.union(item)];
-        } else {
-          return [sofar.concat([current]), item];
-        }
-      }, [[], null]),
-      _intervals$sort$reduc2 = interval_slicedToArray(_intervals$sort$reduc, 2),
-      found = _intervals$sort$reduc2[0],
-      final = _intervals$sort$reduc2[1];
+
+      if (!current) {
+        return [sofar, item];
+      } else if (current.overlaps(item) || current.abutsStart(item)) {
+        return [sofar, current.union(item)];
+      } else {
+        return [sofar.concat([current]), item];
+      }
+    }, [[], null]),
+          _intervals$sort$reduc2 = interval_slicedToArray(_intervals$sort$reduc, 2),
+          found = _intervals$sort$reduc2[0],
+          final = _intervals$sort$reduc2[1];
+
     if (final) {
       found.push(final);
     }
+
     return found;
   }
-
   /**
    * Return an array of Intervals representing the spans of time that only appear in one of the specified Intervals.
    * @param {Array} intervals
    * @return {Array}
    */
+
+
   static xor(intervals) {
-    var start = null,
-      currentCount = 0;
-    var results = [],
-      ends = intervals.map(i => [{
-        time: i.s,
-        type: "s"
-      }, {
-        time: i.e,
-        type: "e"
-      }]),
-      flattened = Array.prototype.concat(...ends),
-      arr = flattened.sort((a, b) => a.time - b.time);
+    let start = null,
+        currentCount = 0;
+    const results = [],
+          ends = intervals.map(i => [{
+      time: i.s,
+      type: "s"
+    }, {
+      time: i.e,
+      type: "e"
+    }]),
+          flattened = Array.prototype.concat(...ends),
+          arr = flattened.sort((a, b) => a.time - b.time);
+
     var _iterator = interval_createForOfIteratorHelper(arr),
-      _step;
+        _step;
+
     try {
       for (_iterator.s(); !(_step = _iterator.n()).done;) {
-        var i = _step.value;
+        const i = _step.value;
         currentCount += i.type === "s" ? 1 : -1;
+
         if (currentCount === 1) {
           start = i.time;
         } else {
           if (start && +start !== +i.time) {
             results.push(Interval.fromDateTimes(start, i.time));
           }
+
           start = null;
         }
       }
@@ -4466,30 +5044,33 @@ class Interval {
     } finally {
       _iterator.f();
     }
+
     return Interval.merge(results);
   }
-
   /**
    * Return an Interval representing the span of time in this Interval that doesn't overlap with any of the specified Intervals.
    * @param {...Interval} intervals
    * @return {Array}
    */
+
+
   difference() {
     for (var _len2 = arguments.length, intervals = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
       intervals[_key2] = arguments[_key2];
     }
+
     return Interval.xor([this].concat(intervals)).map(i => this.intersection(i)).filter(i => i && !i.isEmpty());
   }
-
   /**
    * Returns a string representation of this Interval appropriate for debugging.
    * @return {string}
    */
+
+
   toString() {
     if (!this.isValid) return interval_INVALID;
     return `[${this.s.toISO()} – ${this.e.toISO()})`;
   }
-
   /**
    * Returns a localized string representing this Interval. Accepts the same options as the
    * Intl.DateTimeFormat constructor and any presets defined by Luxon, such as
@@ -4508,34 +5089,37 @@ class Interval {
    * @example Interval.fromISO('2022-11-07T17:00Z/2022-11-07T19:00Z').toLocaleString({ weekday: 'short', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }); //=> Mon, Nov 07, 6:00 – 8:00 p
    * @return {string}
    */
+
+
   toLocaleString() {
-    var formatOpts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : DATE_SHORT;
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    let formatOpts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : DATE_SHORT;
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     return this.isValid ? Formatter.create(this.s.loc.clone(opts), formatOpts).formatInterval(this) : interval_INVALID;
   }
-
   /**
    * Returns an ISO 8601-compliant string representation of this Interval.
    * @see https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
    * @param {Object} opts - The same options as {@link DateTime#toISO}
    * @return {string}
    */
+
+
   toISO(opts) {
     if (!this.isValid) return interval_INVALID;
     return `${this.s.toISO(opts)}/${this.e.toISO(opts)}`;
   }
-
   /**
    * Returns an ISO 8601-compliant string representation of date of this Interval.
    * The time components are ignored.
    * @see https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
    * @return {string}
    */
+
+
   toISODate() {
     if (!this.isValid) return interval_INVALID;
     return `${this.s.toISODate()}/${this.e.toISODate()}`;
   }
-
   /**
    * Returns an ISO 8601-compliant string representation of time of this Interval.
    * The date components are ignored.
@@ -4543,11 +5127,12 @@ class Interval {
    * @param {Object} opts - The same options as {@link DateTime#toISO}
    * @return {string}
    */
+
+
   toISOTime(opts) {
     if (!this.isValid) return interval_INVALID;
     return `${this.s.toISOTime(opts)}/${this.e.toISOTime(opts)}`;
   }
-
   /**
    * Returns a string representation of this Interval formatted according to the specified format
    * string. **You may not want this.** See {@link Interval#toLocaleString} for a more flexible
@@ -4559,14 +5144,16 @@ class Interval {
    * representations.
    * @return {string}
    */
+
+
   toFormat(dateFormat) {
-    var _ref4 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-      _ref4$separator = _ref4.separator,
-      separator = _ref4$separator === void 0 ? " – " : _ref4$separator;
+    let _ref4 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+        _ref4$separator = _ref4.separator,
+        separator = _ref4$separator === void 0 ? " – " : _ref4$separator;
+
     if (!this.isValid) return interval_INVALID;
     return `${this.s.toFormat(dateFormat)}${separator}${this.e.toFormat(dateFormat)}`;
   }
-
   /**
    * Return a Duration representing the time spanned by this interval.
    * @param {string|string[]} [unit=['milliseconds']] - the unit or units (such as 'hours' or 'days') to include in the duration.
@@ -4579,13 +5166,15 @@ class Interval {
    * @example Interval.fromDateTimes(dt1, dt2).toDuration('seconds').toObject() //=> { seconds: 88489.257 }
    * @return {Duration}
    */
+
+
   toDuration(unit, opts) {
     if (!this.isValid) {
       return Duration.invalid(this.invalidReason);
     }
+
     return this.e.diff(this.s, unit, opts);
   }
-
   /**
    * Run mapFn on the interval start and end, returning a new Interval from the resulting DateTimes
    * @param {function} mapFn
@@ -4593,12 +5182,14 @@ class Interval {
    * @example Interval.fromDateTimes(dt1, dt2).mapEndpoints(endpoint => endpoint.toUTC())
    * @example Interval.fromDateTimes(dt1, dt2).mapEndpoints(endpoint => endpoint.plus({ hours: 2 }))
    */
+
+
   mapEndpoints(mapFn) {
     return Interval.fromDateTimes(mapFn(this.s), mapFn(this.e));
   }
+
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/info.js
-
 
 
 
@@ -4608,6 +5199,7 @@ class Interval {
 /**
  * The Info class contains static methods for retrieving general time and date related data. For example, it has methods for finding out if a time zone has a DST, for listing the months in any supported locale, and for discovering which of Luxon features are available in the current environment.
  */
+
 class Info {
   /**
    * Return whether the specified zone contains a DST.
@@ -4615,24 +5207,24 @@ class Info {
    * @return {boolean}
    */
   static hasDST() {
-    var zone = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : Settings.defaultZone;
-    var proto = DateTime.now().setZone(zone).set({
+    let zone = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : Settings.defaultZone;
+    const proto = DateTime.now().setZone(zone).set({
       month: 12
     });
     return !zone.isUniversal && proto.offset !== proto.set({
       month: 6
     }).offset;
   }
-
   /**
    * Return whether the specified zone is a valid IANA specifier.
    * @param {string} zone - Zone to check
    * @return {boolean}
    */
+
+
   static isValidIANAZone(zone) {
     return IANAZone.isValidZone(zone);
   }
-
   /**
    * Converts the input into a {@link Zone} instance.
    *
@@ -4647,10 +5239,11 @@ class Info {
    * @param {string|Zone|number} [input] - the value to be converted
    * @return {Zone}
    */
+
+
   static normalizeZone(input) {
     return normalizeZone(input, Settings.defaultZone);
   }
-
   /**
    * Return an array of standalone month names.
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
@@ -4668,20 +5261,23 @@ class Info {
    * @example Info.months('long', { outputCalendar: 'islamic' })[0] //=> 'Rabiʻ I'
    * @return {Array}
    */
+
+
   static months() {
-    var length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "long";
-    var _ref = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-      _ref$locale = _ref.locale,
-      locale = _ref$locale === void 0 ? null : _ref$locale,
-      _ref$numberingSystem = _ref.numberingSystem,
-      numberingSystem = _ref$numberingSystem === void 0 ? null : _ref$numberingSystem,
-      _ref$locObj = _ref.locObj,
-      locObj = _ref$locObj === void 0 ? null : _ref$locObj,
-      _ref$outputCalendar = _ref.outputCalendar,
-      outputCalendar = _ref$outputCalendar === void 0 ? "gregory" : _ref$outputCalendar;
+    let length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "long";
+
+    let _ref = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+        _ref$locale = _ref.locale,
+        locale = _ref$locale === void 0 ? null : _ref$locale,
+        _ref$numberingSystem = _ref.numberingSystem,
+        numberingSystem = _ref$numberingSystem === void 0 ? null : _ref$numberingSystem,
+        _ref$locObj = _ref.locObj,
+        locObj = _ref$locObj === void 0 ? null : _ref$locObj,
+        _ref$outputCalendar = _ref.outputCalendar,
+        outputCalendar = _ref$outputCalendar === void 0 ? "gregory" : _ref$outputCalendar;
+
     return (locObj || Locale.create(locale, numberingSystem, outputCalendar)).months(length);
   }
-
   /**
    * Return an array of format month names.
    * Format months differ from standalone months in that they're meant to appear next to the day of the month. In some languages, that
@@ -4695,20 +5291,23 @@ class Info {
    * @param {string} [opts.outputCalendar='gregory'] - the calendar
    * @return {Array}
    */
+
+
   static monthsFormat() {
-    var length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "long";
-    var _ref2 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-      _ref2$locale = _ref2.locale,
-      locale = _ref2$locale === void 0 ? null : _ref2$locale,
-      _ref2$numberingSystem = _ref2.numberingSystem,
-      numberingSystem = _ref2$numberingSystem === void 0 ? null : _ref2$numberingSystem,
-      _ref2$locObj = _ref2.locObj,
-      locObj = _ref2$locObj === void 0 ? null : _ref2$locObj,
-      _ref2$outputCalendar = _ref2.outputCalendar,
-      outputCalendar = _ref2$outputCalendar === void 0 ? "gregory" : _ref2$outputCalendar;
+    let length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "long";
+
+    let _ref2 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+        _ref2$locale = _ref2.locale,
+        locale = _ref2$locale === void 0 ? null : _ref2$locale,
+        _ref2$numberingSystem = _ref2.numberingSystem,
+        numberingSystem = _ref2$numberingSystem === void 0 ? null : _ref2$numberingSystem,
+        _ref2$locObj = _ref2.locObj,
+        locObj = _ref2$locObj === void 0 ? null : _ref2$locObj,
+        _ref2$outputCalendar = _ref2.outputCalendar,
+        outputCalendar = _ref2$outputCalendar === void 0 ? "gregory" : _ref2$outputCalendar;
+
     return (locObj || Locale.create(locale, numberingSystem, outputCalendar)).months(length, true);
   }
-
   /**
    * Return an array of standalone week names.
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
@@ -4723,18 +5322,21 @@ class Info {
    * @example Info.weekdays('short', { locale: 'ar' })[0] //=> 'الاثنين'
    * @return {Array}
    */
+
+
   static weekdays() {
-    var length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "long";
-    var _ref3 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-      _ref3$locale = _ref3.locale,
-      locale = _ref3$locale === void 0 ? null : _ref3$locale,
-      _ref3$numberingSystem = _ref3.numberingSystem,
-      numberingSystem = _ref3$numberingSystem === void 0 ? null : _ref3$numberingSystem,
-      _ref3$locObj = _ref3.locObj,
-      locObj = _ref3$locObj === void 0 ? null : _ref3$locObj;
+    let length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "long";
+
+    let _ref3 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+        _ref3$locale = _ref3.locale,
+        locale = _ref3$locale === void 0 ? null : _ref3$locale,
+        _ref3$numberingSystem = _ref3.numberingSystem,
+        numberingSystem = _ref3$numberingSystem === void 0 ? null : _ref3$numberingSystem,
+        _ref3$locObj = _ref3.locObj,
+        locObj = _ref3$locObj === void 0 ? null : _ref3$locObj;
+
     return (locObj || Locale.create(locale, numberingSystem, null)).weekdays(length);
   }
-
   /**
    * Return an array of format week names.
    * Format weekdays differ from standalone weekdays in that they're meant to appear next to more date information. In some languages, that
@@ -4747,18 +5349,21 @@ class Info {
    * @param {string} [opts.locObj=null] - an existing locale object to use
    * @return {Array}
    */
+
+
   static weekdaysFormat() {
-    var length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "long";
-    var _ref4 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-      _ref4$locale = _ref4.locale,
-      locale = _ref4$locale === void 0 ? null : _ref4$locale,
-      _ref4$numberingSystem = _ref4.numberingSystem,
-      numberingSystem = _ref4$numberingSystem === void 0 ? null : _ref4$numberingSystem,
-      _ref4$locObj = _ref4.locObj,
-      locObj = _ref4$locObj === void 0 ? null : _ref4$locObj;
+    let length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "long";
+
+    let _ref4 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+        _ref4$locale = _ref4.locale,
+        locale = _ref4$locale === void 0 ? null : _ref4$locale,
+        _ref4$numberingSystem = _ref4.numberingSystem,
+        numberingSystem = _ref4$numberingSystem === void 0 ? null : _ref4$numberingSystem,
+        _ref4$locObj = _ref4.locObj,
+        locObj = _ref4$locObj === void 0 ? null : _ref4$locObj;
+
     return (locObj || Locale.create(locale, numberingSystem, null)).weekdays(length, true);
   }
-
   /**
    * Return an array of meridiems.
    * @param {Object} opts - options
@@ -4767,13 +5372,15 @@ class Info {
    * @example Info.meridiems({ locale: 'my' }) //=> [ 'နံနက်', 'ညနေ' ]
    * @return {Array}
    */
+
+
   static meridiems() {
-    var _ref5 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-      _ref5$locale = _ref5.locale,
-      locale = _ref5$locale === void 0 ? null : _ref5$locale;
+    let _ref5 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+        _ref5$locale = _ref5.locale,
+        locale = _ref5$locale === void 0 ? null : _ref5$locale;
+
     return Locale.create(locale).meridiems();
   }
-
   /**
    * Return an array of eras, such as ['BC', 'AD']. The locale can be specified, but the calendar system is always Gregorian.
    * @param {string} [length='short'] - the length of the era representation, such as "short" or "long".
@@ -4784,14 +5391,17 @@ class Info {
    * @example Info.eras('long', { locale: 'fr' }) //=> [ 'avant Jésus-Christ', 'après Jésus-Christ' ]
    * @return {Array}
    */
+
+
   static eras() {
-    var length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "short";
-    var _ref6 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-      _ref6$locale = _ref6.locale,
-      locale = _ref6$locale === void 0 ? null : _ref6$locale;
+    let length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "short";
+
+    let _ref6 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+        _ref6$locale = _ref6.locale,
+        locale = _ref6$locale === void 0 ? null : _ref6$locale;
+
     return Locale.create(locale, null, "gregory").eras(length);
   }
-
   /**
    * Return the set of available features in this environment.
    * Some features of Luxon are not available in all environments. For example, on older browsers, relative time formatting support is not available. Use this function to figure out if that's the case.
@@ -4800,43 +5410,58 @@ class Info {
    * @example Info.features() //=> { relative: false }
    * @return {Object}
    */
+
+
   static features() {
     return {
       relative: hasRelative()
     };
   }
+
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/diff.js
 function diff_slicedToArray(arr, i) { return diff_arrayWithHoles(arr) || diff_iterableToArrayLimit(arr, i) || diff_unsupportedIterableToArray(arr, i) || diff_nonIterableRest(); }
+
 function diff_nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
 function diff_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return diff_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return diff_arrayLikeToArray(o, minLen); }
+
 function diff_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-function diff_iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
+
+function diff_iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
 function diff_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
+
+
 function dayDiff(earlier, later) {
-  var utcDayStart = dt => dt.toUTC(0, {
-      keepLocalTime: true
-    }).startOf("day").valueOf(),
-    ms = utcDayStart(later) - utcDayStart(earlier);
+  const utcDayStart = dt => dt.toUTC(0, {
+    keepLocalTime: true
+  }).startOf("day").valueOf(),
+        ms = utcDayStart(later) - utcDayStart(earlier);
+
   return Math.floor(Duration.fromMillis(ms).as("days"));
 }
+
 function highOrderDiffs(cursor, later, units) {
-  var differs = [["years", (a, b) => b.year - a.year], ["quarters", (a, b) => b.quarter - a.quarter + (b.year - a.year) * 4], ["months", (a, b) => b.month - a.month + (b.year - a.year) * 12], ["weeks", (a, b) => {
-    var days = dayDiff(a, b);
+  const differs = [["years", (a, b) => b.year - a.year], ["quarters", (a, b) => b.quarter - a.quarter + (b.year - a.year) * 4], ["months", (a, b) => b.month - a.month + (b.year - a.year) * 12], ["weeks", (a, b) => {
+    const days = dayDiff(a, b);
     return (days - days % 7) / 7;
   }], ["days", dayDiff]];
-  var results = {};
-  var earlier = cursor;
-  var lowestOrder, highWater;
+  const results = {};
+  const earlier = cursor;
+  let lowestOrder, highWater;
+
   for (var _i = 0, _differs = differs; _i < _differs.length; _i++) {
-    var _differs$_i = diff_slicedToArray(_differs[_i], 2),
-      unit = _differs$_i[0],
-      differ = _differs$_i[1];
+    const _differs$_i = diff_slicedToArray(_differs[_i], 2),
+          unit = _differs$_i[0],
+          differ = _differs$_i[1];
+
     if (units.indexOf(unit) >= 0) {
       lowestOrder = unit;
       results[unit] = differ(cursor, later);
       highWater = earlier.plus(results);
+
       if (highWater > later) {
         results[unit]--;
         cursor = earlier.plus(results);
@@ -4845,28 +5470,35 @@ function highOrderDiffs(cursor, later, units) {
       }
     }
   }
+
   return [cursor, results, highWater, lowestOrder];
 }
+
 /* harmony default export */ function diff(earlier, later, units, opts) {
-  var _highOrderDiffs = highOrderDiffs(earlier, later, units),
-    _highOrderDiffs2 = diff_slicedToArray(_highOrderDiffs, 4),
-    cursor = _highOrderDiffs2[0],
-    results = _highOrderDiffs2[1],
-    highWater = _highOrderDiffs2[2],
-    lowestOrder = _highOrderDiffs2[3];
-  var remainingMillis = later - cursor;
-  var lowerOrderUnits = units.filter(u => ["hours", "minutes", "seconds", "milliseconds"].indexOf(u) >= 0);
+  let _highOrderDiffs = highOrderDiffs(earlier, later, units),
+      _highOrderDiffs2 = diff_slicedToArray(_highOrderDiffs, 4),
+      cursor = _highOrderDiffs2[0],
+      results = _highOrderDiffs2[1],
+      highWater = _highOrderDiffs2[2],
+      lowestOrder = _highOrderDiffs2[3];
+
+  const remainingMillis = later - cursor;
+  const lowerOrderUnits = units.filter(u => ["hours", "minutes", "seconds", "milliseconds"].indexOf(u) >= 0);
+
   if (lowerOrderUnits.length === 0) {
     if (highWater < later) {
       highWater = cursor.plus({
         [lowestOrder]: 1
       });
     }
+
     if (highWater !== cursor) {
       results[lowestOrder] = (results[lowestOrder] || 0) + remainingMillis / (highWater - cursor);
     }
   }
-  var duration = Duration.fromObject(results, opts);
+
+  const duration = Duration.fromObject(results, opts);
+
   if (lowerOrderUnits.length > 0) {
     return Duration.fromMillis(remainingMillis, opts).shiftTo(...lowerOrderUnits).plus(duration);
   } else {
@@ -4875,12 +5507,18 @@ function highOrderDiffs(cursor, later, units) {
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/digits.js
 function digits_slicedToArray(arr, i) { return digits_arrayWithHoles(arr) || digits_iterableToArrayLimit(arr, i) || digits_unsupportedIterableToArray(arr, i) || digits_nonIterableRest(); }
+
 function digits_nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
 function digits_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return digits_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return digits_arrayLikeToArray(o, minLen); }
+
 function digits_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-function digits_iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
+
+function digits_iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
 function digits_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-var numberingSystems = {
+
+const numberingSystems = {
   arab: "[\u0660-\u0669]",
   arabext: "[\u06F0-\u06F9]",
   bali: "[\u1B50-\u1B59]",
@@ -4903,7 +5541,7 @@ var numberingSystems = {
   tibt: "[\u0F20-\u0F29]",
   latn: "\\d"
 };
-var numberingSystemsUTF16 = {
+const numberingSystemsUTF16 = {
   arab: [1632, 1641],
   arabext: [1776, 1785],
   bali: [6992, 7001],
@@ -4924,42 +5562,52 @@ var numberingSystemsUTF16 = {
   thai: [3664, 3673],
   tibt: [3872, 3881]
 };
-var hanidecChars = numberingSystems.hanidec.replace(/[\[|\]]/g, "").split("");
+const hanidecChars = numberingSystems.hanidec.replace(/[\[|\]]/g, "").split("");
 function parseDigits(str) {
-  var value = parseInt(str, 10);
+  let value = parseInt(str, 10);
+
   if (isNaN(value)) {
     value = "";
-    for (var i = 0; i < str.length; i++) {
-      var code = str.charCodeAt(i);
+
+    for (let i = 0; i < str.length; i++) {
+      const code = str.charCodeAt(i);
+
       if (str[i].search(numberingSystems.hanidec) !== -1) {
         value += hanidecChars.indexOf(str[i]);
       } else {
-        for (var key in numberingSystemsUTF16) {
-          var _numberingSystemsUTF = digits_slicedToArray(numberingSystemsUTF16[key], 2),
-            min = _numberingSystemsUTF[0],
-            max = _numberingSystemsUTF[1];
+        for (const key in numberingSystemsUTF16) {
+          const _numberingSystemsUTF = digits_slicedToArray(numberingSystemsUTF16[key], 2),
+                min = _numberingSystemsUTF[0],
+                max = _numberingSystemsUTF[1];
+
           if (code >= min && code <= max) {
             value += code - min;
           }
         }
       }
     }
+
     return parseInt(value, 10);
   } else {
     return value;
   }
 }
 function digitRegex(_ref) {
-  var numberingSystem = _ref.numberingSystem;
-  var append = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "";
+  let numberingSystem = _ref.numberingSystem;
+  let append = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "";
   return new RegExp(`${numberingSystems[numberingSystem || "latn"]}${append}`);
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/tokenParser.js
 function tokenParser_slicedToArray(arr, i) { return tokenParser_arrayWithHoles(arr) || tokenParser_iterableToArrayLimit(arr, i) || tokenParser_unsupportedIterableToArray(arr, i) || tokenParser_nonIterableRest(); }
+
 function tokenParser_nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
 function tokenParser_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return tokenParser_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return tokenParser_arrayLikeToArray(o, minLen); }
+
 function tokenParser_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-function tokenParser_iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
+
+function tokenParser_iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
 function tokenParser_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
@@ -4968,31 +5616,38 @@ function tokenParser_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
 
-var MISSING_FTP = "missing Intl.DateTimeFormat.formatToParts support";
+
+const MISSING_FTP = "missing Intl.DateTimeFormat.formatToParts support";
+
 function intUnit(regex) {
-  var post = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : i => i;
+  let post = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : i => i;
   return {
     regex,
     deser: _ref => {
-      var _ref2 = tokenParser_slicedToArray(_ref, 1),
-        s = _ref2[0];
+      let _ref2 = tokenParser_slicedToArray(_ref, 1),
+          s = _ref2[0];
+
       return post(parseDigits(s));
     }
   };
 }
-var NBSP = String.fromCharCode(160);
-var spaceOrNBSP = `[ ${NBSP}]`;
-var spaceOrNBSPRegExp = new RegExp(spaceOrNBSP, "g");
+
+const NBSP = String.fromCharCode(160);
+const spaceOrNBSP = `[ ${NBSP}]`;
+const spaceOrNBSPRegExp = new RegExp(spaceOrNBSP, "g");
+
 function fixListRegex(s) {
   // make dots optional and also make them literal
   // make space and non breakable space characters interchangeable
   return s.replace(/\./g, "\\.?").replace(spaceOrNBSPRegExp, spaceOrNBSP);
 }
+
 function stripInsensitivities(s) {
   return s.replace(/\./g, "") // ignore dots that were made optional
   .replace(spaceOrNBSPRegExp, " ") // interchange space and nbsp
   .toLowerCase();
 }
+
 function oneOf(strings, startIndex) {
   if (strings === null) {
     return null;
@@ -5000,184 +5655,242 @@ function oneOf(strings, startIndex) {
     return {
       regex: RegExp(strings.map(fixListRegex).join("|")),
       deser: _ref3 => {
-        var _ref4 = tokenParser_slicedToArray(_ref3, 1),
-          s = _ref4[0];
+        let _ref4 = tokenParser_slicedToArray(_ref3, 1),
+            s = _ref4[0];
+
         return strings.findIndex(i => stripInsensitivities(s) === stripInsensitivities(i)) + startIndex;
       }
     };
   }
 }
+
 function offset(regex, groups) {
   return {
     regex,
     deser: _ref5 => {
-      var _ref6 = tokenParser_slicedToArray(_ref5, 3),
-        h = _ref6[1],
-        m = _ref6[2];
+      let _ref6 = tokenParser_slicedToArray(_ref5, 3),
+          h = _ref6[1],
+          m = _ref6[2];
+
       return signedOffset(h, m);
     },
     groups
   };
 }
+
 function simple(regex) {
   return {
     regex,
     deser: _ref7 => {
-      var _ref8 = tokenParser_slicedToArray(_ref7, 1),
-        s = _ref8[0];
+      let _ref8 = tokenParser_slicedToArray(_ref7, 1),
+          s = _ref8[0];
+
       return s;
     }
   };
 }
+
 function escapeToken(value) {
   return value.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&");
 }
+
 function unitForToken(token, loc) {
-  var one = digitRegex(loc),
-    two = digitRegex(loc, "{2}"),
-    three = digitRegex(loc, "{3}"),
-    four = digitRegex(loc, "{4}"),
-    six = digitRegex(loc, "{6}"),
-    oneOrTwo = digitRegex(loc, "{1,2}"),
-    oneToThree = digitRegex(loc, "{1,3}"),
-    oneToSix = digitRegex(loc, "{1,6}"),
-    oneToNine = digitRegex(loc, "{1,9}"),
-    twoToFour = digitRegex(loc, "{2,4}"),
-    fourToSix = digitRegex(loc, "{4,6}"),
-    literal = t => ({
-      regex: RegExp(escapeToken(t.val)),
-      deser: _ref9 => {
-        var _ref10 = tokenParser_slicedToArray(_ref9, 1),
+  const one = digitRegex(loc),
+        two = digitRegex(loc, "{2}"),
+        three = digitRegex(loc, "{3}"),
+        four = digitRegex(loc, "{4}"),
+        six = digitRegex(loc, "{6}"),
+        oneOrTwo = digitRegex(loc, "{1,2}"),
+        oneToThree = digitRegex(loc, "{1,3}"),
+        oneToSix = digitRegex(loc, "{1,6}"),
+        oneToNine = digitRegex(loc, "{1,9}"),
+        twoToFour = digitRegex(loc, "{2,4}"),
+        fourToSix = digitRegex(loc, "{4,6}"),
+        literal = t => ({
+    regex: RegExp(escapeToken(t.val)),
+    deser: _ref9 => {
+      let _ref10 = tokenParser_slicedToArray(_ref9, 1),
           s = _ref10[0];
-        return s;
-      },
-      literal: true
-    }),
-    unitate = t => {
-      if (token.literal) {
+
+      return s;
+    },
+    literal: true
+  }),
+        unitate = t => {
+    if (token.literal) {
+      return literal(t);
+    }
+
+    switch (t.val) {
+      // era
+      case "G":
+        return oneOf(loc.eras("short", false), 0);
+
+      case "GG":
+        return oneOf(loc.eras("long", false), 0);
+      // years
+
+      case "y":
+        return intUnit(oneToSix);
+
+      case "yy":
+        return intUnit(twoToFour, untruncateYear);
+
+      case "yyyy":
+        return intUnit(four);
+
+      case "yyyyy":
+        return intUnit(fourToSix);
+
+      case "yyyyyy":
+        return intUnit(six);
+      // months
+
+      case "M":
+        return intUnit(oneOrTwo);
+
+      case "MM":
+        return intUnit(two);
+
+      case "MMM":
+        return oneOf(loc.months("short", true, false), 1);
+
+      case "MMMM":
+        return oneOf(loc.months("long", true, false), 1);
+
+      case "L":
+        return intUnit(oneOrTwo);
+
+      case "LL":
+        return intUnit(two);
+
+      case "LLL":
+        return oneOf(loc.months("short", false, false), 1);
+
+      case "LLLL":
+        return oneOf(loc.months("long", false, false), 1);
+      // dates
+
+      case "d":
+        return intUnit(oneOrTwo);
+
+      case "dd":
+        return intUnit(two);
+      // ordinals
+
+      case "o":
+        return intUnit(oneToThree);
+
+      case "ooo":
+        return intUnit(three);
+      // time
+
+      case "HH":
+        return intUnit(two);
+
+      case "H":
+        return intUnit(oneOrTwo);
+
+      case "hh":
+        return intUnit(two);
+
+      case "h":
+        return intUnit(oneOrTwo);
+
+      case "mm":
+        return intUnit(two);
+
+      case "m":
+        return intUnit(oneOrTwo);
+
+      case "q":
+        return intUnit(oneOrTwo);
+
+      case "qq":
+        return intUnit(two);
+
+      case "s":
+        return intUnit(oneOrTwo);
+
+      case "ss":
+        return intUnit(two);
+
+      case "S":
+        return intUnit(oneToThree);
+
+      case "SSS":
+        return intUnit(three);
+
+      case "u":
+        return simple(oneToNine);
+
+      case "uu":
+        return simple(oneOrTwo);
+
+      case "uuu":
+        return intUnit(one);
+      // meridiem
+
+      case "a":
+        return oneOf(loc.meridiems(), 0);
+      // weekYear (k)
+
+      case "kkkk":
+        return intUnit(four);
+
+      case "kk":
+        return intUnit(twoToFour, untruncateYear);
+      // weekNumber (W)
+
+      case "W":
+        return intUnit(oneOrTwo);
+
+      case "WW":
+        return intUnit(two);
+      // weekdays
+
+      case "E":
+      case "c":
+        return intUnit(one);
+
+      case "EEE":
+        return oneOf(loc.weekdays("short", false, false), 1);
+
+      case "EEEE":
+        return oneOf(loc.weekdays("long", false, false), 1);
+
+      case "ccc":
+        return oneOf(loc.weekdays("short", true, false), 1);
+
+      case "cccc":
+        return oneOf(loc.weekdays("long", true, false), 1);
+      // offset/zone
+
+      case "Z":
+      case "ZZ":
+        return offset(new RegExp(`([+-]${oneOrTwo.source})(?::(${two.source}))?`), 2);
+
+      case "ZZZ":
+        return offset(new RegExp(`([+-]${oneOrTwo.source})(${two.source})?`), 2);
+      // we don't support ZZZZ (PST) or ZZZZZ (Pacific Standard Time) in parsing
+      // because we don't have any way to figure out what they are
+
+      case "z":
+        return simple(/[a-z_+-/]{1,256}?/i);
+
+      default:
         return literal(t);
-      }
-      switch (t.val) {
-        // era
-        case "G":
-          return oneOf(loc.eras("short", false), 0);
-        case "GG":
-          return oneOf(loc.eras("long", false), 0);
-        // years
-        case "y":
-          return intUnit(oneToSix);
-        case "yy":
-          return intUnit(twoToFour, untruncateYear);
-        case "yyyy":
-          return intUnit(four);
-        case "yyyyy":
-          return intUnit(fourToSix);
-        case "yyyyyy":
-          return intUnit(six);
-        // months
-        case "M":
-          return intUnit(oneOrTwo);
-        case "MM":
-          return intUnit(two);
-        case "MMM":
-          return oneOf(loc.months("short", true, false), 1);
-        case "MMMM":
-          return oneOf(loc.months("long", true, false), 1);
-        case "L":
-          return intUnit(oneOrTwo);
-        case "LL":
-          return intUnit(two);
-        case "LLL":
-          return oneOf(loc.months("short", false, false), 1);
-        case "LLLL":
-          return oneOf(loc.months("long", false, false), 1);
-        // dates
-        case "d":
-          return intUnit(oneOrTwo);
-        case "dd":
-          return intUnit(two);
-        // ordinals
-        case "o":
-          return intUnit(oneToThree);
-        case "ooo":
-          return intUnit(three);
-        // time
-        case "HH":
-          return intUnit(two);
-        case "H":
-          return intUnit(oneOrTwo);
-        case "hh":
-          return intUnit(two);
-        case "h":
-          return intUnit(oneOrTwo);
-        case "mm":
-          return intUnit(two);
-        case "m":
-          return intUnit(oneOrTwo);
-        case "q":
-          return intUnit(oneOrTwo);
-        case "qq":
-          return intUnit(two);
-        case "s":
-          return intUnit(oneOrTwo);
-        case "ss":
-          return intUnit(two);
-        case "S":
-          return intUnit(oneToThree);
-        case "SSS":
-          return intUnit(three);
-        case "u":
-          return simple(oneToNine);
-        case "uu":
-          return simple(oneOrTwo);
-        case "uuu":
-          return intUnit(one);
-        // meridiem
-        case "a":
-          return oneOf(loc.meridiems(), 0);
-        // weekYear (k)
-        case "kkkk":
-          return intUnit(four);
-        case "kk":
-          return intUnit(twoToFour, untruncateYear);
-        // weekNumber (W)
-        case "W":
-          return intUnit(oneOrTwo);
-        case "WW":
-          return intUnit(two);
-        // weekdays
-        case "E":
-        case "c":
-          return intUnit(one);
-        case "EEE":
-          return oneOf(loc.weekdays("short", false, false), 1);
-        case "EEEE":
-          return oneOf(loc.weekdays("long", false, false), 1);
-        case "ccc":
-          return oneOf(loc.weekdays("short", true, false), 1);
-        case "cccc":
-          return oneOf(loc.weekdays("long", true, false), 1);
-        // offset/zone
-        case "Z":
-        case "ZZ":
-          return offset(new RegExp(`([+-]${oneOrTwo.source})(?::(${two.source}))?`), 2);
-        case "ZZZ":
-          return offset(new RegExp(`([+-]${oneOrTwo.source})(${two.source})?`), 2);
-        // we don't support ZZZZ (PST) or ZZZZZ (Pacific Standard Time) in parsing
-        // because we don't have any way to figure out what they are
-        case "z":
-          return simple(/[a-z_+-/]{1,256}?/i);
-        default:
-          return literal(t);
-      }
-    };
-  var unit = unitate(token) || {
+    }
+  };
+
+  const unit = unitate(token) || {
     invalidReason: MISSING_FTP
   };
   unit.token = token;
   return unit;
 }
-var partTypeStyleToTokenVal = {
+
+const partTypeStyleToTokenVal = {
   year: {
     "2-digit": "yy",
     numeric: "yyyyy"
@@ -5215,100 +5928,132 @@ var partTypeStyleToTokenVal = {
     short: "ZZZ"
   }
 };
+
 function tokenForPart(part, formatOpts) {
-  var type = part.type,
-    value = part.value;
+  const type = part.type,
+        value = part.value;
+
   if (type === "literal") {
     return {
       literal: true,
       val: value
     };
   }
-  var style = formatOpts[type];
-  var val = partTypeStyleToTokenVal[type];
+
+  const style = formatOpts[type];
+  let val = partTypeStyleToTokenVal[type];
+
   if (typeof val === "object") {
     val = val[style];
   }
+
   if (val) {
     return {
       literal: false,
       val
     };
   }
+
   return undefined;
 }
+
 function buildRegex(units) {
-  var re = units.map(u => u.regex).reduce((f, r) => `${f}(${r.source})`, "");
+  const re = units.map(u => u.regex).reduce((f, r) => `${f}(${r.source})`, "");
   return [`^${re}$`, units];
 }
+
 function match(input, regex, handlers) {
-  var matches = input.match(regex);
+  const matches = input.match(regex);
+
   if (matches) {
-    var all = {};
-    var matchIndex = 1;
-    for (var i in handlers) {
+    const all = {};
+    let matchIndex = 1;
+
+    for (const i in handlers) {
       if (util_hasOwnProperty(handlers, i)) {
-        var h = handlers[i],
-          groups = h.groups ? h.groups + 1 : 1;
+        const h = handlers[i],
+              groups = h.groups ? h.groups + 1 : 1;
+
         if (!h.literal && h.token) {
           all[h.token.val[0]] = h.deser(matches.slice(matchIndex, matchIndex + groups));
         }
+
         matchIndex += groups;
       }
     }
+
     return [matches, all];
   } else {
     return [matches, {}];
   }
 }
+
 function dateTimeFromMatches(matches) {
-  var toField = token => {
+  const toField = token => {
     switch (token) {
       case "S":
         return "millisecond";
+
       case "s":
         return "second";
+
       case "m":
         return "minute";
+
       case "h":
       case "H":
         return "hour";
+
       case "d":
         return "day";
+
       case "o":
         return "ordinal";
+
       case "L":
       case "M":
         return "month";
+
       case "y":
         return "year";
+
       case "E":
       case "c":
         return "weekday";
+
       case "W":
         return "weekNumber";
+
       case "k":
         return "weekYear";
+
       case "q":
         return "quarter";
+
       default:
         return null;
     }
   };
-  var zone = null;
-  var specificOffset;
+
+  let zone = null;
+  let specificOffset;
+
   if (!isUndefined(matches.z)) {
     zone = IANAZone.create(matches.z);
   }
+
   if (!isUndefined(matches.Z)) {
     if (!zone) {
       zone = new FixedOffsetZone(matches.Z);
     }
+
     specificOffset = matches.Z;
   }
+
   if (!isUndefined(matches.q)) {
     matches.M = (matches.q - 1) * 3 + 1;
   }
+
   if (!isUndefined(matches.h)) {
     if (matches.h < 12 && matches.a === 1) {
       matches.h += 12;
@@ -5316,51 +6061,64 @@ function dateTimeFromMatches(matches) {
       matches.h = 0;
     }
   }
+
   if (matches.G === 0 && matches.y) {
     matches.y = -matches.y;
   }
+
   if (!isUndefined(matches.u)) {
     matches.S = parseMillis(matches.u);
   }
-  var vals = Object.keys(matches).reduce((r, k) => {
-    var f = toField(k);
+
+  const vals = Object.keys(matches).reduce((r, k) => {
+    const f = toField(k);
+
     if (f) {
       r[f] = matches[k];
     }
+
     return r;
   }, {});
   return [vals, zone, specificOffset];
 }
-var dummyDateTimeCache = null;
+
+let dummyDateTimeCache = null;
+
 function getDummyDateTime() {
   if (!dummyDateTimeCache) {
     dummyDateTimeCache = DateTime.fromMillis(1555555555555);
   }
+
   return dummyDateTimeCache;
 }
+
 function maybeExpandMacroToken(token, locale) {
   if (token.literal) {
     return token;
   }
-  var formatOpts = Formatter.macroTokenToFormatOpts(token.val);
-  var tokens = formatOptsToTokens(formatOpts, locale);
+
+  const formatOpts = Formatter.macroTokenToFormatOpts(token.val);
+  const tokens = formatOptsToTokens(formatOpts, locale);
+
   if (tokens == null || tokens.includes(undefined)) {
     return token;
   }
+
   return tokens;
 }
+
 function expandMacroTokens(tokens, locale) {
   return Array.prototype.concat(...tokens.map(t => maybeExpandMacroToken(t, locale)));
 }
-
 /**
  * @private
  */
 
 function explainFromTokens(locale, input, format) {
-  var tokens = expandMacroTokens(Formatter.parseFormat(format), locale),
-    units = tokens.map(t => unitForToken(t, locale)),
-    disqualifyingUnit = units.find(t => t.invalidReason);
+  const tokens = expandMacroTokens(Formatter.parseFormat(format), locale),
+        units = tokens.map(t => unitForToken(t, locale)),
+        disqualifyingUnit = units.find(t => t.invalidReason);
+
   if (disqualifyingUnit) {
     return {
       input,
@@ -5368,23 +6126,25 @@ function explainFromTokens(locale, input, format) {
       invalidReason: disqualifyingUnit.invalidReason
     };
   } else {
-    var _buildRegex = buildRegex(units),
-      _buildRegex2 = tokenParser_slicedToArray(_buildRegex, 2),
-      regexString = _buildRegex2[0],
-      handlers = _buildRegex2[1],
-      regex = RegExp(regexString, "i"),
-      _match = match(input, regex, handlers),
-      _match2 = tokenParser_slicedToArray(_match, 2),
-      rawMatches = _match2[0],
-      matches = _match2[1],
-      _ref11 = matches ? dateTimeFromMatches(matches) : [null, null, undefined],
-      _ref12 = tokenParser_slicedToArray(_ref11, 3),
-      result = _ref12[0],
-      zone = _ref12[1],
-      specificOffset = _ref12[2];
+    const _buildRegex = buildRegex(units),
+          _buildRegex2 = tokenParser_slicedToArray(_buildRegex, 2),
+          regexString = _buildRegex2[0],
+          handlers = _buildRegex2[1],
+          regex = RegExp(regexString, "i"),
+          _match = match(input, regex, handlers),
+          _match2 = tokenParser_slicedToArray(_match, 2),
+          rawMatches = _match2[0],
+          matches = _match2[1],
+          _ref11 = matches ? dateTimeFromMatches(matches) : [null, null, undefined],
+          _ref12 = tokenParser_slicedToArray(_ref11, 3),
+          result = _ref12[0],
+          zone = _ref12[1],
+          specificOffset = _ref12[2];
+
     if (util_hasOwnProperty(matches, "a") && util_hasOwnProperty(matches, "H")) {
       throw new ConflictingSpecificationError("Can't include meridiem when specifying 24-hour format");
     }
+
     return {
       input,
       tokens,
@@ -5398,67 +6158,77 @@ function explainFromTokens(locale, input, format) {
   }
 }
 function parseFromTokens(locale, input, format) {
-  var _explainFromTokens = explainFromTokens(locale, input, format),
-    result = _explainFromTokens.result,
-    zone = _explainFromTokens.zone,
-    specificOffset = _explainFromTokens.specificOffset,
-    invalidReason = _explainFromTokens.invalidReason;
+  const _explainFromTokens = explainFromTokens(locale, input, format),
+        result = _explainFromTokens.result,
+        zone = _explainFromTokens.zone,
+        specificOffset = _explainFromTokens.specificOffset,
+        invalidReason = _explainFromTokens.invalidReason;
+
   return [result, zone, specificOffset, invalidReason];
 }
 function formatOptsToTokens(formatOpts, locale) {
   if (!formatOpts) {
     return null;
   }
-  var formatter = Formatter.create(locale, formatOpts);
-  var parts = formatter.formatDateTimeParts(getDummyDateTime());
+
+  const formatter = Formatter.create(locale, formatOpts);
+  const parts = formatter.formatDateTimeParts(getDummyDateTime());
   return parts.map(p => tokenForPart(p, formatOpts));
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/conversions.js
-function conversions_ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
-function conversions_objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? conversions_ownKeys(Object(t), !0).forEach(function (r) { conversions_defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : conversions_ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function conversions_defineProperty(obj, key, value) { key = conversions_toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function conversions_toPropertyKey(t) { var i = conversions_toPrimitive(t, "string"); return "symbol" == typeof i ? i : i + ""; }
-function conversions_toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
+function conversions_ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
+
+function conversions_objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? conversions_ownKeys(Object(source), !0).forEach(function (key) { conversions_defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : conversions_ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
+
+function conversions_defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 
-var nonLeapLadder = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334],
-  leapLadder = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335];
+
+const nonLeapLadder = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334],
+      leapLadder = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335];
+
 function unitOutOfRange(unit, value) {
   return new Invalid("unit out of range", `you specified ${value} (of type ${typeof value}) as a ${unit}, which is invalid`);
 }
+
 function dayOfWeek(year, month, day) {
-  var d = new Date(Date.UTC(year, month - 1, day));
+  const d = new Date(Date.UTC(year, month - 1, day));
+
   if (year < 100 && year >= 0) {
     d.setUTCFullYear(d.getUTCFullYear() - 1900);
   }
-  var js = d.getUTCDay();
+
+  const js = d.getUTCDay();
   return js === 0 ? 7 : js;
 }
+
 function computeOrdinal(year, month, day) {
   return day + (isLeapYear(year) ? leapLadder : nonLeapLadder)[month - 1];
 }
+
 function uncomputeOrdinal(year, ordinal) {
-  var table = isLeapYear(year) ? leapLadder : nonLeapLadder,
-    month0 = table.findIndex(i => i < ordinal),
-    day = ordinal - table[month0];
+  const table = isLeapYear(year) ? leapLadder : nonLeapLadder,
+        month0 = table.findIndex(i => i < ordinal),
+        day = ordinal - table[month0];
   return {
     month: month0 + 1,
     day
   };
 }
-
 /**
  * @private
  */
 
+
 function gregorianToWeek(gregObj) {
-  var year = gregObj.year,
-    month = gregObj.month,
-    day = gregObj.day,
-    ordinal = computeOrdinal(year, month, day),
-    weekday = dayOfWeek(year, month, day);
-  var weekNumber = Math.floor((ordinal - weekday + 10) / 7),
-    weekYear;
+  const year = gregObj.year,
+        month = gregObj.month,
+        day = gregObj.day,
+        ordinal = computeOrdinal(year, month, day),
+        weekday = dayOfWeek(year, month, day);
+  let weekNumber = Math.floor((ordinal - weekday + 10) / 7),
+      weekYear;
+
   if (weekNumber < 1) {
     weekYear = year - 1;
     weekNumber = weeksInWeekYear(weekYear);
@@ -5468,6 +6238,7 @@ function gregorianToWeek(gregObj) {
   } else {
     weekYear = year;
   }
+
   return conversions_objectSpread({
     weekYear,
     weekNumber,
@@ -5475,13 +6246,14 @@ function gregorianToWeek(gregObj) {
   }, timeObject(gregObj));
 }
 function weekToGregorian(weekData) {
-  var weekYear = weekData.weekYear,
-    weekNumber = weekData.weekNumber,
-    weekday = weekData.weekday,
-    weekdayOfJan4 = dayOfWeek(weekYear, 1, 4),
-    yearInDays = daysInYear(weekYear);
-  var ordinal = weekNumber * 7 + weekday - weekdayOfJan4 - 3,
-    year;
+  const weekYear = weekData.weekYear,
+        weekNumber = weekData.weekNumber,
+        weekday = weekData.weekday,
+        weekdayOfJan4 = dayOfWeek(weekYear, 1, 4),
+        yearInDays = daysInYear(weekYear);
+  let ordinal = weekNumber * 7 + weekday - weekdayOfJan4 - 3,
+      year;
+
   if (ordinal < 1) {
     year = weekYear - 1;
     ordinal += daysInYear(year);
@@ -5491,9 +6263,11 @@ function weekToGregorian(weekData) {
   } else {
     year = weekYear;
   }
-  var _uncomputeOrdinal = uncomputeOrdinal(year, ordinal),
-    month = _uncomputeOrdinal.month,
-    day = _uncomputeOrdinal.day;
+
+  const _uncomputeOrdinal = uncomputeOrdinal(year, ordinal),
+        month = _uncomputeOrdinal.month,
+        day = _uncomputeOrdinal.day;
+
   return conversions_objectSpread({
     year,
     month,
@@ -5501,21 +6275,23 @@ function weekToGregorian(weekData) {
   }, timeObject(weekData));
 }
 function gregorianToOrdinal(gregData) {
-  var year = gregData.year,
-    month = gregData.month,
-    day = gregData.day;
-  var ordinal = computeOrdinal(year, month, day);
+  const year = gregData.year,
+        month = gregData.month,
+        day = gregData.day;
+  const ordinal = computeOrdinal(year, month, day);
   return conversions_objectSpread({
     year,
     ordinal
   }, timeObject(gregData));
 }
 function ordinalToGregorian(ordinalData) {
-  var year = ordinalData.year,
-    ordinal = ordinalData.ordinal;
-  var _uncomputeOrdinal2 = uncomputeOrdinal(year, ordinal),
-    month = _uncomputeOrdinal2.month,
-    day = _uncomputeOrdinal2.day;
+  const year = ordinalData.year,
+        ordinal = ordinalData.ordinal;
+
+  const _uncomputeOrdinal2 = uncomputeOrdinal(year, ordinal),
+        month = _uncomputeOrdinal2.month,
+        day = _uncomputeOrdinal2.day;
+
   return conversions_objectSpread({
     year,
     month,
@@ -5523,9 +6299,10 @@ function ordinalToGregorian(ordinalData) {
   }, timeObject(ordinalData));
 }
 function hasInvalidWeekData(obj) {
-  var validYear = isInteger(obj.weekYear),
-    validWeek = integerBetween(obj.weekNumber, 1, weeksInWeekYear(obj.weekYear)),
-    validWeekday = integerBetween(obj.weekday, 1, 7);
+  const validYear = isInteger(obj.weekYear),
+        validWeek = integerBetween(obj.weekNumber, 1, weeksInWeekYear(obj.weekYear)),
+        validWeekday = integerBetween(obj.weekday, 1, 7);
+
   if (!validYear) {
     return unitOutOfRange("weekYear", obj.weekYear);
   } else if (!validWeek) {
@@ -5535,8 +6312,9 @@ function hasInvalidWeekData(obj) {
   } else return false;
 }
 function hasInvalidOrdinalData(obj) {
-  var validYear = isInteger(obj.year),
-    validOrdinal = integerBetween(obj.ordinal, 1, daysInYear(obj.year));
+  const validYear = isInteger(obj.year),
+        validOrdinal = integerBetween(obj.ordinal, 1, daysInYear(obj.year));
+
   if (!validYear) {
     return unitOutOfRange("year", obj.year);
   } else if (!validOrdinal) {
@@ -5544,9 +6322,10 @@ function hasInvalidOrdinalData(obj) {
   } else return false;
 }
 function hasInvalidGregorianData(obj) {
-  var validYear = isInteger(obj.year),
-    validMonth = integerBetween(obj.month, 1, 12),
-    validDay = integerBetween(obj.day, 1, daysInMonth(obj.year, obj.month));
+  const validYear = isInteger(obj.year),
+        validMonth = integerBetween(obj.month, 1, 12),
+        validDay = integerBetween(obj.day, 1, daysInMonth(obj.year, obj.month));
+
   if (!validYear) {
     return unitOutOfRange("year", obj.year);
   } else if (!validMonth) {
@@ -5556,14 +6335,15 @@ function hasInvalidGregorianData(obj) {
   } else return false;
 }
 function hasInvalidTimeData(obj) {
-  var hour = obj.hour,
-    minute = obj.minute,
-    second = obj.second,
-    millisecond = obj.millisecond;
-  var validHour = integerBetween(hour, 0, 23) || hour === 24 && minute === 0 && second === 0 && millisecond === 0,
-    validMinute = integerBetween(minute, 0, 59),
-    validSecond = integerBetween(second, 0, 59),
-    validMillisecond = integerBetween(millisecond, 0, 999);
+  const hour = obj.hour,
+        minute = obj.minute,
+        second = obj.second,
+        millisecond = obj.millisecond;
+  const validHour = integerBetween(hour, 0, 23) || hour === 24 && minute === 0 && second === 0 && millisecond === 0,
+        validMinute = integerBetween(minute, 0, 59),
+        validSecond = integerBetween(second, 0, 59),
+        validMillisecond = integerBetween(millisecond, 0, 999);
+
   if (!validHour) {
     return unitOutOfRange("hour", hour);
   } else if (!validMinute) {
@@ -5575,18 +6355,25 @@ function hasInvalidTimeData(obj) {
   } else return false;
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/datetime.js
-function datetime_createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = datetime_unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
+function datetime_createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = datetime_unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e2) { throw _e2; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e3) { didErr = true; err = _e3; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
+
 function datetime_slicedToArray(arr, i) { return datetime_arrayWithHoles(arr) || datetime_iterableToArrayLimit(arr, i) || datetime_unsupportedIterableToArray(arr, i) || datetime_nonIterableRest(); }
+
 function datetime_nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
 function datetime_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return datetime_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return datetime_arrayLikeToArray(o, minLen); }
+
 function datetime_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-function datetime_iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
+
+function datetime_iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
 function datetime_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-function datetime_ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
-function datetime_objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? datetime_ownKeys(Object(t), !0).forEach(function (r) { datetime_defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : datetime_ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function datetime_defineProperty(obj, key, value) { key = datetime_toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function datetime_toPropertyKey(t) { var i = datetime_toPrimitive(t, "string"); return "symbol" == typeof i ? i : i + ""; }
-function datetime_toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
+
+function datetime_ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
+
+function datetime_objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? datetime_ownKeys(Object(source), !0).forEach(function (key) { datetime_defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : datetime_ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
+
+function datetime_defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 
 
@@ -5603,24 +6390,27 @@ function datetime_toPrimitive(t, r) { if ("object" != typeof t || !t) return t; 
 
 
 
-var datetime_INVALID = "Invalid DateTime";
-var MAX_DATE = 8.64e15;
+
+const datetime_INVALID = "Invalid DateTime";
+const MAX_DATE = 8.64e15;
+
 function unsupportedZone(zone) {
   return new Invalid("unsupported zone", `the zone "${zone.name}" is not supported`);
-}
+} // we cache week data on the DT object and this intermediates the cache
 
-// we cache week data on the DT object and this intermediates the cache
+
 function possiblyCachedWeekData(dt) {
   if (dt.weekData === null) {
     dt.weekData = gregorianToWeek(dt.c);
   }
-  return dt.weekData;
-}
 
-// clone really means, "make a new object with these modifications". all "setters" really use this
+  return dt.weekData;
+} // clone really means, "make a new object with these modifications". all "setters" really use this
 // to create a new object while only changing some of the properties
+
+
 function datetime_clone(inst, alts) {
-  var current = {
+  const current = {
     ts: inst.ts,
     zone: inst.zone,
     c: inst.c,
@@ -5631,39 +6421,37 @@ function datetime_clone(inst, alts) {
   return new DateTime(datetime_objectSpread(datetime_objectSpread(datetime_objectSpread({}, current), alts), {}, {
     old: current
   }));
-}
-
-// find the right offset a given local time. The o input is our guess, which determines which
+} // find the right offset a given local time. The o input is our guess, which determines which
 // offset we'll pick in ambiguous cases (e.g. there are two 3 AMs b/c Fallback DST)
+
+
 function fixOffset(localTS, o, tz) {
   // Our UTC time is just a guess because our offset is just a guess
-  var utcGuess = localTS - o * 60 * 1000;
+  let utcGuess = localTS - o * 60 * 1000; // Test whether the zone matches the offset for this ts
 
-  // Test whether the zone matches the offset for this ts
-  var o2 = tz.offset(utcGuess);
+  const o2 = tz.offset(utcGuess); // If so, offset didn't change and we're done
 
-  // If so, offset didn't change and we're done
   if (o === o2) {
     return [utcGuess, o];
-  }
+  } // If not, change the ts by the difference in the offset
 
-  // If not, change the ts by the difference in the offset
-  utcGuess -= (o2 - o) * 60 * 1000;
 
-  // If that gives us the local time we want, we're done
-  var o3 = tz.offset(utcGuess);
+  utcGuess -= (o2 - o) * 60 * 1000; // If that gives us the local time we want, we're done
+
+  const o3 = tz.offset(utcGuess);
+
   if (o2 === o3) {
     return [utcGuess, o2];
-  }
+  } // If it's different, we're in a hole time. The offset has changed, but the we don't adjust the time
 
-  // If it's different, we're in a hole time. The offset has changed, but the we don't adjust the time
+
   return [localTS - Math.min(o2, o3) * 60 * 1000, Math.max(o2, o3)];
-}
+} // convert an epoch timestamp into a calendar object with the given offset
 
-// convert an epoch timestamp into a calendar object with the given offset
+
 function tsToObj(ts, offset) {
   ts += offset * 60 * 1000;
-  var d = new Date(ts);
+  const d = new Date(ts);
   return {
     year: d.getUTCFullYear(),
     month: d.getUTCMonth() + 1,
@@ -5673,81 +6461,87 @@ function tsToObj(ts, offset) {
     second: d.getUTCSeconds(),
     millisecond: d.getUTCMilliseconds()
   };
-}
+} // convert a calendar object to a epoch timestamp
 
-// convert a calendar object to a epoch timestamp
+
 function objToTS(obj, offset, zone) {
   return fixOffset(objToLocalTS(obj), offset, zone);
-}
+} // create a new DT instance by adding a duration, adjusting for DSTs
 
-// create a new DT instance by adding a duration, adjusting for DSTs
+
 function adjustTime(inst, dur) {
-  var oPre = inst.o,
-    year = inst.c.year + Math.trunc(dur.years),
-    month = inst.c.month + Math.trunc(dur.months) + Math.trunc(dur.quarters) * 3,
-    c = datetime_objectSpread(datetime_objectSpread({}, inst.c), {}, {
-      year,
-      month,
-      day: Math.min(inst.c.day, daysInMonth(year, month)) + Math.trunc(dur.days) + Math.trunc(dur.weeks) * 7
-    }),
-    millisToAdd = Duration.fromObject({
-      years: dur.years - Math.trunc(dur.years),
-      quarters: dur.quarters - Math.trunc(dur.quarters),
-      months: dur.months - Math.trunc(dur.months),
-      weeks: dur.weeks - Math.trunc(dur.weeks),
-      days: dur.days - Math.trunc(dur.days),
-      hours: dur.hours,
-      minutes: dur.minutes,
-      seconds: dur.seconds,
-      milliseconds: dur.milliseconds
-    }).as("milliseconds"),
-    localTS = objToLocalTS(c);
-  var _fixOffset = fixOffset(localTS, oPre, inst.zone),
-    _fixOffset2 = datetime_slicedToArray(_fixOffset, 2),
-    ts = _fixOffset2[0],
-    o = _fixOffset2[1];
+  const oPre = inst.o,
+        year = inst.c.year + Math.trunc(dur.years),
+        month = inst.c.month + Math.trunc(dur.months) + Math.trunc(dur.quarters) * 3,
+        c = datetime_objectSpread(datetime_objectSpread({}, inst.c), {}, {
+    year,
+    month,
+    day: Math.min(inst.c.day, daysInMonth(year, month)) + Math.trunc(dur.days) + Math.trunc(dur.weeks) * 7
+  }),
+        millisToAdd = Duration.fromObject({
+    years: dur.years - Math.trunc(dur.years),
+    quarters: dur.quarters - Math.trunc(dur.quarters),
+    months: dur.months - Math.trunc(dur.months),
+    weeks: dur.weeks - Math.trunc(dur.weeks),
+    days: dur.days - Math.trunc(dur.days),
+    hours: dur.hours,
+    minutes: dur.minutes,
+    seconds: dur.seconds,
+    milliseconds: dur.milliseconds
+  }).as("milliseconds"),
+        localTS = objToLocalTS(c);
+
+  let _fixOffset = fixOffset(localTS, oPre, inst.zone),
+      _fixOffset2 = datetime_slicedToArray(_fixOffset, 2),
+      ts = _fixOffset2[0],
+      o = _fixOffset2[1];
+
   if (millisToAdd !== 0) {
-    ts += millisToAdd;
-    // that could have changed the offset by going over a DST, but we want to keep the ts the same
+    ts += millisToAdd; // that could have changed the offset by going over a DST, but we want to keep the ts the same
+
     o = inst.zone.offset(ts);
   }
+
   return {
     ts,
     o
   };
-}
-
-// helper useful in turning the results of parsing into real dates
+} // helper useful in turning the results of parsing into real dates
 // by handling the zone options
+
+
 function parseDataToDateTime(parsed, parsedZone, opts, format, text, specificOffset) {
-  var setZone = opts.setZone,
-    zone = opts.zone;
+  const setZone = opts.setZone,
+        zone = opts.zone;
+
   if (parsed && Object.keys(parsed).length !== 0) {
-    var interpretationZone = parsedZone || zone,
-      inst = DateTime.fromObject(parsed, datetime_objectSpread(datetime_objectSpread({}, opts), {}, {
-        zone: interpretationZone,
-        specificOffset
-      }));
+    const interpretationZone = parsedZone || zone,
+          inst = DateTime.fromObject(parsed, datetime_objectSpread(datetime_objectSpread({}, opts), {}, {
+      zone: interpretationZone,
+      specificOffset
+    }));
     return setZone ? inst : inst.setZone(zone);
   } else {
     return DateTime.invalid(new Invalid("unparsable", `the input "${text}" can't be parsed as ${format}`));
   }
-}
-
-// if you want to output a technical format (e.g. RFC 2822), this helper
+} // if you want to output a technical format (e.g. RFC 2822), this helper
 // helps handle the details
+
+
 function toTechFormat(dt, format) {
-  var allowZ = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
+  let allowZ = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
   return dt.isValid ? Formatter.create(Locale.create("en-US"), {
     allowZ,
     forceSimple: true
   }).formatDateTimeFromString(dt, format) : null;
 }
+
 function toISODate(o, extended) {
-  var longFormat = o.c.year > 9999 || o.c.year < 0;
-  var c = "";
+  const longFormat = o.c.year > 9999 || o.c.year < 0;
+  let c = "";
   if (longFormat && o.c.year >= 0) c += "+";
   c += padStart(o.c.year, longFormat ? 6 : 4);
+
   if (extended) {
     c += "-";
     c += padStart(o.c.month);
@@ -5757,26 +6551,33 @@ function toISODate(o, extended) {
     c += padStart(o.c.month);
     c += padStart(o.c.day);
   }
+
   return c;
 }
+
 function toISOTime(o, extended, suppressSeconds, suppressMilliseconds, includeOffset, extendedZone) {
-  var c = padStart(o.c.hour);
+  let c = padStart(o.c.hour);
+
   if (extended) {
     c += ":";
     c += padStart(o.c.minute);
+
     if (o.c.second !== 0 || !suppressSeconds) {
       c += ":";
     }
   } else {
     c += padStart(o.c.minute);
   }
+
   if (o.c.second !== 0 || !suppressSeconds) {
     c += padStart(o.c.second);
+
     if (o.c.millisecond !== 0 || !suppressMilliseconds) {
       c += ".";
       c += padStart(o.c.millisecond, 3);
     }
   }
+
   if (includeOffset) {
     if (o.isOffsetFixed && o.offset === 0 && !extendedZone) {
       c += "Z";
@@ -5792,45 +6593,45 @@ function toISOTime(o, extended, suppressSeconds, suppressMilliseconds, includeOf
       c += padStart(Math.trunc(o.o % 60));
     }
   }
+
   if (extendedZone) {
     c += "[" + o.zone.ianaName + "]";
   }
+
   return c;
-}
+} // defaults for unspecified units in the supported calendars
 
-// defaults for unspecified units in the supported calendars
-var defaultUnitValues = {
-    month: 1,
-    day: 1,
-    hour: 0,
-    minute: 0,
-    second: 0,
-    millisecond: 0
-  },
-  defaultWeekUnitValues = {
-    weekNumber: 1,
-    weekday: 1,
-    hour: 0,
-    minute: 0,
-    second: 0,
-    millisecond: 0
-  },
-  defaultOrdinalUnitValues = {
-    ordinal: 1,
-    hour: 0,
-    minute: 0,
-    second: 0,
-    millisecond: 0
-  };
 
-// Units in the supported calendars, sorted by bigness
-var datetime_orderedUnits = ["year", "month", "day", "hour", "minute", "second", "millisecond"],
-  orderedWeekUnits = ["weekYear", "weekNumber", "weekday", "hour", "minute", "second", "millisecond"],
-  orderedOrdinalUnits = ["year", "ordinal", "hour", "minute", "second", "millisecond"];
+const defaultUnitValues = {
+  month: 1,
+  day: 1,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0
+},
+      defaultWeekUnitValues = {
+  weekNumber: 1,
+  weekday: 1,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0
+},
+      defaultOrdinalUnitValues = {
+  ordinal: 1,
+  hour: 0,
+  minute: 0,
+  second: 0,
+  millisecond: 0
+}; // Units in the supported calendars, sorted by bigness
 
-// standardize case and plurality in units
+const datetime_orderedUnits = ["year", "month", "day", "hour", "minute", "second", "millisecond"],
+      orderedWeekUnits = ["weekYear", "weekNumber", "weekday", "hour", "minute", "second", "millisecond"],
+      orderedOrdinalUnits = ["year", "ordinal", "hour", "minute", "second", "millisecond"]; // standardize case and plurality in units
+
 function normalizeUnit(unit) {
-  var normalized = {
+  const normalized = {
     year: "year",
     years: "year",
     month: "month",
@@ -5858,37 +6659,53 @@ function normalizeUnit(unit) {
   }[unit.toLowerCase()];
   if (!normalized) throw new InvalidUnitError(unit);
   return normalized;
-}
-
-// this is a dumbed down version of fromObject() that runs about 60% faster
+} // this is a dumbed down version of fromObject() that runs about 60% faster
 // but doesn't do any validation, makes a bunch of assumptions about what units
 // are present, and so on.
-function quickDT(obj, opts) {
-  var zone = normalizeZone(opts.zone, Settings.defaultZone),
-    loc = Locale.fromObject(opts),
-    tsNow = Settings.now();
-  var ts, o;
 
-  // assume we have the higher-order units
+
+function quickDT(obj, opts) {
+  const zone = normalizeZone(opts.zone, Settings.defaultZone),
+        loc = Locale.fromObject(opts),
+        tsNow = Settings.now();
+  let ts, o; // assume we have the higher-order units
+
   if (!isUndefined(obj.year)) {
-    for (var _i = 0, _orderedUnits = datetime_orderedUnits; _i < _orderedUnits.length; _i++) {
-      var u = _orderedUnits[_i];
-      if (isUndefined(obj[u])) {
-        obj[u] = defaultUnitValues[u];
+    var _iterator = datetime_createForOfIteratorHelper(datetime_orderedUnits),
+        _step;
+
+    try {
+      for (_iterator.s(); !(_step = _iterator.n()).done;) {
+        const u = _step.value;
+
+        if (isUndefined(obj[u])) {
+          obj[u] = defaultUnitValues[u];
+        }
       }
+    } catch (err) {
+      _iterator.e(err);
+    } finally {
+      _iterator.f();
     }
-    var invalid = hasInvalidGregorianData(obj) || hasInvalidTimeData(obj);
+
+    const invalid = hasInvalidGregorianData(obj) || hasInvalidTimeData(obj);
+
     if (invalid) {
       return DateTime.invalid(invalid);
     }
-    var offsetProvis = zone.offset(tsNow);
+
+    const offsetProvis = zone.offset(tsNow);
+
     var _objToTS = objToTS(obj, offsetProvis, zone);
+
     var _objToTS2 = datetime_slicedToArray(_objToTS, 2);
+
     ts = _objToTS2[0];
     o = _objToTS2[1];
   } else {
     ts = tsNow;
   }
+
   return new DateTime({
     ts,
     zone,
@@ -5896,54 +6713,62 @@ function quickDT(obj, opts) {
     o
   });
 }
+
 function diffRelative(start, end, opts) {
-  var round = isUndefined(opts.round) ? true : opts.round,
-    format = (c, unit) => {
-      c = roundTo(c, round || opts.calendary ? 0 : 2, true);
-      var formatter = end.loc.clone(opts).relFormatter(opts);
-      return formatter.format(c, unit);
-    },
-    differ = unit => {
-      if (opts.calendary) {
-        if (!end.hasSame(start, unit)) {
-          return end.startOf(unit).diff(start.startOf(unit), unit).get(unit);
-        } else return 0;
-      } else {
-        return end.diff(start, unit).get(unit);
-      }
-    };
+  const round = isUndefined(opts.round) ? true : opts.round,
+        format = (c, unit) => {
+    c = roundTo(c, round || opts.calendary ? 0 : 2, true);
+    const formatter = end.loc.clone(opts).relFormatter(opts);
+    return formatter.format(c, unit);
+  },
+        differ = unit => {
+    if (opts.calendary) {
+      if (!end.hasSame(start, unit)) {
+        return end.startOf(unit).diff(start.startOf(unit), unit).get(unit);
+      } else return 0;
+    } else {
+      return end.diff(start, unit).get(unit);
+    }
+  };
+
   if (opts.unit) {
     return format(differ(opts.unit), opts.unit);
   }
-  var _iterator = datetime_createForOfIteratorHelper(opts.units),
-    _step;
+
+  var _iterator2 = datetime_createForOfIteratorHelper(opts.units),
+      _step2;
+
   try {
-    for (_iterator.s(); !(_step = _iterator.n()).done;) {
-      var unit = _step.value;
-      var count = differ(unit);
+    for (_iterator2.s(); !(_step2 = _iterator2.n()).done;) {
+      const unit = _step2.value;
+      const count = differ(unit);
+
       if (Math.abs(count) >= 1) {
         return format(count, unit);
       }
     }
   } catch (err) {
-    _iterator.e(err);
+    _iterator2.e(err);
   } finally {
-    _iterator.f();
+    _iterator2.f();
   }
+
   return format(start > end ? -0 : 0, opts.units[opts.units.length - 1]);
 }
+
 function lastOpts(argList) {
-  var opts = {},
-    args;
+  let opts = {},
+      args;
+
   if (argList.length > 0 && typeof argList[argList.length - 1] === "object") {
     opts = argList[argList.length - 1];
     args = Array.from(argList).slice(0, argList.length - 1);
   } else {
     args = Array.from(argList);
   }
+
   return [opts, args];
 }
-
 /**
  * A DateTime is an immutable data structure representing a specific date and time and accompanying methods. It contains class and instance methods for creating, parsing, interrogating, transforming, and formatting them.
  *
@@ -5964,65 +6789,75 @@ function lastOpts(argList) {
  *
  * There's plenty others documented below. In addition, for more information on subtler topics like internationalization, time zones, alternative calendars, validity, and so on, see the external documentation.
  */
+
+
 class DateTime {
   /**
    * @access private
    */
   constructor(config) {
-    var zone = config.zone || Settings.defaultZone;
-    var invalid = config.invalid || (Number.isNaN(config.ts) ? new Invalid("invalid input") : null) || (!zone.isValid ? unsupportedZone(zone) : null);
+    const zone = config.zone || Settings.defaultZone;
+    let invalid = config.invalid || (Number.isNaN(config.ts) ? new Invalid("invalid input") : null) || (!zone.isValid ? unsupportedZone(zone) : null);
     /**
      * @access private
      */
+
     this.ts = isUndefined(config.ts) ? Settings.now() : config.ts;
-    var c = null,
-      o = null;
+    let c = null,
+        o = null;
+
     if (!invalid) {
-      var unchanged = config.old && config.old.ts === this.ts && config.old.zone.equals(zone);
+      const unchanged = config.old && config.old.ts === this.ts && config.old.zone.equals(zone);
+
       if (unchanged) {
         var _ref = [config.old.c, config.old.o];
         c = _ref[0];
         o = _ref[1];
       } else {
-        var ot = zone.offset(this.ts);
+        const ot = zone.offset(this.ts);
         c = tsToObj(this.ts, ot);
         invalid = Number.isNaN(c.year) ? new Invalid("invalid input") : null;
         c = invalid ? null : c;
         o = invalid ? null : ot;
       }
     }
-
     /**
      * @access private
      */
+
+
     this._zone = zone;
     /**
      * @access private
      */
+
     this.loc = config.loc || Locale.create();
     /**
      * @access private
      */
+
     this.invalid = invalid;
     /**
      * @access private
      */
+
     this.weekData = null;
     /**
      * @access private
      */
+
     this.c = c;
     /**
      * @access private
      */
+
     this.o = o;
     /**
      * @access private
      */
-    this.isLuxonDateTime = true;
-  }
 
-  // CONSTRUCT
+    this.isLuxonDateTime = true;
+  } // CONSTRUCT
 
   /**
    * Create a DateTime for the current instant, in the system's time zone.
@@ -6031,10 +6866,11 @@ class DateTime {
    * @example DateTime.now().toISO() //~> now in the ISO format
    * @return {DateTime}
    */
+
+
   static now() {
     return new DateTime({});
   }
-
   /**
    * Create a local DateTime
    * @param {number} [year] - The calendar year. If omitted (as in, call `local()` with no arguments), the current time will be used
@@ -6056,19 +6892,22 @@ class DateTime {
    * @example DateTime.local(2017, 3, 12, 5, 45, 10, 765)       //~> 2017-03-12T05:45:10.765
    * @return {DateTime}
    */
+
+
   static local() {
-    var _lastOpts = lastOpts(arguments),
-      _lastOpts2 = datetime_slicedToArray(_lastOpts, 2),
-      opts = _lastOpts2[0],
-      args = _lastOpts2[1],
-      _args = datetime_slicedToArray(args, 7),
-      year = _args[0],
-      month = _args[1],
-      day = _args[2],
-      hour = _args[3],
-      minute = _args[4],
-      second = _args[5],
-      millisecond = _args[6];
+    const _lastOpts = lastOpts(arguments),
+          _lastOpts2 = datetime_slicedToArray(_lastOpts, 2),
+          opts = _lastOpts2[0],
+          args = _lastOpts2[1],
+          _args = datetime_slicedToArray(args, 7),
+          year = _args[0],
+          month = _args[1],
+          day = _args[2],
+          hour = _args[3],
+          minute = _args[4],
+          second = _args[5],
+          millisecond = _args[6];
+
     return quickDT({
       year,
       month,
@@ -6079,7 +6918,6 @@ class DateTime {
       millisecond
     }, opts);
   }
-
   /**
    * Create a DateTime in UTC
    * @param {number} [year] - The calendar year. If omitted (as in, call `utc()` with no arguments), the current time will be used
@@ -6104,19 +6942,22 @@ class DateTime {
    * @example DateTime.utc(2017, 3, 12, 5, 45, 10, 765, { locale: "fr" }) //~> 2017-03-12T05:45:10.765Z with a French locale
    * @return {DateTime}
    */
+
+
   static utc() {
-    var _lastOpts3 = lastOpts(arguments),
-      _lastOpts4 = datetime_slicedToArray(_lastOpts3, 2),
-      opts = _lastOpts4[0],
-      args = _lastOpts4[1],
-      _args2 = datetime_slicedToArray(args, 7),
-      year = _args2[0],
-      month = _args2[1],
-      day = _args2[2],
-      hour = _args2[3],
-      minute = _args2[4],
-      second = _args2[5],
-      millisecond = _args2[6];
+    const _lastOpts3 = lastOpts(arguments),
+          _lastOpts4 = datetime_slicedToArray(_lastOpts3, 2),
+          opts = _lastOpts4[0],
+          args = _lastOpts4[1],
+          _args2 = datetime_slicedToArray(args, 7),
+          year = _args2[0],
+          month = _args2[1],
+          day = _args2[2],
+          hour = _args2[3],
+          minute = _args2[4],
+          second = _args2[5],
+          millisecond = _args2[6];
+
     opts.zone = FixedOffsetZone.utcInstance;
     return quickDT({
       year,
@@ -6128,7 +6969,6 @@ class DateTime {
       millisecond
     }, opts);
   }
-
   /**
    * Create a DateTime from a JavaScript Date object. Uses the default zone.
    * @param {Date} date - a JavaScript Date object
@@ -6136,23 +6976,28 @@ class DateTime {
    * @param {string|Zone} [options.zone='local'] - the zone to place the DateTime into
    * @return {DateTime}
    */
+
+
   static fromJSDate(date) {
-    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    var ts = isDate(date) ? date.valueOf() : NaN;
+    let options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    const ts = isDate(date) ? date.valueOf() : NaN;
+
     if (Number.isNaN(ts)) {
       return DateTime.invalid("invalid input");
     }
-    var zoneToUse = normalizeZone(options.zone, Settings.defaultZone);
+
+    const zoneToUse = normalizeZone(options.zone, Settings.defaultZone);
+
     if (!zoneToUse.isValid) {
       return DateTime.invalid(unsupportedZone(zoneToUse));
     }
+
     return new DateTime({
       ts: ts,
       zone: zoneToUse,
       loc: Locale.fromObject(options)
     });
   }
-
   /**
    * Create a DateTime from a number of milliseconds since the epoch (meaning since 1 January 1970 00:00:00 UTC). Uses the default zone.
    * @param {number} milliseconds - a number of milliseconds since 1970 UTC
@@ -6163,8 +7008,11 @@ class DateTime {
    * @param {string} options.numberingSystem - the numbering system to set on the resulting DateTime instance
    * @return {DateTime}
    */
+
+
   static fromMillis(milliseconds) {
-    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    let options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
     if (!isNumber(milliseconds)) {
       throw new InvalidArgumentError(`fromMillis requires a numerical input, but received a ${typeof milliseconds} with value ${milliseconds}`);
     } else if (milliseconds < -MAX_DATE || milliseconds > MAX_DATE) {
@@ -6178,7 +7026,6 @@ class DateTime {
       });
     }
   }
-
   /**
    * Create a DateTime from a number of seconds since the epoch (meaning since 1 January 1970 00:00:00 UTC). Uses the default zone.
    * @param {number} seconds - a number of seconds since 1970 UTC
@@ -6189,8 +7036,11 @@ class DateTime {
    * @param {string} options.numberingSystem - the numbering system to set on the resulting DateTime instance
    * @return {DateTime}
    */
+
+
   static fromSeconds(seconds) {
-    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    let options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
     if (!isNumber(seconds)) {
       throw new InvalidArgumentError("fromSeconds requires a numerical input");
     } else {
@@ -6201,7 +7051,6 @@ class DateTime {
       });
     }
   }
-
   /**
    * Create a DateTime from a JavaScript object with keys like 'year' and 'hour' with reasonable defaults.
    * @param {Object} obj - the object to create the DateTime from
@@ -6230,24 +7079,26 @@ class DateTime {
    * @example DateTime.fromObject({ weekYear: 2016, weekNumber: 2, weekday: 3 }).toISODate() //=> '2016-01-13'
    * @return {DateTime}
    */
+
+
   static fromObject(obj) {
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     obj = obj || {};
-    var zoneToUse = normalizeZone(opts.zone, Settings.defaultZone);
+    const zoneToUse = normalizeZone(opts.zone, Settings.defaultZone);
+
     if (!zoneToUse.isValid) {
       return DateTime.invalid(unsupportedZone(zoneToUse));
     }
-    var tsNow = Settings.now(),
-      offsetProvis = !isUndefined(opts.specificOffset) ? opts.specificOffset : zoneToUse.offset(tsNow),
-      normalized = normalizeObject(obj, normalizeUnit),
-      containsOrdinal = !isUndefined(normalized.ordinal),
-      containsGregorYear = !isUndefined(normalized.year),
-      containsGregorMD = !isUndefined(normalized.month) || !isUndefined(normalized.day),
-      containsGregor = containsGregorYear || containsGregorMD,
-      definiteWeekDef = normalized.weekYear || normalized.weekNumber,
-      loc = Locale.fromObject(opts);
 
-    // cases:
+    const tsNow = Settings.now(),
+          offsetProvis = !isUndefined(opts.specificOffset) ? opts.specificOffset : zoneToUse.offset(tsNow),
+          normalized = normalizeObject(obj, normalizeUnit),
+          containsOrdinal = !isUndefined(normalized.ordinal),
+          containsGregorYear = !isUndefined(normalized.year),
+          containsGregorMD = !isUndefined(normalized.month) || !isUndefined(normalized.day),
+          containsGregor = containsGregorYear || containsGregorMD,
+          definiteWeekDef = normalized.weekYear || normalized.weekNumber,
+          loc = Locale.fromObject(opts); // cases:
     // just a weekday -> this week's instance of that weekday, no worries
     // (gregorian data or ordinal) + (weekYear or weekNumber) -> error
     // (gregorian month or day) + ordinal -> error
@@ -6256,15 +7107,17 @@ class DateTime {
     if ((containsGregor || containsOrdinal) && definiteWeekDef) {
       throw new ConflictingSpecificationError("Can't mix weekYear/weekNumber units with year/month/day or ordinals");
     }
+
     if (containsGregorMD && containsOrdinal) {
       throw new ConflictingSpecificationError("Can't mix ordinal dates with month/day");
     }
-    var useWeekData = definiteWeekDef || normalized.weekday && !containsGregor;
 
-    // configure ourselves to deal with gregorian dates or week stuff
-    var units,
-      defaultValues,
-      objNow = tsToObj(tsNow, offsetProvis);
+    const useWeekData = definiteWeekDef || normalized.weekday && !containsGregor; // configure ourselves to deal with gregorian dates or week stuff
+
+    let units,
+        defaultValues,
+        objNow = tsToObj(tsNow, offsetProvis);
+
     if (useWeekData) {
       units = orderedWeekUnits;
       defaultValues = defaultWeekUnitValues;
@@ -6276,16 +7129,19 @@ class DateTime {
     } else {
       units = datetime_orderedUnits;
       defaultValues = defaultUnitValues;
-    }
+    } // set default values for missing stuff
 
-    // set default values for missing stuff
-    var foundFirst = false;
-    var _iterator2 = datetime_createForOfIteratorHelper(units),
-      _step2;
+
+    let foundFirst = false;
+
+    var _iterator3 = datetime_createForOfIteratorHelper(units),
+        _step3;
+
     try {
-      for (_iterator2.s(); !(_step2 = _iterator2.n()).done;) {
-        var u = _step2.value;
-        var v = normalized[u];
+      for (_iterator3.s(); !(_step3 = _iterator3.n()).done;) {
+        const u = _step3.value;
+        const v = normalized[u];
+
         if (!isUndefined(v)) {
           foundFirst = true;
         } else if (foundFirst) {
@@ -6293,40 +7149,41 @@ class DateTime {
         } else {
           normalized[u] = objNow[u];
         }
-      }
+      } // make sure the values we have are in range
 
-      // make sure the values we have are in range
     } catch (err) {
-      _iterator2.e(err);
+      _iterator3.e(err);
     } finally {
-      _iterator2.f();
+      _iterator3.f();
     }
-    var higherOrderInvalid = useWeekData ? hasInvalidWeekData(normalized) : containsOrdinal ? hasInvalidOrdinalData(normalized) : hasInvalidGregorianData(normalized),
-      invalid = higherOrderInvalid || hasInvalidTimeData(normalized);
+
+    const higherOrderInvalid = useWeekData ? hasInvalidWeekData(normalized) : containsOrdinal ? hasInvalidOrdinalData(normalized) : hasInvalidGregorianData(normalized),
+          invalid = higherOrderInvalid || hasInvalidTimeData(normalized);
+
     if (invalid) {
       return DateTime.invalid(invalid);
-    }
+    } // compute the actual time
 
-    // compute the actual time
-    var gregorian = useWeekData ? weekToGregorian(normalized) : containsOrdinal ? ordinalToGregorian(normalized) : normalized,
-      _objToTS3 = objToTS(gregorian, offsetProvis, zoneToUse),
-      _objToTS4 = datetime_slicedToArray(_objToTS3, 2),
-      tsFinal = _objToTS4[0],
-      offsetFinal = _objToTS4[1],
-      inst = new DateTime({
-        ts: tsFinal,
-        zone: zoneToUse,
-        o: offsetFinal,
-        loc
-      });
 
-    // gregorian data + weekday serves only to validate
+    const gregorian = useWeekData ? weekToGregorian(normalized) : containsOrdinal ? ordinalToGregorian(normalized) : normalized,
+          _objToTS3 = objToTS(gregorian, offsetProvis, zoneToUse),
+          _objToTS4 = datetime_slicedToArray(_objToTS3, 2),
+          tsFinal = _objToTS4[0],
+          offsetFinal = _objToTS4[1],
+          inst = new DateTime({
+      ts: tsFinal,
+      zone: zoneToUse,
+      o: offsetFinal,
+      loc
+    }); // gregorian data + weekday serves only to validate
+
+
     if (normalized.weekday && containsGregor && obj.weekday !== inst.weekday) {
       return DateTime.invalid("mismatched weekday", `you can't specify both a weekday of ${normalized.weekday} and a date of ${inst.toISO()}`);
     }
+
     return inst;
   }
-
   /**
    * Create a DateTime from an ISO 8601 string
    * @param {string} text - the ISO string
@@ -6343,15 +7200,18 @@ class DateTime {
    * @example DateTime.fromISO('2016-W05-4')
    * @return {DateTime}
    */
+
+
   static fromISO(text) {
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    var _parseISODate = parseISODate(text),
-      _parseISODate2 = datetime_slicedToArray(_parseISODate, 2),
-      vals = _parseISODate2[0],
-      parsedZone = _parseISODate2[1];
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+    const _parseISODate = parseISODate(text),
+          _parseISODate2 = datetime_slicedToArray(_parseISODate, 2),
+          vals = _parseISODate2[0],
+          parsedZone = _parseISODate2[1];
+
     return parseDataToDateTime(vals, parsedZone, opts, "ISO 8601", text);
   }
-
   /**
    * Create a DateTime from an RFC 2822 string
    * @param {string} text - the RFC 2822 string
@@ -6366,15 +7226,18 @@ class DateTime {
    * @example DateTime.fromRFC2822('25 Nov 2016 13:23 Z')
    * @return {DateTime}
    */
+
+
   static fromRFC2822(text) {
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    var _parseRFC2822Date = parseRFC2822Date(text),
-      _parseRFC2822Date2 = datetime_slicedToArray(_parseRFC2822Date, 2),
-      vals = _parseRFC2822Date2[0],
-      parsedZone = _parseRFC2822Date2[1];
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+    const _parseRFC2822Date = parseRFC2822Date(text),
+          _parseRFC2822Date2 = datetime_slicedToArray(_parseRFC2822Date, 2),
+          vals = _parseRFC2822Date2[0],
+          parsedZone = _parseRFC2822Date2[1];
+
     return parseDataToDateTime(vals, parsedZone, opts, "RFC 2822", text);
   }
-
   /**
    * Create a DateTime from an HTTP header date
    * @see https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1
@@ -6390,15 +7253,18 @@ class DateTime {
    * @example DateTime.fromHTTP('Sun Nov  6 08:49:37 1994')
    * @return {DateTime}
    */
+
+
   static fromHTTP(text) {
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    var _parseHTTPDate = parseHTTPDate(text),
-      _parseHTTPDate2 = datetime_slicedToArray(_parseHTTPDate, 2),
-      vals = _parseHTTPDate2[0],
-      parsedZone = _parseHTTPDate2[1];
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+    const _parseHTTPDate = parseHTTPDate(text),
+          _parseHTTPDate2 = datetime_slicedToArray(_parseHTTPDate, 2),
+          vals = _parseHTTPDate2[0],
+          parsedZone = _parseHTTPDate2[1];
+
     return parseDataToDateTime(vals, parsedZone, opts, "HTTP", opts);
   }
-
   /**
    * Create a DateTime from an input string and format string.
    * Defaults to en-US if no locale has been specified, regardless of the system's locale. For a table of tokens and their interpretations, see [here](https://moment.github.io/luxon/#/parsing?id=table-of-tokens).
@@ -6412,41 +7278,46 @@ class DateTime {
    * @param {string} opts.outputCalendar - the output calendar to set on the resulting DateTime instance
    * @return {DateTime}
    */
+
+
   static fromFormat(text, fmt) {
-    var opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+    let opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
     if (isUndefined(text) || isUndefined(fmt)) {
       throw new InvalidArgumentError("fromFormat requires an input string and a format");
     }
-    var _opts$locale = opts.locale,
-      locale = _opts$locale === void 0 ? null : _opts$locale,
-      _opts$numberingSystem = opts.numberingSystem,
-      numberingSystem = _opts$numberingSystem === void 0 ? null : _opts$numberingSystem,
-      localeToUse = Locale.fromOpts({
-        locale,
-        numberingSystem,
-        defaultToEN: true
-      }),
-      _parseFromTokens = parseFromTokens(localeToUse, text, fmt),
-      _parseFromTokens2 = datetime_slicedToArray(_parseFromTokens, 4),
-      vals = _parseFromTokens2[0],
-      parsedZone = _parseFromTokens2[1],
-      specificOffset = _parseFromTokens2[2],
-      invalid = _parseFromTokens2[3];
+
+    const _opts$locale = opts.locale,
+          locale = _opts$locale === void 0 ? null : _opts$locale,
+          _opts$numberingSystem = opts.numberingSystem,
+          numberingSystem = _opts$numberingSystem === void 0 ? null : _opts$numberingSystem,
+          localeToUse = Locale.fromOpts({
+      locale,
+      numberingSystem,
+      defaultToEN: true
+    }),
+          _parseFromTokens = parseFromTokens(localeToUse, text, fmt),
+          _parseFromTokens2 = datetime_slicedToArray(_parseFromTokens, 4),
+          vals = _parseFromTokens2[0],
+          parsedZone = _parseFromTokens2[1],
+          specificOffset = _parseFromTokens2[2],
+          invalid = _parseFromTokens2[3];
+
     if (invalid) {
       return DateTime.invalid(invalid);
     } else {
       return parseDataToDateTime(vals, parsedZone, opts, `format ${fmt}`, text, specificOffset);
     }
   }
-
   /**
    * @deprecated use fromFormat instead
    */
+
+
   static fromString(text, fmt) {
-    var opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+    let opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
     return DateTime.fromFormat(text, fmt, opts);
   }
-
   /**
    * Create a DateTime from a SQL date, time, or datetime
    * Defaults to en-US if no locale has been specified, regardless of the system's locale
@@ -6467,27 +7338,35 @@ class DateTime {
    * @example DateTime.fromSQL('09:12:34.342')
    * @return {DateTime}
    */
+
+
   static fromSQL(text) {
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    var _parseSQL = parseSQL(text),
-      _parseSQL2 = datetime_slicedToArray(_parseSQL, 2),
-      vals = _parseSQL2[0],
-      parsedZone = _parseSQL2[1];
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+    const _parseSQL = parseSQL(text),
+          _parseSQL2 = datetime_slicedToArray(_parseSQL, 2),
+          vals = _parseSQL2[0],
+          parsedZone = _parseSQL2[1];
+
     return parseDataToDateTime(vals, parsedZone, opts, "SQL", text);
   }
-
   /**
    * Create an invalid DateTime.
    * @param {DateTime} reason - simple string of why this DateTime is invalid. Should not contain parameters or anything else data-dependent
    * @param {string} [explanation=null] - longer explanation, may include parameters and other useful debugging information
    * @return {DateTime}
    */
+
+
   static invalid(reason) {
-    var explanation = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
+    let explanation = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
+
     if (!reason) {
       throw new InvalidArgumentError("need to specify a reason the DateTime is invalid");
     }
-    var invalid = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
+
+    const invalid = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
+
     if (Settings.throwOnInvalid) {
       throw new InvalidDateTimeError(invalid);
     } else {
@@ -6496,28 +7375,29 @@ class DateTime {
       });
     }
   }
-
   /**
    * Check if an object is an instance of DateTime. Works across context boundaries
    * @param {object} o
    * @return {boolean}
    */
+
+
   static isDateTime(o) {
     return o && o.isLuxonDateTime || false;
   }
-
   /**
    * Produce the format string for a set of options
    * @param formatOpts
    * @param localeOpts
    * @returns {string}
    */
+
+
   static parseFormatForOpts(formatOpts) {
-    var localeOpts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    var tokenList = formatOptsToTokens(formatOpts, Locale.fromObject(localeOpts));
+    let localeOpts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    const tokenList = formatOptsToTokens(formatOpts, Locale.fromObject(localeOpts));
     return !tokenList ? null : tokenList.map(t => t ? t.val : null).join("");
   }
-
   /**
    * Produce the the fully expanded format token for the locale
    * Does NOT quote characters, so quoted tokens will not round trip correctly
@@ -6525,13 +7405,13 @@ class DateTime {
    * @param localeOpts
    * @returns {string}
    */
-  static expandFormat(fmt) {
-    var localeOpts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    var expanded = expandMacroTokens(Formatter.parseFormat(fmt), Locale.fromObject(localeOpts));
-    return expanded.map(t => t.val).join("");
-  }
 
-  // INFO
+
+  static expandFormat(fmt) {
+    let localeOpts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    const expanded = expandMacroTokens(Formatter.parseFormat(fmt), Locale.fromObject(localeOpts));
+    return expanded.map(t => t.val).join("");
+  } // INFO
 
   /**
    * Get the value of unit.
@@ -6540,171 +7420,190 @@ class DateTime {
    * @example DateTime.local(2017, 7, 4).get('day'); //=> 4
    * @return {number}
    */
+
+
   get(unit) {
     return this[unit];
   }
-
   /**
    * Returns whether the DateTime is valid. Invalid DateTimes occur when:
    * * The DateTime was created from invalid calendar information, such as the 13th month or February 30
    * * The DateTime was created by an operation on another invalid date
    * @type {boolean}
    */
+
+
   get isValid() {
     return this.invalid === null;
   }
-
   /**
    * Returns an error code if this DateTime is invalid, or null if the DateTime is valid
    * @type {string}
    */
+
+
   get invalidReason() {
     return this.invalid ? this.invalid.reason : null;
   }
-
   /**
    * Returns an explanation of why this DateTime became invalid, or null if the DateTime is valid
    * @type {string}
    */
+
+
   get invalidExplanation() {
     return this.invalid ? this.invalid.explanation : null;
   }
-
   /**
    * Get the locale of a DateTime, such 'en-GB'. The locale is used when formatting the DateTime
    *
    * @type {string}
    */
+
+
   get locale() {
     return this.isValid ? this.loc.locale : null;
   }
-
   /**
    * Get the numbering system of a DateTime, such 'beng'. The numbering system is used when formatting the DateTime
    *
    * @type {string}
    */
+
+
   get numberingSystem() {
     return this.isValid ? this.loc.numberingSystem : null;
   }
-
   /**
    * Get the output calendar of a DateTime, such 'islamic'. The output calendar is used when formatting the DateTime
    *
    * @type {string}
    */
+
+
   get outputCalendar() {
     return this.isValid ? this.loc.outputCalendar : null;
   }
-
   /**
    * Get the time zone associated with this DateTime.
    * @type {Zone}
    */
+
+
   get zone() {
     return this._zone;
   }
-
   /**
    * Get the name of the time zone.
    * @type {string}
    */
+
+
   get zoneName() {
     return this.isValid ? this.zone.name : null;
   }
-
   /**
    * Get the year
    * @example DateTime.local(2017, 5, 25).year //=> 2017
    * @type {number}
    */
+
+
   get year() {
     return this.isValid ? this.c.year : NaN;
   }
-
   /**
    * Get the quarter
    * @example DateTime.local(2017, 5, 25).quarter //=> 2
    * @type {number}
    */
+
+
   get quarter() {
     return this.isValid ? Math.ceil(this.c.month / 3) : NaN;
   }
-
   /**
    * Get the month (1-12).
    * @example DateTime.local(2017, 5, 25).month //=> 5
    * @type {number}
    */
+
+
   get month() {
     return this.isValid ? this.c.month : NaN;
   }
-
   /**
    * Get the day of the month (1-30ish).
    * @example DateTime.local(2017, 5, 25).day //=> 25
    * @type {number}
    */
+
+
   get day() {
     return this.isValid ? this.c.day : NaN;
   }
-
   /**
    * Get the hour of the day (0-23).
    * @example DateTime.local(2017, 5, 25, 9).hour //=> 9
    * @type {number}
    */
+
+
   get hour() {
     return this.isValid ? this.c.hour : NaN;
   }
-
   /**
    * Get the minute of the hour (0-59).
    * @example DateTime.local(2017, 5, 25, 9, 30).minute //=> 30
    * @type {number}
    */
+
+
   get minute() {
     return this.isValid ? this.c.minute : NaN;
   }
-
   /**
    * Get the second of the minute (0-59).
    * @example DateTime.local(2017, 5, 25, 9, 30, 52).second //=> 52
    * @type {number}
    */
+
+
   get second() {
     return this.isValid ? this.c.second : NaN;
   }
-
   /**
    * Get the millisecond of the second (0-999).
    * @example DateTime.local(2017, 5, 25, 9, 30, 52, 654).millisecond //=> 654
    * @type {number}
    */
+
+
   get millisecond() {
     return this.isValid ? this.c.millisecond : NaN;
   }
-
   /**
    * Get the week year
    * @see https://en.wikipedia.org/wiki/ISO_week_date
    * @example DateTime.local(2014, 12, 31).weekYear //=> 2015
    * @type {number}
    */
+
+
   get weekYear() {
     return this.isValid ? possiblyCachedWeekData(this).weekYear : NaN;
   }
-
   /**
    * Get the week number of the week year (1-52ish).
    * @see https://en.wikipedia.org/wiki/ISO_week_date
    * @example DateTime.local(2017, 5, 25).weekNumber //=> 21
    * @type {number}
    */
+
+
   get weekNumber() {
     return this.isValid ? possiblyCachedWeekData(this).weekNumber : NaN;
   }
-
   /**
    * Get the day of the week.
    * 1 is Monday and 7 is Sunday
@@ -6712,82 +7611,91 @@ class DateTime {
    * @example DateTime.local(2014, 11, 31).weekday //=> 4
    * @type {number}
    */
+
+
   get weekday() {
     return this.isValid ? possiblyCachedWeekData(this).weekday : NaN;
   }
-
   /**
    * Get the ordinal (meaning the day of the year)
    * @example DateTime.local(2017, 5, 25).ordinal //=> 145
    * @type {number|DateTime}
    */
+
+
   get ordinal() {
     return this.isValid ? gregorianToOrdinal(this.c).ordinal : NaN;
   }
-
   /**
    * Get the human readable short month name, such as 'Oct'.
    * Defaults to the system's locale if no locale has been specified
    * @example DateTime.local(2017, 10, 30).monthShort //=> Oct
    * @type {string}
    */
+
+
   get monthShort() {
     return this.isValid ? Info.months("short", {
       locObj: this.loc
     })[this.month - 1] : null;
   }
-
   /**
    * Get the human readable long month name, such as 'October'.
    * Defaults to the system's locale if no locale has been specified
    * @example DateTime.local(2017, 10, 30).monthLong //=> October
    * @type {string}
    */
+
+
   get monthLong() {
     return this.isValid ? Info.months("long", {
       locObj: this.loc
     })[this.month - 1] : null;
   }
-
   /**
    * Get the human readable short weekday, such as 'Mon'.
    * Defaults to the system's locale if no locale has been specified
    * @example DateTime.local(2017, 10, 30).weekdayShort //=> Mon
    * @type {string}
    */
+
+
   get weekdayShort() {
     return this.isValid ? Info.weekdays("short", {
       locObj: this.loc
     })[this.weekday - 1] : null;
   }
-
   /**
    * Get the human readable long weekday, such as 'Monday'.
    * Defaults to the system's locale if no locale has been specified
    * @example DateTime.local(2017, 10, 30).weekdayLong //=> Monday
    * @type {string}
    */
+
+
   get weekdayLong() {
     return this.isValid ? Info.weekdays("long", {
       locObj: this.loc
     })[this.weekday - 1] : null;
   }
-
   /**
    * Get the UTC offset of this DateTime in minutes
    * @example DateTime.now().offset //=> -240
    * @example DateTime.utc().offset //=> 0
    * @type {number}
    */
+
+
   get offset() {
     return this.isValid ? +this.o : NaN;
   }
-
   /**
    * Get the short human name for the zone's current offset, for example "EST" or "EDT".
    * Defaults to the system's locale if no locale has been specified
    * @type {string}
    */
+
+
   get offsetNameShort() {
     if (this.isValid) {
       return this.zone.offsetName(this.ts, {
@@ -6798,12 +7706,13 @@ class DateTime {
       return null;
     }
   }
-
   /**
    * Get the long human name for the zone's current offset, for example "Eastern Standard Time" or "Eastern Daylight Time".
    * Defaults to the system's locale if no locale has been specified
    * @type {string}
    */
+
+
   get offsetNameLong() {
     if (this.isValid) {
       return this.zone.offsetName(this.ts, {
@@ -6814,19 +7723,21 @@ class DateTime {
       return null;
     }
   }
-
   /**
    * Get whether this zone's offset ever changes, as in a DST.
    * @type {boolean}
    */
+
+
   get isOffsetFixed() {
     return this.isValid ? this.zone.isUniversal : null;
   }
-
   /**
    * Get whether the DateTime is in a DST.
    * @type {boolean}
    */
+
+
   get isInDST() {
     if (this.isOffsetFixed) {
       return false;
@@ -6839,37 +7750,39 @@ class DateTime {
       }).offset;
     }
   }
-
   /**
    * Returns true if this DateTime is in a leap year, false otherwise
    * @example DateTime.local(2016).isInLeapYear //=> true
    * @example DateTime.local(2013).isInLeapYear //=> false
    * @type {boolean}
    */
+
+
   get isInLeapYear() {
     return isLeapYear(this.year);
   }
-
   /**
    * Returns the number of days in this DateTime's month
    * @example DateTime.local(2016, 2).daysInMonth //=> 29
    * @example DateTime.local(2016, 3).daysInMonth //=> 31
    * @type {number}
    */
+
+
   get daysInMonth() {
     return daysInMonth(this.year, this.month);
   }
-
   /**
    * Returns the number of days in this DateTime's year
    * @example DateTime.local(2016).daysInYear //=> 366
    * @example DateTime.local(2013).daysInYear //=> 365
    * @type {number}
    */
+
+
   get daysInYear() {
     return this.isValid ? daysInYear(this.year) : NaN;
   }
-
   /**
    * Returns the number of weeks in this DateTime's year
    * @see https://en.wikipedia.org/wiki/ISO_week_date
@@ -6877,30 +7790,33 @@ class DateTime {
    * @example DateTime.local(2013).weeksInWeekYear //=> 52
    * @type {number}
    */
+
+
   get weeksInWeekYear() {
     return this.isValid ? weeksInWeekYear(this.weekYear) : NaN;
   }
-
   /**
    * Returns the resolved Intl options for this DateTime.
    * This is useful in understanding the behavior of formatting methods
    * @param {Object} opts - the same options as toLocaleString
    * @return {Object}
    */
+
+
   resolvedLocaleOptions() {
-    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-    var _Formatter$create$res = Formatter.create(this.loc.clone(opts), opts).resolvedOptions(this),
-      locale = _Formatter$create$res.locale,
-      numberingSystem = _Formatter$create$res.numberingSystem,
-      calendar = _Formatter$create$res.calendar;
+    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+    const _Formatter$create$res = Formatter.create(this.loc.clone(opts), opts).resolvedOptions(this),
+          locale = _Formatter$create$res.locale,
+          numberingSystem = _Formatter$create$res.numberingSystem,
+          calendar = _Formatter$create$res.calendar;
+
     return {
       locale,
       numberingSystem,
       outputCalendar: calendar
     };
-  }
-
-  // TRANSFORM
+  } // TRANSFORM
 
   /**
    * "Set" the DateTime's zone to UTC. Returns a newly-constructed DateTime.
@@ -6910,22 +7826,24 @@ class DateTime {
    * @param {Object} [opts={}] - options to pass to `setZone()`
    * @return {DateTime}
    */
+
+
   toUTC() {
-    var offset = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    let offset = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     return this.setZone(FixedOffsetZone.instance(offset), opts);
   }
-
   /**
    * "Set" the DateTime's zone to the host's local zone. Returns a newly-constructed DateTime.
    *
    * Equivalent to `setZone('local')`
    * @return {DateTime}
    */
+
+
   toLocal() {
     return this.setZone(Settings.defaultZone);
   }
-
   /**
    * "Set" the DateTime's zone to specified zone. Returns a newly-constructed DateTime.
    *
@@ -6935,45 +7853,56 @@ class DateTime {
    * @param {boolean} [opts.keepLocalTime=false] - If true, adjust the underlying time so that the local time stays the same, but in the target zone. You should rarely need this.
    * @return {DateTime}
    */
+
+
   setZone(zone) {
-    var _ref2 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-      _ref2$keepLocalTime = _ref2.keepLocalTime,
-      keepLocalTime = _ref2$keepLocalTime === void 0 ? false : _ref2$keepLocalTime,
-      _ref2$keepCalendarTim = _ref2.keepCalendarTime,
-      keepCalendarTime = _ref2$keepCalendarTim === void 0 ? false : _ref2$keepCalendarTim;
+    let _ref2 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+        _ref2$keepLocalTime = _ref2.keepLocalTime,
+        keepLocalTime = _ref2$keepLocalTime === void 0 ? false : _ref2$keepLocalTime,
+        _ref2$keepCalendarTim = _ref2.keepCalendarTime,
+        keepCalendarTime = _ref2$keepCalendarTim === void 0 ? false : _ref2$keepCalendarTim;
+
     zone = normalizeZone(zone, Settings.defaultZone);
+
     if (zone.equals(this.zone)) {
       return this;
     } else if (!zone.isValid) {
       return DateTime.invalid(unsupportedZone(zone));
     } else {
-      var newTS = this.ts;
+      let newTS = this.ts;
+
       if (keepLocalTime || keepCalendarTime) {
-        var offsetGuess = zone.offset(this.ts);
-        var asObj = this.toObject();
+        const offsetGuess = zone.offset(this.ts);
+        const asObj = this.toObject();
+
         var _objToTS5 = objToTS(asObj, offsetGuess, zone);
+
         var _objToTS6 = datetime_slicedToArray(_objToTS5, 1);
+
         newTS = _objToTS6[0];
       }
+
       return datetime_clone(this, {
         ts: newTS,
         zone
       });
     }
   }
-
   /**
    * "Set" the locale, numberingSystem, or outputCalendar. Returns a newly-constructed DateTime.
    * @param {Object} properties - the properties to set
    * @example DateTime.local(2017, 5, 25).reconfigure({ locale: 'en-GB' })
    * @return {DateTime}
    */
+
+
   reconfigure() {
-    var _ref3 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-      locale = _ref3.locale,
-      numberingSystem = _ref3.numberingSystem,
-      outputCalendar = _ref3.outputCalendar;
-    var loc = this.loc.clone({
+    let _ref3 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+        locale = _ref3.locale,
+        numberingSystem = _ref3.numberingSystem,
+        outputCalendar = _ref3.outputCalendar;
+
+    const loc = this.loc.clone({
       locale,
       numberingSystem,
       outputCalendar
@@ -6982,19 +7911,19 @@ class DateTime {
       loc
     });
   }
-
   /**
    * "Set" the locale. Returns a newly-constructed DateTime.
    * Just a convenient alias for reconfigure({ locale })
    * @example DateTime.local(2017, 5, 25).setLocale('en-GB')
    * @return {DateTime}
    */
+
+
   setLocale(locale) {
     return this.reconfigure({
       locale
     });
   }
-
   /**
    * "Set" the values of specified units. Returns a newly-constructed DateTime.
    * You can only set units with this method; for "setting" metadata, see {@link DateTime#reconfigure} and {@link DateTime#setZone}.
@@ -7005,45 +7934,51 @@ class DateTime {
    * @example dt.set({ year: 2005, ordinal: 234 })
    * @return {DateTime}
    */
+
+
   set(values) {
     if (!this.isValid) return this;
-    var normalized = normalizeObject(values, normalizeUnit),
-      settingWeekStuff = !isUndefined(normalized.weekYear) || !isUndefined(normalized.weekNumber) || !isUndefined(normalized.weekday),
-      containsOrdinal = !isUndefined(normalized.ordinal),
-      containsGregorYear = !isUndefined(normalized.year),
-      containsGregorMD = !isUndefined(normalized.month) || !isUndefined(normalized.day),
-      containsGregor = containsGregorYear || containsGregorMD,
-      definiteWeekDef = normalized.weekYear || normalized.weekNumber;
+    const normalized = normalizeObject(values, normalizeUnit),
+          settingWeekStuff = !isUndefined(normalized.weekYear) || !isUndefined(normalized.weekNumber) || !isUndefined(normalized.weekday),
+          containsOrdinal = !isUndefined(normalized.ordinal),
+          containsGregorYear = !isUndefined(normalized.year),
+          containsGregorMD = !isUndefined(normalized.month) || !isUndefined(normalized.day),
+          containsGregor = containsGregorYear || containsGregorMD,
+          definiteWeekDef = normalized.weekYear || normalized.weekNumber;
+
     if ((containsGregor || containsOrdinal) && definiteWeekDef) {
       throw new ConflictingSpecificationError("Can't mix weekYear/weekNumber units with year/month/day or ordinals");
     }
+
     if (containsGregorMD && containsOrdinal) {
       throw new ConflictingSpecificationError("Can't mix ordinal dates with month/day");
     }
-    var mixed;
+
+    let mixed;
+
     if (settingWeekStuff) {
       mixed = weekToGregorian(datetime_objectSpread(datetime_objectSpread({}, gregorianToWeek(this.c)), normalized));
     } else if (!isUndefined(normalized.ordinal)) {
       mixed = ordinalToGregorian(datetime_objectSpread(datetime_objectSpread({}, gregorianToOrdinal(this.c)), normalized));
     } else {
-      mixed = datetime_objectSpread(datetime_objectSpread({}, this.toObject()), normalized);
-
-      // if we didn't set the day but we ended up on an overflow date,
+      mixed = datetime_objectSpread(datetime_objectSpread({}, this.toObject()), normalized); // if we didn't set the day but we ended up on an overflow date,
       // use the last day of the right month
+
       if (isUndefined(normalized.day)) {
         mixed.day = Math.min(daysInMonth(mixed.year, mixed.month), mixed.day);
       }
     }
-    var _objToTS7 = objToTS(mixed, this.o, this.zone),
-      _objToTS8 = datetime_slicedToArray(_objToTS7, 2),
-      ts = _objToTS8[0],
-      o = _objToTS8[1];
+
+    const _objToTS7 = objToTS(mixed, this.o, this.zone),
+          _objToTS8 = datetime_slicedToArray(_objToTS7, 2),
+          ts = _objToTS8[0],
+          o = _objToTS8[1];
+
     return datetime_clone(this, {
       ts,
       o
     });
   }
-
   /**
    * Add a period of time to this DateTime and return the resulting DateTime
    *
@@ -7057,24 +7992,26 @@ class DateTime {
    * @example DateTime.now().plus(Duration.fromObject({ hours: 3, minutes: 13 })) //~> in 3 hr, 13 min
    * @return {DateTime}
    */
+
+
   plus(duration) {
     if (!this.isValid) return this;
-    var dur = Duration.fromDurationLike(duration);
+    const dur = Duration.fromDurationLike(duration);
     return datetime_clone(this, adjustTime(this, dur));
   }
-
   /**
    * Subtract a period of time to this DateTime and return the resulting DateTime
    * See {@link DateTime#plus}
    * @param {Duration|Object|number} duration - The amount to subtract. Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
    @return {DateTime}
    */
+
+
   minus(duration) {
     if (!this.isValid) return this;
-    var dur = Duration.fromDurationLike(duration).negate();
+    const dur = Duration.fromDurationLike(duration).negate();
     return datetime_clone(this, adjustTime(this, dur));
   }
-
   /**
    * "Set" this DateTime to the beginning of a unit of time.
    * @param {string} unit - The unit to go to the beginning of. Can be 'year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second', or 'millisecond'.
@@ -7085,45 +8022,56 @@ class DateTime {
    * @example DateTime.local(2014, 3, 3, 5, 30).startOf('hour').toISOTime(); //=> '05:00:00.000-05:00'
    * @return {DateTime}
    */
+
+
   startOf(unit) {
     if (!this.isValid) return this;
-    var o = {},
-      normalizedUnit = Duration.normalizeUnit(unit);
+    const o = {},
+          normalizedUnit = Duration.normalizeUnit(unit);
+
     switch (normalizedUnit) {
       case "years":
         o.month = 1;
       // falls through
+
       case "quarters":
       case "months":
         o.day = 1;
       // falls through
+
       case "weeks":
       case "days":
         o.hour = 0;
       // falls through
+
       case "hours":
         o.minute = 0;
       // falls through
+
       case "minutes":
         o.second = 0;
       // falls through
+
       case "seconds":
         o.millisecond = 0;
         break;
+
       case "milliseconds":
         break;
       // no default, invalid units throw in normalizeUnit()
     }
+
     if (normalizedUnit === "weeks") {
       o.weekday = 1;
     }
+
     if (normalizedUnit === "quarters") {
-      var q = Math.ceil(this.month / 3);
+      const q = Math.ceil(this.month / 3);
       o.month = (q - 1) * 3 + 1;
     }
+
     return this.set(o);
   }
-
   /**
    * "Set" this DateTime to the end (meaning the last millisecond) of a unit of time
    * @param {string} unit - The unit to go to the end of. Can be 'year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second', or 'millisecond'.
@@ -7134,13 +8082,13 @@ class DateTime {
    * @example DateTime.local(2014, 3, 3, 5, 30).endOf('hour').toISO(); //=> '2014-03-03T05:59:59.999-05:00'
    * @return {DateTime}
    */
+
+
   endOf(unit) {
     return this.isValid ? this.plus({
       [unit]: 1
     }).startOf(unit).minus(1) : this;
-  }
-
-  // OUTPUT
+  } // OUTPUT
 
   /**
    * Returns a string representation of this DateTime formatted according to the specified format string.
@@ -7154,11 +8102,12 @@ class DateTime {
    * @example DateTime.now().toFormat("HH 'hours and' mm 'minutes'") //=> '20 hours and 55 minutes'
    * @return {string}
    */
+
+
   toFormat(fmt) {
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     return this.isValid ? Formatter.create(this.loc.redefaultToEN(opts)).formatDateTimeFromString(this, fmt) : datetime_INVALID;
   }
-
   /**
    * Returns a localized string representing this date. Accepts the same options as the Intl.DateTimeFormat constructor and any presets defined by Luxon, such as `DateTime.DATE_FULL` or `DateTime.TIME_SIMPLE`.
    * The exact behavior of this method is browser-specific, but in general it will return an appropriate representation
@@ -7178,12 +8127,13 @@ class DateTime {
    * @example DateTime.now().toLocaleString({ hour: '2-digit', minute: '2-digit', hourCycle: 'h23' }); //=> '11:32'
    * @return {string}
    */
+
+
   toLocaleString() {
-    var formatOpts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : DATE_SHORT;
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    let formatOpts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : DATE_SHORT;
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     return this.isValid ? Formatter.create(this.loc.clone(opts), formatOpts).formatDateTime(this) : datetime_INVALID;
   }
-
   /**
    * Returns an array of format "parts", meaning individual tokens along with metadata. This is allows callers to post-process individual sections of the formatted output.
    * Defaults to the system's locale if no locale has been specified
@@ -7197,11 +8147,12 @@ class DateTime {
    *                                   //=>   { type: 'year', value: '1982' }
    *                                   //=> ]
    */
+
+
   toLocaleParts() {
-    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     return this.isValid ? Formatter.create(this.loc.clone(opts), opts).formatDateTimeParts(this) : [];
   }
-
   /**
    * Returns an ISO 8601-compliant string representation of this DateTime
    * @param {Object} opts - options
@@ -7216,28 +8167,31 @@ class DateTime {
    * @example DateTime.now().toISO({ format: 'basic' }) //=> '20170422T204705.335-0400'
    * @return {string}
    */
+
+
   toISO() {
-    var _ref4 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-      _ref4$format = _ref4.format,
-      format = _ref4$format === void 0 ? "extended" : _ref4$format,
-      _ref4$suppressSeconds = _ref4.suppressSeconds,
-      suppressSeconds = _ref4$suppressSeconds === void 0 ? false : _ref4$suppressSeconds,
-      _ref4$suppressMillise = _ref4.suppressMilliseconds,
-      suppressMilliseconds = _ref4$suppressMillise === void 0 ? false : _ref4$suppressMillise,
-      _ref4$includeOffset = _ref4.includeOffset,
-      includeOffset = _ref4$includeOffset === void 0 ? true : _ref4$includeOffset,
-      _ref4$extendedZone = _ref4.extendedZone,
-      extendedZone = _ref4$extendedZone === void 0 ? false : _ref4$extendedZone;
+    let _ref4 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+        _ref4$format = _ref4.format,
+        format = _ref4$format === void 0 ? "extended" : _ref4$format,
+        _ref4$suppressSeconds = _ref4.suppressSeconds,
+        suppressSeconds = _ref4$suppressSeconds === void 0 ? false : _ref4$suppressSeconds,
+        _ref4$suppressMillise = _ref4.suppressMilliseconds,
+        suppressMilliseconds = _ref4$suppressMillise === void 0 ? false : _ref4$suppressMillise,
+        _ref4$includeOffset = _ref4.includeOffset,
+        includeOffset = _ref4$includeOffset === void 0 ? true : _ref4$includeOffset,
+        _ref4$extendedZone = _ref4.extendedZone,
+        extendedZone = _ref4$extendedZone === void 0 ? false : _ref4$extendedZone;
+
     if (!this.isValid) {
       return null;
     }
-    var ext = format === "extended";
-    var c = toISODate(this, ext);
+
+    const ext = format === "extended";
+    let c = toISODate(this, ext);
     c += "T";
     c += toISOTime(this, ext, suppressSeconds, suppressMilliseconds, includeOffset, extendedZone);
     return c;
   }
-
   /**
    * Returns an ISO 8601-compliant string representation of this DateTime's date component
    * @param {Object} opts - options
@@ -7246,25 +8200,29 @@ class DateTime {
    * @example DateTime.utc(1982, 5, 25).toISODate({ format: 'basic' }) //=> '19820525'
    * @return {string}
    */
+
+
   toISODate() {
-    var _ref5 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-      _ref5$format = _ref5.format,
-      format = _ref5$format === void 0 ? "extended" : _ref5$format;
+    let _ref5 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+        _ref5$format = _ref5.format,
+        format = _ref5$format === void 0 ? "extended" : _ref5$format;
+
     if (!this.isValid) {
       return null;
     }
+
     return toISODate(this, format === "extended");
   }
-
   /**
    * Returns an ISO 8601-compliant string representation of this DateTime's week date
    * @example DateTime.utc(1982, 5, 25).toISOWeekDate() //=> '1982-W21-2'
    * @return {string}
    */
+
+
   toISOWeekDate() {
     return toTechFormat(this, "kkkk-'W'WW-c");
   }
-
   /**
    * Returns an ISO 8601-compliant string representation of this DateTime's time component
    * @param {Object} opts - options
@@ -7280,37 +8238,41 @@ class DateTime {
    * @example DateTime.utc().set({ hour: 7, minute: 34 }).toISOTime({ includePrefix: true }) //=> 'T07:34:19.361Z'
    * @return {string}
    */
+
+
   toISOTime() {
-    var _ref6 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-      _ref6$suppressMillise = _ref6.suppressMilliseconds,
-      suppressMilliseconds = _ref6$suppressMillise === void 0 ? false : _ref6$suppressMillise,
-      _ref6$suppressSeconds = _ref6.suppressSeconds,
-      suppressSeconds = _ref6$suppressSeconds === void 0 ? false : _ref6$suppressSeconds,
-      _ref6$includeOffset = _ref6.includeOffset,
-      includeOffset = _ref6$includeOffset === void 0 ? true : _ref6$includeOffset,
-      _ref6$includePrefix = _ref6.includePrefix,
-      includePrefix = _ref6$includePrefix === void 0 ? false : _ref6$includePrefix,
-      _ref6$extendedZone = _ref6.extendedZone,
-      extendedZone = _ref6$extendedZone === void 0 ? false : _ref6$extendedZone,
-      _ref6$format = _ref6.format,
-      format = _ref6$format === void 0 ? "extended" : _ref6$format;
+    let _ref6 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+        _ref6$suppressMillise = _ref6.suppressMilliseconds,
+        suppressMilliseconds = _ref6$suppressMillise === void 0 ? false : _ref6$suppressMillise,
+        _ref6$suppressSeconds = _ref6.suppressSeconds,
+        suppressSeconds = _ref6$suppressSeconds === void 0 ? false : _ref6$suppressSeconds,
+        _ref6$includeOffset = _ref6.includeOffset,
+        includeOffset = _ref6$includeOffset === void 0 ? true : _ref6$includeOffset,
+        _ref6$includePrefix = _ref6.includePrefix,
+        includePrefix = _ref6$includePrefix === void 0 ? false : _ref6$includePrefix,
+        _ref6$extendedZone = _ref6.extendedZone,
+        extendedZone = _ref6$extendedZone === void 0 ? false : _ref6$extendedZone,
+        _ref6$format = _ref6.format,
+        format = _ref6$format === void 0 ? "extended" : _ref6$format;
+
     if (!this.isValid) {
       return null;
     }
-    var c = includePrefix ? "T" : "";
+
+    let c = includePrefix ? "T" : "";
     return c + toISOTime(this, format === "extended", suppressSeconds, suppressMilliseconds, includeOffset, extendedZone);
   }
-
   /**
    * Returns an RFC 2822-compatible string representation of this DateTime
    * @example DateTime.utc(2014, 7, 13).toRFC2822() //=> 'Sun, 13 Jul 2014 00:00:00 +0000'
    * @example DateTime.local(2014, 7, 13).toRFC2822() //=> 'Sun, 13 Jul 2014 00:00:00 -0400'
    * @return {string}
    */
+
+
   toRFC2822() {
     return toTechFormat(this, "EEE, dd LLL yyyy HH:mm:ss ZZZ", false);
   }
-
   /**
    * Returns a string representation of this DateTime appropriate for use in HTTP headers. The output is always expressed in GMT.
    * Specifically, the string conforms to RFC 1123.
@@ -7319,22 +8281,25 @@ class DateTime {
    * @example DateTime.utc(2014, 7, 13, 19).toHTTP() //=> 'Sun, 13 Jul 2014 19:00:00 GMT'
    * @return {string}
    */
+
+
   toHTTP() {
     return toTechFormat(this.toUTC(), "EEE, dd LLL yyyy HH:mm:ss 'GMT'");
   }
-
   /**
    * Returns a string representation of this DateTime appropriate for use in SQL Date
    * @example DateTime.utc(2014, 7, 13).toSQLDate() //=> '2014-07-13'
    * @return {string}
    */
+
+
   toSQLDate() {
     if (!this.isValid) {
       return null;
     }
+
     return toISODate(this, true);
   }
-
   /**
    * Returns a string representation of this DateTime appropriate for use in SQL Time
    * @param {Object} opts - options
@@ -7347,28 +8312,33 @@ class DateTime {
    * @example DateTime.now().toSQL({ includeZone: false }) //=> '05:15:16.345 America/New_York'
    * @return {string}
    */
+
+
   toSQLTime() {
-    var _ref7 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-      _ref7$includeOffset = _ref7.includeOffset,
-      includeOffset = _ref7$includeOffset === void 0 ? true : _ref7$includeOffset,
-      _ref7$includeZone = _ref7.includeZone,
-      includeZone = _ref7$includeZone === void 0 ? false : _ref7$includeZone,
-      _ref7$includeOffsetSp = _ref7.includeOffsetSpace,
-      includeOffsetSpace = _ref7$includeOffsetSp === void 0 ? true : _ref7$includeOffsetSp;
-    var fmt = "HH:mm:ss.SSS";
+    let _ref7 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+        _ref7$includeOffset = _ref7.includeOffset,
+        includeOffset = _ref7$includeOffset === void 0 ? true : _ref7$includeOffset,
+        _ref7$includeZone = _ref7.includeZone,
+        includeZone = _ref7$includeZone === void 0 ? false : _ref7$includeZone,
+        _ref7$includeOffsetSp = _ref7.includeOffsetSpace,
+        includeOffsetSpace = _ref7$includeOffsetSp === void 0 ? true : _ref7$includeOffsetSp;
+
+    let fmt = "HH:mm:ss.SSS";
+
     if (includeZone || includeOffset) {
       if (includeOffsetSpace) {
         fmt += " ";
       }
+
       if (includeZone) {
         fmt += "z";
       } else if (includeOffset) {
         fmt += "ZZ";
       }
     }
+
     return toTechFormat(this, fmt, true);
   }
-
   /**
    * Returns a string representation of this DateTime appropriate for use in SQL DateTime
    * @param {Object} opts - options
@@ -7381,70 +8351,80 @@ class DateTime {
    * @example DateTime.local(2014, 7, 13).toSQL({ includeZone: true }) //=> '2014-07-13 00:00:00.000 America/New_York'
    * @return {string}
    */
+
+
   toSQL() {
-    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
     if (!this.isValid) {
       return null;
     }
+
     return `${this.toSQLDate()} ${this.toSQLTime(opts)}`;
   }
-
   /**
    * Returns a string representation of this DateTime appropriate for debugging
    * @return {string}
    */
+
+
   toString() {
     return this.isValid ? this.toISO() : datetime_INVALID;
   }
-
   /**
    * Returns the epoch milliseconds of this DateTime. Alias of {@link DateTime#toMillis}
    * @return {number}
    */
+
+
   valueOf() {
     return this.toMillis();
   }
-
   /**
    * Returns the epoch milliseconds of this DateTime.
    * @return {number}
    */
+
+
   toMillis() {
     return this.isValid ? this.ts : NaN;
   }
-
   /**
    * Returns the epoch seconds of this DateTime.
    * @return {number}
    */
+
+
   toSeconds() {
     return this.isValid ? this.ts / 1000 : NaN;
   }
-
   /**
    * Returns the epoch seconds (as a whole number) of this DateTime.
    * @return {number}
    */
+
+
   toUnixInteger() {
     return this.isValid ? Math.floor(this.ts / 1000) : NaN;
   }
-
   /**
    * Returns an ISO 8601 representation of this DateTime appropriate for use in JSON.
    * @return {string}
    */
+
+
   toJSON() {
     return this.toISO();
   }
-
   /**
    * Returns a BSON serializable equivalent to this DateTime.
    * @return {Date}
    */
+
+
   toBSON() {
     return this.toJSDate();
   }
-
   /**
    * Returns a JavaScript object with this DateTime's year, month, day, and so on.
    * @param opts - options for generating the object
@@ -7452,27 +8432,31 @@ class DateTime {
    * @example DateTime.now().toObject() //=> { year: 2017, month: 4, day: 22, hour: 20, minute: 49, second: 42, millisecond: 268 }
    * @return {Object}
    */
+
+
   toObject() {
-    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     if (!this.isValid) return {};
-    var base = datetime_objectSpread({}, this.c);
+
+    const base = datetime_objectSpread({}, this.c);
+
     if (opts.includeConfig) {
       base.outputCalendar = this.outputCalendar;
       base.numberingSystem = this.loc.numberingSystem;
       base.locale = this.loc.locale;
     }
+
     return base;
   }
-
   /**
    * Returns a JavaScript Date equivalent to this DateTime.
    * @return {Date}
    */
+
+
   toJSDate() {
     return new Date(this.isValid ? this.ts : NaN);
-  }
-
-  // COMPARE
+  } // COMPARE
 
   /**
    * Return the difference between two DateTimes as a Duration.
@@ -7489,24 +8473,28 @@ class DateTime {
    * i2.diff(i1, ['months', 'days', 'hours']).toObject() //=> { months: 16, days: 19, hours: 0.75 }
    * @return {Duration}
    */
+
+
   diff(otherDateTime) {
-    var unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "milliseconds";
-    var opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+    let unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "milliseconds";
+    let opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
     if (!this.isValid || !otherDateTime.isValid) {
       return Duration.invalid("created by diffing an invalid DateTime");
     }
-    var durOpts = datetime_objectSpread({
+
+    const durOpts = datetime_objectSpread({
       locale: this.locale,
       numberingSystem: this.numberingSystem
     }, opts);
-    var units = maybeArray(unit).map(Duration.normalizeUnit),
-      otherIsLater = otherDateTime.valueOf() > this.valueOf(),
-      earlier = otherIsLater ? this : otherDateTime,
-      later = otherIsLater ? otherDateTime : this,
-      diffed = diff(earlier, later, units, durOpts);
+
+    const units = maybeArray(unit).map(Duration.normalizeUnit),
+          otherIsLater = otherDateTime.valueOf() > this.valueOf(),
+          earlier = otherIsLater ? this : otherDateTime,
+          later = otherIsLater ? otherDateTime : this,
+          diffed = diff(earlier, later, units, durOpts);
     return otherIsLater ? diffed.negate() : diffed;
   }
-
   /**
    * Return the difference between this DateTime and right now.
    * See {@link DateTime#diff}
@@ -7515,21 +8503,23 @@ class DateTime {
    * @param {string} [opts.conversionAccuracy='casual'] - the conversion system to use
    * @return {Duration}
    */
+
+
   diffNow() {
-    var unit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "milliseconds";
-    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    let unit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "milliseconds";
+    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     return this.diff(DateTime.now(), unit, opts);
   }
-
   /**
    * Return an Interval spanning between this DateTime and another DateTime
    * @param {DateTime} otherDateTime - the other end point of the Interval
    * @return {Interval}
    */
+
+
   until(otherDateTime) {
     return this.isValid ? Interval.fromDateTimes(this, otherDateTime) : this;
   }
-
   /**
    * Return whether this DateTime is in the same unit of time as another DateTime.
    * Higher-order units must also be identical for this function to return `true`.
@@ -7539,15 +8529,16 @@ class DateTime {
    * @example DateTime.now().hasSame(otherDT, 'day'); //~> true if otherDT is in the same current calendar day
    * @return {boolean}
    */
+
+
   hasSame(otherDateTime, unit) {
     if (!this.isValid) return false;
-    var inputMs = otherDateTime.valueOf();
-    var adjustedToZone = this.setZone(otherDateTime.zone, {
+    const inputMs = otherDateTime.valueOf();
+    const adjustedToZone = this.setZone(otherDateTime.zone, {
       keepLocalTime: true
     });
     return adjustedToZone.startOf(unit) <= inputMs && inputMs <= adjustedToZone.endOf(unit);
   }
-
   /**
    * Equality check
    * Two DateTimes are equal if and only if they represent the same millisecond, have the same zone and location, and are both valid.
@@ -7555,10 +8546,11 @@ class DateTime {
    * @param {DateTime} other - the other DateTime
    * @return {boolean}
    */
+
+
   equals(other) {
     return this.isValid && other.isValid && this.valueOf() === other.valueOf() && this.zone.equals(other.zone) && this.loc.equals(other.loc);
   }
-
   /**
    * Returns a string representation of a this time relative to now, such as "in two days". Can only internationalize if your
    * platform supports Intl.RelativeTimeFormat. Rounds down by default.
@@ -7577,26 +8569,29 @@ class DateTime {
    * @example DateTime.now().minus({ days: 2 }).toRelative({ unit: "hours" }) //=> "48 hours ago"
    * @example DateTime.now().minus({ hours: 36 }).toRelative({ round: false }) //=> "1.5 days ago"
    */
+
+
   toRelative() {
-    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    let options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     if (!this.isValid) return null;
-    var base = options.base || DateTime.fromObject({}, {
-        zone: this.zone
-      }),
-      padding = options.padding ? this < base ? -options.padding : options.padding : 0;
-    var units = ["years", "months", "days", "hours", "minutes", "seconds"];
-    var unit = options.unit;
+    const base = options.base || DateTime.fromObject({}, {
+      zone: this.zone
+    }),
+          padding = options.padding ? this < base ? -options.padding : options.padding : 0;
+    let units = ["years", "months", "days", "hours", "minutes", "seconds"];
+    let unit = options.unit;
+
     if (Array.isArray(options.unit)) {
       units = options.unit;
       unit = undefined;
     }
+
     return diffRelative(base, this.plus(padding), datetime_objectSpread(datetime_objectSpread({}, options), {}, {
       numeric: "always",
       units,
       unit
     }));
   }
-
   /**
    * Returns a string representation of this date relative to today, such as "yesterday" or "next month".
    * Only internationalizes on platforms that supports Intl.RelativeTimeFormat.
@@ -7610,8 +8605,10 @@ class DateTime {
    * @example DateTime.now().plus({ days: 1 }).toRelativeCalendar({ locale: "fr" }) //=> "demain"
    * @example DateTime.now().minus({ days: 2 }).toRelativeCalendar() //=> "2 days ago"
    */
+
+
   toRelativeCalendar() {
-    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    let options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     if (!this.isValid) return null;
     return diffRelative(options.base || DateTime.fromObject({}, {
       zone: this.zone
@@ -7621,38 +8618,42 @@ class DateTime {
       calendary: true
     }));
   }
-
   /**
    * Return the min of several date times
    * @param {...DateTime} dateTimes - the DateTimes from which to choose the minimum
    * @return {DateTime} the min DateTime, or undefined if called with no argument
    */
+
+
   static min() {
     for (var _len = arguments.length, dateTimes = new Array(_len), _key = 0; _key < _len; _key++) {
       dateTimes[_key] = arguments[_key];
     }
+
     if (!dateTimes.every(DateTime.isDateTime)) {
       throw new InvalidArgumentError("min requires all arguments be DateTimes");
     }
+
     return bestBy(dateTimes, i => i.valueOf(), Math.min);
   }
-
   /**
    * Return the max of several date times
    * @param {...DateTime} dateTimes - the DateTimes from which to choose the maximum
    * @return {DateTime} the max DateTime, or undefined if called with no argument
    */
+
+
   static max() {
     for (var _len2 = arguments.length, dateTimes = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
       dateTimes[_key2] = arguments[_key2];
     }
+
     if (!dateTimes.every(DateTime.isDateTime)) {
       throw new InvalidArgumentError("max requires all arguments be DateTimes");
     }
-    return bestBy(dateTimes, i => i.valueOf(), Math.max);
-  }
 
-  // MISC
+    return bestBy(dateTimes, i => i.valueOf(), Math.max);
+  } // MISC
 
   /**
    * Explain how a string would be parsed by fromFormat()
@@ -7661,210 +8662,235 @@ class DateTime {
    * @param {Object} options - options taken by fromFormat()
    * @return {Object}
    */
+
+
   static fromFormatExplain(text, fmt) {
-    var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
-    var _options$locale = options.locale,
-      locale = _options$locale === void 0 ? null : _options$locale,
-      _options$numberingSys = options.numberingSystem,
-      numberingSystem = _options$numberingSys === void 0 ? null : _options$numberingSys,
-      localeToUse = Locale.fromOpts({
-        locale,
-        numberingSystem,
-        defaultToEN: true
-      });
+    let options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+    const _options$locale = options.locale,
+          locale = _options$locale === void 0 ? null : _options$locale,
+          _options$numberingSys = options.numberingSystem,
+          numberingSystem = _options$numberingSys === void 0 ? null : _options$numberingSys,
+          localeToUse = Locale.fromOpts({
+      locale,
+      numberingSystem,
+      defaultToEN: true
+    });
     return explainFromTokens(localeToUse, text, fmt);
   }
-
   /**
    * @deprecated use fromFormatExplain instead
    */
-  static fromStringExplain(text, fmt) {
-    var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
-    return DateTime.fromFormatExplain(text, fmt, options);
-  }
 
-  // FORMAT PRESETS
+
+  static fromStringExplain(text, fmt) {
+    let options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+    return DateTime.fromFormatExplain(text, fmt, options);
+  } // FORMAT PRESETS
 
   /**
    * {@link DateTime#toLocaleString} format like 10/14/1983
    * @type {Object}
    */
+
+
   static get DATE_SHORT() {
     return DATE_SHORT;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like 'Oct 14, 1983'
    * @type {Object}
    */
+
+
   static get DATE_MED() {
     return DATE_MED;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like 'Fri, Oct 14, 1983'
    * @type {Object}
    */
+
+
   static get DATE_MED_WITH_WEEKDAY() {
     return DATE_MED_WITH_WEEKDAY;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like 'October 14, 1983'
    * @type {Object}
    */
+
+
   static get DATE_FULL() {
     return DATE_FULL;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like 'Tuesday, October 14, 1983'
    * @type {Object}
    */
+
+
   static get DATE_HUGE() {
     return DATE_HUGE;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like '09:30 AM'. Only 12-hour if the locale is.
    * @type {Object}
    */
+
+
   static get TIME_SIMPLE() {
     return TIME_SIMPLE;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like '09:30:23 AM'. Only 12-hour if the locale is.
    * @type {Object}
    */
+
+
   static get TIME_WITH_SECONDS() {
     return TIME_WITH_SECONDS;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like '09:30:23 AM EDT'. Only 12-hour if the locale is.
    * @type {Object}
    */
+
+
   static get TIME_WITH_SHORT_OFFSET() {
     return TIME_WITH_SHORT_OFFSET;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like '09:30:23 AM Eastern Daylight Time'. Only 12-hour if the locale is.
    * @type {Object}
    */
+
+
   static get TIME_WITH_LONG_OFFSET() {
     return TIME_WITH_LONG_OFFSET;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like '09:30', always 24-hour.
    * @type {Object}
    */
+
+
   static get TIME_24_SIMPLE() {
     return TIME_24_SIMPLE;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like '09:30:23', always 24-hour.
    * @type {Object}
    */
+
+
   static get TIME_24_WITH_SECONDS() {
     return TIME_24_WITH_SECONDS;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like '09:30:23 EDT', always 24-hour.
    * @type {Object}
    */
+
+
   static get TIME_24_WITH_SHORT_OFFSET() {
     return TIME_24_WITH_SHORT_OFFSET;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like '09:30:23 Eastern Daylight Time', always 24-hour.
    * @type {Object}
    */
+
+
   static get TIME_24_WITH_LONG_OFFSET() {
     return TIME_24_WITH_LONG_OFFSET;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like '10/14/1983, 9:30 AM'. Only 12-hour if the locale is.
    * @type {Object}
    */
+
+
   static get DATETIME_SHORT() {
     return DATETIME_SHORT;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like '10/14/1983, 9:30:33 AM'. Only 12-hour if the locale is.
    * @type {Object}
    */
+
+
   static get DATETIME_SHORT_WITH_SECONDS() {
     return DATETIME_SHORT_WITH_SECONDS;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like 'Oct 14, 1983, 9:30 AM'. Only 12-hour if the locale is.
    * @type {Object}
    */
+
+
   static get DATETIME_MED() {
     return DATETIME_MED;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like 'Oct 14, 1983, 9:30:33 AM'. Only 12-hour if the locale is.
    * @type {Object}
    */
+
+
   static get DATETIME_MED_WITH_SECONDS() {
     return DATETIME_MED_WITH_SECONDS;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like 'Fri, 14 Oct 1983, 9:30 AM'. Only 12-hour if the locale is.
    * @type {Object}
    */
+
+
   static get DATETIME_MED_WITH_WEEKDAY() {
     return DATETIME_MED_WITH_WEEKDAY;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like 'October 14, 1983, 9:30 AM EDT'. Only 12-hour if the locale is.
    * @type {Object}
    */
+
+
   static get DATETIME_FULL() {
     return DATETIME_FULL;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like 'October 14, 1983, 9:30:33 AM EDT'. Only 12-hour if the locale is.
    * @type {Object}
    */
+
+
   static get DATETIME_FULL_WITH_SECONDS() {
     return DATETIME_FULL_WITH_SECONDS;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like 'Friday, October 14, 1983, 9:30 AM Eastern Daylight Time'. Only 12-hour if the locale is.
    * @type {Object}
    */
+
+
   static get DATETIME_HUGE() {
     return DATETIME_HUGE;
   }
-
   /**
    * {@link DateTime#toLocaleString} format like 'Friday, October 14, 1983, 9:30:33 AM Eastern Daylight Time'. Only 12-hour if the locale is.
    * @type {Object}
    */
+
+
   static get DATETIME_HUGE_WITH_SECONDS() {
     return DATETIME_HUGE_WITH_SECONDS;
   }
-}
 
+}
 /**
  * @private
  */
+
 function friendlyDateTime(dateTimeish) {
   if (DateTime.isDateTime(dateTimeish)) {
     return dateTimeish;
@@ -7887,7 +8913,7 @@ function friendlyDateTime(dateTimeish) {
 
 
 
-var VERSION = "3.2.0";
+const VERSION = "3.2.0";
 
 ;// CONCATENATED MODULE: ./src/3_8/utils.ts
 
@@ -8911,7 +9937,10 @@ class GeoLocation {
                 logger_Logger.Debug("Returning cached geolocation info for '" + searchText + "'.");
                 return cached;
             }
-            const locationData = await this.App.LoadJsonAsync(`${this.url}?q=${searchText}&${this.params}`, cancellable);
+            const locationData = await this.App.LoadJsonAsync({
+                url: `${this.url}?q=${searchText}&${this.params}`,
+                cancellable
+            });
             if (locationData == null)
                 return null;
             if (locationData.length == 0) {
@@ -9103,13 +10132,19 @@ class MetUk extends BaseProvider {
     }
     ;
     async GetClosestForecastSite(loc, cancellable) {
-        const forecastSitelist = await this.app.LoadJsonAsync(this.baseUrl + this.forecastPrefix + this.sitesUrl + "?" + this.key, cancellable);
+        const forecastSitelist = await this.app.LoadJsonAsync({
+            url: this.baseUrl + this.forecastPrefix + this.sitesUrl + "?" + this.key,
+            cancellable
+        });
         if (forecastSitelist == null)
             return null;
         return this.GetClosestSite(forecastSitelist, loc);
     }
     async GetObservationSitesInRange(loc, range, cancellable) {
-        const observationSiteList = await this.app.LoadJsonAsync(this.baseUrl + this.currentPrefix + this.sitesUrl + "?" + this.key, cancellable);
+        const observationSiteList = await this.app.LoadJsonAsync({
+            url: this.baseUrl + this.currentPrefix + this.sitesUrl + "?" + this.key,
+            cancellable
+        });
         if (observationSiteList == null)
             return null;
         let observationSites = [];
@@ -9127,7 +10162,10 @@ class MetUk extends BaseProvider {
         const observations = [];
         for (const element of observationSites) {
             logger_Logger.Debug("Getting observation data from station: " + element.id);
-            const payload = await this.app.LoadJsonAsync(this.baseUrl + this.currentPrefix + element.id + "?res=hourly&" + this.key, cancellable);
+            const payload = await this.app.LoadJsonAsync({
+                url: this.baseUrl + this.currentPrefix + element.id + "?res=hourly&" + this.key,
+                cancellable
+            });
             if (!!payload)
                 observations.push(payload);
             else {
@@ -9140,7 +10178,7 @@ class MetUk extends BaseProvider {
         if (query == null)
             return null;
         logger_Logger.Debug("Query: " + query);
-        const json = await this.app.LoadJsonAsync(query, cancellable);
+        const json = await this.app.LoadJsonAsync({ url: query, cancellable });
         if (json == null)
             return null;
         return ParseFunction(json, loc);
@@ -9660,8 +10698,13 @@ class OpenWeatherMap extends BaseProvider {
         const params = this.ConstructParams(loc);
         const cachedID = IDCache[`${loc.lat},${loc.lon}`];
         const [json, idPayload] = await Promise.all([
-            this.app.LoadJsonAsync(this.base_url, cancellable, params, this.HandleError),
-            (cachedID == null) ? this.app.LoadJsonAsync(this.id_irl, cancellable, params) : Promise.resolve()
+            this.app.LoadJsonAsync({
+                url: this.base_url,
+                cancellable,
+                params: params,
+                HandleError: this.HandleError
+            }),
+            (cachedID == null) ? this.app.LoadJsonAsync({ url: this.id_irl, cancellable, params }) : Promise.resolve()
         ]);
         if (cachedID == null && (idPayload === null || idPayload === void 0 ? void 0 : idPayload.id) != null)
             IDCache[`${loc.lat},${loc.lon}`] = idPayload.id;
@@ -10089,8 +11132,17 @@ class MetNorway extends BaseProvider {
     }
     async GetWeather(loc, cancellable) {
         const [forecast, nowcast] = await Promise.all([
-            this.app.LoadJsonAsync(`${this.baseUrl}/locationforecast/2.0/complete`, cancellable, { lat: loc.lat, lon: loc.lon }),
-            this.app.LoadJsonAsync(`${this.baseUrl}/nowcast/2.0/complete`, cancellable, { lat: loc.lat, lon: loc.lon }, (e) => e.ErrorData.code != 422),
+            this.app.LoadJsonAsync({
+                url: `${this.baseUrl}/locationforecast/2.0/complete`,
+                cancellable,
+                params: { lat: loc.lat, lon: loc.lon }
+            }),
+            this.app.LoadJsonAsync({
+                url: `${this.baseUrl}/nowcast/2.0/complete`,
+                cancellable,
+                params: { lat: loc.lat, lon: loc.lon },
+                HandleError: (e) => e.ErrorData.code != 422
+            }),
         ]);
         if (!forecast) {
             logger_Logger.Error("MET Norway: Empty response from API");
@@ -10772,7 +11824,11 @@ class Weatherbit extends BaseProvider {
         const query = this.ConstructQuery(baseUrl, loc);
         if (query == null)
             return null;
-        const json = await this.app.LoadJsonAsync(query, cancellable, undefined, (e) => this.HandleError(e));
+        const json = await this.app.LoadJsonAsync({
+            url: query,
+            cancellable,
+            HandleError: (e) => this.HandleError(e)
+        });
         if (json == null)
             return null;
         return ParseFunction(json);
@@ -10781,7 +11837,11 @@ class Weatherbit extends BaseProvider {
         const query = this.ConstructQuery(baseUrl, loc);
         if (query == null)
             return null;
-        const json = await this.app.LoadJsonAsync(query, cancellable, undefined, (e) => this.HandleHourlyError(e));
+        const json = await this.app.LoadJsonAsync({
+            url: query,
+            cancellable,
+            HandleError: (e) => this.HandleHourlyError(e)
+        });
         if (!!(json === null || json === void 0 ? void 0 : json.error)) {
             return null;
         }
@@ -11067,7 +12127,12 @@ class ClimacellV4 extends BaseProvider {
             return null;
         this.params.apikey = this.app.config.ApiKey;
         this.params.location = loc.lat + "," + loc.lon;
-        const response = await this.app.LoadJsonAsync(this.url, cancellable, this.params, (m) => this.HandleHTTPError(m));
+        const response = await this.app.LoadJsonAsync({
+            url: this.url,
+            cancellable,
+            params: this.params,
+            HandleError: (m) => this.HandleHTTPError(m)
+        });
         if (response == null)
             return null;
         return this.ParseWeather(loc, response);
@@ -11487,8 +12552,14 @@ class USWeather extends BaseProvider {
             logger_Logger.Debug("Site data downloading skipped");
         }
         const observations = await this.GetObservationsInRange(this.MAX_STATION_DIST, loc, this.observationStations, cancellable);
-        const hourlyForecastPromise = this.app.LoadJsonAsync(this.grid.properties.forecastHourly + "?units=si", cancellable);
-        const forecastPromise = this.app.LoadJsonAsync(this.grid.properties.forecast, cancellable);
+        const hourlyForecastPromise = this.app.LoadJsonAsync({
+            url: this.grid.properties.forecastHourly + "?units=si",
+            cancellable
+        });
+        const forecastPromise = this.app.LoadJsonAsync({
+            url: this.grid.properties.forecast,
+            cancellable
+        });
         const hourly = await hourlyForecastPromise;
         const forecast = await forecastPromise;
         if (!hourly || !forecast) {
@@ -11504,11 +12575,18 @@ class USWeather extends BaseProvider {
     }
     ;
     async GetGridData(loc, cancellable) {
-        const siteData = await this.app.LoadJsonAsync(this.sitesUrl + loc.lat.toString() + "," + loc.lon.toString(), cancellable, {}, this.OnObtainingGridData);
+        const siteData = await this.app.LoadJsonAsync({
+            url: this.sitesUrl + loc.lat.toString() + "," + loc.lon.toString(),
+            cancellable,
+            HandleError: this.OnObtainingGridData
+        });
         return siteData;
     }
     async GetStationData(stationListUrl, cancellable) {
-        const stations = await this.app.LoadJsonAsync(stationListUrl, cancellable);
+        const stations = await this.app.LoadJsonAsync({
+            url: stationListUrl,
+            cancellable
+        });
         return stations === null || stations === void 0 ? void 0 : stations.features;
     }
     async GetObservationsInRange(range, loc, stations, cancellable) {
@@ -11517,7 +12595,11 @@ class USWeather extends BaseProvider {
             element.dist = GetDistance(element.geometry.coordinates[1], element.geometry.coordinates[0], loc.lat, loc.lon);
             if (element.dist > range)
                 break;
-            const observation = await this.app.LoadJsonAsync(element.id + "/observations/latest", cancellable, {}, (msg) => false);
+            const observation = await this.app.LoadJsonAsync({
+                url: element.id + "/observations/latest",
+                cancellable,
+                HandleError: (msg) => false
+            });
             if (observation == null) {
                 logger_Logger.Debug("Failed to get observations from " + element.id);
             }
@@ -11956,7 +13038,12 @@ class VisualCrossing extends BaseProvider {
             translate = false;
         }
         const url = this.url + loc.lat + "," + loc.lon;
-        const json = await this.app.LoadJsonAsync(url, cancellable, this.params, (e) => this.HandleHttpError(e));
+        const json = await this.app.LoadJsonAsync({
+            url,
+            cancellable,
+            params: this.params,
+            HandleError: (e) => this.HandleHttpError(e)
+        });
         if (!json)
             return null;
         return this.ParseWeather(json, translate);
@@ -12252,10 +13339,18 @@ class DanishMI extends BaseProvider {
         if (loc == null)
             return null;
         this.GetLocationBoundingBox(loc);
-        const observations = this.OrderObservations(await this.app.LoadJsonAsync(this.url, cancellable, this.observationParams), loc);
+        const observations = this.OrderObservations(await this.app.LoadJsonAsync({
+            url: this.url,
+            cancellable,
+            params: this.observationParams
+        }), loc);
         this.forecastParams.lat = loc.lat;
         this.forecastParams.lon = loc.lon;
-        const forecasts = await this.app.LoadJsonAsync(this.url, cancellable, this.forecastParams);
+        const forecasts = await this.app.LoadJsonAsync({
+            url: this.url,
+            cancellable,
+            params: this.forecastParams
+        });
         if (forecasts == null)
             return null;
         return this.ParseWeather(observations, forecasts, loc);
@@ -12602,17 +13697,39 @@ class AccuWeather extends BaseProvider {
         const userLocale = (_b = (_a = this.app.config.currentLocale) === null || _a === void 0 ? void 0 : _a.toLowerCase()) !== null && _b !== void 0 ? _b : "en-us";
         const locale = this.app.config._translateCondition ? userLocale : "en-us";
         let location;
-        if (this.locationCache[locationID] != null)
+        if (this.locationCache[locationID] != null) {
             location = this.locationCache[locationID];
-        else
-            location = await this.app.LoadJsonAsync(this.locSearchUrl, cancellable, { q: locationID, details: true, language: userLocale, apikey: this.app.config.ApiKey }, this.HandleErrors);
+        }
+        else {
+            location = await this.app.LoadJsonAsync({
+                url: this.locSearchUrl,
+                cancellable,
+                params: { q: locationID, details: true, language: userLocale, apikey: this.app.config.ApiKey },
+                HandleError: this.HandleErrors
+            });
+        }
         if (location == null) {
             return null;
         }
         const [current, forecast, hourly] = await Promise.all([
-            this.app.LoadJsonAsyncWithDetails(this.currentConditionUrl + location.Key, cancellable, { apikey: this.app.config.ApiKey, details: true, language: locale, }, this.HandleErrors),
-            this.app.LoadJsonAsyncWithDetails(this.dailyForecastUrl + location.Key, cancellable, { apikey: this.app.config.ApiKey, details: true, metric: true, language: locale, }, this.HandleErrors),
-            this.app.LoadJsonAsyncWithDetails(this.hourlyForecastUrl + location.Key, cancellable, { apikey: this.app.config.ApiKey, details: true, metric: true, language: locale, }, this.HandleErrors)
+            this.app.LoadJsonAsyncWithDetails({
+                url: this.currentConditionUrl + location.Key,
+                cancellable,
+                params: { apikey: this.app.config.ApiKey, details: true, language: locale, },
+                HandleError: this.HandleErrors
+            }),
+            this.app.LoadJsonAsyncWithDetails({
+                url: this.dailyForecastUrl + location.Key,
+                cancellable,
+                params: { apikey: this.app.config.ApiKey, details: true, metric: true, language: locale, },
+                HandleError: this.HandleErrors
+            }),
+            this.app.LoadJsonAsyncWithDetails({
+                url: this.hourlyForecastUrl + location.Key,
+                cancellable,
+                params: { apikey: this.app.config.ApiKey, details: true, metric: true, language: locale, },
+                HandleError: this.HandleErrors
+            })
         ]);
         if (!current.Success || !forecast.Success || !hourly.Success)
             return null;
@@ -12944,8 +14061,18 @@ class DeutscherWetterdienst extends BaseProvider {
     async GetWeather(loc, cancellable) {
         var _a, _b, _c, _d;
         const [current, hourly] = await Promise.all([
-            this.app.LoadJsonAsync(`${this.baseUrl}current_weather`, cancellable, this.GetDefaultParams(loc), this.HandleErrors),
-            this.app.LoadJsonAsync(`${this.baseUrl}weather`, cancellable, this.GetHourlyParams(loc), this.HandleErrors)
+            this.app.LoadJsonAsync({
+                url: `${this.baseUrl}current_weather`,
+                cancellable,
+                params: this.GetDefaultParams(loc),
+                HandleError: this.HandleErrors
+            }),
+            this.app.LoadJsonAsync({
+                url: `${this.baseUrl}weather`,
+                cancellable,
+                params: this.GetHourlyParams(loc),
+                HandleError: this.HandleErrors,
+            })
         ]);
         if (current == null || hourly == null)
             return null;
@@ -13247,12 +14374,16 @@ class WeatherUnderground extends BaseProvider {
                 return null;
             }
             this.locationCache[locString] = location;
-            const forecast = await this.app.LoadJsonAsync(`${this.baseURl}v3/wx/forecast/daily/5day`, cancellable, {
-                geocode: locString,
-                language: (_b = this.app.config.currentLocale) !== null && _b !== void 0 ? _b : "en-US",
-                format: "json",
-                apiKey: this.app.config.ApiKey,
-                units: this.currentUnit,
+            const forecast = await this.app.LoadJsonAsync({
+                url: `${this.baseURl}v3/wx/forecast/daily/5day`,
+                cancellable,
+                params: {
+                    geocode: locString,
+                    language: (_b = this.app.config.currentLocale) !== null && _b !== void 0 ? _b : "en-US",
+                    format: "json",
+                    apiKey: this.app.config.ApiKey,
+                    units: this.currentUnit,
+                }
             });
             if (forecast == null)
                 return null;
@@ -13292,12 +14423,17 @@ class WeatherUnderground extends BaseProvider {
         this.GetNearbyStations = async (loc, cancellable) => {
             var _a;
             const result = [];
-            const payload = await this.app.LoadJsonAsync(`${this.baseURl}v3/location/near`, cancellable, {
-                geocode: `${loc.lat},${loc.lon}`,
-                format: "json",
-                apiKey: this.app.config.ApiKey,
-                product: "pws"
-            }, this.HandleErrors);
+            const payload = await this.app.LoadJsonAsync({
+                url: `${this.baseURl}v3/location/near`,
+                cancellable,
+                params: {
+                    geocode: `${loc.lat},${loc.lon}`,
+                    format: "json",
+                    apiKey: this.app.config.ApiKey,
+                    product: "pws"
+                },
+                HandleError: this.HandleErrors
+            });
             if (payload == null)
                 return null;
             for (let i = 0; i < payload.location.stationId.length; i++) {
@@ -13393,13 +14529,18 @@ class WeatherUnderground extends BaseProvider {
         };
         this.GetObservation = async (stationID, cancellable) => {
             var _a;
-            const observationString = await this.app.LoadAsync(`${this.baseURl}v2/pws/observations/current`, cancellable, {
-                format: "json",
-                stationId: stationID,
-                apiKey: this.app.config.ApiKey,
-                units: "s",
-                numericPrecision: "decimal",
-            }, this.HandleErrors);
+            const observationString = await this.app.LoadAsync({
+                url: `${this.baseURl}v2/pws/observations/current`,
+                cancellable,
+                params: {
+                    format: "json",
+                    stationId: stationID,
+                    apiKey: this.app.config.ApiKey,
+                    units: "s",
+                    numericPrecision: "decimal",
+                },
+                HandleError: this.HandleErrors
+            });
             let observation = null;
             if (observationString != null) {
                 try {
@@ -13855,9 +14996,12 @@ class PirateWeather extends BaseProvider {
     }
     async GetWeather(loc, cancellable) {
         const unit = this.GetQueryUnit();
-        const response = await this.app.LoadJsonAsyncWithDetails(`${this.query}${this.app.config.ApiKey}/${loc.lat},${loc.lon}`, cancellable, {
-            units: this.GetQueryUnit()
-        }, this.HandleError);
+        const response = await this.app.LoadJsonAsyncWithDetails({
+            url: `${this.query}${this.app.config.ApiKey}/${loc.lat},${loc.lon}`,
+            cancellable,
+            params: { units: this.GetQueryUnit() },
+            HandleError: this.HandleError
+        });
         if (!response.Success)
             return null;
         return this.ParseWeather(response.Data, unit);
@@ -14135,7 +15279,7 @@ class GeoIPFedora {
         this.app = app;
     }
     async GetLocation(cancellable) {
-        const json = await this.app.LoadJsonAsync(this.query, cancellable);
+        const json = await this.app.LoadJsonAsync({ url: this.query, cancellable });
         if (!json) {
             logger_Logger.Info("geoip.fedoraproject didn't return any data");
             return null;
@@ -14469,7 +15613,7 @@ class Config {
     DoneTypingLocation() {
         logger_Logger.Debug("User has finished typing, beginning refresh");
         this.doneTypingLocation = null;
-        this.app.Refresh({ rebuild: true });
+        this.app.Refresh();
     }
     SetLocation(value) {
         this.settings.setValue(this.WEATHER_LOCATION, value);
@@ -16345,7 +17489,8 @@ class Soup3 {
         this._httpSession.timeout = 10;
         this._httpSession.idle_timeout = 10;
     }
-    async Send(url, params, headers, method = "GET", cancellable) {
+    async Send(url, options = {}) {
+        const { params, headers, method = "GET", cancellable } = options;
         if (cancellable === null || cancellable === void 0 ? void 0 : cancellable.is_cancelled()) {
             return Promise.resolve(null);
         }
@@ -16399,7 +17544,8 @@ class Soup2 {
         this._httpSession.use_thread_context = true;
         this._httpSession.add_feature(new ProxyResolverDefault());
     }
-    async Send(url, params, headers, method = "GET", cancellable) {
+    async Send(url, options = {}) {
+        const { params, headers, method = "GET", cancellable } = options;
         if (cancellable === null || cancellable === void 0 ? void 0 : cancellable.is_cancelled()) {
             return Promise.resolve(null);
         }
@@ -16477,8 +17623,8 @@ class HttpLib {
             this.instance = new HttpLib();
         return this.instance;
     }
-    async LoadJsonAsync(url, cancellable, params, headers, method = "GET") {
-        const response = await this.LoadAsync(url, cancellable, params, headers, method);
+    async LoadJsonAsync(url, options = {}) {
+        const response = await this.LoadAsync(url, options);
         try {
             const payload = JSON.parse(response.Data);
             response.Data = payload;
@@ -16499,9 +17645,9 @@ class HttpLib {
             return response;
         }
     }
-    async LoadAsync(url, cancellable, params, headers, method = "GET") {
+    async LoadAsync(url, options = {}) {
         var _a, _b, _c, _d, _e, _f;
-        const message = await soupLib.Send(url, params, headers, method, cancellable);
+        const message = await soupLib.Send(url, options);
         let error = undefined;
         if (!message) {
             error = {
@@ -16552,6 +17698,17 @@ class HttpLib {
 }
 
 ;// CONCATENATED MODULE: ./src/3_8/main.ts
+var __rest = (undefined && undefined.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                t[p[i]] = s[p[i]];
+        }
+    return t;
+};
 
 
 
@@ -16587,8 +17744,6 @@ class WeatherApplet extends TextIconApplet {
     constructor(metadata, orientation, panelHeight, instanceId) {
         super(orientation, panelHeight, instanceId);
         this.refreshing = null;
-        this.unlockFunc = null;
-        this.manualRefreshTriggeredWhileLocked = false;
         this.currentWeatherInfo = null;
         this.encounteredError = false;
         this.online = null;
@@ -16853,8 +18008,9 @@ class WeatherApplet extends TextIconApplet {
             return this.config._forecastHours;
         return Math.min(this.config._forecastHours, this.provider.maxHourlyForecastSupport);
     }
-    async LoadJsonAsyncWithDetails(url, cancellable, params, HandleError, headers, method = "GET") {
-        const response = await HttpLib.Instance.LoadJsonAsync(url, cancellable, params, headers, method);
+    async LoadJsonAsyncWithDetails(options) {
+        const { HandleError, url } = options, params = __rest(options, ["HandleError", "url"]);
+        const response = await HttpLib.Instance.LoadJsonAsync(url, params);
         if (!response.Success) {
             if (!!HandleError && !HandleError(response))
                 return response;
@@ -16865,12 +18021,13 @@ class WeatherApplet extends TextIconApplet {
         }
         return response;
     }
-    async LoadJsonAsync(url, cancellable, params, HandleError, headers, method = "GET") {
-        const response = await this.LoadJsonAsyncWithDetails(url, cancellable, params, HandleError, headers, method);
+    async LoadJsonAsync(options) {
+        const response = await this.LoadJsonAsyncWithDetails(options);
         return (response.Success) ? response.Data : null;
     }
-    async LoadAsync(url, cancellable, params, HandleError, headers, method = "GET") {
-        const response = await HttpLib.Instance.LoadAsync(url, cancellable, params, headers, method);
+    async LoadAsync(options) {
+        const { HandleError, url } = options, params = __rest(options, ["HandleError", "url"]);
+        const response = await HttpLib.Instance.LoadAsync(url, params);
         if (!response.Success) {
             if (!!HandleError && !HandleError(response))
                 return null;

--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -9468,9 +9468,16 @@ const ByteArray = imports.byteArray;
 async function GetFileInfo(file) {
     return new Promise((resolve, reject) => {
         file.query_info_async("", Gio.FileQueryInfoFlags.NONE, null, null, (obj, res) => {
-            const result = file.query_info_finish(res);
-            resolve(result);
-            return result;
+            try {
+                const result = file.query_info_finish(res);
+                resolve(result);
+                return result;
+            }
+            catch (e) {
+                Logger.Error("Error getting file info: ", e);
+                resolve(null);
+                return null;
+            }
         });
     });
 }
@@ -9537,9 +9544,16 @@ async function OverwriteAndGetIOStream(file) {
         parent.make_directory_with_parents(null);
     return new Promise((resolve, reject) => {
         file.replace_readwrite_async(null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null, null, (source_object, result) => {
-            const ioStream = file.replace_readwrite_finish(result);
-            resolve(ioStream);
-            return ioStream;
+            try {
+                const ioStream = file.replace_readwrite_finish(result);
+                resolve(ioStream);
+                return ioStream;
+            }
+            catch (e) {
+                logger_Logger.Error("Error overwriting file: ", e);
+                resolve(null);
+                return null;
+            }
         });
     });
 }
@@ -9549,18 +9563,32 @@ async function WriteAsync(outputStream, buffer) {
         return false;
     return new Promise((resolve, reject) => {
         outputStream.write_bytes_async(text, null, null, (obj, res) => {
-            const ioStream = outputStream.write_bytes_finish(res);
-            resolve(true);
-            return true;
+            try {
+                outputStream.write_bytes_finish(res);
+                resolve(true);
+                return true;
+            }
+            catch (e) {
+                logger_Logger.Error("Error writing to stream: ", e);
+                resolve(false);
+                return false;
+            }
         });
     });
 }
 async function CloseStream(stream) {
     return new Promise((resolve, reject) => {
         stream.close_async(null, null, (obj, res) => {
-            const result = stream.close_finish(res);
-            resolve(result);
-            return result;
+            try {
+                const result = stream.close_finish(res);
+                resolve(result);
+                return result;
+            }
+            catch (e) {
+                logger_Logger.Error("Error closing stream: ", e);
+                resolve(false);
+                return false;
+            }
         });
     });
 }
@@ -9578,6 +9606,57 @@ const LogLevelSeverity = {
     info: 10,
     debug: 50,
     verbose: 100
+};
+const IOErrorEnumNames = {
+    [imports.gi.Gio.IOErrorEnum.FAILED]: "FAILED",
+    [imports.gi.Gio.IOErrorEnum.NOT_FOUND]: "NOT_FOUND",
+    [imports.gi.Gio.IOErrorEnum.EXISTS]: "EXISTS",
+    [imports.gi.Gio.IOErrorEnum.IS_DIRECTORY]: "IS_DIRECTORY",
+    [imports.gi.Gio.IOErrorEnum.NOT_DIRECTORY]: "NOT_DIRECTORY",
+    [imports.gi.Gio.IOErrorEnum.NOT_EMPTY]: "NOT_EMPTY",
+    [imports.gi.Gio.IOErrorEnum.NOT_REGULAR_FILE]: "NOT_REGULAR_FILE",
+    [imports.gi.Gio.IOErrorEnum.NOT_SYMBOLIC_LINK]: "NOT_SYMBOLIC_LINK",
+    [imports.gi.Gio.IOErrorEnum.NOT_MOUNTABLE_FILE]: "NOT_MOUNTABLE_FILE",
+    [imports.gi.Gio.IOErrorEnum.FILENAME_TOO_LONG]: "FILENAME_TOO_LONG",
+    [imports.gi.Gio.IOErrorEnum.INVALID_FILENAME]: "INVALID_FILENAME",
+    [imports.gi.Gio.IOErrorEnum.TOO_MANY_LINKS]: "TOO_MANY_LINKS",
+    [imports.gi.Gio.IOErrorEnum.NO_SPACE]: "NO_SPACE",
+    [imports.gi.Gio.IOErrorEnum.INVALID_ARGUMENT]: "INVALID_ARGUMENT",
+    [imports.gi.Gio.IOErrorEnum.PERMISSION_DENIED]: "PERMISSION_DENIED",
+    [imports.gi.Gio.IOErrorEnum.NOT_SUPPORTED]: "NOT_SUPPORTED",
+    [imports.gi.Gio.IOErrorEnum.NOT_MOUNTED]: "NOT_MOUNTED",
+    [imports.gi.Gio.IOErrorEnum.ALREADY_MOUNTED]: "ALREADY_MOUNTED",
+    [imports.gi.Gio.IOErrorEnum.CLOSED]: "CLOSED",
+    [imports.gi.Gio.IOErrorEnum.CANCELLED]: "CANCELLED",
+    [imports.gi.Gio.IOErrorEnum.PENDING]: "PENDING",
+    [imports.gi.Gio.IOErrorEnum.READ_ONLY]: "READ_ONLY",
+    [imports.gi.Gio.IOErrorEnum.CANT_CREATE_BACKUP]: "CANT_CREATE_BACKUP",
+    [imports.gi.Gio.IOErrorEnum.WRONG_ETAG]: "WRONG_ETAG",
+    [imports.gi.Gio.IOErrorEnum.TIMED_OUT]: "TIMED_OUT",
+    [imports.gi.Gio.IOErrorEnum.WOULD_RECURSE]: "WOULD_RECURSE",
+    [imports.gi.Gio.IOErrorEnum.BUSY]: "BUSY",
+    [imports.gi.Gio.IOErrorEnum.WOULD_BLOCK]: "WOULD_BLOCK",
+    [imports.gi.Gio.IOErrorEnum.HOST_NOT_FOUND]: "HOST_NOT_FOUND",
+    [imports.gi.Gio.IOErrorEnum.WOULD_MERGE]: "WOULD_MERGE",
+    [imports.gi.Gio.IOErrorEnum.FAILED_HANDLED]: "FAILED_HANDLED",
+    [imports.gi.Gio.IOErrorEnum.TOO_MANY_OPEN_FILES]: "TOO_MANY_OPEN_FILES",
+    [imports.gi.Gio.IOErrorEnum.NOT_INITIALIZED]: "NOT_INITIALIZED",
+    [imports.gi.Gio.IOErrorEnum.ADDRESS_IN_USE]: "ADDRESS_IN_USE",
+    [imports.gi.Gio.IOErrorEnum.PARTIAL_INPUT]: "PARTIAL_INPUT",
+    [imports.gi.Gio.IOErrorEnum.INVALID_DATA]: "INVALID_DATA",
+    [imports.gi.Gio.IOErrorEnum.DBUS_ERROR]: "DBUS_ERROR",
+    [imports.gi.Gio.IOErrorEnum.HOST_UNREACHABLE]: "HOST_UNREACHABLE",
+    [imports.gi.Gio.IOErrorEnum.NETWORK_UNREACHABLE]: "NETWORK_UNREACHABLE",
+    [imports.gi.Gio.IOErrorEnum.CONNECTION_REFUSED]: "CONNECTION_REFUSED",
+    [imports.gi.Gio.IOErrorEnum.PROXY_FAILED]: "PROXY_FAILED",
+    [imports.gi.Gio.IOErrorEnum.PROXY_AUTH_FAILED]: "PROXY_AUTH_FAILED",
+    [imports.gi.Gio.IOErrorEnum.PROXY_NEED_AUTH]: "PROXY_NEED_AUTH",
+    [imports.gi.Gio.IOErrorEnum.PROXY_NOT_ALLOWED]: "PROXY_NOT_ALLOWED",
+    [imports.gi.Gio.IOErrorEnum.BROKEN_PIPE]: "BROKEN_PIPE",
+    [imports.gi.Gio.IOErrorEnum.CONNECTION_CLOSED]: "CONNECTION_CLOSED",
+    [imports.gi.Gio.IOErrorEnum.NOT_CONNECTED]: "NOT_CONNECTED",
+    [imports.gi.Gio.IOErrorEnum.MESSAGE_TOO_LARGE]: "MESSAGE_TOO_LARGE",
+    [imports.gi.Gio.IOErrorEnum.NO_SUCH_DEVICE]: "NO_SUCH_DEVICE",
 };
 class Log {
     constructor(_instanceId) {
@@ -9597,11 +9676,17 @@ class Log {
         global.log(msg);
     }
     Error(error, e) {
+        var _a;
         if (!this.CanLog("error"))
             return;
         global.logError("[" + UUID + "#" + this.ID + ":Error]: " + error.toString());
-        if (!!(e === null || e === void 0 ? void 0 : e.stack))
-            global.logError(e.stack);
+        if (typeof e === "string") {
+            return;
+        }
+        const gjsE = e;
+        global.logError(`GJS Error context - Name: ${gjsE.name}, domain: ${gjsE.domain}, code: ${(_a = IOErrorEnumNames[gjsE.code]) !== null && _a !== void 0 ? _a : gjsE.code}, message: ${gjsE.message}`);
+        if (gjsE.stack)
+            global.logError(gjsE.stack);
     }
     ;
     Debug(message) {
@@ -10051,7 +10136,13 @@ class Soup2 {
         const read_chunk_async = () => {
             return new Promise((resolve) => {
                 stream.read_bytes_async(8192, 0, cancellable, (source, read_result) => {
-                    resolve(stream.read_bytes_finish(read_result));
+                    try {
+                        resolve(stream.read_bytes_finish(read_result));
+                    }
+                    catch (e) {
+                        logger_Logger.Error("Error reading chunk from http request stream: " + e);
+                        resolve(imports.gi.GLib.Bytes.new());
+                    }
                 });
             });
         };
@@ -15477,6 +15568,7 @@ class PirateWeather extends BaseProvider {
 
 ;// CONCATENATED MODULE: ./src/3_8/location_services/geoip_services/geoclue.ts
 
+
 let GeoClueLib = undefined;
 let GeocodeGlib = undefined;
 class GeoClue {
@@ -15496,16 +15588,28 @@ class GeoClue {
         }
         const { AccuracyLevel, Simple: GeoClue } = GeoClueLib;
         const res = await new Promise((resolve, reject) => {
-            GeoClue.new_with_thresholds("weather_mockturtl", AccuracyLevel.EXACT, 0, 0, cancellable !== null && cancellable !== void 0 ? cancellable : null, (client, res) => {
-                const simple = GeoClue.new_finish(res);
-                const clientObj = simple.get_client();
-                if (clientObj == null || !clientObj.active) {
-                    logger_Logger.Debug("GeoGlue2 Geolocation disabled, skipping");
+            logger_Logger.Debug("Requesting coordinates from GeoClue");
+            const start = DateTime.now();
+            GeoClue.new_with_thresholds("weather_mockturtl", AccuracyLevel.EXACT, 0, 0, cancellable, (client, res) => {
+                logger_Logger.Debug(`Getting GeoClue coordinates finished, took ${start.diffNow().negate().as("seconds")} seconds.`);
+                let simple = null;
+                try {
+                    simple = GeoClue.new_finish(res);
+                    const clientObj = simple.get_client();
+                    if (clientObj == null || !clientObj.active) {
+                        logger_Logger.Debug("GeoGlue Geolocation disabled, skipping");
+                        resolve(null);
+                        return;
+                    }
+                }
+                catch (e) {
+                    logger_Logger.Error("Error while fetching GeoClue coordinates: ", e);
                     resolve(null);
                     return;
                 }
                 const loc = simple.get_location();
                 if (loc == null) {
+                    logger_Logger.Debug("GeoGlue coordinates is not known.");
                     resolve(null);
                     return;
                 }
@@ -15519,36 +15623,52 @@ class GeoClue {
                     altitude: loc.altitude,
                     accuracy: loc.accuracy,
                 };
+                logger_Logger.Debug(`GeoClue coordinates received ${JSON.stringify(result)}`);
                 resolve(result);
+                return;
             });
         });
         if (res == null) {
             return null;
         }
-        const geoCodeRes = await this.GetGeoCodeData(res.lat, res.lon, res.accuracy);
+        const geoCodeRes = await this.GetGeoCodeData(cancellable, res.lat, res.lon, res.accuracy);
         if (geoCodeRes == null) {
             return res;
         }
         return Object.assign(Object.assign({}, res), geoCodeRes);
     }
     ;
-    async GetGeoCodeData(lat, lon, accuracy) {
+    async GetGeoCodeData(cancellable, lat, lon, accuracy) {
         if (GeocodeGlib == null) {
             return null;
         }
         const geoCodeLoc = GeocodeGlib.Location.new(lat, lon, accuracy);
         const geoCodeRes = GeocodeGlib.Reverse.new_for_location(geoCodeLoc);
         return new Promise((resolve, reject) => {
-            geoCodeRes.resolve_async(null, (obj, res) => {
-                const result = geoCodeRes.resolve_finish(res);
-                if (result == null) {
+            logger_Logger.Debug("Requesting location data from GeoCode");
+            const start = DateTime.now();
+            geoCodeRes.resolve_async(cancellable, (obj, res) => {
+                logger_Logger.Debug(`Getting GeoCode location data finished, took ${start.diffNow().negate().as("seconds")} seconds.`);
+                let result = null;
+                try {
+                    result = geoCodeRes.resolve_finish(res);
+                }
+                catch (e) {
+                    logger_Logger.Error("Error while fetching GeoCode data: ", e);
                     resolve(null);
                     return;
                 }
+                if (result == null) {
+                    logger_Logger.Debug("GeoCode location data not available.");
+                    resolve(null);
+                    return;
+                }
+                logger_Logger.Debug(`GeoCode location data received ${JSON.stringify(result)}`);
                 resolve({
                     city: result.town,
                     country: result.country,
                 });
+                return;
             });
         });
     }
@@ -17856,6 +17976,10 @@ class WeatherApplet extends TextIconApplet {
             }
             const appletLogFile = main_File.new_for_path(this.config._selectedLogPath);
             const stream = await OverwriteAndGetIOStream(appletLogFile);
+            if (stream == null) {
+                NotificationService.Instance.Send(_("Error Saving Debug Information"), _("Could not open file {filePath} for writing", { filePath: this.config._selectedLogPath }));
+                return;
+            }
             await WriteAsync(stream.get_output_stream(), logLines.join("\n"));
             if (settings != null) {
                 await WriteAsync(stream.get_output_stream(), "\n\n------------------- SETTINGS JSON -----------------\n\n");

--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -16155,7 +16155,7 @@ class WeatherLoop {
                         NetworkMonitor.get_default().connectivity == NetworkConnectivity.LIMITED ? "LIMITED"
                             : "PORTAL";
                     logger_Logger.Info(`Internet access "${name} (${NetworkMonitor.get_default().connectivity})" now available, initiating refresh.`);
-                    this.DoCheck();
+                    this.Resume();
                     break;
                 case NetworkConnectivity.LOCAL:
                     logger_Logger.Info(`Internet access now down with "${NetworkMonitor.get_default().connectivity}".`);

--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -15644,6 +15644,7 @@ class GeoClue {
         }
         const geoCodeLoc = GeocodeGlib.Location.new(lat, lon, accuracy);
         const geoCodeRes = GeocodeGlib.Reverse.new_for_location(geoCodeLoc);
+        geoCodeRes.set_backend(GeocodeGlib.Nominatim.new("https://nominatim.openstreetmap.org", "weatherapplet@gmail.com"));
         return new Promise((resolve, reject) => {
             logger_Logger.Debug("Requesting location data from GeoCode");
             const start = DateTime.now();
@@ -15663,7 +15664,7 @@ class GeoClue {
                     resolve(null);
                     return;
                 }
-                logger_Logger.Debug(`GeoCode location data received ${JSON.stringify(result)}`);
+                logger_Logger.Debug(`GeoCode location data received ${result.town}, ${result.country}`);
                 resolve({
                     city: result.town,
                     country: result.country,

--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -16163,7 +16163,7 @@ class WeatherLoop {
             }
         };
         this.DoCheck = async (options = {}) => {
-            var _a, _b;
+            var _a, _b, _c;
             logger_Logger.Debug("Main loop check started.");
             if (this.IsStray())
                 return;
@@ -16242,6 +16242,7 @@ class WeatherLoop {
             finally {
                 (_b = this.refreshingResolver) === null || _b === void 0 ? void 0 : _b.call(this);
                 this.refreshingResolver = null;
+                (_c = this.runningRefresh) === null || _c === void 0 ? void 0 : _c.cancel();
                 this.runningRefresh = null;
             }
         };

--- a/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
+++ b/weather@mockturtl/files/weather@mockturtl/3.8/weather-applet.js
@@ -10,165 +10,163 @@ var weatherApplet;
  SunCalc is a JavaScript library for calculating sun/moon position and light phases.
  https://github.com/mourner/suncalc
 */
-(function () {
-  'use strict'; // shortcuts for easier to read formulas
 
+(function () {
+  'use strict';
+
+  // shortcuts for easier to read formulas
   var PI = Math.PI,
-      sin = Math.sin,
-      cos = Math.cos,
-      tan = Math.tan,
-      asin = Math.asin,
-      atan = Math.atan2,
-      acos = Math.acos,
-      rad = PI / 180; // sun calculations are based on http://aa.quae.nl/en/reken/zonpositie.html formulas
+    sin = Math.sin,
+    cos = Math.cos,
+    tan = Math.tan,
+    asin = Math.asin,
+    atan = Math.atan2,
+    acos = Math.acos,
+    rad = PI / 180;
+
+  // sun calculations are based on http://aa.quae.nl/en/reken/zonpositie.html formulas
+
   // date/time constants and conversions
 
   var dayMs = 1000 * 60 * 60 * 24,
-      J1970 = 2440588,
-      J2000 = 2451545;
-
+    J1970 = 2440588,
+    J2000 = 2451545;
   function toJulian(date) {
     return date.valueOf() / dayMs - 0.5 + J1970;
   }
-
   function fromJulian(j) {
     return new Date((j + 0.5 - J1970) * dayMs);
   }
-
   function toDays(date) {
     return toJulian(date) - J2000;
-  } // general calculations for position
+  }
 
+  // general calculations for position
 
   var e = rad * 23.4397; // obliquity of the Earth
 
   function rightAscension(l, b) {
     return atan(sin(l) * cos(e) - tan(b) * sin(e), cos(l));
   }
-
   function declination(l, b) {
     return asin(sin(b) * cos(e) + cos(b) * sin(e) * sin(l));
   }
-
   function azimuth(H, phi, dec) {
     return atan(sin(H), cos(H) * sin(phi) - tan(dec) * cos(phi));
   }
-
   function altitude(H, phi, dec) {
     return asin(sin(phi) * sin(dec) + cos(phi) * cos(dec) * cos(H));
   }
-
   function siderealTime(d, lw) {
     return rad * (280.16 + 360.9856235 * d) - lw;
   }
-
   function astroRefraction(h) {
-    if (h < 0) // the following formula works for positive altitudes only.
+    if (h < 0)
+      // the following formula works for positive altitudes only.
       h = 0; // if h = -0.08901179 a div/0 would occur.
+
     // formula 16.4 of "Astronomical Algorithms" 2nd edition by Jean Meeus (Willmann-Bell, Richmond) 1998.
     // 1.02 / tan(h + 10.26 / (h + 5.10)) h in degrees, result in arc minutes -> converted to rad:
-
     return 0.0002967 / Math.tan(h + 0.00312536 / (h + 0.08901179));
-  } // general sun calculations
+  }
 
+  // general sun calculations
 
   function solarMeanAnomaly(d) {
     return rad * (357.5291 + 0.98560028 * d);
   }
-
   function eclipticLongitude(M) {
     var C = rad * (1.9148 * sin(M) + 0.02 * sin(2 * M) + 0.0003 * sin(3 * M)),
-        // equation of center
-    P = rad * 102.9372; // perihelion of the Earth
+      // equation of center
+      P = rad * 102.9372; // perihelion of the Earth
 
     return M + C + P + PI;
   }
-
   function sunCoords(d) {
     var M = solarMeanAnomaly(d),
-        L = eclipticLongitude(M);
+      L = eclipticLongitude(M);
     return {
       dec: declination(L, 0),
       ra: rightAscension(L, 0)
     };
   }
+  var SunCalc = {};
 
-  var SunCalc = {}; // calculates sun position for a given date and latitude/longitude
+  // calculates sun position for a given date and latitude/longitude
 
   SunCalc.getPosition = function (date, lat, lng) {
     var lw = rad * -lng,
-        phi = rad * lat,
-        d = toDays(date),
-        c = sunCoords(d),
-        H = siderealTime(d, lw) - c.ra;
+      phi = rad * lat,
+      d = toDays(date),
+      c = sunCoords(d),
+      H = siderealTime(d, lw) - c.ra;
     return {
       azimuth: azimuth(H, phi, c.dec),
       altitude: altitude(H, phi, c.dec)
     };
-  }; // sun times configuration (angle, morning name, evening name)
+  };
 
+  // sun times configuration (angle, morning name, evening name)
 
-  var times = SunCalc.times = [[-0.833, 'sunrise', 'sunset'], [-0.3, 'sunriseEnd', 'sunsetStart'], [-6, 'dawn', 'dusk'], [-12, 'nauticalDawn', 'nauticalDusk'], [-18, 'nightEnd', 'night'], [6, 'goldenHourEnd', 'goldenHour']]; // adds a custom time to the times config
+  var times = SunCalc.times = [[-0.833, 'sunrise', 'sunset'], [-0.3, 'sunriseEnd', 'sunsetStart'], [-6, 'dawn', 'dusk'], [-12, 'nauticalDawn', 'nauticalDusk'], [-18, 'nightEnd', 'night'], [6, 'goldenHourEnd', 'goldenHour']];
+
+  // adds a custom time to the times config
 
   SunCalc.addTime = function (angle, riseName, setName) {
     times.push([angle, riseName, setName]);
-  }; // calculations for sun times
+  };
 
+  // calculations for sun times
 
   var J0 = 0.0009;
-
   function julianCycle(d, lw) {
     return Math.round(d - J0 - lw / (2 * PI));
   }
-
   function approxTransit(Ht, lw, n) {
     return J0 + (Ht + lw) / (2 * PI) + n;
   }
-
   function solarTransitJ(ds, M, L) {
     return J2000 + ds + 0.0053 * sin(M) - 0.0069 * sin(2 * L);
   }
-
   function hourAngle(h, phi, d) {
     return acos((sin(h) - sin(phi) * sin(d)) / (cos(phi) * cos(d)));
   }
-
   function observerAngle(height) {
     return -2.076 * Math.sqrt(height) / 60;
-  } // returns set time for the given sun altitude
+  }
 
-
+  // returns set time for the given sun altitude
   function getSetJ(h, lw, phi, dec, n, M, L) {
     var w = hourAngle(h, phi, dec),
-        a = approxTransit(w, lw, n);
+      a = approxTransit(w, lw, n);
     return solarTransitJ(a, M, L);
-  } // calculates sun times for a given date, latitude/longitude, and, optionally,
-  // the observer height (in meters) relative to the horizon
+  }
 
+  // calculates sun times for a given date, latitude/longitude, and, optionally,
+  // the observer height (in meters) relative to the horizon
 
   SunCalc.getTimes = function (date, lat, lng, height) {
     height = height || 0;
     var lw = rad * -lng,
-        phi = rad * lat,
-        dh = observerAngle(height),
-        d = toDays(date),
-        n = julianCycle(d, lw),
-        ds = approxTransit(0, lw, n),
-        M = solarMeanAnomaly(ds),
-        L = eclipticLongitude(M),
-        dec = declination(L, 0),
-        Jnoon = solarTransitJ(ds, M, L),
-        i,
-        len,
-        time,
-        h0,
-        Jset,
-        Jrise;
+      phi = rad * lat,
+      dh = observerAngle(height),
+      d = toDays(date),
+      n = julianCycle(d, lw),
+      ds = approxTransit(0, lw, n),
+      M = solarMeanAnomaly(ds),
+      L = eclipticLongitude(M),
+      dec = declination(L, 0),
+      Jnoon = solarTransitJ(ds, M, L),
+      i,
+      len,
+      time,
+      h0,
+      Jset,
+      Jrise;
     var result = {
       solarNoon: fromJulian(Jnoon),
       nadir: fromJulian(Jnoon - 0.5)
     };
-
     for (i = 0, len = times.length; i < len; i += 1) {
       time = times[i];
       h0 = (time[0] + dh) * rad;
@@ -177,24 +175,26 @@ var weatherApplet;
       result[time[1]] = fromJulian(Jrise);
       result[time[2]] = fromJulian(Jset);
     }
-
     return result;
-  }; // moon calculations, based on http://aa.quae.nl/en/reken/hemelpositie.html formulas
+  };
 
+  // moon calculations, based on http://aa.quae.nl/en/reken/hemelpositie.html formulas
 
   function moonCoords(d) {
     // geocentric ecliptic coordinates of the moon
+
     var L = rad * (218.316 + 13.176396 * d),
-        // ecliptic longitude
-    M = rad * (134.963 + 13.064993 * d),
-        // mean anomaly
-    F = rad * (93.272 + 13.229350 * d),
-        // mean distance
-    l = L + rad * 6.289 * sin(M),
-        // longitude
-    b = rad * 5.128 * sin(F),
-        // latitude
-    dt = 385001 - 20905 * cos(M); // distance to the moon in km
+      // ecliptic longitude
+      M = rad * (134.963 + 13.064993 * d),
+      // mean anomaly
+      F = rad * (93.272 + 13.229350 * d),
+      // mean distance
+
+      l = L + rad * 6.289 * sin(M),
+      // longitude
+      b = rad * 5.128 * sin(F),
+      // latitude
+      dt = 385001 - 20905 * cos(M); // distance to the moon in km
 
     return {
       ra: rightAscension(l, b),
@@ -202,16 +202,15 @@ var weatherApplet;
       dist: dt
     };
   }
-
   SunCalc.getMoonPosition = function (date, lat, lng) {
     var lw = rad * -lng,
-        phi = rad * lat,
-        d = toDays(date),
-        c = moonCoords(d),
-        H = siderealTime(d, lw) - c.ra,
-        h = altitude(H, phi, c.dec),
-        // formula 14.1 of "Astronomical Algorithms" 2nd edition by Jean Meeus (Willmann-Bell, Richmond) 1998.
-    pa = atan(sin(H), tan(phi) * cos(c.dec) - sin(c.dec) * cos(H));
+      phi = rad * lat,
+      d = toDays(date),
+      c = moonCoords(d),
+      H = siderealTime(d, lw) - c.ra,
+      h = altitude(H, phi, c.dec),
+      // formula 14.1 of "Astronomical Algorithms" 2nd edition by Jean Meeus (Willmann-Bell, Richmond) 1998.
+      pa = atan(sin(H), tan(phi) * cos(c.dec) - sin(c.dec) * cos(H));
     h = h + astroRefraction(h); // altitude correction for refraction
 
     return {
@@ -220,51 +219,54 @@ var weatherApplet;
       distance: c.dist,
       parallacticAngle: pa
     };
-  }; // calculations for illumination parameters of the moon,
+  };
+
+  // calculations for illumination parameters of the moon,
   // based on http://idlastro.gsfc.nasa.gov/ftp/pro/astro/mphase.pro formulas and
   // Chapter 48 of "Astronomical Algorithms" 2nd edition by Jean Meeus (Willmann-Bell, Richmond) 1998.
 
-
   SunCalc.getMoonIllumination = function (date) {
     var d = toDays(date || new Date()),
-        s = sunCoords(d),
-        m = moonCoords(d),
-        sdist = 149598000,
-        // distance from Earth to Sun in km
-    phi = acos(sin(s.dec) * sin(m.dec) + cos(s.dec) * cos(m.dec) * cos(s.ra - m.ra)),
-        inc = atan(sdist * sin(phi), m.dist - sdist * cos(phi)),
-        angle = atan(cos(s.dec) * sin(s.ra - m.ra), sin(s.dec) * cos(m.dec) - cos(s.dec) * sin(m.dec) * cos(s.ra - m.ra));
+      s = sunCoords(d),
+      m = moonCoords(d),
+      sdist = 149598000,
+      // distance from Earth to Sun in km
+
+      phi = acos(sin(s.dec) * sin(m.dec) + cos(s.dec) * cos(m.dec) * cos(s.ra - m.ra)),
+      inc = atan(sdist * sin(phi), m.dist - sdist * cos(phi)),
+      angle = atan(cos(s.dec) * sin(s.ra - m.ra), sin(s.dec) * cos(m.dec) - cos(s.dec) * sin(m.dec) * cos(s.ra - m.ra));
     return {
       fraction: (1 + cos(inc)) / 2,
       phase: 0.5 + 0.5 * inc * (angle < 0 ? -1 : 1) / Math.PI,
       angle: angle
     };
   };
-
   function hoursLater(date, h) {
     return new Date(date.valueOf() + h * dayMs / 24);
-  } // calculations for moon rise/set times are based on http://www.stargazing.net/kepler/moonrise.html article
+  }
 
+  // calculations for moon rise/set times are based on http://www.stargazing.net/kepler/moonrise.html article
 
   SunCalc.getMoonTimes = function (date, lat, lng, inUTC) {
     var t = new Date(date);
     if (inUTC) t.setUTCHours(0, 0, 0, 0);else t.setHours(0, 0, 0, 0);
     var hc = 0.133 * rad,
-        h0 = SunCalc.getMoonPosition(t, lat, lng).altitude - hc,
-        h1,
-        h2,
-        rise,
-        set,
-        a,
-        b,
-        xe,
-        ye,
-        d,
-        roots,
-        x1,
-        x2,
-        dx; // go in 2-hour chunks, each time seeing if a 3-point quadratic curve crosses zero (which means rise or set)
+      h0 = SunCalc.getMoonPosition(t, lat, lng).altitude - hc,
+      h1,
+      h2,
+      rise,
+      set,
+      a,
+      b,
+      xe,
+      ye,
+      d,
+      roots,
+      x1,
+      x2,
+      dx;
 
+    // go in 2-hour chunks, each time seeing if a 3-point quadratic curve crosses zero (which means rise or set)
     for (var i = 1; i <= 24; i += 2) {
       h1 = SunCalc.getMoonPosition(hoursLater(t, i), lat, lng).altitude - hc;
       h2 = SunCalc.getMoonPosition(hoursLater(t, i + 1), lat, lng).altitude - hc;
@@ -274,7 +276,6 @@ var weatherApplet;
       ye = (a * xe + b) * xe + h1;
       d = b * b - 4 * a * h1;
       roots = 0;
-
       if (d >= 0) {
         dx = Math.sqrt(d) / (Math.abs(a) * 2);
         x1 = xe - dx;
@@ -283,26 +284,23 @@ var weatherApplet;
         if (Math.abs(x2) <= 1) roots++;
         if (x1 < -1) x1 = x2;
       }
-
       if (roots === 1) {
         if (h0 < 0) rise = i + x1;else set = i + x1;
       } else if (roots === 2) {
         rise = i + (ye < 0 ? x2 : x1);
         set = i + (ye < 0 ? x1 : x2);
       }
-
       if (rise && set) break;
       h0 = h2;
     }
-
     var result = {};
     if (rise) result.rise = hoursLater(t, rise);
     if (set) result.set = hoursLater(t, set);
     if (!rise && !set) result[ye > 0 ? 'alwaysUp' : 'alwaysDown'] = true;
     return result;
-  }; // export as Node module / AMD module / browser variable
+  };
 
-
+  // export as Node module / AMD module / browser variable
   if (true) module.exports = SunCalc;else {}
 })();
 
@@ -511,155 +509,150 @@ const distanceUnitLocales = {
  * @private
  */
 class LuxonError extends Error {}
+
 /**
  * @private
  */
-
-
 class InvalidDateTimeError extends LuxonError {
   constructor(reason) {
     super(`Invalid DateTime: ${reason.toMessage()}`);
   }
-
 }
+
 /**
  * @private
  */
-
 class InvalidIntervalError extends LuxonError {
   constructor(reason) {
     super(`Invalid Interval: ${reason.toMessage()}`);
   }
-
 }
+
 /**
  * @private
  */
-
 class InvalidDurationError extends LuxonError {
   constructor(reason) {
     super(`Invalid Duration: ${reason.toMessage()}`);
   }
-
 }
+
 /**
  * @private
  */
-
 class ConflictingSpecificationError extends LuxonError {}
+
 /**
  * @private
  */
-
 class InvalidUnitError extends LuxonError {
   constructor(unit) {
     super(`Invalid unit ${unit}`);
   }
-
 }
+
 /**
  * @private
  */
-
 class InvalidArgumentError extends LuxonError {}
+
 /**
  * @private
  */
-
 class ZoneIsAbstractError extends LuxonError {
   constructor() {
     super("Zone is an abstract class");
   }
-
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/formats.js
 /**
  * @private
  */
-const n = "numeric",
-      s = "short",
-      l = "long";
-const DATE_SHORT = {
+
+var n = "numeric",
+  s = "short",
+  l = "long";
+var DATE_SHORT = {
   year: n,
   month: n,
   day: n
 };
-const DATE_MED = {
+var DATE_MED = {
   year: n,
   month: s,
   day: n
 };
-const DATE_MED_WITH_WEEKDAY = {
+var DATE_MED_WITH_WEEKDAY = {
   year: n,
   month: s,
   day: n,
   weekday: s
 };
-const DATE_FULL = {
+var DATE_FULL = {
   year: n,
   month: l,
   day: n
 };
-const DATE_HUGE = {
+var DATE_HUGE = {
   year: n,
   month: l,
   day: n,
   weekday: l
 };
-const TIME_SIMPLE = {
+var TIME_SIMPLE = {
   hour: n,
   minute: n
 };
-const TIME_WITH_SECONDS = {
+var TIME_WITH_SECONDS = {
   hour: n,
   minute: n,
   second: n
 };
-const TIME_WITH_SHORT_OFFSET = {
+var TIME_WITH_SHORT_OFFSET = {
   hour: n,
   minute: n,
   second: n,
   timeZoneName: s
 };
-const TIME_WITH_LONG_OFFSET = {
+var TIME_WITH_LONG_OFFSET = {
   hour: n,
   minute: n,
   second: n,
   timeZoneName: l
 };
-const TIME_24_SIMPLE = {
+var TIME_24_SIMPLE = {
   hour: n,
   minute: n,
   hourCycle: "h23"
 };
-const TIME_24_WITH_SECONDS = {
+var TIME_24_WITH_SECONDS = {
   hour: n,
   minute: n,
   second: n,
   hourCycle: "h23"
 };
-const TIME_24_WITH_SHORT_OFFSET = {
+var TIME_24_WITH_SHORT_OFFSET = {
   hour: n,
   minute: n,
   second: n,
   hourCycle: "h23",
   timeZoneName: s
 };
-const TIME_24_WITH_LONG_OFFSET = {
+var TIME_24_WITH_LONG_OFFSET = {
   hour: n,
   minute: n,
   second: n,
   hourCycle: "h23",
   timeZoneName: l
 };
-const DATETIME_SHORT = {
+var DATETIME_SHORT = {
   year: n,
   month: n,
   day: n,
   hour: n,
   minute: n
 };
-const DATETIME_SHORT_WITH_SECONDS = {
+var DATETIME_SHORT_WITH_SECONDS = {
   year: n,
   month: n,
   day: n,
@@ -667,14 +660,14 @@ const DATETIME_SHORT_WITH_SECONDS = {
   minute: n,
   second: n
 };
-const DATETIME_MED = {
+var DATETIME_MED = {
   year: n,
   month: s,
   day: n,
   hour: n,
   minute: n
 };
-const DATETIME_MED_WITH_SECONDS = {
+var DATETIME_MED_WITH_SECONDS = {
   year: n,
   month: s,
   day: n,
@@ -682,7 +675,7 @@ const DATETIME_MED_WITH_SECONDS = {
   minute: n,
   second: n
 };
-const DATETIME_MED_WITH_WEEKDAY = {
+var DATETIME_MED_WITH_WEEKDAY = {
   year: n,
   month: s,
   day: n,
@@ -690,7 +683,7 @@ const DATETIME_MED_WITH_WEEKDAY = {
   hour: n,
   minute: n
 };
-const DATETIME_FULL = {
+var DATETIME_FULL = {
   year: n,
   month: l,
   day: n,
@@ -698,7 +691,7 @@ const DATETIME_FULL = {
   minute: n,
   timeZoneName: s
 };
-const DATETIME_FULL_WITH_SECONDS = {
+var DATETIME_FULL_WITH_SECONDS = {
   year: n,
   month: l,
   day: n,
@@ -707,7 +700,7 @@ const DATETIME_FULL_WITH_SECONDS = {
   second: n,
   timeZoneName: s
 };
-const DATETIME_HUGE = {
+var DATETIME_HUGE = {
   year: n,
   month: l,
   day: n,
@@ -716,7 +709,7 @@ const DATETIME_HUGE = {
   minute: n,
   timeZoneName: l
 };
-const DATETIME_HUGE_WITH_SECONDS = {
+var DATETIME_HUGE_WITH_SECONDS = {
   year: n,
   month: l,
   day: n,
@@ -728,10 +721,10 @@ const DATETIME_HUGE_WITH_SECONDS = {
 };
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/zone.js
 
+
 /**
  * @interface
  */
-
 class Zone {
   /**
    * The type of zone
@@ -741,30 +734,28 @@ class Zone {
   get type() {
     throw new ZoneIsAbstractError();
   }
+
   /**
    * The name of this zone.
    * @abstract
    * @type {string}
    */
-
-
   get name() {
     throw new ZoneIsAbstractError();
   }
-
   get ianaName() {
     return this.name;
   }
+
   /**
    * Returns whether the offset is known to be fixed for the whole year.
    * @abstract
    * @type {boolean}
    */
-
-
   get isUniversal() {
     throw new ZoneIsAbstractError();
   }
+
   /**
    * Returns the offset's common name (such as EST) at the specified timestamp
    * @abstract
@@ -774,11 +765,10 @@ class Zone {
    * @param {string} opts.locale - What locale to return the offset name in.
    * @return {string}
    */
-
-
   offsetName(ts, opts) {
     throw new ZoneIsAbstractError();
   }
+
   /**
    * Returns the offset's value as a string
    * @abstract
@@ -787,54 +777,48 @@ class Zone {
    *                          Accepts 'narrow', 'short', or 'techie'. Returning '+6', '+06:00', or '+0600' respectively
    * @return {string}
    */
-
-
   formatOffset(ts, format) {
     throw new ZoneIsAbstractError();
   }
+
   /**
    * Return the offset in minutes for this zone at the specified timestamp.
    * @abstract
    * @param {number} ts - Epoch milliseconds for which to compute the offset
    * @return {number}
    */
-
-
   offset(ts) {
     throw new ZoneIsAbstractError();
   }
+
   /**
    * Return whether this Zone is equal to another zone
    * @abstract
    * @param {Zone} otherZone - the zone to compare
    * @return {boolean}
    */
-
-
   equals(otherZone) {
     throw new ZoneIsAbstractError();
   }
+
   /**
    * Return whether this Zone is valid.
    * @abstract
    * @type {boolean}
    */
-
-
   get isValid() {
     throw new ZoneIsAbstractError();
   }
-
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/zones/systemZone.js
 
 
-let singleton = null;
+var singleton = null;
+
 /**
  * Represents the local zone for this JavaScript environment.
  * @implements {Zone}
  */
-
 class SystemZone extends Zone {
   /**
    * Get a singleton instance of the local zone
@@ -844,78 +828,61 @@ class SystemZone extends Zone {
     if (singleton === null) {
       singleton = new SystemZone();
     }
-
     return singleton;
   }
+
   /** @override **/
-
-
   get type() {
     return "system";
   }
+
   /** @override **/
-
-
   get name() {
     return new Intl.DateTimeFormat().resolvedOptions().timeZone;
   }
+
   /** @override **/
-
-
   get isUniversal() {
     return false;
   }
+
   /** @override **/
-
-
   offsetName(ts, _ref) {
-    let format = _ref.format,
-        locale = _ref.locale;
+    var format = _ref.format,
+      locale = _ref.locale;
     return parseZoneInfo(ts, format, locale);
   }
+
   /** @override **/
-
-
   formatOffset(ts, format) {
     return formatOffset(this.offset(ts), format);
   }
+
   /** @override **/
-
-
   offset(ts) {
     return -new Date(ts).getTimezoneOffset();
   }
+
   /** @override **/
-
-
   equals(otherZone) {
     return otherZone.type === "system";
   }
+
   /** @override **/
-
-
   get isValid() {
     return true;
   }
-
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/zones/IANAZone.js
 function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
-
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-
-function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
+function _iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
-
-let dtfCache = {};
-
+var dtfCache = {};
 function makeDTF(zone) {
   if (!dtfCache[zone]) {
     dtfCache[zone] = new Intl.DateTimeFormat("en-US", {
@@ -930,11 +897,9 @@ function makeDTF(zone) {
       era: "short"
     });
   }
-
   return dtfCache[zone];
 }
-
-const typeToPos = {
+var typeToPos = {
   year: 0,
   month: 1,
   day: 2,
@@ -943,48 +908,40 @@ const typeToPos = {
   minute: 5,
   second: 6
 };
-
 function hackyOffset(dtf, date) {
-  const formatted = dtf.format(date).replace(/\u200E/g, ""),
-        parsed = /(\d+)\/(\d+)\/(\d+) (AD|BC),? (\d+):(\d+):(\d+)/.exec(formatted),
-        _parsed = _slicedToArray(parsed, 8),
-        fMonth = _parsed[1],
-        fDay = _parsed[2],
-        fYear = _parsed[3],
-        fadOrBc = _parsed[4],
-        fHour = _parsed[5],
-        fMinute = _parsed[6],
-        fSecond = _parsed[7];
-
+  var formatted = dtf.format(date).replace(/\u200E/g, ""),
+    parsed = /(\d+)\/(\d+)\/(\d+) (AD|BC),? (\d+):(\d+):(\d+)/.exec(formatted),
+    _parsed = _slicedToArray(parsed, 8),
+    fMonth = _parsed[1],
+    fDay = _parsed[2],
+    fYear = _parsed[3],
+    fadOrBc = _parsed[4],
+    fHour = _parsed[5],
+    fMinute = _parsed[6],
+    fSecond = _parsed[7];
   return [fYear, fMonth, fDay, fadOrBc, fHour, fMinute, fSecond];
 }
-
 function partsOffset(dtf, date) {
-  const formatted = dtf.formatToParts(date);
-  const filled = [];
-
-  for (let i = 0; i < formatted.length; i++) {
-    const _formatted$i = formatted[i],
-          type = _formatted$i.type,
-          value = _formatted$i.value;
-    const pos = typeToPos[type];
-
+  var formatted = dtf.formatToParts(date);
+  var filled = [];
+  for (var i = 0; i < formatted.length; i++) {
+    var _formatted$i = formatted[i],
+      type = _formatted$i.type,
+      value = _formatted$i.value;
+    var pos = typeToPos[type];
     if (type === "era") {
       filled[pos] = value;
     } else if (!isUndefined(pos)) {
       filled[pos] = parseInt(value, 10);
     }
   }
-
   return filled;
 }
-
-let ianaZoneCache = {};
+var ianaZoneCache = {};
 /**
  * A zone identified by an IANA identifier, like America/New_York
  * @implements {Zone}
  */
-
 class IANAZone extends Zone {
   /**
    * @param {string} name - Zone name
@@ -994,19 +951,18 @@ class IANAZone extends Zone {
     if (!ianaZoneCache[name]) {
       ianaZoneCache[name] = new IANAZone(name);
     }
-
     return ianaZoneCache[name];
   }
+
   /**
    * Reset local caches. Should only be necessary in testing scenarios.
    * @return {void}
    */
-
-
   static resetCache() {
     ianaZoneCache = {};
     dtfCache = {};
   }
+
   /**
    * Returns whether the provided string is a valid specifier. This only checks the string's format, not that the specifier identifies a known zone; see isValidZone for that.
    * @param {string} s - The string to check validity on
@@ -1015,11 +971,10 @@ class IANAZone extends Zone {
    * @deprecated This method returns false for some valid IANA names. Use isValidZone instead.
    * @return {boolean}
    */
-
-
   static isValidSpecifier(s) {
     return this.isValidZone(s);
   }
+
   /**
    * Returns whether the provided string identifies a real zone
    * @param {string} zone - The string to check
@@ -1028,13 +983,10 @@ class IANAZone extends Zone {
    * @example IANAZone.isValidZone("Sport~~blorp") //=> false
    * @return {boolean}
    */
-
-
   static isValidZone(zone) {
     if (!zone) {
       return false;
     }
-
     try {
       new Intl.DateTimeFormat("en-US", {
         timeZone: zone
@@ -1044,73 +996,62 @@ class IANAZone extends Zone {
       return false;
     }
   }
-
   constructor(name) {
     super();
     /** @private **/
-
     this.zoneName = name;
     /** @private **/
-
     this.valid = IANAZone.isValidZone(name);
   }
+
   /** @override **/
-
-
   get type() {
     return "iana";
   }
+
   /** @override **/
-
-
   get name() {
     return this.zoneName;
   }
+
   /** @override **/
-
-
   get isUniversal() {
     return false;
   }
+
   /** @override **/
-
-
   offsetName(ts, _ref) {
-    let format = _ref.format,
-        locale = _ref.locale;
+    var format = _ref.format,
+      locale = _ref.locale;
     return parseZoneInfo(ts, format, locale, this.name);
   }
+
   /** @override **/
-
-
   formatOffset(ts, format) {
     return formatOffset(this.offset(ts), format);
   }
+
   /** @override **/
-
-
   offset(ts) {
-    const date = new Date(ts);
+    var date = new Date(ts);
     if (isNaN(date)) return NaN;
-    const dtf = makeDTF(this.name);
-
-    let _ref2 = dtf.formatToParts ? partsOffset(dtf, date) : hackyOffset(dtf, date),
-        _ref3 = _slicedToArray(_ref2, 7),
-        year = _ref3[0],
-        month = _ref3[1],
-        day = _ref3[2],
-        adOrBc = _ref3[3],
-        hour = _ref3[4],
-        minute = _ref3[5],
-        second = _ref3[6];
-
+    var dtf = makeDTF(this.name);
+    var _ref2 = dtf.formatToParts ? partsOffset(dtf, date) : hackyOffset(dtf, date),
+      _ref3 = _slicedToArray(_ref2, 7),
+      year = _ref3[0],
+      month = _ref3[1],
+      day = _ref3[2],
+      adOrBc = _ref3[3],
+      hour = _ref3[4],
+      minute = _ref3[5],
+      second = _ref3[6];
     if (adOrBc === "BC") {
       year = -Math.abs(year) + 1;
-    } // because we're using hour12 and https://bugs.chromium.org/p/chromium/issues/detail?id=1025564&can=2&q=%2224%3A00%22%20datetimeformat
+    }
 
-
-    const adjustedHour = hour === 24 ? 0 : hour;
-    const asUTC = objToLocalTS({
+    // because we're using hour12 and https://bugs.chromium.org/p/chromium/issues/detail?id=1025564&can=2&q=%2224%3A00%22%20datetimeformat
+    var adjustedHour = hour === 24 ? 0 : hour;
+    var asUTC = objToLocalTS({
       year,
       month,
       day,
@@ -1119,124 +1060,93 @@ class IANAZone extends Zone {
       second,
       millisecond: 0
     });
-    let asTS = +date;
-    const over = asTS % 1000;
+    var asTS = +date;
+    var over = asTS % 1000;
     asTS -= over >= 0 ? over : 1000 + over;
     return (asUTC - asTS) / (60 * 1000);
   }
+
   /** @override **/
-
-
   equals(otherZone) {
     return otherZone.type === "iana" && otherZone.name === this.name;
   }
+
   /** @override **/
-
-
   get isValid() {
     return this.valid;
   }
-
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/locale.js
-const _excluded = ["base"],
-      _excluded2 = ["padTo", "floor"];
-
+var _excluded = ["base"],
+  _excluded2 = ["padTo", "floor"];
 function locale_slicedToArray(arr, i) { return locale_arrayWithHoles(arr) || locale_iterableToArrayLimit(arr, i) || locale_unsupportedIterableToArray(arr, i) || locale_nonIterableRest(); }
-
 function locale_nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
 function locale_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return locale_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return locale_arrayLikeToArray(o, minLen); }
-
 function locale_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-
-function locale_iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
+function locale_iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
 function locale_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
-
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
+function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
+function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
+function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == typeof i ? i : i + ""; }
+function _toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
 function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
-
-function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
-
+function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } } return target; }
 
 
 
 
- // todo - remap caching
 
-let intlLFCache = {};
 
+// todo - remap caching
+
+var intlLFCache = {};
 function getCachedLF(locString) {
-  let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-  const key = JSON.stringify([locString, opts]);
-  let dtf = intlLFCache[key];
-
+  var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  var key = JSON.stringify([locString, opts]);
+  var dtf = intlLFCache[key];
   if (!dtf) {
     dtf = new Intl.ListFormat(locString, opts);
     intlLFCache[key] = dtf;
   }
-
   return dtf;
 }
-
-let intlDTCache = {};
-
+var intlDTCache = {};
 function getCachedDTF(locString) {
-  let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-  const key = JSON.stringify([locString, opts]);
-  let dtf = intlDTCache[key];
-
+  var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  var key = JSON.stringify([locString, opts]);
+  var dtf = intlDTCache[key];
   if (!dtf) {
     dtf = new Intl.DateTimeFormat(locString, opts);
     intlDTCache[key] = dtf;
   }
-
   return dtf;
 }
-
-let intlNumCache = {};
-
+var intlNumCache = {};
 function getCachedINF(locString) {
-  let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-  const key = JSON.stringify([locString, opts]);
-  let inf = intlNumCache[key];
-
+  var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  var key = JSON.stringify([locString, opts]);
+  var inf = intlNumCache[key];
   if (!inf) {
     inf = new Intl.NumberFormat(locString, opts);
     intlNumCache[key] = inf;
   }
-
   return inf;
 }
-
-let intlRelCache = {};
-
+var intlRelCache = {};
 function getCachedRTF(locString) {
-  let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-  const base = opts.base,
-        cacheKeyOpts = _objectWithoutProperties(opts, _excluded); // exclude `base` from the options
-
-
-  const key = JSON.stringify([locString, cacheKeyOpts]);
-  let inf = intlRelCache[key];
-
+  var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  var base = opts.base,
+    cacheKeyOpts = _objectWithoutProperties(opts, _excluded); // exclude `base` from the options
+  var key = JSON.stringify([locString, cacheKeyOpts]);
+  var inf = intlRelCache[key];
   if (!inf) {
     inf = new Intl.RelativeTimeFormat(locString, opts);
     intlRelCache[key] = inf;
   }
-
   return inf;
 }
-
-let sysLocaleCache = null;
-
+var sysLocaleCache = null;
 function systemLocale() {
   if (sysLocaleCache) {
     return sysLocaleCache;
@@ -1245,79 +1155,65 @@ function systemLocale() {
     return sysLocaleCache;
   }
 }
-
 function parseLocaleString(localeStr) {
   // I really want to avoid writing a BCP 47 parser
   // see, e.g. https://github.com/wooorm/bcp-47
   // Instead, we'll do this:
+
   // a) if the string has no -u extensions, just leave it alone
   // b) if it does, use Intl to resolve everything
   // c) if Intl fails, try again without the -u
-  const uIndex = localeStr.indexOf("-u-");
 
+  var uIndex = localeStr.indexOf("-u-");
   if (uIndex === -1) {
     return [localeStr];
   } else {
-    let options;
-    const smaller = localeStr.substring(0, uIndex);
-
+    var options;
+    var smaller = localeStr.substring(0, uIndex);
     try {
       options = getCachedDTF(localeStr).resolvedOptions();
     } catch (e) {
       options = getCachedDTF(smaller).resolvedOptions();
     }
-
-    const _options = options,
-          numberingSystem = _options.numberingSystem,
-          calendar = _options.calendar; // return the smaller one so that we can append the calendar and numbering overrides to it
-
+    var _options = options,
+      numberingSystem = _options.numberingSystem,
+      calendar = _options.calendar;
+    // return the smaller one so that we can append the calendar and numbering overrides to it
     return [smaller, numberingSystem, calendar];
   }
 }
-
 function intlConfigString(localeStr, numberingSystem, outputCalendar) {
   if (outputCalendar || numberingSystem) {
     localeStr += "-u";
-
     if (outputCalendar) {
       localeStr += `-ca-${outputCalendar}`;
     }
-
     if (numberingSystem) {
       localeStr += `-nu-${numberingSystem}`;
     }
-
     return localeStr;
   } else {
     return localeStr;
   }
 }
-
 function mapMonths(f) {
-  const ms = [];
-
-  for (let i = 1; i <= 12; i++) {
-    const dt = DateTime.utc(2016, i, 1);
+  var ms = [];
+  for (var i = 1; i <= 12; i++) {
+    var dt = DateTime.utc(2016, i, 1);
     ms.push(f(dt));
   }
-
   return ms;
 }
-
 function mapWeekdays(f) {
-  const ms = [];
-
-  for (let i = 1; i <= 7; i++) {
-    const dt = DateTime.utc(2016, 11, 13 + i);
+  var ms = [];
+  for (var i = 1; i <= 7; i++) {
+    var dt = DateTime.utc(2016, 11, 13 + i);
     ms.push(f(dt));
   }
-
   return ms;
 }
-
 function listStuff(loc, length, defaultOK, englishFn, intlFn) {
-  const mode = loc.listingMode(defaultOK);
-
+  var mode = loc.listingMode(defaultOK);
   if (mode === "error") {
     return null;
   } else if (mode === "en") {
@@ -1326,7 +1222,6 @@ function listStuff(loc, length, defaultOK, englishFn, intlFn) {
     return intlFn(length);
   }
 }
-
 function supportsFastNumbers(loc) {
   if (loc.numberingSystem && loc.numberingSystem !== "latn") {
     return false;
@@ -1334,52 +1229,46 @@ function supportsFastNumbers(loc) {
     return loc.numberingSystem === "latn" || !loc.locale || loc.locale.startsWith("en") || new Intl.DateTimeFormat(loc.intl).resolvedOptions().numberingSystem === "latn";
   }
 }
+
 /**
  * @private
  */
-
 
 class PolyNumberFormatter {
   constructor(intl, forceSimple, opts) {
     this.padTo = opts.padTo || 0;
     this.floor = opts.floor || false;
-
-    const padTo = opts.padTo,
-          floor = opts.floor,
-          otherOpts = _objectWithoutProperties(opts, _excluded2);
-
+    var padTo = opts.padTo,
+      floor = opts.floor,
+      otherOpts = _objectWithoutProperties(opts, _excluded2);
     if (!forceSimple || Object.keys(otherOpts).length > 0) {
-      const intlOpts = _objectSpread({
+      var intlOpts = _objectSpread({
         useGrouping: false
       }, opts);
-
       if (opts.padTo > 0) intlOpts.minimumIntegerDigits = opts.padTo;
       this.inf = getCachedINF(intl, intlOpts);
     }
   }
-
   format(i) {
     if (this.inf) {
-      const fixed = this.floor ? Math.floor(i) : i;
+      var fixed = this.floor ? Math.floor(i) : i;
       return this.inf.format(fixed);
     } else {
       // to match the browser's numberformatter defaults
-      const fixed = this.floor ? Math.floor(i) : roundTo(i, 3);
-      return padStart(fixed, this.padTo);
+      var _fixed = this.floor ? Math.floor(i) : roundTo(i, 3);
+      return padStart(_fixed, this.padTo);
     }
   }
-
 }
+
 /**
  * @private
  */
 
-
 class PolyDateFormatter {
   constructor(dt, intl, opts) {
     this.opts = opts;
-    let z = undefined;
-
+    var z = undefined;
     if (dt.zone.isUniversal) {
       // UTC-8 or Etc/UTC-8 are not part of tzdata, only Etc/GMT+8 and the like.
       // That is why fixed-offset TZ is set to that unless it is:
@@ -1387,9 +1276,8 @@ class PolyDateFormatter {
       // 2. Unsupported by the browser:
       //    - some do not support Etc/
       //    - < Etc/GMT-14, > Etc/GMT+12, and 30-minute or 45-minute offsets are not part of tzdata
-      const gmtOffset = -1 * (dt.offset / 60);
-      const offsetZ = gmtOffset >= 0 ? `Etc/GMT+${gmtOffset}` : `Etc/GMT${gmtOffset}`;
-
+      var gmtOffset = -1 * (dt.offset / 60);
+      var offsetZ = gmtOffset >= 0 ? `Etc/GMT+${gmtOffset}` : `Etc/GMT${gmtOffset}`;
       if (dt.offset !== 0 && IANAZone.create(offsetZ).valid) {
         z = offsetZ;
         this.dt = dt;
@@ -1402,7 +1290,6 @@ class PolyDateFormatter {
         // the time and tell the formatter to show it to us in UTC, so that the time is right
         // and the bad zone doesn't show up.
         z = "UTC";
-
         if (opts.timeZoneName) {
           this.dt = dt;
         } else {
@@ -1415,42 +1302,33 @@ class PolyDateFormatter {
       this.dt = dt;
       z = dt.zone.name;
     }
-
-    const intlOpts = _objectSpread({}, this.opts);
-
+    var intlOpts = _objectSpread({}, this.opts);
     intlOpts.timeZone = intlOpts.timeZone || z;
     this.dtf = getCachedDTF(intl, intlOpts);
   }
-
   format() {
     return this.dtf.format(this.dt.toJSDate());
   }
-
   formatToParts() {
     return this.dtf.formatToParts(this.dt.toJSDate());
   }
-
   resolvedOptions() {
     return this.dtf.resolvedOptions();
   }
-
 }
+
 /**
  * @private
  */
-
-
 class PolyRelFormatter {
   constructor(intl, isEnglish, opts) {
     this.opts = _objectSpread({
       style: "long"
     }, opts);
-
     if (!isEnglish && hasRelative()) {
       this.rtf = getCachedRTF(intl, opts);
     }
   }
-
   format(count, unit) {
     if (this.rtf) {
       return this.rtf.format(count, unit);
@@ -1458,7 +1336,6 @@ class PolyRelFormatter {
       return formatRelativeTime(unit, count, this.opts.numeric, this.opts.style !== "long");
     }
   }
-
   formatToParts(count, unit) {
     if (this.rtf) {
       return this.rtf.formatToParts(count, unit);
@@ -1466,51 +1343,44 @@ class PolyRelFormatter {
       return [];
     }
   }
-
 }
+
 /**
  * @private
  */
-
 
 class Locale {
   static fromOpts(opts) {
     return Locale.create(opts.locale, opts.numberingSystem, opts.outputCalendar, opts.defaultToEN);
   }
-
   static create(locale, numberingSystem, outputCalendar) {
-    let defaultToEN = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
-    const specifiedLocale = locale || Settings.defaultLocale; // the system locale is useful for human readable strings but annoying for parsing/formatting known formats
-
-    const localeR = specifiedLocale || (defaultToEN ? "en-US" : systemLocale());
-    const numberingSystemR = numberingSystem || Settings.defaultNumberingSystem;
-    const outputCalendarR = outputCalendar || Settings.defaultOutputCalendar;
+    var defaultToEN = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
+    var specifiedLocale = locale || Settings.defaultLocale;
+    // the system locale is useful for human readable strings but annoying for parsing/formatting known formats
+    var localeR = specifiedLocale || (defaultToEN ? "en-US" : systemLocale());
+    var numberingSystemR = numberingSystem || Settings.defaultNumberingSystem;
+    var outputCalendarR = outputCalendar || Settings.defaultOutputCalendar;
     return new Locale(localeR, numberingSystemR, outputCalendarR, specifiedLocale);
   }
-
   static resetCache() {
     sysLocaleCache = null;
     intlDTCache = {};
     intlNumCache = {};
     intlRelCache = {};
   }
-
   static fromObject() {
-    let _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-        locale = _ref.locale,
-        numberingSystem = _ref.numberingSystem,
-        outputCalendar = _ref.outputCalendar;
-
+    var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+      locale = _ref.locale,
+      numberingSystem = _ref.numberingSystem,
+      outputCalendar = _ref.outputCalendar;
     return Locale.create(locale, numberingSystem, outputCalendar);
   }
-
   constructor(locale, numbering, outputCalendar, specifiedLocale) {
-    const _parseLocaleString = parseLocaleString(locale),
-          _parseLocaleString2 = locale_slicedToArray(_parseLocaleString, 3),
-          parsedLocale = _parseLocaleString2[0],
-          parsedNumberingSystem = _parseLocaleString2[1],
-          parsedOutputCalendar = _parseLocaleString2[2];
-
+    var _parseLocaleString = parseLocaleString(locale),
+      _parseLocaleString2 = locale_slicedToArray(_parseLocaleString, 3),
+      parsedLocale = _parseLocaleString2[0],
+      parsedNumberingSystem = _parseLocaleString2[1],
+      parsedOutputCalendar = _parseLocaleString2[2];
     this.locale = parsedLocale;
     this.numberingSystem = numbering || parsedNumberingSystem || null;
     this.outputCalendar = outputCalendar || parsedOutputCalendar || null;
@@ -1528,21 +1398,17 @@ class Locale {
     this.specifiedLocale = specifiedLocale;
     this.fastNumbersCached = null;
   }
-
   get fastNumbers() {
     if (this.fastNumbersCached == null) {
       this.fastNumbersCached = supportsFastNumbers(this);
     }
-
     return this.fastNumbersCached;
   }
-
   listingMode() {
-    const isActuallyEn = this.isEnglish();
-    const hasNoWeirdness = (this.numberingSystem === null || this.numberingSystem === "latn") && (this.outputCalendar === null || this.outputCalendar === "gregory");
+    var isActuallyEn = this.isEnglish();
+    var hasNoWeirdness = (this.numberingSystem === null || this.numberingSystem === "latn") && (this.outputCalendar === null || this.outputCalendar === "gregory");
     return isActuallyEn && hasNoWeirdness ? "en" : "intl";
   }
-
   clone(alts) {
     if (!alts || Object.getOwnPropertyNames(alts).length === 0) {
       return this;
@@ -1550,143 +1416,124 @@ class Locale {
       return Locale.create(alts.locale || this.specifiedLocale, alts.numberingSystem || this.numberingSystem, alts.outputCalendar || this.outputCalendar, alts.defaultToEN || false);
     }
   }
-
   redefaultToEN() {
-    let alts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var alts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     return this.clone(_objectSpread(_objectSpread({}, alts), {}, {
       defaultToEN: true
     }));
   }
-
   redefaultToSystem() {
-    let alts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var alts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     return this.clone(_objectSpread(_objectSpread({}, alts), {}, {
       defaultToEN: false
     }));
   }
-
   months(length) {
-    let format = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
-    let defaultOK = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
+    var format = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+    var defaultOK = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
     return listStuff(this, length, defaultOK, months, () => {
-      const intl = format ? {
-        month: length,
-        day: "numeric"
-      } : {
-        month: length
-      },
-            formatStr = format ? "format" : "standalone";
-
+      var intl = format ? {
+          month: length,
+          day: "numeric"
+        } : {
+          month: length
+        },
+        formatStr = format ? "format" : "standalone";
       if (!this.monthsCache[formatStr][length]) {
         this.monthsCache[formatStr][length] = mapMonths(dt => this.extract(dt, intl, "month"));
       }
-
       return this.monthsCache[formatStr][length];
     });
   }
-
   weekdays(length) {
-    let format = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
-    let defaultOK = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
+    var format = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+    var defaultOK = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
     return listStuff(this, length, defaultOK, weekdays, () => {
-      const intl = format ? {
-        weekday: length,
-        year: "numeric",
-        month: "long",
-        day: "numeric"
-      } : {
-        weekday: length
-      },
-            formatStr = format ? "format" : "standalone";
-
+      var intl = format ? {
+          weekday: length,
+          year: "numeric",
+          month: "long",
+          day: "numeric"
+        } : {
+          weekday: length
+        },
+        formatStr = format ? "format" : "standalone";
       if (!this.weekdaysCache[formatStr][length]) {
         this.weekdaysCache[formatStr][length] = mapWeekdays(dt => this.extract(dt, intl, "weekday"));
       }
-
       return this.weekdaysCache[formatStr][length];
     });
   }
-
   meridiems() {
-    let defaultOK = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
+    var defaultOK = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
     return listStuff(this, undefined, defaultOK, () => meridiems, () => {
       // In theory there could be aribitrary day periods. We're gonna assume there are exactly two
       // for AM and PM. This is probably wrong, but it's makes parsing way easier.
       if (!this.meridiemCache) {
-        const intl = {
+        var intl = {
           hour: "numeric",
           hourCycle: "h12"
         };
         this.meridiemCache = [DateTime.utc(2016, 11, 13, 9), DateTime.utc(2016, 11, 13, 19)].map(dt => this.extract(dt, intl, "dayperiod"));
       }
-
       return this.meridiemCache;
     });
   }
-
   eras(length) {
-    let defaultOK = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
+    var defaultOK = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
     return listStuff(this, length, defaultOK, eras, () => {
-      const intl = {
+      var intl = {
         era: length
-      }; // This is problematic. Different calendars are going to define eras totally differently. What I need is the minimum set of dates
-      // to definitely enumerate them.
+      };
 
+      // This is problematic. Different calendars are going to define eras totally differently. What I need is the minimum set of dates
+      // to definitely enumerate them.
       if (!this.eraCache[length]) {
         this.eraCache[length] = [DateTime.utc(-40, 1, 1), DateTime.utc(2017, 1, 1)].map(dt => this.extract(dt, intl, "era"));
       }
-
       return this.eraCache[length];
     });
   }
-
   extract(dt, intlOpts, field) {
-    const df = this.dtFormatter(dt, intlOpts),
-          results = df.formatToParts(),
-          matching = results.find(m => m.type.toLowerCase() === field);
+    var df = this.dtFormatter(dt, intlOpts),
+      results = df.formatToParts(),
+      matching = results.find(m => m.type.toLowerCase() === field);
     return matching ? matching.value : null;
   }
-
   numberFormatter() {
-    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     // this forcesimple option is never used (the only caller short-circuits on it, but it seems safer to leave)
     // (in contrast, the rest of the condition is used heavily)
     return new PolyNumberFormatter(this.intl, opts.forceSimple || this.fastNumbers, opts);
   }
-
   dtFormatter(dt) {
-    let intlOpts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var intlOpts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     return new PolyDateFormatter(dt, this.intl, intlOpts);
   }
-
   relFormatter() {
-    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     return new PolyRelFormatter(this.intl, this.isEnglish(), opts);
   }
-
   listFormatter() {
-    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     return getCachedLF(this.intl, opts);
   }
-
   isEnglish() {
     return this.locale === "en" || this.locale.toLowerCase() === "en-us" || new Intl.DateTimeFormat(this.intl).resolvedOptions().locale.startsWith("en-us");
   }
-
   equals(other) {
     return this.locale === other.locale && this.numberingSystem === other.numberingSystem && this.outputCalendar === other.outputCalendar;
   }
-
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/zones/fixedOffsetZone.js
 
 
-let fixedOffsetZone_singleton = null;
+var fixedOffsetZone_singleton = null;
+
 /**
  * A zone with a fixed offset (meaning no DST)
  * @implements {Zone}
  */
-
 class FixedOffsetZone extends Zone {
   /**
    * Get a singleton instance of UTC
@@ -1696,19 +1543,18 @@ class FixedOffsetZone extends Zone {
     if (fixedOffsetZone_singleton === null) {
       fixedOffsetZone_singleton = new FixedOffsetZone(0);
     }
-
     return fixedOffsetZone_singleton;
   }
+
   /**
    * Get an instance with a specified offset
    * @param {number} offset - The offset in minutes
    * @return {FixedOffsetZone}
    */
-
-
   static instance(offset) {
     return offset === 0 ? FixedOffsetZone.utcInstance : new FixedOffsetZone(offset);
   }
+
   /**
    * Get an instance of FixedOffsetZone from a UTC offset string, like "UTC+6"
    * @param {string} s - The offset string to parse
@@ -1717,39 +1563,30 @@ class FixedOffsetZone extends Zone {
    * @example FixedOffsetZone.parseSpecifier("UTC-6:00")
    * @return {FixedOffsetZone}
    */
-
-
   static parseSpecifier(s) {
     if (s) {
-      const r = s.match(/^utc(?:([+-]\d{1,2})(?::(\d{2}))?)?$/i);
-
+      var r = s.match(/^utc(?:([+-]\d{1,2})(?::(\d{2}))?)?$/i);
       if (r) {
         return new FixedOffsetZone(signedOffset(r[1], r[2]));
       }
     }
-
     return null;
   }
-
   constructor(offset) {
     super();
     /** @private **/
-
     this.fixed = offset;
   }
+
   /** @override **/
-
-
   get type() {
     return "fixed";
   }
+
   /** @override **/
-
-
   get name() {
     return this.fixed === 0 ? "UTC" : `UTC${formatOffset(this.fixed, "narrow")}`;
   }
-
   get ianaName() {
     if (this.fixed === 0) {
       return "Etc/UTC";
@@ -1757,107 +1594,90 @@ class FixedOffsetZone extends Zone {
       return `Etc/GMT${formatOffset(-this.fixed, "narrow")}`;
     }
   }
+
   /** @override **/
-
-
   offsetName() {
     return this.name;
   }
+
   /** @override **/
-
-
   formatOffset(ts, format) {
     return formatOffset(this.fixed, format);
   }
+
   /** @override **/
-
-
   get isUniversal() {
     return true;
   }
+
   /** @override **/
-
-
   offset() {
     return this.fixed;
   }
+
   /** @override **/
-
-
   equals(otherZone) {
     return otherZone.type === "fixed" && otherZone.fixed === this.fixed;
   }
+
   /** @override **/
-
-
   get isValid() {
     return true;
   }
-
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/zones/invalidZone.js
+
 
 /**
  * A zone that failed to parse. You should never need to instantiate this.
  * @implements {Zone}
  */
-
 class InvalidZone extends Zone {
   constructor(zoneName) {
     super();
     /**  @private */
-
     this.zoneName = zoneName;
   }
+
   /** @override **/
-
-
   get type() {
     return "invalid";
   }
+
   /** @override **/
-
-
   get name() {
     return this.zoneName;
   }
+
   /** @override **/
-
-
   get isUniversal() {
     return false;
   }
+
   /** @override **/
-
-
   offsetName() {
     return null;
   }
+
   /** @override **/
-
-
   formatOffset() {
     return "";
   }
+
   /** @override **/
-
-
   offset() {
     return NaN;
   }
+
   /** @override **/
-
-
   equals() {
     return false;
   }
+
   /** @override **/
-
-
   get isValid() {
     return false;
   }
-
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/zoneUtil.js
 /**
@@ -1869,15 +1689,15 @@ class InvalidZone extends Zone {
 
 
 
-function normalizeZone(input, defaultZone) {
-  let offset;
 
+function normalizeZone(input, defaultZone) {
+  var offset;
   if (isUndefined(input) || input === null) {
     return defaultZone;
   } else if (input instanceof Zone) {
     return input;
   } else if (isString(input)) {
-    const lowered = input.toLowerCase();
+    var lowered = input.toLowerCase();
     if (lowered === "default") return defaultZone;else if (lowered === "local" || lowered === "system") return SystemZone.instance;else if (lowered === "utc" || lowered === "gmt") return FixedOffsetZone.utcInstance;else return FixedOffsetZone.parseSpecifier(lowered) || IANAZone.create(input);
   } else if (isNumber(input)) {
     return FixedOffsetZone.instance(input);
@@ -1894,19 +1714,17 @@ function normalizeZone(input, defaultZone) {
 
 
 
+var now = () => Date.now(),
+  defaultZone = "system",
+  defaultLocale = null,
+  defaultNumberingSystem = null,
+  defaultOutputCalendar = null,
+  twoDigitCutoffYear = 60,
+  throwOnInvalid;
 
-let now = () => Date.now(),
-    defaultZone = "system",
-    defaultLocale = null,
-    defaultNumberingSystem = null,
-    defaultOutputCalendar = null,
-    twoDigitCutoffYear = 60,
-    throwOnInvalid;
 /**
  * Settings contains static getters and setters that control Luxon's overall behavior. Luxon is a simple library with few options, but the ones it does have live here.
  */
-
-
 class Settings {
   /**
    * Get the callback for returning the current timestamp.
@@ -1915,6 +1733,7 @@ class Settings {
   static get now() {
     return now;
   }
+
   /**
    * Set the callback for returning the current timestamp.
    * The function should return a number, which will be interpreted as an Epoch millisecond count
@@ -1922,94 +1741,84 @@ class Settings {
    * @example Settings.now = () => Date.now() + 3000 // pretend it is 3 seconds in the future
    * @example Settings.now = () => 0 // always pretend it's Jan 1, 1970 at midnight in UTC time
    */
-
-
   static set now(n) {
     now = n;
   }
+
   /**
    * Set the default time zone to create DateTimes in. Does not affect existing instances.
    * Use the value "system" to reset this value to the system's time zone.
    * @type {string}
    */
-
-
   static set defaultZone(zone) {
     defaultZone = zone;
   }
+
   /**
    * Get the default time zone object currently used to create DateTimes. Does not affect existing instances.
    * The default value is the system's time zone (the one set on the machine that runs this code).
    * @type {Zone}
    */
-
-
   static get defaultZone() {
     return normalizeZone(defaultZone, SystemZone.instance);
   }
+
   /**
    * Get the default locale to create DateTimes with. Does not affect existing instances.
    * @type {string}
    */
-
-
   static get defaultLocale() {
     return defaultLocale;
   }
+
   /**
    * Set the default locale to create DateTimes with. Does not affect existing instances.
    * @type {string}
    */
-
-
   static set defaultLocale(locale) {
     defaultLocale = locale;
   }
+
   /**
    * Get the default numbering system to create DateTimes with. Does not affect existing instances.
    * @type {string}
    */
-
-
   static get defaultNumberingSystem() {
     return defaultNumberingSystem;
   }
+
   /**
    * Set the default numbering system to create DateTimes with. Does not affect existing instances.
    * @type {string}
    */
-
-
   static set defaultNumberingSystem(numberingSystem) {
     defaultNumberingSystem = numberingSystem;
   }
+
   /**
    * Get the default output calendar to create DateTimes with. Does not affect existing instances.
    * @type {string}
    */
-
-
   static get defaultOutputCalendar() {
     return defaultOutputCalendar;
   }
+
   /**
    * Set the default output calendar to create DateTimes with. Does not affect existing instances.
    * @type {string}
    */
-
-
   static set defaultOutputCalendar(outputCalendar) {
     defaultOutputCalendar = outputCalendar;
   }
+
   /**
    * Get the cutoff year after which a string encoding a year as two digits is interpreted to occur in the current century.
    * @type {number}
    */
-
-
   static get twoDigitCutoffYear() {
     return twoDigitCutoffYear;
   }
+
   /**
    * Set the cutoff year after which a string encoding a year as two digits is interpreted to occur in the current century.
    * @type {number}
@@ -2018,48 +1827,41 @@ class Settings {
    * @example Settings.twoDigitCutoffYear = 1950 // interpretted as 50
    * @example Settings.twoDigitCutoffYear = 2050 // ALSO interpretted as 50
    */
-
-
   static set twoDigitCutoffYear(cutoffYear) {
     twoDigitCutoffYear = cutoffYear % 100;
   }
+
   /**
    * Get whether Luxon will throw when it encounters invalid DateTimes, Durations, or Intervals
    * @type {boolean}
    */
-
-
   static get throwOnInvalid() {
     return throwOnInvalid;
   }
+
   /**
    * Set whether Luxon will throw when it encounters invalid DateTimes, Durations, or Intervals
    * @type {boolean}
    */
-
-
   static set throwOnInvalid(t) {
     throwOnInvalid = t;
   }
+
   /**
    * Reset Luxon's global caches. Should only be necessary in testing scenarios.
    * @return {void}
    */
-
-
   static resetCaches() {
     Locale.resetCache();
     IANAZone.resetCache();
   }
-
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/util.js
-function util_ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
-
-function util_objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? util_ownKeys(Object(source), !0).forEach(function (key) { util_defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : util_ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
-
-function util_defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
+function util_ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
+function util_objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? util_ownKeys(Object(t), !0).forEach(function (r) { util_defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : util_ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
+function util_defineProperty(obj, key, value) { key = util_toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function util_toPropertyKey(t) { var i = util_toPrimitive(t, "string"); return "symbol" == typeof i ? i : i + ""; }
+function util_toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
 /*
   This is just a junk drawer, containing anything used across multiple classes.
   Because Luxon is small(ish), this should stay small and we won't worry about splitting
@@ -2067,9 +1869,12 @@ function util_defineProperty(obj, key, value) { if (key in obj) { Object.defineP
 */
 
 
+
+
 /**
  * @private
  */
+
 // TYPES
 
 function isUndefined(o) {
@@ -2086,7 +1891,9 @@ function isString(o) {
 }
 function isDate(o) {
   return Object.prototype.toString.call(o) === "[object Date]";
-} // CAPABILITIES
+}
+
+// CAPABILITIES
 
 function hasRelative() {
   try {
@@ -2094,7 +1901,9 @@ function hasRelative() {
   } catch (e) {
     return false;
   }
-} // OBJECTS AND ARRAYS
+}
+
+// OBJECTS AND ARRAYS
 
 function maybeArray(thing) {
   return Array.isArray(thing) ? thing : [thing];
@@ -2103,10 +1912,8 @@ function bestBy(arr, by, compare) {
   if (arr.length === 0) {
     return undefined;
   }
-
   return arr.reduce((best, next) => {
-    const pair = [by(next), next];
-
+    var pair = [by(next), next];
     if (!best) {
       return pair;
     } else if (compare(best[0], pair[0]) === best[0]) {
@@ -2124,26 +1931,27 @@ function util_pick(obj, keys) {
 }
 function util_hasOwnProperty(obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
-} // NUMBERS AND STRINGS
+}
+
+// NUMBERS AND STRINGS
 
 function integerBetween(thing, bottom, top) {
   return isInteger(thing) && thing >= bottom && thing <= top;
-} // x % n but takes the sign of n instead of x
+}
 
+// x % n but takes the sign of n instead of x
 function floorMod(x, n) {
   return x - n * Math.floor(x / n);
 }
 function padStart(input) {
-  let n = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 2;
-  const isNeg = input < 0;
-  let padded;
-
+  var n = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 2;
+  var isNeg = input < 0;
+  var padded;
   if (isNeg) {
     padded = "-" + ("" + -input).padStart(n, "0");
   } else {
     padded = ("" + input).padStart(n, "0");
   }
-
   return padded;
 }
 function parseInteger(string) {
@@ -2165,16 +1973,18 @@ function parseMillis(fraction) {
   if (isUndefined(fraction) || fraction === null || fraction === "") {
     return undefined;
   } else {
-    const f = parseFloat("0." + fraction) * 1000;
+    var f = parseFloat("0." + fraction) * 1000;
     return Math.floor(f);
   }
 }
 function roundTo(number, digits) {
-  let towardZero = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
-  const factor = 10 ** digits,
-        rounder = towardZero ? Math.trunc : Math.round;
+  var towardZero = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
+  var factor = 10 ** digits,
+    rounder = towardZero ? Math.trunc : Math.round;
   return rounder(number * factor) / factor;
-} // DATE BASICS
+}
+
+// DATE BASICS
 
 function isLeapYear(year) {
   return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
@@ -2183,107 +1993,103 @@ function daysInYear(year) {
   return isLeapYear(year) ? 366 : 365;
 }
 function daysInMonth(year, month) {
-  const modMonth = floorMod(month - 1, 12) + 1,
-        modYear = year + (month - modMonth) / 12;
-
+  var modMonth = floorMod(month - 1, 12) + 1,
+    modYear = year + (month - modMonth) / 12;
   if (modMonth === 2) {
     return isLeapYear(modYear) ? 29 : 28;
   } else {
     return [31, null, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][modMonth - 1];
   }
-} // covert a calendar object to a local timestamp (epoch, but with the offset baked in)
+}
 
+// covert a calendar object to a local timestamp (epoch, but with the offset baked in)
 function objToLocalTS(obj) {
-  let d = Date.UTC(obj.year, obj.month - 1, obj.day, obj.hour, obj.minute, obj.second, obj.millisecond); // for legacy reasons, years between 0 and 99 are interpreted as 19XX; revert that
+  var d = Date.UTC(obj.year, obj.month - 1, obj.day, obj.hour, obj.minute, obj.second, obj.millisecond);
 
+  // for legacy reasons, years between 0 and 99 are interpreted as 19XX; revert that
   if (obj.year < 100 && obj.year >= 0) {
     d = new Date(d);
     d.setUTCFullYear(d.getUTCFullYear() - 1900);
   }
-
   return +d;
 }
 function weeksInWeekYear(weekYear) {
-  const p1 = (weekYear + Math.floor(weekYear / 4) - Math.floor(weekYear / 100) + Math.floor(weekYear / 400)) % 7,
-        last = weekYear - 1,
-        p2 = (last + Math.floor(last / 4) - Math.floor(last / 100) + Math.floor(last / 400)) % 7;
+  var p1 = (weekYear + Math.floor(weekYear / 4) - Math.floor(weekYear / 100) + Math.floor(weekYear / 400)) % 7,
+    last = weekYear - 1,
+    p2 = (last + Math.floor(last / 4) - Math.floor(last / 100) + Math.floor(last / 400)) % 7;
   return p1 === 4 || p2 === 3 ? 53 : 52;
 }
 function untruncateYear(year) {
   if (year > 99) {
     return year;
   } else return year > Settings.twoDigitCutoffYear ? 1900 + year : 2000 + year;
-} // PARSING
+}
+
+// PARSING
 
 function parseZoneInfo(ts, offsetFormat, locale) {
-  let timeZone = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : null;
-  const date = new Date(ts),
-        intlOpts = {
-    hourCycle: "h23",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit"
-  };
-
+  var timeZone = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : null;
+  var date = new Date(ts),
+    intlOpts = {
+      hourCycle: "h23",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit"
+    };
   if (timeZone) {
     intlOpts.timeZone = timeZone;
   }
-
-  const modified = util_objectSpread({
+  var modified = util_objectSpread({
     timeZoneName: offsetFormat
   }, intlOpts);
-
-  const parsed = new Intl.DateTimeFormat(locale, modified).formatToParts(date).find(m => m.type.toLowerCase() === "timezonename");
+  var parsed = new Intl.DateTimeFormat(locale, modified).formatToParts(date).find(m => m.type.toLowerCase() === "timezonename");
   return parsed ? parsed.value : null;
-} // signedOffset('-5', '30') -> -330
+}
 
+// signedOffset('-5', '30') -> -330
 function signedOffset(offHourStr, offMinuteStr) {
-  let offHour = parseInt(offHourStr, 10); // don't || this because we want to preserve -0
+  var offHour = parseInt(offHourStr, 10);
 
+  // don't || this because we want to preserve -0
   if (Number.isNaN(offHour)) {
     offHour = 0;
   }
-
-  const offMin = parseInt(offMinuteStr, 10) || 0,
-        offMinSigned = offHour < 0 || Object.is(offHour, -0) ? -offMin : offMin;
+  var offMin = parseInt(offMinuteStr, 10) || 0,
+    offMinSigned = offHour < 0 || Object.is(offHour, -0) ? -offMin : offMin;
   return offHour * 60 + offMinSigned;
-} // COERCION
+}
+
+// COERCION
 
 function asNumber(value) {
-  const numericValue = Number(value);
+  var numericValue = Number(value);
   if (typeof value === "boolean" || value === "" || Number.isNaN(numericValue)) throw new InvalidArgumentError(`Invalid unit value ${value}`);
   return numericValue;
 }
 function normalizeObject(obj, normalizer) {
-  const normalized = {};
-
-  for (const u in obj) {
+  var normalized = {};
+  for (var u in obj) {
     if (util_hasOwnProperty(obj, u)) {
-      const v = obj[u];
+      var v = obj[u];
       if (v === undefined || v === null) continue;
       normalized[normalizer(u)] = asNumber(v);
     }
   }
-
   return normalized;
 }
 function formatOffset(offset, format) {
-  const hours = Math.trunc(Math.abs(offset / 60)),
-        minutes = Math.trunc(Math.abs(offset % 60)),
-        sign = offset >= 0 ? "+" : "-";
-
+  var hours = Math.trunc(Math.abs(offset / 60)),
+    minutes = Math.trunc(Math.abs(offset % 60)),
+    sign = offset >= 0 ? "+" : "-";
   switch (format) {
     case "short":
       return `${sign}${padStart(hours, 2)}:${padStart(minutes, 2)}`;
-
     case "narrow":
       return `${sign}${hours}${minutes > 0 ? `:${minutes}` : ""}`;
-
     case "techie":
       return `${sign}${padStart(hours, 2)}${padStart(minutes, 2)}`;
-
     default:
       throw new RangeError(`Value format ${format} is out of range for property format`);
   }
@@ -2294,75 +2100,62 @@ function timeObject(obj) {
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/english.js
 
 
-
 function stringify(obj) {
   return JSON.stringify(obj, Object.keys(obj).sort());
 }
+
 /**
  * @private
  */
 
-
-const monthsLong = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
-const monthsShort = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-const monthsNarrow = ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"];
+var monthsLong = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+var monthsShort = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+var monthsNarrow = ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"];
 function months(length) {
   switch (length) {
     case "narrow":
       return [...monthsNarrow];
-
     case "short":
       return [...monthsShort];
-
     case "long":
       return [...monthsLong];
-
     case "numeric":
       return ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"];
-
     case "2-digit":
       return ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"];
-
     default:
       return null;
   }
 }
-const weekdaysLong = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
-const weekdaysShort = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-const weekdaysNarrow = ["M", "T", "W", "T", "F", "S", "S"];
+var weekdaysLong = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+var weekdaysShort = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+var weekdaysNarrow = ["M", "T", "W", "T", "F", "S", "S"];
 function weekdays(length) {
   switch (length) {
     case "narrow":
       return [...weekdaysNarrow];
-
     case "short":
       return [...weekdaysShort];
-
     case "long":
       return [...weekdaysLong];
-
     case "numeric":
       return ["1", "2", "3", "4", "5", "6", "7"];
-
     default:
       return null;
   }
 }
-const meridiems = ["AM", "PM"];
-const erasLong = ["Before Christ", "Anno Domini"];
-const erasShort = ["BC", "AD"];
-const erasNarrow = ["B", "A"];
+var meridiems = ["AM", "PM"];
+var erasLong = ["Before Christ", "Anno Domini"];
+var erasShort = ["BC", "AD"];
+var erasNarrow = ["B", "A"];
 function eras(length) {
   switch (length) {
     case "narrow":
       return [...erasNarrow];
-
     case "short":
       return [...erasShort];
-
     case "long":
       return [...erasLong];
-
     default:
       return null;
   }
@@ -2380,9 +2173,9 @@ function eraForDateTime(dt, length) {
   return eras(length)[dt.year < 0 ? 0 : 1];
 }
 function formatRelativeTime(unit, count) {
-  let numeric = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : "always";
-  let narrow = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
-  const units = {
+  var numeric = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : "always";
+  var narrow = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
+  var units = {
     years: ["year", "yr."],
     quarters: ["quarter", "qtr."],
     months: ["month", "mo."],
@@ -2392,138 +2185,100 @@ function formatRelativeTime(unit, count) {
     minutes: ["minute", "min."],
     seconds: ["second", "sec."]
   };
-  const lastable = ["hours", "minutes", "seconds"].indexOf(unit) === -1;
-
+  var lastable = ["hours", "minutes", "seconds"].indexOf(unit) === -1;
   if (numeric === "auto" && lastable) {
-    const isDay = unit === "days";
-
+    var isDay = unit === "days";
     switch (count) {
       case 1:
         return isDay ? "tomorrow" : `next ${units[unit][0]}`;
-
       case -1:
         return isDay ? "yesterday" : `last ${units[unit][0]}`;
-
       case 0:
         return isDay ? "today" : `this ${units[unit][0]}`;
-
       default: // fall through
-
     }
   }
-
-  const isInPast = Object.is(count, -0) || count < 0,
-        fmtValue = Math.abs(count),
-        singular = fmtValue === 1,
-        lilUnits = units[unit],
-        fmtUnit = narrow ? singular ? lilUnits[1] : lilUnits[2] || lilUnits[1] : singular ? units[unit][0] : unit;
+  var isInPast = Object.is(count, -0) || count < 0,
+    fmtValue = Math.abs(count),
+    singular = fmtValue === 1,
+    lilUnits = units[unit],
+    fmtUnit = narrow ? singular ? lilUnits[1] : lilUnits[2] || lilUnits[1] : singular ? units[unit][0] : unit;
   return isInPast ? `${fmtValue} ${fmtUnit} ago` : `in ${fmtValue} ${fmtUnit}`;
 }
 function formatString(knownFormat) {
   // these all have the offsets removed because we don't have access to them
   // without all the intl stuff this is backfilling
-  const filtered = pick(knownFormat, ["weekday", "era", "year", "month", "day", "hour", "minute", "second", "timeZoneName", "hourCycle"]),
-        key = stringify(filtered),
-        dateTimeHuge = "EEEE, LLLL d, yyyy, h:mm a";
-
+  var filtered = pick(knownFormat, ["weekday", "era", "year", "month", "day", "hour", "minute", "second", "timeZoneName", "hourCycle"]),
+    key = stringify(filtered),
+    dateTimeHuge = "EEEE, LLLL d, yyyy, h:mm a";
   switch (key) {
     case stringify(Formats.DATE_SHORT):
       return "M/d/yyyy";
-
     case stringify(Formats.DATE_MED):
       return "LLL d, yyyy";
-
     case stringify(Formats.DATE_MED_WITH_WEEKDAY):
       return "EEE, LLL d, yyyy";
-
     case stringify(Formats.DATE_FULL):
       return "LLLL d, yyyy";
-
     case stringify(Formats.DATE_HUGE):
       return "EEEE, LLLL d, yyyy";
-
     case stringify(Formats.TIME_SIMPLE):
       return "h:mm a";
-
     case stringify(Formats.TIME_WITH_SECONDS):
       return "h:mm:ss a";
-
     case stringify(Formats.TIME_WITH_SHORT_OFFSET):
       return "h:mm a";
-
     case stringify(Formats.TIME_WITH_LONG_OFFSET):
       return "h:mm a";
-
     case stringify(Formats.TIME_24_SIMPLE):
       return "HH:mm";
-
     case stringify(Formats.TIME_24_WITH_SECONDS):
       return "HH:mm:ss";
-
     case stringify(Formats.TIME_24_WITH_SHORT_OFFSET):
       return "HH:mm";
-
     case stringify(Formats.TIME_24_WITH_LONG_OFFSET):
       return "HH:mm";
-
     case stringify(Formats.DATETIME_SHORT):
       return "M/d/yyyy, h:mm a";
-
     case stringify(Formats.DATETIME_MED):
       return "LLL d, yyyy, h:mm a";
-
     case stringify(Formats.DATETIME_FULL):
       return "LLLL d, yyyy, h:mm a";
-
     case stringify(Formats.DATETIME_HUGE):
       return dateTimeHuge;
-
     case stringify(Formats.DATETIME_SHORT_WITH_SECONDS):
       return "M/d/yyyy, h:mm:ss a";
-
     case stringify(Formats.DATETIME_MED_WITH_SECONDS):
       return "LLL d, yyyy, h:mm:ss a";
-
     case stringify(Formats.DATETIME_MED_WITH_WEEKDAY):
       return "EEE, d LLL yyyy, h:mm a";
-
     case stringify(Formats.DATETIME_FULL_WITH_SECONDS):
       return "LLLL d, yyyy, h:mm:ss a";
-
     case stringify(Formats.DATETIME_HUGE_WITH_SECONDS):
       return "EEEE, LLLL d, yyyy, h:mm:ss a";
-
     default:
       return dateTimeHuge;
   }
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/formatter.js
-function formatter_ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
-
-function formatter_objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? formatter_ownKeys(Object(source), !0).forEach(function (key) { formatter_defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : formatter_ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
-
-function formatter_defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
+function formatter_ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
+function formatter_objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? formatter_ownKeys(Object(t), !0).forEach(function (r) { formatter_defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : formatter_ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
+function formatter_defineProperty(obj, key, value) { key = formatter_toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function formatter_toPropertyKey(t) { var i = formatter_toPrimitive(t, "string"); return "symbol" == typeof i ? i : i + ""; }
+function formatter_toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
 function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = formatter_unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-
 function formatter_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return formatter_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return formatter_arrayLikeToArray(o, minLen); }
-
 function formatter_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
 
 
 
-
-
 function stringifyTokens(splits, tokenToString) {
-  let s = "";
-
+  var s = "";
   var _iterator = _createForOfIteratorHelper(splits),
-      _step;
-
+    _step;
   try {
     for (_iterator.s(); !(_step = _iterator.n()).done;) {
-      const token = _step.value;
-
+      var token = _step.value;
       if (token.literal) {
         s += token.val;
       } else {
@@ -2535,11 +2290,9 @@ function stringifyTokens(splits, tokenToString) {
   } finally {
     _iterator.f();
   }
-
   return s;
 }
-
-const macroTokenToFormatOpts = {
+var macroTokenToFormatOpts = {
   D: DATE_SHORT,
   DD: DATE_MED,
   DDD: DATE_FULL,
@@ -2561,25 +2314,23 @@ const macroTokenToFormatOpts = {
   FFF: DATETIME_FULL_WITH_SECONDS,
   FFFF: DATETIME_HUGE_WITH_SECONDS
 };
+
 /**
  * @private
  */
 
 class Formatter {
   static create(locale) {
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     return new Formatter(locale, opts);
   }
-
   static parseFormat(fmt) {
-    let current = null,
-        currentFull = "",
-        bracketed = false;
-    const splits = [];
-
-    for (let i = 0; i < fmt.length; i++) {
-      const c = fmt.charAt(i);
-
+    var current = null,
+      currentFull = "",
+      bracketed = false;
+    var splits = [];
+    for (var i = 0; i < fmt.length; i++) {
+      var c = fmt.charAt(i);
       if (c === "'") {
         if (currentFull.length > 0) {
           splits.push({
@@ -2587,7 +2338,6 @@ class Formatter {
             val: currentFull
           });
         }
-
         current = null;
         currentFull = "";
         bracketed = !bracketed;
@@ -2602,438 +2352,350 @@ class Formatter {
             val: currentFull
           });
         }
-
         currentFull = c;
         current = c;
       }
     }
-
     if (currentFull.length > 0) {
       splits.push({
         literal: bracketed,
         val: currentFull
       });
     }
-
     return splits;
   }
-
   static macroTokenToFormatOpts(token) {
     return macroTokenToFormatOpts[token];
   }
-
   constructor(locale, formatOpts) {
     this.opts = formatOpts;
     this.loc = locale;
     this.systemLoc = null;
   }
-
   formatWithSystemDefault(dt, opts) {
     if (this.systemLoc === null) {
       this.systemLoc = this.loc.redefaultToSystem();
     }
-
-    const df = this.systemLoc.dtFormatter(dt, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
+    var df = this.systemLoc.dtFormatter(dt, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
     return df.format();
   }
-
   formatDateTime(dt) {
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    const df = this.loc.dtFormatter(dt, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var df = this.loc.dtFormatter(dt, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
     return df.format();
   }
-
   formatDateTimeParts(dt) {
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    const df = this.loc.dtFormatter(dt, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var df = this.loc.dtFormatter(dt, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
     return df.formatToParts();
   }
-
   formatInterval(interval) {
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    const df = this.loc.dtFormatter(interval.start, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var df = this.loc.dtFormatter(interval.start, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
     return df.dtf.formatRange(interval.start.toJSDate(), interval.end.toJSDate());
   }
-
   resolvedOptions(dt) {
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    const df = this.loc.dtFormatter(dt, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var df = this.loc.dtFormatter(dt, formatter_objectSpread(formatter_objectSpread({}, this.opts), opts));
     return df.resolvedOptions();
   }
-
   num(n) {
-    let p = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
-
+    var p = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
     // we get some perf out of doing this here, annoyingly
     if (this.opts.forceSimple) {
       return padStart(n, p);
     }
-
-    const opts = formatter_objectSpread({}, this.opts);
-
+    var opts = formatter_objectSpread({}, this.opts);
     if (p > 0) {
       opts.padTo = p;
     }
-
     return this.loc.numberFormatter(opts).format(n);
   }
-
   formatDateTimeFromString(dt, fmt) {
-    const knownEnglish = this.loc.listingMode() === "en",
-          useDateTimeFormatter = this.loc.outputCalendar && this.loc.outputCalendar !== "gregory",
-          string = (opts, extract) => this.loc.extract(dt, opts, extract),
-          formatOffset = opts => {
-      if (dt.isOffsetFixed && dt.offset === 0 && opts.allowZ) {
-        return "Z";
-      }
-
-      return dt.isValid ? dt.zone.formatOffset(dt.ts, opts.format) : "";
-    },
-          meridiem = () => knownEnglish ? meridiemForDateTime(dt) : string({
-      hour: "numeric",
-      hourCycle: "h12"
-    }, "dayperiod"),
-          month = (length, standalone) => knownEnglish ? monthForDateTime(dt, length) : string(standalone ? {
-      month: length
-    } : {
-      month: length,
-      day: "numeric"
-    }, "month"),
-          weekday = (length, standalone) => knownEnglish ? weekdayForDateTime(dt, length) : string(standalone ? {
-      weekday: length
-    } : {
-      weekday: length,
-      month: "long",
-      day: "numeric"
-    }, "weekday"),
-          maybeMacro = token => {
-      const formatOpts = Formatter.macroTokenToFormatOpts(token);
-
-      if (formatOpts) {
-        return this.formatWithSystemDefault(dt, formatOpts);
-      } else {
-        return token;
-      }
-    },
-          era = length => knownEnglish ? eraForDateTime(dt, length) : string({
-      era: length
-    }, "era"),
-          tokenToString = token => {
-      // Where possible: http://cldr.unicode.org/translation/date-time-1/date-time#TOC-Standalone-vs.-Format-Styles
-      switch (token) {
-        // ms
-        case "S":
-          return this.num(dt.millisecond);
-
-        case "u": // falls through
-
-        case "SSS":
-          return this.num(dt.millisecond, 3);
-        // seconds
-
-        case "s":
-          return this.num(dt.second);
-
-        case "ss":
-          return this.num(dt.second, 2);
-        // fractional seconds
-
-        case "uu":
-          return this.num(Math.floor(dt.millisecond / 10), 2);
-
-        case "uuu":
-          return this.num(Math.floor(dt.millisecond / 100));
-        // minutes
-
-        case "m":
-          return this.num(dt.minute);
-
-        case "mm":
-          return this.num(dt.minute, 2);
-        // hours
-
-        case "h":
-          return this.num(dt.hour % 12 === 0 ? 12 : dt.hour % 12);
-
-        case "hh":
-          return this.num(dt.hour % 12 === 0 ? 12 : dt.hour % 12, 2);
-
-        case "H":
-          return this.num(dt.hour);
-
-        case "HH":
-          return this.num(dt.hour, 2);
-        // offset
-
-        case "Z":
-          // like +6
-          return formatOffset({
-            format: "narrow",
-            allowZ: this.opts.allowZ
-          });
-
-        case "ZZ":
-          // like +06:00
-          return formatOffset({
-            format: "short",
-            allowZ: this.opts.allowZ
-          });
-
-        case "ZZZ":
-          // like +0600
-          return formatOffset({
-            format: "techie",
-            allowZ: this.opts.allowZ
-          });
-
-        case "ZZZZ":
-          // like EST
-          return dt.zone.offsetName(dt.ts, {
-            format: "short",
-            locale: this.loc.locale
-          });
-
-        case "ZZZZZ":
-          // like Eastern Standard Time
-          return dt.zone.offsetName(dt.ts, {
-            format: "long",
-            locale: this.loc.locale
-          });
-        // zone
-
-        case "z":
-          // like America/New_York
-          return dt.zoneName;
-        // meridiems
-
-        case "a":
-          return meridiem();
-        // dates
-
-        case "d":
-          return useDateTimeFormatter ? string({
-            day: "numeric"
-          }, "day") : this.num(dt.day);
-
-        case "dd":
-          return useDateTimeFormatter ? string({
-            day: "2-digit"
-          }, "day") : this.num(dt.day, 2);
-        // weekdays - standalone
-
-        case "c":
-          // like 1
-          return this.num(dt.weekday);
-
-        case "ccc":
-          // like 'Tues'
-          return weekday("short", true);
-
-        case "cccc":
-          // like 'Tuesday'
-          return weekday("long", true);
-
-        case "ccccc":
-          // like 'T'
-          return weekday("narrow", true);
-        // weekdays - format
-
-        case "E":
-          // like 1
-          return this.num(dt.weekday);
-
-        case "EEE":
-          // like 'Tues'
-          return weekday("short", false);
-
-        case "EEEE":
-          // like 'Tuesday'
-          return weekday("long", false);
-
-        case "EEEEE":
-          // like 'T'
-          return weekday("narrow", false);
-        // months - standalone
-
-        case "L":
-          // like 1
-          return useDateTimeFormatter ? string({
-            month: "numeric",
-            day: "numeric"
-          }, "month") : this.num(dt.month);
-
-        case "LL":
-          // like 01, doesn't seem to work
-          return useDateTimeFormatter ? string({
-            month: "2-digit",
-            day: "numeric"
-          }, "month") : this.num(dt.month, 2);
-
-        case "LLL":
-          // like Jan
-          return month("short", true);
-
-        case "LLLL":
-          // like January
-          return month("long", true);
-
-        case "LLLLL":
-          // like J
-          return month("narrow", true);
-        // months - format
-
-        case "M":
-          // like 1
-          return useDateTimeFormatter ? string({
-            month: "numeric"
-          }, "month") : this.num(dt.month);
-
-        case "MM":
-          // like 01
-          return useDateTimeFormatter ? string({
-            month: "2-digit"
-          }, "month") : this.num(dt.month, 2);
-
-        case "MMM":
-          // like Jan
-          return month("short", false);
-
-        case "MMMM":
-          // like January
-          return month("long", false);
-
-        case "MMMMM":
-          // like J
-          return month("narrow", false);
-        // years
-
-        case "y":
-          // like 2014
-          return useDateTimeFormatter ? string({
-            year: "numeric"
-          }, "year") : this.num(dt.year);
-
-        case "yy":
-          // like 14
-          return useDateTimeFormatter ? string({
-            year: "2-digit"
-          }, "year") : this.num(dt.year.toString().slice(-2), 2);
-
-        case "yyyy":
-          // like 0012
-          return useDateTimeFormatter ? string({
-            year: "numeric"
-          }, "year") : this.num(dt.year, 4);
-
-        case "yyyyyy":
-          // like 000012
-          return useDateTimeFormatter ? string({
-            year: "numeric"
-          }, "year") : this.num(dt.year, 6);
-        // eras
-
-        case "G":
-          // like AD
-          return era("short");
-
-        case "GG":
-          // like Anno Domini
-          return era("long");
-
-        case "GGGGG":
-          return era("narrow");
-
-        case "kk":
-          return this.num(dt.weekYear.toString().slice(-2), 2);
-
-        case "kkkk":
-          return this.num(dt.weekYear, 4);
-
-        case "W":
-          return this.num(dt.weekNumber);
-
-        case "WW":
-          return this.num(dt.weekNumber, 2);
-
-        case "o":
-          return this.num(dt.ordinal);
-
-        case "ooo":
-          return this.num(dt.ordinal, 3);
-
-        case "q":
-          // like 1
-          return this.num(dt.quarter);
-
-        case "qq":
-          // like 01
-          return this.num(dt.quarter, 2);
-
-        case "X":
-          return this.num(Math.floor(dt.ts / 1000));
-
-        case "x":
-          return this.num(dt.ts);
-
-        default:
-          return maybeMacro(token);
-      }
-    };
-
+    var knownEnglish = this.loc.listingMode() === "en",
+      useDateTimeFormatter = this.loc.outputCalendar && this.loc.outputCalendar !== "gregory",
+      string = (opts, extract) => this.loc.extract(dt, opts, extract),
+      formatOffset = opts => {
+        if (dt.isOffsetFixed && dt.offset === 0 && opts.allowZ) {
+          return "Z";
+        }
+        return dt.isValid ? dt.zone.formatOffset(dt.ts, opts.format) : "";
+      },
+      meridiem = () => knownEnglish ? meridiemForDateTime(dt) : string({
+        hour: "numeric",
+        hourCycle: "h12"
+      }, "dayperiod"),
+      month = (length, standalone) => knownEnglish ? monthForDateTime(dt, length) : string(standalone ? {
+        month: length
+      } : {
+        month: length,
+        day: "numeric"
+      }, "month"),
+      weekday = (length, standalone) => knownEnglish ? weekdayForDateTime(dt, length) : string(standalone ? {
+        weekday: length
+      } : {
+        weekday: length,
+        month: "long",
+        day: "numeric"
+      }, "weekday"),
+      maybeMacro = token => {
+        var formatOpts = Formatter.macroTokenToFormatOpts(token);
+        if (formatOpts) {
+          return this.formatWithSystemDefault(dt, formatOpts);
+        } else {
+          return token;
+        }
+      },
+      era = length => knownEnglish ? eraForDateTime(dt, length) : string({
+        era: length
+      }, "era"),
+      tokenToString = token => {
+        // Where possible: http://cldr.unicode.org/translation/date-time-1/date-time#TOC-Standalone-vs.-Format-Styles
+        switch (token) {
+          // ms
+          case "S":
+            return this.num(dt.millisecond);
+          case "u":
+          // falls through
+          case "SSS":
+            return this.num(dt.millisecond, 3);
+          // seconds
+          case "s":
+            return this.num(dt.second);
+          case "ss":
+            return this.num(dt.second, 2);
+          // fractional seconds
+          case "uu":
+            return this.num(Math.floor(dt.millisecond / 10), 2);
+          case "uuu":
+            return this.num(Math.floor(dt.millisecond / 100));
+          // minutes
+          case "m":
+            return this.num(dt.minute);
+          case "mm":
+            return this.num(dt.minute, 2);
+          // hours
+          case "h":
+            return this.num(dt.hour % 12 === 0 ? 12 : dt.hour % 12);
+          case "hh":
+            return this.num(dt.hour % 12 === 0 ? 12 : dt.hour % 12, 2);
+          case "H":
+            return this.num(dt.hour);
+          case "HH":
+            return this.num(dt.hour, 2);
+          // offset
+          case "Z":
+            // like +6
+            return formatOffset({
+              format: "narrow",
+              allowZ: this.opts.allowZ
+            });
+          case "ZZ":
+            // like +06:00
+            return formatOffset({
+              format: "short",
+              allowZ: this.opts.allowZ
+            });
+          case "ZZZ":
+            // like +0600
+            return formatOffset({
+              format: "techie",
+              allowZ: this.opts.allowZ
+            });
+          case "ZZZZ":
+            // like EST
+            return dt.zone.offsetName(dt.ts, {
+              format: "short",
+              locale: this.loc.locale
+            });
+          case "ZZZZZ":
+            // like Eastern Standard Time
+            return dt.zone.offsetName(dt.ts, {
+              format: "long",
+              locale: this.loc.locale
+            });
+          // zone
+          case "z":
+            // like America/New_York
+            return dt.zoneName;
+          // meridiems
+          case "a":
+            return meridiem();
+          // dates
+          case "d":
+            return useDateTimeFormatter ? string({
+              day: "numeric"
+            }, "day") : this.num(dt.day);
+          case "dd":
+            return useDateTimeFormatter ? string({
+              day: "2-digit"
+            }, "day") : this.num(dt.day, 2);
+          // weekdays - standalone
+          case "c":
+            // like 1
+            return this.num(dt.weekday);
+          case "ccc":
+            // like 'Tues'
+            return weekday("short", true);
+          case "cccc":
+            // like 'Tuesday'
+            return weekday("long", true);
+          case "ccccc":
+            // like 'T'
+            return weekday("narrow", true);
+          // weekdays - format
+          case "E":
+            // like 1
+            return this.num(dt.weekday);
+          case "EEE":
+            // like 'Tues'
+            return weekday("short", false);
+          case "EEEE":
+            // like 'Tuesday'
+            return weekday("long", false);
+          case "EEEEE":
+            // like 'T'
+            return weekday("narrow", false);
+          // months - standalone
+          case "L":
+            // like 1
+            return useDateTimeFormatter ? string({
+              month: "numeric",
+              day: "numeric"
+            }, "month") : this.num(dt.month);
+          case "LL":
+            // like 01, doesn't seem to work
+            return useDateTimeFormatter ? string({
+              month: "2-digit",
+              day: "numeric"
+            }, "month") : this.num(dt.month, 2);
+          case "LLL":
+            // like Jan
+            return month("short", true);
+          case "LLLL":
+            // like January
+            return month("long", true);
+          case "LLLLL":
+            // like J
+            return month("narrow", true);
+          // months - format
+          case "M":
+            // like 1
+            return useDateTimeFormatter ? string({
+              month: "numeric"
+            }, "month") : this.num(dt.month);
+          case "MM":
+            // like 01
+            return useDateTimeFormatter ? string({
+              month: "2-digit"
+            }, "month") : this.num(dt.month, 2);
+          case "MMM":
+            // like Jan
+            return month("short", false);
+          case "MMMM":
+            // like January
+            return month("long", false);
+          case "MMMMM":
+            // like J
+            return month("narrow", false);
+          // years
+          case "y":
+            // like 2014
+            return useDateTimeFormatter ? string({
+              year: "numeric"
+            }, "year") : this.num(dt.year);
+          case "yy":
+            // like 14
+            return useDateTimeFormatter ? string({
+              year: "2-digit"
+            }, "year") : this.num(dt.year.toString().slice(-2), 2);
+          case "yyyy":
+            // like 0012
+            return useDateTimeFormatter ? string({
+              year: "numeric"
+            }, "year") : this.num(dt.year, 4);
+          case "yyyyyy":
+            // like 000012
+            return useDateTimeFormatter ? string({
+              year: "numeric"
+            }, "year") : this.num(dt.year, 6);
+          // eras
+          case "G":
+            // like AD
+            return era("short");
+          case "GG":
+            // like Anno Domini
+            return era("long");
+          case "GGGGG":
+            return era("narrow");
+          case "kk":
+            return this.num(dt.weekYear.toString().slice(-2), 2);
+          case "kkkk":
+            return this.num(dt.weekYear, 4);
+          case "W":
+            return this.num(dt.weekNumber);
+          case "WW":
+            return this.num(dt.weekNumber, 2);
+          case "o":
+            return this.num(dt.ordinal);
+          case "ooo":
+            return this.num(dt.ordinal, 3);
+          case "q":
+            // like 1
+            return this.num(dt.quarter);
+          case "qq":
+            // like 01
+            return this.num(dt.quarter, 2);
+          case "X":
+            return this.num(Math.floor(dt.ts / 1000));
+          case "x":
+            return this.num(dt.ts);
+          default:
+            return maybeMacro(token);
+        }
+      };
     return stringifyTokens(Formatter.parseFormat(fmt), tokenToString);
   }
-
   formatDurationFromString(dur, fmt) {
-    const tokenToField = token => {
-      switch (token[0]) {
-        case "S":
-          return "millisecond";
-
-        case "s":
-          return "second";
-
-        case "m":
-          return "minute";
-
-        case "h":
-          return "hour";
-
-        case "d":
-          return "day";
-
-        case "w":
-          return "week";
-
-        case "M":
-          return "month";
-
-        case "y":
-          return "year";
-
-        default:
-          return null;
-      }
-    },
-          tokenToString = lildur => token => {
-      const mapped = tokenToField(token);
-
-      if (mapped) {
-        return this.num(lildur.get(mapped), token.length);
-      } else {
-        return token;
-      }
-    },
-          tokens = Formatter.parseFormat(fmt),
-          realTokens = tokens.reduce((found, _ref) => {
-      let literal = _ref.literal,
+    var tokenToField = token => {
+        switch (token[0]) {
+          case "S":
+            return "millisecond";
+          case "s":
+            return "second";
+          case "m":
+            return "minute";
+          case "h":
+            return "hour";
+          case "d":
+            return "day";
+          case "w":
+            return "week";
+          case "M":
+            return "month";
+          case "y":
+            return "year";
+          default:
+            return null;
+        }
+      },
+      tokenToString = lildur => token => {
+        var mapped = tokenToField(token);
+        if (mapped) {
+          return this.num(lildur.get(mapped), token.length);
+        } else {
+          return token;
+        }
+      },
+      tokens = Formatter.parseFormat(fmt),
+      realTokens = tokens.reduce((found, _ref) => {
+        var literal = _ref.literal,
           val = _ref.val;
-      return literal ? found : found.concat(val);
-    }, []),
-          collapsed = dur.shiftTo(...realTokens.map(tokenToField).filter(t => t));
-
+        return literal ? found : found.concat(val);
+      }, []),
+      collapsed = dur.shiftTo(...realTokens.map(tokenToField).filter(t => t));
     return stringifyTokens(tokens, tokenToString(collapsed));
   }
-
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/invalid.js
 class Invalid {
@@ -3041,7 +2703,6 @@ class Invalid {
     this.reason = reason;
     this.explanation = explanation;
   }
-
   toMessage() {
     if (this.explanation) {
       return `${this.reason}: ${this.explanation}`;
@@ -3049,25 +2710,18 @@ class Invalid {
       return this.reason;
     }
   }
-
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/regexParser.js
-function regexParser_ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
-
-function regexParser_objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? regexParser_ownKeys(Object(source), !0).forEach(function (key) { regexParser_defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : regexParser_ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
-
-function regexParser_defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
+function regexParser_ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
+function regexParser_objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? regexParser_ownKeys(Object(t), !0).forEach(function (r) { regexParser_defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : regexParser_ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
+function regexParser_defineProperty(obj, key, value) { key = regexParser_toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function regexParser_toPropertyKey(t) { var i = regexParser_toPrimitive(t, "string"); return "symbol" == typeof i ? i : i + ""; }
+function regexParser_toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
 function regexParser_slicedToArray(arr, i) { return regexParser_arrayWithHoles(arr) || regexParser_iterableToArrayLimit(arr, i) || regexParser_unsupportedIterableToArray(arr, i) || regexParser_nonIterableRest(); }
-
 function regexParser_nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
 function regexParser_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return regexParser_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return regexParser_arrayLikeToArray(o, minLen); }
-
 function regexParser_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-
-function regexParser_iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
+function regexParser_iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
 function regexParser_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
@@ -3084,111 +2738,91 @@ function regexParser_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
  * Some extractions are super dumb and simpleParse and fromStrings help DRY them.
  */
 
-const ianaRegex = /[A-Za-z_+-]{1,256}(?::?\/[A-Za-z0-9_+-]{1,256}(?:\/[A-Za-z0-9_+-]{1,256})?)?/;
-
+var ianaRegex = /[A-Za-z_+-]{1,256}(?::?\/[A-Za-z0-9_+-]{1,256}(?:\/[A-Za-z0-9_+-]{1,256})?)?/;
 function combineRegexes() {
   for (var _len = arguments.length, regexes = new Array(_len), _key = 0; _key < _len; _key++) {
     regexes[_key] = arguments[_key];
   }
-
-  const full = regexes.reduce((f, r) => f + r.source, "");
+  var full = regexes.reduce((f, r) => f + r.source, "");
   return RegExp(`^${full}$`);
 }
-
 function combineExtractors() {
   for (var _len2 = arguments.length, extractors = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
     extractors[_key2] = arguments[_key2];
   }
-
   return m => extractors.reduce((_ref, ex) => {
-    let _ref2 = regexParser_slicedToArray(_ref, 3),
-        mergedVals = _ref2[0],
-        mergedZone = _ref2[1],
-        cursor = _ref2[2];
-
-    const _ex = ex(m, cursor),
-          _ex2 = regexParser_slicedToArray(_ex, 3),
-          val = _ex2[0],
-          zone = _ex2[1],
-          next = _ex2[2];
-
+    var _ref2 = regexParser_slicedToArray(_ref, 3),
+      mergedVals = _ref2[0],
+      mergedZone = _ref2[1],
+      cursor = _ref2[2];
+    var _ex = ex(m, cursor),
+      _ex2 = regexParser_slicedToArray(_ex, 3),
+      val = _ex2[0],
+      zone = _ex2[1],
+      next = _ex2[2];
     return [regexParser_objectSpread(regexParser_objectSpread({}, mergedVals), val), zone || mergedZone, next];
   }, [{}, null, 1]).slice(0, 2);
 }
-
 function parse(s) {
   if (s == null) {
     return [null, null];
   }
-
   for (var _len3 = arguments.length, patterns = new Array(_len3 > 1 ? _len3 - 1 : 0), _key3 = 1; _key3 < _len3; _key3++) {
     patterns[_key3 - 1] = arguments[_key3];
   }
-
-  for (var _i2 = 0, _patterns = patterns; _i2 < _patterns.length; _i2++) {
-    const _patterns$_i = regexParser_slicedToArray(_patterns[_i2], 2),
-          regex = _patterns$_i[0],
-          extractor = _patterns$_i[1];
-
-    const m = regex.exec(s);
-
+  for (var _i = 0, _patterns = patterns; _i < _patterns.length; _i++) {
+    var _patterns$_i = regexParser_slicedToArray(_patterns[_i], 2),
+      regex = _patterns$_i[0],
+      extractor = _patterns$_i[1];
+    var m = regex.exec(s);
     if (m) {
       return extractor(m);
     }
   }
-
   return [null, null];
 }
-
 function simpleParse() {
   for (var _len4 = arguments.length, keys = new Array(_len4), _key4 = 0; _key4 < _len4; _key4++) {
     keys[_key4] = arguments[_key4];
   }
-
   return (match, cursor) => {
-    const ret = {};
-    let i;
-
+    var ret = {};
+    var i;
     for (i = 0; i < keys.length; i++) {
       ret[keys[i]] = parseInteger(match[cursor + i]);
     }
-
     return [ret, null, cursor + i];
   };
-} // ISO and SQL parsing
-
-
-const offsetRegex = /(?:(Z)|([+-]\d\d)(?::?(\d\d))?)/;
-const isoExtendedZone = `(?:${offsetRegex.source}?(?:\\[(${ianaRegex.source})\\])?)?`;
-const isoTimeBaseRegex = /(\d\d)(?::?(\d\d)(?::?(\d\d)(?:[.,](\d{1,30}))?)?)?/;
-const isoTimeRegex = RegExp(`${isoTimeBaseRegex.source}${isoExtendedZone}`);
-const isoTimeExtensionRegex = RegExp(`(?:T${isoTimeRegex.source})?`);
-const isoYmdRegex = /([+-]\d{6}|\d{4})(?:-?(\d\d)(?:-?(\d\d))?)?/;
-const isoWeekRegex = /(\d{4})-?W(\d\d)(?:-?(\d))?/;
-const isoOrdinalRegex = /(\d{4})-?(\d{3})/;
-const extractISOWeekData = simpleParse("weekYear", "weekNumber", "weekDay");
-const extractISOOrdinalData = simpleParse("year", "ordinal");
-const sqlYmdRegex = /(\d{4})-(\d\d)-(\d\d)/; // dumbed-down version of the ISO one
-
-const sqlTimeRegex = RegExp(`${isoTimeBaseRegex.source} ?(?:${offsetRegex.source}|(${ianaRegex.source}))?`);
-const sqlTimeExtensionRegex = RegExp(`(?: ${sqlTimeRegex.source})?`);
-
-function regexParser_int(match, pos, fallback) {
-  const m = match[pos];
-  return isUndefined(m) ? fallback : parseInteger(m);
 }
 
+// ISO and SQL parsing
+var offsetRegex = /(?:(Z)|([+-]\d\d)(?::?(\d\d))?)/;
+var isoExtendedZone = `(?:${offsetRegex.source}?(?:\\[(${ianaRegex.source})\\])?)?`;
+var isoTimeBaseRegex = /(\d\d)(?::?(\d\d)(?::?(\d\d)(?:[.,](\d{1,30}))?)?)?/;
+var isoTimeRegex = RegExp(`${isoTimeBaseRegex.source}${isoExtendedZone}`);
+var isoTimeExtensionRegex = RegExp(`(?:T${isoTimeRegex.source})?`);
+var isoYmdRegex = /([+-]\d{6}|\d{4})(?:-?(\d\d)(?:-?(\d\d))?)?/;
+var isoWeekRegex = /(\d{4})-?W(\d\d)(?:-?(\d))?/;
+var isoOrdinalRegex = /(\d{4})-?(\d{3})/;
+var extractISOWeekData = simpleParse("weekYear", "weekNumber", "weekDay");
+var extractISOOrdinalData = simpleParse("year", "ordinal");
+var sqlYmdRegex = /(\d{4})-(\d\d)-(\d\d)/; // dumbed-down version of the ISO one
+var sqlTimeRegex = RegExp(`${isoTimeBaseRegex.source} ?(?:${offsetRegex.source}|(${ianaRegex.source}))?`);
+var sqlTimeExtensionRegex = RegExp(`(?: ${sqlTimeRegex.source})?`);
+function regexParser_int(match, pos, fallback) {
+  var m = match[pos];
+  return isUndefined(m) ? fallback : parseInteger(m);
+}
 function extractISOYmd(match, cursor) {
-  const item = {
+  var item = {
     year: regexParser_int(match, cursor),
     month: regexParser_int(match, cursor + 1, 1),
     day: regexParser_int(match, cursor + 2, 1)
   };
   return [item, null, cursor + 3];
 }
-
 function extractISOTime(match, cursor) {
-  const item = {
+  var item = {
     hours: regexParser_int(match, cursor, 0),
     minutes: regexParser_int(match, cursor + 1, 0),
     seconds: regexParser_int(match, cursor + 2, 0),
@@ -3196,44 +2830,41 @@ function extractISOTime(match, cursor) {
   };
   return [item, null, cursor + 4];
 }
-
 function extractISOOffset(match, cursor) {
-  const local = !match[cursor] && !match[cursor + 1],
-        fullOffset = signedOffset(match[cursor + 1], match[cursor + 2]),
-        zone = local ? null : FixedOffsetZone.instance(fullOffset);
+  var local = !match[cursor] && !match[cursor + 1],
+    fullOffset = signedOffset(match[cursor + 1], match[cursor + 2]),
+    zone = local ? null : FixedOffsetZone.instance(fullOffset);
   return [{}, zone, cursor + 3];
 }
-
 function extractIANAZone(match, cursor) {
-  const zone = match[cursor] ? IANAZone.create(match[cursor]) : null;
+  var zone = match[cursor] ? IANAZone.create(match[cursor]) : null;
   return [{}, zone, cursor + 1];
-} // ISO time parsing
+}
 
+// ISO time parsing
 
-const isoTimeOnly = RegExp(`^T?${isoTimeBaseRegex.source}$`); // ISO duration parsing
+var isoTimeOnly = RegExp(`^T?${isoTimeBaseRegex.source}$`);
 
-const isoDuration = /^-?P(?:(?:(-?\d{1,20}(?:\.\d{1,20})?)Y)?(?:(-?\d{1,20}(?:\.\d{1,20})?)M)?(?:(-?\d{1,20}(?:\.\d{1,20})?)W)?(?:(-?\d{1,20}(?:\.\d{1,20})?)D)?(?:T(?:(-?\d{1,20}(?:\.\d{1,20})?)H)?(?:(-?\d{1,20}(?:\.\d{1,20})?)M)?(?:(-?\d{1,20})(?:[.,](-?\d{1,20}))?S)?)?)$/;
+// ISO duration parsing
 
+var isoDuration = /^-?P(?:(?:(-?\d{1,20}(?:\.\d{1,20})?)Y)?(?:(-?\d{1,20}(?:\.\d{1,20})?)M)?(?:(-?\d{1,20}(?:\.\d{1,20})?)W)?(?:(-?\d{1,20}(?:\.\d{1,20})?)D)?(?:T(?:(-?\d{1,20}(?:\.\d{1,20})?)H)?(?:(-?\d{1,20}(?:\.\d{1,20})?)M)?(?:(-?\d{1,20})(?:[.,](-?\d{1,20}))?S)?)?)$/;
 function extractISODuration(match) {
-  const _match = regexParser_slicedToArray(match, 9),
-        s = _match[0],
-        yearStr = _match[1],
-        monthStr = _match[2],
-        weekStr = _match[3],
-        dayStr = _match[4],
-        hourStr = _match[5],
-        minuteStr = _match[6],
-        secondStr = _match[7],
-        millisecondsStr = _match[8];
-
-  const hasNegativePrefix = s[0] === "-";
-  const negativeSeconds = secondStr && secondStr[0] === "-";
-
-  const maybeNegate = function maybeNegate(num) {
-    let force = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+  var _match = regexParser_slicedToArray(match, 9),
+    s = _match[0],
+    yearStr = _match[1],
+    monthStr = _match[2],
+    weekStr = _match[3],
+    dayStr = _match[4],
+    hourStr = _match[5],
+    minuteStr = _match[6],
+    secondStr = _match[7],
+    millisecondsStr = _match[8];
+  var hasNegativePrefix = s[0] === "-";
+  var negativeSeconds = secondStr && secondStr[0] === "-";
+  var maybeNegate = function maybeNegate(num) {
+    var force = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
     return num !== undefined && (force || num && hasNegativePrefix) ? -num : num;
   };
-
   return [{
     years: maybeNegate(parseFloating(yearStr)),
     months: maybeNegate(parseFloating(monthStr)),
@@ -3244,12 +2875,12 @@ function extractISODuration(match) {
     seconds: maybeNegate(parseFloating(secondStr), secondStr === "-0"),
     milliseconds: maybeNegate(parseMillis(millisecondsStr), negativeSeconds)
   }];
-} // These are a little braindead. EDT *should* tell us that we're in, say, America/New_York
+}
+
+// These are a little braindead. EDT *should* tell us that we're in, say, America/New_York
 // and not just that we're in -240 *right now*. But since I don't think these are used that often
 // I'm just going to ignore that
-
-
-const obsOffsets = {
+var obsOffsets = {
   GMT: 0,
   EDT: -4 * 60,
   EST: -5 * 60,
@@ -3260,9 +2891,8 @@ const obsOffsets = {
   PDT: -7 * 60,
   PST: -8 * 60
 };
-
 function fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr) {
-  const result = {
+  var result = {
     year: yearStr.length === 2 ? untruncateYear(parseInteger(yearStr)) : parseInteger(yearStr),
     month: monthsShort.indexOf(monthStr) + 1,
     day: parseInteger(dayStr),
@@ -3270,34 +2900,29 @@ function fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, 
     minute: parseInteger(minuteStr)
   };
   if (secondStr) result.second = parseInteger(secondStr);
-
   if (weekdayStr) {
     result.weekday = weekdayStr.length > 3 ? weekdaysLong.indexOf(weekdayStr) + 1 : weekdaysShort.indexOf(weekdayStr) + 1;
   }
-
   return result;
-} // RFC 2822/5322
+}
 
-
-const rfc2822 = /^(?:(Mon|Tue|Wed|Thu|Fri|Sat|Sun),\s)?(\d{1,2})\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(\d{2,4})\s(\d\d):(\d\d)(?::(\d\d))?\s(?:(UT|GMT|[ECMP][SD]T)|([Zz])|(?:([+-]\d\d)(\d\d)))$/;
-
+// RFC 2822/5322
+var rfc2822 = /^(?:(Mon|Tue|Wed|Thu|Fri|Sat|Sun),\s)?(\d{1,2})\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s(\d{2,4})\s(\d\d):(\d\d)(?::(\d\d))?\s(?:(UT|GMT|[ECMP][SD]T)|([Zz])|(?:([+-]\d\d)(\d\d)))$/;
 function extractRFC2822(match) {
-  const _match2 = regexParser_slicedToArray(match, 12),
-        weekdayStr = _match2[1],
-        dayStr = _match2[2],
-        monthStr = _match2[3],
-        yearStr = _match2[4],
-        hourStr = _match2[5],
-        minuteStr = _match2[6],
-        secondStr = _match2[7],
-        obsOffset = _match2[8],
-        milOffset = _match2[9],
-        offHourStr = _match2[10],
-        offMinuteStr = _match2[11],
-        result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
-
-  let offset;
-
+  var _match2 = regexParser_slicedToArray(match, 12),
+    weekdayStr = _match2[1],
+    dayStr = _match2[2],
+    monthStr = _match2[3],
+    yearStr = _match2[4],
+    hourStr = _match2[5],
+    minuteStr = _match2[6],
+    secondStr = _match2[7],
+    obsOffset = _match2[8],
+    milOffset = _match2[9],
+    offHourStr = _match2[10],
+    offMinuteStr = _match2[11],
+    result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
+  var offset;
   if (obsOffset) {
     offset = obsOffsets[obsOffset];
   } else if (milOffset) {
@@ -3305,56 +2930,51 @@ function extractRFC2822(match) {
   } else {
     offset = signedOffset(offHourStr, offMinuteStr);
   }
-
   return [result, new FixedOffsetZone(offset)];
 }
-
 function preprocessRFC2822(s) {
   // Remove comments and folding whitespace and replace multiple-spaces with a single space
   return s.replace(/\([^)]*\)|[\n\t]/g, " ").replace(/(\s\s+)/g, " ").trim();
-} // http date
+}
 
+// http date
 
-const rfc1123 = /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (\d\d) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d\d):(\d\d):(\d\d) GMT$/,
-      rfc850 = /^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), (\d\d)-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(\d\d) (\d\d):(\d\d):(\d\d) GMT$/,
-      ascii = /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ( \d|\d\d) (\d\d):(\d\d):(\d\d) (\d{4})$/;
-
+var rfc1123 = /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (\d\d) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d\d):(\d\d):(\d\d) GMT$/,
+  rfc850 = /^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), (\d\d)-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(\d\d) (\d\d):(\d\d):(\d\d) GMT$/,
+  ascii = /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ( \d|\d\d) (\d\d):(\d\d):(\d\d) (\d{4})$/;
 function extractRFC1123Or850(match) {
-  const _match3 = regexParser_slicedToArray(match, 8),
-        weekdayStr = _match3[1],
-        dayStr = _match3[2],
-        monthStr = _match3[3],
-        yearStr = _match3[4],
-        hourStr = _match3[5],
-        minuteStr = _match3[6],
-        secondStr = _match3[7],
-        result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
-
+  var _match3 = regexParser_slicedToArray(match, 8),
+    weekdayStr = _match3[1],
+    dayStr = _match3[2],
+    monthStr = _match3[3],
+    yearStr = _match3[4],
+    hourStr = _match3[5],
+    minuteStr = _match3[6],
+    secondStr = _match3[7],
+    result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
   return [result, FixedOffsetZone.utcInstance];
 }
-
 function extractASCII(match) {
-  const _match4 = regexParser_slicedToArray(match, 8),
-        weekdayStr = _match4[1],
-        monthStr = _match4[2],
-        dayStr = _match4[3],
-        hourStr = _match4[4],
-        minuteStr = _match4[5],
-        secondStr = _match4[6],
-        yearStr = _match4[7],
-        result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
-
+  var _match4 = regexParser_slicedToArray(match, 8),
+    weekdayStr = _match4[1],
+    monthStr = _match4[2],
+    dayStr = _match4[3],
+    hourStr = _match4[4],
+    minuteStr = _match4[5],
+    secondStr = _match4[6],
+    yearStr = _match4[7],
+    result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
   return [result, FixedOffsetZone.utcInstance];
 }
+var isoYmdWithTimeExtensionRegex = combineRegexes(isoYmdRegex, isoTimeExtensionRegex);
+var isoWeekWithTimeExtensionRegex = combineRegexes(isoWeekRegex, isoTimeExtensionRegex);
+var isoOrdinalWithTimeExtensionRegex = combineRegexes(isoOrdinalRegex, isoTimeExtensionRegex);
+var isoTimeCombinedRegex = combineRegexes(isoTimeRegex);
+var extractISOYmdTimeAndOffset = combineExtractors(extractISOYmd, extractISOTime, extractISOOffset, extractIANAZone);
+var extractISOWeekTimeAndOffset = combineExtractors(extractISOWeekData, extractISOTime, extractISOOffset, extractIANAZone);
+var extractISOOrdinalDateAndTime = combineExtractors(extractISOOrdinalData, extractISOTime, extractISOOffset, extractIANAZone);
+var extractISOTimeAndOffset = combineExtractors(extractISOTime, extractISOOffset, extractIANAZone);
 
-const isoYmdWithTimeExtensionRegex = combineRegexes(isoYmdRegex, isoTimeExtensionRegex);
-const isoWeekWithTimeExtensionRegex = combineRegexes(isoWeekRegex, isoTimeExtensionRegex);
-const isoOrdinalWithTimeExtensionRegex = combineRegexes(isoOrdinalRegex, isoTimeExtensionRegex);
-const isoTimeCombinedRegex = combineRegexes(isoTimeRegex);
-const extractISOYmdTimeAndOffset = combineExtractors(extractISOYmd, extractISOTime, extractISOOffset, extractIANAZone);
-const extractISOWeekTimeAndOffset = combineExtractors(extractISOWeekData, extractISOTime, extractISOOffset, extractIANAZone);
-const extractISOOrdinalDateAndTime = combineExtractors(extractISOOrdinalData, extractISOTime, extractISOOffset, extractIANAZone);
-const extractISOTimeAndOffset = combineExtractors(extractISOTime, extractISOOffset, extractIANAZone);
 /*
  * @private
  */
@@ -3371,37 +2991,28 @@ function parseHTTPDate(s) {
 function parseISODuration(s) {
   return parse(s, [isoDuration, extractISODuration]);
 }
-const extractISOTimeOnly = combineExtractors(extractISOTime);
+var extractISOTimeOnly = combineExtractors(extractISOTime);
 function parseISOTimeOnly(s) {
   return parse(s, [isoTimeOnly, extractISOTimeOnly]);
 }
-const sqlYmdWithTimeExtensionRegex = combineRegexes(sqlYmdRegex, sqlTimeExtensionRegex);
-const sqlTimeCombinedRegex = combineRegexes(sqlTimeRegex);
-const extractISOTimeOffsetAndIANAZone = combineExtractors(extractISOTime, extractISOOffset, extractIANAZone);
+var sqlYmdWithTimeExtensionRegex = combineRegexes(sqlYmdRegex, sqlTimeExtensionRegex);
+var sqlTimeCombinedRegex = combineRegexes(sqlTimeRegex);
+var extractISOTimeOffsetAndIANAZone = combineExtractors(extractISOTime, extractISOOffset, extractIANAZone);
 function parseSQL(s) {
   return parse(s, [sqlYmdWithTimeExtensionRegex, extractISOYmdTimeAndOffset], [sqlTimeCombinedRegex, extractISOTimeOffsetAndIANAZone]);
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/duration.js
-function duration_createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = duration_unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e2) { throw _e2; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e3) { didErr = true; err = _e3; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-
 function duration_slicedToArray(arr, i) { return duration_arrayWithHoles(arr) || duration_iterableToArrayLimit(arr, i) || duration_unsupportedIterableToArray(arr, i) || duration_nonIterableRest(); }
-
 function duration_nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
 function duration_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return duration_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return duration_arrayLikeToArray(o, minLen); }
-
 function duration_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-
-function duration_iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
+function duration_iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
 function duration_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
-function duration_ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
-
-function duration_objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? duration_ownKeys(Object(source), !0).forEach(function (key) { duration_defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : duration_ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
-
-function duration_defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
+function duration_ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
+function duration_objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? duration_ownKeys(Object(t), !0).forEach(function (r) { duration_defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : duration_ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
+function duration_defineProperty(obj, key, value) { key = duration_toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function duration_toPropertyKey(t) { var i = duration_toPrimitive(t, "string"); return "symbol" == typeof i ? i : i + ""; }
+function duration_toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
 
 
 
@@ -3409,103 +3020,106 @@ function duration_defineProperty(obj, key, value) { if (key in obj) { Object.def
 
 
 
-const INVALID = "Invalid Duration"; // unit conversion constants
+var INVALID = "Invalid Duration";
 
-const lowOrderMatrix = {
-  weeks: {
-    days: 7,
-    hours: 7 * 24,
-    minutes: 7 * 24 * 60,
-    seconds: 7 * 24 * 60 * 60,
-    milliseconds: 7 * 24 * 60 * 60 * 1000
+// unit conversion constants
+var lowOrderMatrix = {
+    weeks: {
+      days: 7,
+      hours: 7 * 24,
+      minutes: 7 * 24 * 60,
+      seconds: 7 * 24 * 60 * 60,
+      milliseconds: 7 * 24 * 60 * 60 * 1000
+    },
+    days: {
+      hours: 24,
+      minutes: 24 * 60,
+      seconds: 24 * 60 * 60,
+      milliseconds: 24 * 60 * 60 * 1000
+    },
+    hours: {
+      minutes: 60,
+      seconds: 60 * 60,
+      milliseconds: 60 * 60 * 1000
+    },
+    minutes: {
+      seconds: 60,
+      milliseconds: 60 * 1000
+    },
+    seconds: {
+      milliseconds: 1000
+    }
   },
-  days: {
-    hours: 24,
-    minutes: 24 * 60,
-    seconds: 24 * 60 * 60,
-    milliseconds: 24 * 60 * 60 * 1000
-  },
-  hours: {
-    minutes: 60,
-    seconds: 60 * 60,
-    milliseconds: 60 * 60 * 1000
-  },
-  minutes: {
-    seconds: 60,
-    milliseconds: 60 * 1000
-  },
-  seconds: {
-    milliseconds: 1000
-  }
-},
-      casualMatrix = duration_objectSpread({
-  years: {
-    quarters: 4,
-    months: 12,
-    weeks: 52,
-    days: 365,
-    hours: 365 * 24,
-    minutes: 365 * 24 * 60,
-    seconds: 365 * 24 * 60 * 60,
-    milliseconds: 365 * 24 * 60 * 60 * 1000
-  },
-  quarters: {
-    months: 3,
-    weeks: 13,
-    days: 91,
-    hours: 91 * 24,
-    minutes: 91 * 24 * 60,
-    seconds: 91 * 24 * 60 * 60,
-    milliseconds: 91 * 24 * 60 * 60 * 1000
-  },
-  months: {
-    weeks: 4,
-    days: 30,
-    hours: 30 * 24,
-    minutes: 30 * 24 * 60,
-    seconds: 30 * 24 * 60 * 60,
-    milliseconds: 30 * 24 * 60 * 60 * 1000
-  }
-}, lowOrderMatrix),
-      daysInYearAccurate = 146097.0 / 400,
-      daysInMonthAccurate = 146097.0 / 4800,
-      accurateMatrix = duration_objectSpread({
-  years: {
-    quarters: 4,
-    months: 12,
-    weeks: daysInYearAccurate / 7,
-    days: daysInYearAccurate,
-    hours: daysInYearAccurate * 24,
-    minutes: daysInYearAccurate * 24 * 60,
-    seconds: daysInYearAccurate * 24 * 60 * 60,
-    milliseconds: daysInYearAccurate * 24 * 60 * 60 * 1000
-  },
-  quarters: {
-    months: 3,
-    weeks: daysInYearAccurate / 28,
-    days: daysInYearAccurate / 4,
-    hours: daysInYearAccurate * 24 / 4,
-    minutes: daysInYearAccurate * 24 * 60 / 4,
-    seconds: daysInYearAccurate * 24 * 60 * 60 / 4,
-    milliseconds: daysInYearAccurate * 24 * 60 * 60 * 1000 / 4
-  },
-  months: {
-    weeks: daysInMonthAccurate / 7,
-    days: daysInMonthAccurate,
-    hours: daysInMonthAccurate * 24,
-    minutes: daysInMonthAccurate * 24 * 60,
-    seconds: daysInMonthAccurate * 24 * 60 * 60,
-    milliseconds: daysInMonthAccurate * 24 * 60 * 60 * 1000
-  }
-}, lowOrderMatrix); // units ordered by size
+  casualMatrix = duration_objectSpread({
+    years: {
+      quarters: 4,
+      months: 12,
+      weeks: 52,
+      days: 365,
+      hours: 365 * 24,
+      minutes: 365 * 24 * 60,
+      seconds: 365 * 24 * 60 * 60,
+      milliseconds: 365 * 24 * 60 * 60 * 1000
+    },
+    quarters: {
+      months: 3,
+      weeks: 13,
+      days: 91,
+      hours: 91 * 24,
+      minutes: 91 * 24 * 60,
+      seconds: 91 * 24 * 60 * 60,
+      milliseconds: 91 * 24 * 60 * 60 * 1000
+    },
+    months: {
+      weeks: 4,
+      days: 30,
+      hours: 30 * 24,
+      minutes: 30 * 24 * 60,
+      seconds: 30 * 24 * 60 * 60,
+      milliseconds: 30 * 24 * 60 * 60 * 1000
+    }
+  }, lowOrderMatrix),
+  daysInYearAccurate = 146097.0 / 400,
+  daysInMonthAccurate = 146097.0 / 4800,
+  accurateMatrix = duration_objectSpread({
+    years: {
+      quarters: 4,
+      months: 12,
+      weeks: daysInYearAccurate / 7,
+      days: daysInYearAccurate,
+      hours: daysInYearAccurate * 24,
+      minutes: daysInYearAccurate * 24 * 60,
+      seconds: daysInYearAccurate * 24 * 60 * 60,
+      milliseconds: daysInYearAccurate * 24 * 60 * 60 * 1000
+    },
+    quarters: {
+      months: 3,
+      weeks: daysInYearAccurate / 28,
+      days: daysInYearAccurate / 4,
+      hours: daysInYearAccurate * 24 / 4,
+      minutes: daysInYearAccurate * 24 * 60 / 4,
+      seconds: daysInYearAccurate * 24 * 60 * 60 / 4,
+      milliseconds: daysInYearAccurate * 24 * 60 * 60 * 1000 / 4
+    },
+    months: {
+      weeks: daysInMonthAccurate / 7,
+      days: daysInMonthAccurate,
+      hours: daysInMonthAccurate * 24,
+      minutes: daysInMonthAccurate * 24 * 60,
+      seconds: daysInMonthAccurate * 24 * 60 * 60,
+      milliseconds: daysInMonthAccurate * 24 * 60 * 60 * 1000
+    }
+  }, lowOrderMatrix);
 
-const orderedUnits = ["years", "quarters", "months", "weeks", "days", "hours", "minutes", "seconds", "milliseconds"];
-const reverseUnits = orderedUnits.slice(0).reverse(); // clone really means "create another instance just like this one, but with these changes"
+// units ordered by size
+var orderedUnits = ["years", "quarters", "months", "weeks", "days", "hours", "minutes", "seconds", "milliseconds"];
+var reverseUnits = orderedUnits.slice(0).reverse();
 
+// clone really means "create another instance just like this one, but with these changes"
 function clone(dur, alts) {
-  let clear = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
+  var clear = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
   // deep merge for vals
-  const conf = {
+  var conf = {
     values: clear ? alts.values : duration_objectSpread(duration_objectSpread({}, dur.values), alts.values || {}),
     loc: dur.loc.clone(alts.loc),
     conversionAccuracy: alts.conversionAccuracy || dur.conversionAccuracy,
@@ -3513,53 +3127,49 @@ function clone(dur, alts) {
   };
   return new Duration(conf);
 }
-
 function antiTrunc(n) {
   return n < 0 ? Math.floor(n) : Math.ceil(n);
-} // NB: mutates parameters
+}
 
-
+// NB: mutates parameters
 function convert(matrix, fromMap, fromUnit, toMap, toUnit) {
-  const conv = matrix[toUnit][fromUnit],
-        raw = fromMap[fromUnit] / conv,
-        sameSign = Math.sign(raw) === Math.sign(toMap[toUnit]),
-        // ok, so this is wild, but see the matrix in the tests
-  added = !sameSign && toMap[toUnit] !== 0 && Math.abs(raw) <= 1 ? antiTrunc(raw) : Math.trunc(raw);
+  var conv = matrix[toUnit][fromUnit],
+    raw = fromMap[fromUnit] / conv,
+    sameSign = Math.sign(raw) === Math.sign(toMap[toUnit]),
+    // ok, so this is wild, but see the matrix in the tests
+    added = !sameSign && toMap[toUnit] !== 0 && Math.abs(raw) <= 1 ? antiTrunc(raw) : Math.trunc(raw);
   toMap[toUnit] += added;
   fromMap[fromUnit] -= added * conv;
-} // NB: mutates parameters
+}
 
-
+// NB: mutates parameters
 function normalizeValues(matrix, vals) {
   reverseUnits.reduce((previous, current) => {
     if (!isUndefined(vals[current])) {
       if (previous) {
         convert(matrix, vals, previous, vals, current);
       }
-
       return current;
     } else {
       return previous;
     }
   }, null);
-} // Remove all properties with a value of 0 from an object
+}
 
-
+// Remove all properties with a value of 0 from an object
 function removeZeroes(vals) {
-  const newVals = {};
-
+  var newVals = {};
   for (var _i = 0, _Object$entries = Object.entries(vals); _i < _Object$entries.length; _i++) {
-    const _Object$entries$_i = duration_slicedToArray(_Object$entries[_i], 2),
-          key = _Object$entries$_i[0],
-          value = _Object$entries$_i[1];
-
+    var _Object$entries$_i = duration_slicedToArray(_Object$entries[_i], 2),
+      key = _Object$entries$_i[0],
+      value = _Object$entries$_i[1];
     if (value !== 0) {
       newVals[key] = value;
     }
   }
-
   return newVals;
 }
+
 /**
  * A Duration object represents a period of time, like "2 months" or "1 day, 1 hour". Conceptually, it's just a map of units to their quantities, accompanied by some additional configuration and methods for creating, parsing, interrogating, transforming, and formatting them. They can be used on their own or in conjunction with other Luxon types; for example, you can use {@link DateTime#plus} to add a Duration object to a DateTime, producing another DateTime.
  *
@@ -3573,51 +3183,43 @@ function removeZeroes(vals) {
  *
  * There's are more methods documented below. In addition, for more information on subtler topics like internationalization and validity, see the external documentation.
  */
-
-
 class Duration {
   /**
    * @private
    */
   constructor(config) {
-    const accurate = config.conversionAccuracy === "longterm" || false;
-    let matrix = accurate ? accurateMatrix : casualMatrix;
-
+    var accurate = config.conversionAccuracy === "longterm" || false;
+    var matrix = accurate ? accurateMatrix : casualMatrix;
     if (config.matrix) {
       matrix = config.matrix;
     }
+
     /**
      * @access private
      */
-
-
     this.values = config.values;
     /**
      * @access private
      */
-
     this.loc = config.loc || Locale.create();
     /**
      * @access private
      */
-
     this.conversionAccuracy = accurate ? "longterm" : "casual";
     /**
      * @access private
      */
-
     this.invalid = config.invalid || null;
     /**
      * @access private
      */
-
     this.matrix = matrix;
     /**
      * @access private
      */
-
     this.isLuxonDuration = true;
   }
+
   /**
    * Create Duration from a number of milliseconds.
    * @param {number} count of milliseconds
@@ -3627,13 +3229,12 @@ class Duration {
    * @param {string} [opts.conversionAccuracy='casual'] - the conversion system to use
    * @return {Duration}
    */
-
-
   static fromMillis(count, opts) {
     return Duration.fromObject({
       milliseconds: count
     }, opts);
   }
+
   /**
    * Create a Duration from a JavaScript object with keys like 'years' and 'hours'.
    * If this object is empty then a zero milliseconds duration is returned.
@@ -3654,15 +3255,11 @@ class Duration {
    * @param {string} [opts.matrix=Object] - the custom conversion system to use
    * @return {Duration}
    */
-
-
   static fromObject(obj) {
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     if (obj == null || typeof obj !== "object") {
       throw new InvalidArgumentError(`Duration.fromObject: argument expected to be an object, got ${obj === null ? "null" : typeof obj}`);
     }
-
     return new Duration({
       values: normalizeObject(obj, Duration.normalizeUnit),
       loc: Locale.fromObject(opts),
@@ -3670,6 +3267,7 @@ class Duration {
       matrix: opts.matrix
     });
   }
+
   /**
    * Create a Duration from DurationLike.
    *
@@ -3680,8 +3278,6 @@ class Duration {
    * - Duration instance
    * @return {Duration}
    */
-
-
   static fromDurationLike(durationLike) {
     if (isNumber(durationLike)) {
       return Duration.fromMillis(durationLike);
@@ -3693,6 +3289,7 @@ class Duration {
       throw new InvalidArgumentError(`Unknown duration argument ${durationLike} of type ${typeof durationLike}`);
     }
   }
+
   /**
    * Create a Duration from an ISO 8601 duration string.
    * @param {string} text - text to parse
@@ -3707,19 +3304,17 @@ class Duration {
    * @example Duration.fromISO('P5Y3M').toObject() //=> { years: 5, months: 3 }
    * @return {Duration}
    */
-
-
   static fromISO(text, opts) {
-    const _parseISODuration = parseISODuration(text),
-          _parseISODuration2 = duration_slicedToArray(_parseISODuration, 1),
-          parsed = _parseISODuration2[0];
-
+    var _parseISODuration = parseISODuration(text),
+      _parseISODuration2 = duration_slicedToArray(_parseISODuration, 1),
+      parsed = _parseISODuration2[0];
     if (parsed) {
       return Duration.fromObject(parsed, opts);
     } else {
       return Duration.invalid("unparsable", `the input "${text}" can't be parsed as ISO 8601`);
     }
   }
+
   /**
    * Create a Duration from an ISO 8601 time string.
    * @param {string} text - text to parse
@@ -3736,36 +3331,29 @@ class Duration {
    * @example Duration.fromISOTime('T1100').toObject() //=> { hours: 11, minutes: 0, seconds: 0 }
    * @return {Duration}
    */
-
-
   static fromISOTime(text, opts) {
-    const _parseISOTimeOnly = parseISOTimeOnly(text),
-          _parseISOTimeOnly2 = duration_slicedToArray(_parseISOTimeOnly, 1),
-          parsed = _parseISOTimeOnly2[0];
-
+    var _parseISOTimeOnly = parseISOTimeOnly(text),
+      _parseISOTimeOnly2 = duration_slicedToArray(_parseISOTimeOnly, 1),
+      parsed = _parseISOTimeOnly2[0];
     if (parsed) {
       return Duration.fromObject(parsed, opts);
     } else {
       return Duration.invalid("unparsable", `the input "${text}" can't be parsed as ISO 8601`);
     }
   }
+
   /**
    * Create an invalid Duration.
    * @param {string} reason - simple string of why this datetime is invalid. Should not contain parameters or anything else data-dependent
    * @param {string} [explanation=null] - longer explanation, may include parameters and other useful debugging information
    * @return {Duration}
    */
-
-
   static invalid(reason) {
-    let explanation = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
-
+    var explanation = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
     if (!reason) {
       throw new InvalidArgumentError("need to specify a reason the Duration is invalid");
     }
-
-    const invalid = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
-
+    var invalid = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
     if (Settings.throwOnInvalid) {
       throw new InvalidDurationError(invalid);
     } else {
@@ -3774,13 +3362,12 @@ class Duration {
       });
     }
   }
+
   /**
    * @private
    */
-
-
   static normalizeUnit(unit) {
-    const normalized = {
+    var normalized = {
       year: "years",
       years: "years",
       quarter: "quarters",
@@ -3803,35 +3390,33 @@ class Duration {
     if (!normalized) throw new InvalidUnitError(unit);
     return normalized;
   }
+
   /**
    * Check if an object is a Duration. Works across context boundaries
    * @param {object} o
    * @return {boolean}
    */
-
-
   static isDuration(o) {
     return o && o.isLuxonDuration || false;
   }
+
   /**
    * Get  the locale of a Duration, such 'en-GB'
    * @type {string}
    */
-
-
   get locale() {
     return this.isValid ? this.loc.locale : null;
   }
+
   /**
    * Get the numbering system of a Duration, such 'beng'. The numbering system is used when formatting the Duration
    *
    * @type {string}
    */
-
-
   get numberingSystem() {
     return this.isValid ? this.loc.numberingSystem : null;
   }
+
   /**
    * Returns a string representation of this Duration formatted according to the specified format string. You may use these tokens:
    * * `S` for milliseconds
@@ -3854,18 +3439,15 @@ class Duration {
    * @example Duration.fromObject({ years: 1, days: 6, seconds: 2 }).toFormat("M S") //=> "12 518402000"
    * @return {string}
    */
-
-
   toFormat(fmt) {
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     // reverse-compat since 1.2; we always round down now, never up, and we do it by default
-    const fmtOpts = duration_objectSpread(duration_objectSpread({}, opts), {}, {
+    var fmtOpts = duration_objectSpread(duration_objectSpread({}, opts), {}, {
       floor: opts.round !== false && opts.floor !== false
     });
-
     return this.isValid ? Formatter.create(this.loc, fmtOpts).formatDurationFromString(this, fmt) : INVALID;
   }
+
   /**
    * Returns a string representation of a Duration with all units included.
    * To modify its behavior use the `listStyle` and any Intl.NumberFormat option, though `unitDisplay` is especially relevant.
@@ -3879,17 +3461,13 @@ class Duration {
    * dur.toHuman({ unitDisplay: "short" }) //=> '1 day, 5 hr, 6 min'
    * ```
    */
-
-
   toHuman() {
-    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-    const l = orderedUnits.map(unit => {
-      const val = this.values[unit];
-
+    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var l = orderedUnits.map(unit => {
+      var val = this.values[unit];
       if (isUndefined(val)) {
         return null;
       }
-
       return this.loc.numberFormatter(duration_objectSpread(duration_objectSpread({
         style: "unit",
         unitDisplay: "long"
@@ -3902,17 +3480,17 @@ class Duration {
       style: opts.listStyle || "narrow"
     }, opts)).format(l);
   }
+
   /**
    * Returns a JavaScript object with this Duration's values.
    * @example Duration.fromObject({ years: 1, days: 6, seconds: 2 }).toObject() //=> { years: 1, days: 6, seconds: 2 }
    * @return {Object}
    */
-
-
   toObject() {
     if (!this.isValid) return {};
     return duration_objectSpread({}, this.values);
   }
+
   /**
    * Returns an ISO 8601-compliant string representation of this Duration.
    * @see https://en.wikipedia.org/wiki/ISO_8601#Durations
@@ -3923,12 +3501,10 @@ class Duration {
    * @example Duration.fromObject({ milliseconds: 6 }).toISO() //=> 'PT0.006S'
    * @return {string}
    */
-
-
   toISO() {
     // we could use the formatter, but this is an easier way to get the minimum string
     if (!this.isValid) return null;
-    let s = "P";
+    var s = "P";
     if (this.years !== 0) s += this.years + "Y";
     if (this.months !== 0 || this.quarters !== 0) s += this.months + this.quarters * 3 + "M";
     if (this.weeks !== 0) s += this.weeks + "W";
@@ -3936,12 +3512,14 @@ class Duration {
     if (this.hours !== 0 || this.minutes !== 0 || this.seconds !== 0 || this.milliseconds !== 0) s += "T";
     if (this.hours !== 0) s += this.hours + "H";
     if (this.minutes !== 0) s += this.minutes + "M";
-    if (this.seconds !== 0 || this.milliseconds !== 0) // this will handle "floating point madness" by removing extra decimal places
+    if (this.seconds !== 0 || this.milliseconds !== 0)
+      // this will handle "floating point madness" by removing extra decimal places
       // https://stackoverflow.com/questions/588004/is-floating-point-math-broken
       s += roundTo(this.seconds + this.milliseconds / 1000, 3) + "S";
     if (s === "P") s += "T0S";
     return s;
   }
+
   /**
    * Returns an ISO 8601-compliant string representation of this Duration, formatted as a time of day.
    * Note that this will return null if the duration is invalid, negative, or equal to or greater than 24 hours.
@@ -3958,12 +3536,10 @@ class Duration {
    * @example Duration.fromObject({ hours: 11 }).toISOTime({ format: 'basic' }) //=> '110000.000'
    * @return {string}
    */
-
-
   toISOTime() {
-    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     if (!this.isValid) return null;
-    const millis = this.toMillis();
+    var millis = this.toMillis();
     if (millis < 0 || millis >= 86400000) return null;
     opts = duration_objectSpread({
       suppressMilliseconds: false,
@@ -3971,106 +3547,84 @@ class Duration {
       includePrefix: false,
       format: "extended"
     }, opts);
-    const value = this.shiftTo("hours", "minutes", "seconds", "milliseconds");
-    let fmt = opts.format === "basic" ? "hhmm" : "hh:mm";
-
+    var value = this.shiftTo("hours", "minutes", "seconds", "milliseconds");
+    var fmt = opts.format === "basic" ? "hhmm" : "hh:mm";
     if (!opts.suppressSeconds || value.seconds !== 0 || value.milliseconds !== 0) {
       fmt += opts.format === "basic" ? "ss" : ":ss";
-
       if (!opts.suppressMilliseconds || value.milliseconds !== 0) {
         fmt += ".SSS";
       }
     }
-
-    let str = value.toFormat(fmt);
-
+    var str = value.toFormat(fmt);
     if (opts.includePrefix) {
       str = "T" + str;
     }
-
     return str;
   }
+
   /**
    * Returns an ISO 8601 representation of this Duration appropriate for use in JSON.
    * @return {string}
    */
-
-
   toJSON() {
     return this.toISO();
   }
+
   /**
    * Returns an ISO 8601 representation of this Duration appropriate for use in debugging.
    * @return {string}
    */
-
-
   toString() {
     return this.toISO();
   }
+
   /**
    * Returns an milliseconds value of this Duration.
    * @return {number}
    */
-
-
   toMillis() {
     return this.as("milliseconds");
   }
+
   /**
    * Returns an milliseconds value of this Duration. Alias of {@link toMillis}
    * @return {number}
    */
-
-
   valueOf() {
     return this.toMillis();
   }
+
   /**
    * Make this Duration longer by the specified amount. Return a newly-constructed Duration.
    * @param {Duration|Object|number} duration - The amount to add. Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
    * @return {Duration}
    */
-
-
   plus(duration) {
     if (!this.isValid) return this;
-    const dur = Duration.fromDurationLike(duration),
-          result = {};
-
-    var _iterator = duration_createForOfIteratorHelper(orderedUnits),
-        _step;
-
-    try {
-      for (_iterator.s(); !(_step = _iterator.n()).done;) {
-        const k = _step.value;
-
-        if (util_hasOwnProperty(dur.values, k) || util_hasOwnProperty(this.values, k)) {
-          result[k] = dur.get(k) + this.get(k);
-        }
+    var dur = Duration.fromDurationLike(duration),
+      result = {};
+    for (var _i2 = 0, _orderedUnits = orderedUnits; _i2 < _orderedUnits.length; _i2++) {
+      var k = _orderedUnits[_i2];
+      if (util_hasOwnProperty(dur.values, k) || util_hasOwnProperty(this.values, k)) {
+        result[k] = dur.get(k) + this.get(k);
       }
-    } catch (err) {
-      _iterator.e(err);
-    } finally {
-      _iterator.f();
     }
-
     return clone(this, {
       values: result
     }, true);
   }
+
   /**
    * Make this Duration shorter by the specified amount. Return a newly-constructed Duration.
    * @param {Duration|Object|number} duration - The amount to subtract. Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
    * @return {Duration}
    */
-
-
   minus(duration) {
     if (!this.isValid) return this;
-    const dur = Duration.fromDurationLike(duration);
+    var dur = Duration.fromDurationLike(duration);
     return this.plus(dur.negate());
   }
+
   /**
    * Scale this Duration by the specified amount. Return a newly-constructed Duration.
    * @param {function} fn - The function to apply to each unit. Arity is 1 or 2: the value of the unit and, optionally, the unit name. Must return a number.
@@ -4078,21 +3632,18 @@ class Duration {
    * @example Duration.fromObject({ hours: 1, minutes: 30 }).mapUnits((x, u) => u === "hours" ? x * 2 : x) //=> { hours: 2, minutes: 30 }
    * @return {Duration}
    */
-
-
   mapUnits(fn) {
     if (!this.isValid) return this;
-    const result = {};
-
-    for (var _i2 = 0, _Object$keys = Object.keys(this.values); _i2 < _Object$keys.length; _i2++) {
-      const k = _Object$keys[_i2];
+    var result = {};
+    for (var _i3 = 0, _Object$keys = Object.keys(this.values); _i3 < _Object$keys.length; _i3++) {
+      var k = _Object$keys[_i3];
       result[k] = asNumber(fn(this.values[k], k));
     }
-
     return clone(this, {
       values: result
     }, true);
   }
+
   /**
    * Get the value of unit.
    * @param {string} unit - a unit such as 'minute' or 'day'
@@ -4101,11 +3652,10 @@ class Duration {
    * @example Duration.fromObject({years: 2, days: 3}).get('days') //=> 3
    * @return {number}
    */
-
-
   get(unit) {
     return this[Duration.normalizeUnit(unit)];
   }
+
   /**
    * "Set" the values of specified units. Return a newly-constructed Duration.
    * @param {Object} values - a mapping of units to numbers
@@ -4113,42 +3663,37 @@ class Duration {
    * @example dur.set({ hours: 8, minutes: 30 })
    * @return {Duration}
    */
-
-
   set(values) {
     if (!this.isValid) return this;
-
-    const mixed = duration_objectSpread(duration_objectSpread({}, this.values), normalizeObject(values, Duration.normalizeUnit));
-
+    var mixed = duration_objectSpread(duration_objectSpread({}, this.values), normalizeObject(values, Duration.normalizeUnit));
     return clone(this, {
       values: mixed
     });
   }
+
   /**
    * "Set" the locale and/or numberingSystem.  Returns a newly-constructed Duration.
    * @example dur.reconfigure({ locale: 'en-GB' })
    * @return {Duration}
    */
-
-
   reconfigure() {
-    let _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-        locale = _ref.locale,
-        numberingSystem = _ref.numberingSystem,
-        conversionAccuracy = _ref.conversionAccuracy,
-        matrix = _ref.matrix;
-
-    const loc = this.loc.clone({
+    var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+      locale = _ref.locale,
+      numberingSystem = _ref.numberingSystem,
+      conversionAccuracy = _ref.conversionAccuracy,
+      matrix = _ref.matrix;
+    var loc = this.loc.clone({
       locale,
       numberingSystem
     });
-    const opts = {
+    var opts = {
       loc,
       matrix,
       conversionAccuracy
     };
     return clone(this, opts);
   }
+
   /**
    * Return the length of the duration in the specified unit.
    * @param {string} unit - a unit such as 'minutes' or 'days'
@@ -4157,315 +3702,258 @@ class Duration {
    * @example Duration.fromObject({hours: 60}).as('days') //=> 2.5
    * @return {number}
    */
-
-
   as(unit) {
     return this.isValid ? this.shiftTo(unit).get(unit) : NaN;
   }
+
   /**
    * Reduce this Duration to its canonical representation in its current units.
    * @example Duration.fromObject({ years: 2, days: 5000 }).normalize().toObject() //=> { years: 15, days: 255 }
    * @example Duration.fromObject({ hours: 12, minutes: -45 }).normalize().toObject() //=> { hours: 11, minutes: 15 }
    * @return {Duration}
    */
-
-
   normalize() {
     if (!this.isValid) return this;
-    const vals = this.toObject();
+    var vals = this.toObject();
     normalizeValues(this.matrix, vals);
     return clone(this, {
       values: vals
     }, true);
   }
+
   /**
    * Rescale units to its largest representation
    * @example Duration.fromObject({ milliseconds: 90000 }).rescale().toObject() //=> { minutes: 1, seconds: 30 }
    * @return {Duration}
    */
-
-
   rescale() {
     if (!this.isValid) return this;
-    const vals = removeZeroes(this.normalize().shiftToAll().toObject());
+    var vals = removeZeroes(this.normalize().shiftToAll().toObject());
     return clone(this, {
       values: vals
     }, true);
   }
+
   /**
    * Convert this Duration into its representation in a different set of units.
    * @example Duration.fromObject({ hours: 1, seconds: 30 }).shiftTo('minutes', 'milliseconds').toObject() //=> { minutes: 60, milliseconds: 30000 }
    * @return {Duration}
    */
-
-
   shiftTo() {
     for (var _len = arguments.length, units = new Array(_len), _key = 0; _key < _len; _key++) {
       units[_key] = arguments[_key];
     }
-
     if (!this.isValid) return this;
-
     if (units.length === 0) {
       return this;
     }
-
     units = units.map(u => Duration.normalizeUnit(u));
-    const built = {},
-          accumulated = {},
-          vals = this.toObject();
-    let lastUnit;
+    var built = {},
+      accumulated = {},
+      vals = this.toObject();
+    var lastUnit;
+    for (var _i4 = 0, _orderedUnits2 = orderedUnits; _i4 < _orderedUnits2.length; _i4++) {
+      var k = _orderedUnits2[_i4];
+      if (units.indexOf(k) >= 0) {
+        lastUnit = k;
+        var own = 0;
 
-    var _iterator2 = duration_createForOfIteratorHelper(orderedUnits),
-        _step2;
-
-    try {
-      for (_iterator2.s(); !(_step2 = _iterator2.n()).done;) {
-        const k = _step2.value;
-
-        if (units.indexOf(k) >= 0) {
-          lastUnit = k;
-          let own = 0; // anything we haven't boiled down yet should get boiled to this unit
-
-          for (const ak in accumulated) {
-            own += this.matrix[ak][k] * accumulated[ak];
-            accumulated[ak] = 0;
-          } // plus anything that's already in this unit
-
-
-          if (isNumber(vals[k])) {
-            own += vals[k];
-          }
-
-          const i = Math.trunc(own);
-          built[k] = i;
-          accumulated[k] = (own * 1000 - i * 1000) / 1000; // plus anything further down the chain that should be rolled up in to this
-
-          for (const down in vals) {
-            if (orderedUnits.indexOf(down) > orderedUnits.indexOf(k)) {
-              convert(this.matrix, vals, down, built, k);
-            }
-          } // otherwise, keep it in the wings to boil it later
-
-        } else if (isNumber(vals[k])) {
-          accumulated[k] = vals[k];
+        // anything we haven't boiled down yet should get boiled to this unit
+        for (var ak in accumulated) {
+          own += this.matrix[ak][k] * accumulated[ak];
+          accumulated[ak] = 0;
         }
-      } // anything leftover becomes the decimal for the last unit
-      // lastUnit must be defined since units is not empty
 
-    } catch (err) {
-      _iterator2.e(err);
-    } finally {
-      _iterator2.f();
+        // plus anything that's already in this unit
+        if (isNumber(vals[k])) {
+          own += vals[k];
+        }
+        var i = Math.trunc(own);
+        built[k] = i;
+        accumulated[k] = (own * 1000 - i * 1000) / 1000;
+
+        // plus anything further down the chain that should be rolled up in to this
+        for (var down in vals) {
+          if (orderedUnits.indexOf(down) > orderedUnits.indexOf(k)) {
+            convert(this.matrix, vals, down, built, k);
+          }
+        }
+        // otherwise, keep it in the wings to boil it later
+      } else if (isNumber(vals[k])) {
+        accumulated[k] = vals[k];
+      }
     }
 
-    for (const key in accumulated) {
+    // anything leftover becomes the decimal for the last unit
+    // lastUnit must be defined since units is not empty
+    for (var key in accumulated) {
       if (accumulated[key] !== 0) {
         built[lastUnit] += key === lastUnit ? accumulated[key] : accumulated[key] / this.matrix[lastUnit][key];
       }
     }
-
     return clone(this, {
       values: built
     }, true).normalize();
   }
+
   /**
    * Shift this Duration to all available units.
    * Same as shiftTo("years", "months", "weeks", "days", "hours", "minutes", "seconds", "milliseconds")
    * @return {Duration}
    */
-
-
   shiftToAll() {
     if (!this.isValid) return this;
     return this.shiftTo("years", "months", "weeks", "days", "hours", "minutes", "seconds", "milliseconds");
   }
+
   /**
    * Return the negative of this Duration.
    * @example Duration.fromObject({ hours: 1, seconds: 30 }).negate().toObject() //=> { hours: -1, seconds: -30 }
    * @return {Duration}
    */
-
-
   negate() {
     if (!this.isValid) return this;
-    const negated = {};
-
-    for (var _i3 = 0, _Object$keys2 = Object.keys(this.values); _i3 < _Object$keys2.length; _i3++) {
-      const k = _Object$keys2[_i3];
+    var negated = {};
+    for (var _i5 = 0, _Object$keys2 = Object.keys(this.values); _i5 < _Object$keys2.length; _i5++) {
+      var k = _Object$keys2[_i5];
       negated[k] = this.values[k] === 0 ? 0 : -this.values[k];
     }
-
     return clone(this, {
       values: negated
     }, true);
   }
+
   /**
    * Get the years.
    * @type {number}
    */
-
-
   get years() {
     return this.isValid ? this.values.years || 0 : NaN;
   }
+
   /**
    * Get the quarters.
    * @type {number}
    */
-
-
   get quarters() {
     return this.isValid ? this.values.quarters || 0 : NaN;
   }
+
   /**
    * Get the months.
    * @type {number}
    */
-
-
   get months() {
     return this.isValid ? this.values.months || 0 : NaN;
   }
+
   /**
    * Get the weeks
    * @type {number}
    */
-
-
   get weeks() {
     return this.isValid ? this.values.weeks || 0 : NaN;
   }
+
   /**
    * Get the days.
    * @type {number}
    */
-
-
   get days() {
     return this.isValid ? this.values.days || 0 : NaN;
   }
+
   /**
    * Get the hours.
    * @type {number}
    */
-
-
   get hours() {
     return this.isValid ? this.values.hours || 0 : NaN;
   }
+
   /**
    * Get the minutes.
    * @type {number}
    */
-
-
   get minutes() {
     return this.isValid ? this.values.minutes || 0 : NaN;
   }
+
   /**
    * Get the seconds.
    * @return {number}
    */
-
-
   get seconds() {
     return this.isValid ? this.values.seconds || 0 : NaN;
   }
+
   /**
    * Get the milliseconds.
    * @return {number}
    */
-
-
   get milliseconds() {
     return this.isValid ? this.values.milliseconds || 0 : NaN;
   }
+
   /**
    * Returns whether the Duration is invalid. Invalid durations are returned by diff operations
    * on invalid DateTimes or Intervals.
    * @return {boolean}
    */
-
-
   get isValid() {
     return this.invalid === null;
   }
+
   /**
    * Returns an error code if this Duration became invalid, or null if the Duration is valid
    * @return {string}
    */
-
-
   get invalidReason() {
     return this.invalid ? this.invalid.reason : null;
   }
+
   /**
    * Returns an explanation of why this Duration became invalid, or null if the Duration is valid
    * @type {string}
    */
-
-
   get invalidExplanation() {
     return this.invalid ? this.invalid.explanation : null;
   }
+
   /**
    * Equality check
    * Two Durations are equal iff they have the same units and the same values for each unit.
    * @param {Duration} other
    * @return {boolean}
    */
-
-
   equals(other) {
     if (!this.isValid || !other.isValid) {
       return false;
     }
-
     if (!this.loc.equals(other.loc)) {
       return false;
     }
-
     function eq(v1, v2) {
       // Consider 0 and undefined as equal
       if (v1 === undefined || v1 === 0) return v2 === undefined || v2 === 0;
       return v1 === v2;
     }
-
-    var _iterator3 = duration_createForOfIteratorHelper(orderedUnits),
-        _step3;
-
-    try {
-      for (_iterator3.s(); !(_step3 = _iterator3.n()).done;) {
-        const u = _step3.value;
-
-        if (!eq(this.values[u], other.values[u])) {
-          return false;
-        }
+    for (var _i6 = 0, _orderedUnits3 = orderedUnits; _i6 < _orderedUnits3.length; _i6++) {
+      var u = _orderedUnits3[_i6];
+      if (!eq(this.values[u], other.values[u])) {
+        return false;
       }
-    } catch (err) {
-      _iterator3.e(err);
-    } finally {
-      _iterator3.f();
     }
-
     return true;
   }
-
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/interval.js
-function interval_createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = interval_unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e2) { throw _e2; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e3) { didErr = true; err = _e3; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-
+function interval_createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = interval_unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
 function interval_slicedToArray(arr, i) { return interval_arrayWithHoles(arr) || interval_iterableToArrayLimit(arr, i) || interval_unsupportedIterableToArray(arr, i) || interval_nonIterableRest(); }
-
 function interval_nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
 function interval_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return interval_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return interval_arrayLikeToArray(o, minLen); }
-
 function interval_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-
-function interval_iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
+function interval_iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
 function interval_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
@@ -4474,9 +3962,9 @@ function interval_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
 
+var interval_INVALID = "Invalid Interval";
 
-const interval_INVALID = "Invalid Interval"; // checks if the start is equal to or before the end
-
+// checks if the start is equal to or before the end
 function validateStartEnd(start, end) {
   if (!start || !start.isValid) {
     return Interval.invalid("missing or invalid start");
@@ -4488,6 +3976,7 @@ function validateStartEnd(start, end) {
     return null;
   }
 }
+
 /**
  * An Interval object represents a half-open interval of time, where each endpoint is a {@link DateTime}. Conceptually, it's a container for those two endpoints, accompanied by methods for creating, parsing, interrogating, comparing, transforming, and formatting them.
  *
@@ -4500,8 +3989,6 @@ function validateStartEnd(start, end) {
  * * **Comparison** To compare this Interval to another one, use {@link Interval#equals}, {@link Interval#overlaps}, {@link Interval#abutsStart}, {@link Interval#abutsEnd}, {@link Interval#engulfs}
  * * **Output** To convert the Interval into other representations, see {@link Interval#toString}, {@link Interval#toLocaleString}, {@link Interval#toISO}, {@link Interval#toISODate}, {@link Interval#toISOTime}, {@link Interval#toFormat}, and {@link Interval#toDuration}.
  */
-
-
 class Interval {
   /**
    * @private
@@ -4514,36 +4001,29 @@ class Interval {
     /**
      * @access private
      */
-
     this.e = config.end;
     /**
      * @access private
      */
-
     this.invalid = config.invalid || null;
     /**
      * @access private
      */
-
     this.isLuxonInterval = true;
   }
+
   /**
    * Create an invalid Interval.
    * @param {string} reason - simple string of why this Interval is invalid. Should not contain parameters or anything else data-dependent
    * @param {string} [explanation=null] - longer explanation, may include parameters and other useful debugging information
    * @return {Interval}
    */
-
-
   static invalid(reason) {
-    let explanation = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
-
+    var explanation = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
     if (!reason) {
       throw new InvalidArgumentError("need to specify a reason the Interval is invalid");
     }
-
-    const invalid = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
-
+    var invalid = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
     if (Settings.throwOnInvalid) {
       throw new InvalidIntervalError(invalid);
     } else {
@@ -4552,19 +4032,17 @@ class Interval {
       });
     }
   }
+
   /**
    * Create an Interval from a start DateTime and an end DateTime. Inclusive of the start but not the end.
    * @param {DateTime|Date|Object} start
    * @param {DateTime|Date|Object} end
    * @return {Interval}
    */
-
-
   static fromDateTimes(start, end) {
-    const builtStart = friendlyDateTime(start),
-          builtEnd = friendlyDateTime(end);
-    const validateError = validateStartEnd(builtStart, builtEnd);
-
+    var builtStart = friendlyDateTime(start),
+      builtEnd = friendlyDateTime(end);
+    var validateError = validateStartEnd(builtStart, builtEnd);
     if (validateError == null) {
       return new Interval({
         start: builtStart,
@@ -4574,32 +4052,31 @@ class Interval {
       return validateError;
     }
   }
+
   /**
    * Create an Interval from a start DateTime and a Duration to extend to.
    * @param {DateTime|Date|Object} start
    * @param {Duration|Object|number} duration - the length of the Interval.
    * @return {Interval}
    */
-
-
   static after(start, duration) {
-    const dur = Duration.fromDurationLike(duration),
-          dt = friendlyDateTime(start);
+    var dur = Duration.fromDurationLike(duration),
+      dt = friendlyDateTime(start);
     return Interval.fromDateTimes(dt, dt.plus(dur));
   }
+
   /**
    * Create an Interval from an end DateTime and a Duration to extend backwards to.
    * @param {DateTime|Date|Object} end
    * @param {Duration|Object|number} duration - the length of the Interval.
    * @return {Interval}
    */
-
-
   static before(end, duration) {
-    const dur = Duration.fromDurationLike(duration),
-          dt = friendlyDateTime(end);
+    var dur = Duration.fromDurationLike(duration),
+      dt = friendlyDateTime(end);
     return Interval.fromDateTimes(dt.minus(dur), dt);
   }
+
   /**
    * Create an Interval from an ISO 8601 string.
    * Accepts `<start>/<end>`, `<start>/<duration>`, and `<duration>/<end>` formats.
@@ -4608,120 +4085,103 @@ class Interval {
    * @see https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
    * @return {Interval}
    */
-
-
   static fromISO(text, opts) {
-    const _split = (text || "").split("/", 2),
-          _split2 = interval_slicedToArray(_split, 2),
-          s = _split2[0],
-          e = _split2[1];
-
+    var _split = (text || "").split("/", 2),
+      _split2 = interval_slicedToArray(_split, 2),
+      s = _split2[0],
+      e = _split2[1];
     if (s && e) {
-      let start, startIsValid;
-
+      var start, startIsValid;
       try {
         start = DateTime.fromISO(s, opts);
         startIsValid = start.isValid;
       } catch (e) {
         startIsValid = false;
       }
-
-      let end, endIsValid;
-
+      var end, endIsValid;
       try {
         end = DateTime.fromISO(e, opts);
         endIsValid = end.isValid;
       } catch (e) {
         endIsValid = false;
       }
-
       if (startIsValid && endIsValid) {
         return Interval.fromDateTimes(start, end);
       }
-
       if (startIsValid) {
-        const dur = Duration.fromISO(e, opts);
-
+        var dur = Duration.fromISO(e, opts);
         if (dur.isValid) {
           return Interval.after(start, dur);
         }
       } else if (endIsValid) {
-        const dur = Duration.fromISO(s, opts);
-
-        if (dur.isValid) {
-          return Interval.before(end, dur);
+        var _dur = Duration.fromISO(s, opts);
+        if (_dur.isValid) {
+          return Interval.before(end, _dur);
         }
       }
     }
-
     return Interval.invalid("unparsable", `the input "${text}" can't be parsed as ISO 8601`);
   }
+
   /**
    * Check if an object is an Interval. Works across context boundaries
    * @param {object} o
    * @return {boolean}
    */
-
-
   static isInterval(o) {
     return o && o.isLuxonInterval || false;
   }
+
   /**
    * Returns the start of the Interval
    * @type {DateTime}
    */
-
-
   get start() {
     return this.isValid ? this.s : null;
   }
+
   /**
    * Returns the end of the Interval
    * @type {DateTime}
    */
-
-
   get end() {
     return this.isValid ? this.e : null;
   }
+
   /**
    * Returns whether this Interval's end is at least its start, meaning that the Interval isn't 'backwards'.
    * @type {boolean}
    */
-
-
   get isValid() {
     return this.invalidReason === null;
   }
+
   /**
    * Returns an error code if this Interval is invalid, or null if the Interval is valid
    * @type {string}
    */
-
-
   get invalidReason() {
     return this.invalid ? this.invalid.reason : null;
   }
+
   /**
    * Returns an explanation of why this Interval became invalid, or null if the Interval is valid
    * @type {string}
    */
-
-
   get invalidExplanation() {
     return this.invalid ? this.invalid.explanation : null;
   }
+
   /**
    * Returns the length of the Interval in the specified unit.
    * @param {string} unit - the unit (such as 'hours' or 'days') to return the length in.
    * @return {number}
    */
-
-
   length() {
-    let unit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "milliseconds";
+    var unit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "milliseconds";
     return this.isValid ? this.toDuration(...[unit]).get(unit) : NaN;
   }
+
   /**
    * Returns the count of minutes, hours, days, months, or years included in the Interval, even in part.
    * Unlike {@link Interval#length} this counts sections of the calendar, not periods of time, e.g. specifying 'day'
@@ -4729,67 +4189,61 @@ class Interval {
    * @param {string} [unit='milliseconds'] - the unit of time to count.
    * @return {number}
    */
-
-
   count() {
-    let unit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "milliseconds";
+    var unit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "milliseconds";
     if (!this.isValid) return NaN;
-    const start = this.start.startOf(unit),
-          end = this.end.startOf(unit);
+    var start = this.start.startOf(unit),
+      end = this.end.startOf(unit);
     return Math.floor(end.diff(start, unit).get(unit)) + 1;
   }
+
   /**
    * Returns whether this Interval's start and end are both in the same unit of time
    * @param {string} unit - the unit of time to check sameness on
    * @return {boolean}
    */
-
-
   hasSame(unit) {
     return this.isValid ? this.isEmpty() || this.e.minus(1).hasSame(this.s, unit) : false;
   }
+
   /**
    * Return whether this Interval has the same start and end DateTimes.
    * @return {boolean}
    */
-
-
   isEmpty() {
     return this.s.valueOf() === this.e.valueOf();
   }
+
   /**
    * Return whether this Interval's start is after the specified DateTime.
    * @param {DateTime} dateTime
    * @return {boolean}
    */
-
-
   isAfter(dateTime) {
     if (!this.isValid) return false;
     return this.s > dateTime;
   }
+
   /**
    * Return whether this Interval's end is before the specified DateTime.
    * @param {DateTime} dateTime
    * @return {boolean}
    */
-
-
   isBefore(dateTime) {
     if (!this.isValid) return false;
     return this.e <= dateTime;
   }
+
   /**
    * Return whether this Interval contains the specified DateTime.
    * @param {DateTime} dateTime
    * @return {boolean}
    */
-
-
   contains(dateTime) {
     if (!this.isValid) return false;
     return this.s <= dateTime && this.e > dateTime;
   }
+
   /**
    * "Sets" the start and/or end dates. Returns a newly-constructed Interval.
    * @param {Object} values - the values to set
@@ -4797,143 +4251,124 @@ class Interval {
    * @param {DateTime} values.end - the ending DateTime
    * @return {Interval}
    */
-
-
   set() {
-    let _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-        start = _ref.start,
-        end = _ref.end;
-
+    var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+      start = _ref.start,
+      end = _ref.end;
     if (!this.isValid) return this;
     return Interval.fromDateTimes(start || this.s, end || this.e);
   }
+
   /**
    * Split this Interval at each of the specified DateTimes
    * @param {...DateTime} dateTimes - the unit of time to count.
    * @return {Array}
    */
-
-
   splitAt() {
     if (!this.isValid) return [];
-
     for (var _len = arguments.length, dateTimes = new Array(_len), _key = 0; _key < _len; _key++) {
       dateTimes[_key] = arguments[_key];
     }
-
-    const sorted = dateTimes.map(friendlyDateTime).filter(d => this.contains(d)).sort(),
-          results = [];
-    let s = this.s,
-        i = 0;
-
+    var sorted = dateTimes.map(friendlyDateTime).filter(d => this.contains(d)).sort(),
+      results = [];
+    var s = this.s,
+      i = 0;
     while (s < this.e) {
-      const added = sorted[i] || this.e,
-            next = +added > +this.e ? this.e : added;
+      var added = sorted[i] || this.e,
+        next = +added > +this.e ? this.e : added;
       results.push(Interval.fromDateTimes(s, next));
       s = next;
       i += 1;
     }
-
     return results;
   }
+
   /**
    * Split this Interval into smaller Intervals, each of the specified length.
    * Left over time is grouped into a smaller interval
    * @param {Duration|Object|number} duration - The length of each resulting interval.
    * @return {Array}
    */
-
-
   splitBy(duration) {
-    const dur = Duration.fromDurationLike(duration);
-
+    var dur = Duration.fromDurationLike(duration);
     if (!this.isValid || !dur.isValid || dur.as("milliseconds") === 0) {
       return [];
     }
-
-    let s = this.s,
-        idx = 1,
-        next;
-    const results = [];
-
+    var s = this.s,
+      idx = 1,
+      next;
+    var results = [];
     while (s < this.e) {
-      const added = this.start.plus(dur.mapUnits(x => x * idx));
+      var added = this.start.plus(dur.mapUnits(x => x * idx));
       next = +added > +this.e ? this.e : added;
       results.push(Interval.fromDateTimes(s, next));
       s = next;
       idx += 1;
     }
-
     return results;
   }
+
   /**
    * Split this Interval into the specified number of smaller intervals.
    * @param {number} numberOfParts - The number of Intervals to divide the Interval into.
    * @return {Array}
    */
-
-
   divideEqually(numberOfParts) {
     if (!this.isValid) return [];
     return this.splitBy(this.length() / numberOfParts).slice(0, numberOfParts);
   }
+
   /**
    * Return whether this Interval overlaps with the specified Interval
    * @param {Interval} other
    * @return {boolean}
    */
-
-
   overlaps(other) {
     return this.e > other.s && this.s < other.e;
   }
+
   /**
    * Return whether this Interval's end is adjacent to the specified Interval's start.
    * @param {Interval} other
    * @return {boolean}
    */
-
-
   abutsStart(other) {
     if (!this.isValid) return false;
     return +this.e === +other.s;
   }
+
   /**
    * Return whether this Interval's start is adjacent to the specified Interval's end.
    * @param {Interval} other
    * @return {boolean}
    */
-
-
   abutsEnd(other) {
     if (!this.isValid) return false;
     return +other.e === +this.s;
   }
+
   /**
    * Return whether this Interval engulfs the start and end of the specified Interval.
    * @param {Interval} other
    * @return {boolean}
    */
-
-
   engulfs(other) {
     if (!this.isValid) return false;
     return this.s <= other.s && this.e >= other.e;
   }
+
   /**
    * Return whether this Interval has the same start and end as the specified Interval.
    * @param {Interval} other
    * @return {boolean}
    */
-
-
   equals(other) {
     if (!this.isValid || !other.isValid) {
       return false;
     }
-
     return this.s.equals(other.s) && this.e.equals(other.e);
   }
+
   /**
    * Return an Interval representing the intersection of this Interval and the specified Interval.
    * Specifically, the resulting Interval has the maximum start time and the minimum end time of the two Intervals.
@@ -4941,101 +4376,88 @@ class Interval {
    * @param {Interval} other
    * @return {Interval}
    */
-
-
   intersection(other) {
     if (!this.isValid) return this;
-    const s = this.s > other.s ? this.s : other.s,
-          e = this.e < other.e ? this.e : other.e;
-
+    var s = this.s > other.s ? this.s : other.s,
+      e = this.e < other.e ? this.e : other.e;
     if (s >= e) {
       return null;
     } else {
       return Interval.fromDateTimes(s, e);
     }
   }
+
   /**
    * Return an Interval representing the union of this Interval and the specified Interval.
    * Specifically, the resulting Interval has the minimum start time and the maximum end time of the two Intervals.
    * @param {Interval} other
    * @return {Interval}
    */
-
-
   union(other) {
     if (!this.isValid) return this;
-    const s = this.s < other.s ? this.s : other.s,
-          e = this.e > other.e ? this.e : other.e;
+    var s = this.s < other.s ? this.s : other.s,
+      e = this.e > other.e ? this.e : other.e;
     return Interval.fromDateTimes(s, e);
   }
+
   /**
    * Merge an array of Intervals into a equivalent minimal set of Intervals.
    * Combines overlapping and adjacent Intervals.
    * @param {Array} intervals
    * @return {Array}
    */
-
-
   static merge(intervals) {
-    const _intervals$sort$reduc = intervals.sort((a, b) => a.s - b.s).reduce((_ref2, item) => {
-      let _ref3 = interval_slicedToArray(_ref2, 2),
+    var _intervals$sort$reduc = intervals.sort((a, b) => a.s - b.s).reduce((_ref2, item) => {
+        var _ref3 = interval_slicedToArray(_ref2, 2),
           sofar = _ref3[0],
           current = _ref3[1];
-
-      if (!current) {
-        return [sofar, item];
-      } else if (current.overlaps(item) || current.abutsStart(item)) {
-        return [sofar, current.union(item)];
-      } else {
-        return [sofar.concat([current]), item];
-      }
-    }, [[], null]),
-          _intervals$sort$reduc2 = interval_slicedToArray(_intervals$sort$reduc, 2),
-          found = _intervals$sort$reduc2[0],
-          final = _intervals$sort$reduc2[1];
-
+        if (!current) {
+          return [sofar, item];
+        } else if (current.overlaps(item) || current.abutsStart(item)) {
+          return [sofar, current.union(item)];
+        } else {
+          return [sofar.concat([current]), item];
+        }
+      }, [[], null]),
+      _intervals$sort$reduc2 = interval_slicedToArray(_intervals$sort$reduc, 2),
+      found = _intervals$sort$reduc2[0],
+      final = _intervals$sort$reduc2[1];
     if (final) {
       found.push(final);
     }
-
     return found;
   }
+
   /**
    * Return an array of Intervals representing the spans of time that only appear in one of the specified Intervals.
    * @param {Array} intervals
    * @return {Array}
    */
-
-
   static xor(intervals) {
-    let start = null,
-        currentCount = 0;
-    const results = [],
-          ends = intervals.map(i => [{
-      time: i.s,
-      type: "s"
-    }, {
-      time: i.e,
-      type: "e"
-    }]),
-          flattened = Array.prototype.concat(...ends),
-          arr = flattened.sort((a, b) => a.time - b.time);
-
+    var start = null,
+      currentCount = 0;
+    var results = [],
+      ends = intervals.map(i => [{
+        time: i.s,
+        type: "s"
+      }, {
+        time: i.e,
+        type: "e"
+      }]),
+      flattened = Array.prototype.concat(...ends),
+      arr = flattened.sort((a, b) => a.time - b.time);
     var _iterator = interval_createForOfIteratorHelper(arr),
-        _step;
-
+      _step;
     try {
       for (_iterator.s(); !(_step = _iterator.n()).done;) {
-        const i = _step.value;
+        var i = _step.value;
         currentCount += i.type === "s" ? 1 : -1;
-
         if (currentCount === 1) {
           start = i.time;
         } else {
           if (start && +start !== +i.time) {
             results.push(Interval.fromDateTimes(start, i.time));
           }
-
           start = null;
         }
       }
@@ -5044,33 +4466,30 @@ class Interval {
     } finally {
       _iterator.f();
     }
-
     return Interval.merge(results);
   }
+
   /**
    * Return an Interval representing the span of time in this Interval that doesn't overlap with any of the specified Intervals.
    * @param {...Interval} intervals
    * @return {Array}
    */
-
-
   difference() {
     for (var _len2 = arguments.length, intervals = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
       intervals[_key2] = arguments[_key2];
     }
-
     return Interval.xor([this].concat(intervals)).map(i => this.intersection(i)).filter(i => i && !i.isEmpty());
   }
+
   /**
    * Returns a string representation of this Interval appropriate for debugging.
    * @return {string}
    */
-
-
   toString() {
     if (!this.isValid) return interval_INVALID;
     return `[${this.s.toISO()} – ${this.e.toISO()})`;
   }
+
   /**
    * Returns a localized string representing this Interval. Accepts the same options as the
    * Intl.DateTimeFormat constructor and any presets defined by Luxon, such as
@@ -5089,37 +4508,34 @@ class Interval {
    * @example Interval.fromISO('2022-11-07T17:00Z/2022-11-07T19:00Z').toLocaleString({ weekday: 'short', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }); //=> Mon, Nov 07, 6:00 – 8:00 p
    * @return {string}
    */
-
-
   toLocaleString() {
-    let formatOpts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : DATE_SHORT;
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var formatOpts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : DATE_SHORT;
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     return this.isValid ? Formatter.create(this.s.loc.clone(opts), formatOpts).formatInterval(this) : interval_INVALID;
   }
+
   /**
    * Returns an ISO 8601-compliant string representation of this Interval.
    * @see https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
    * @param {Object} opts - The same options as {@link DateTime#toISO}
    * @return {string}
    */
-
-
   toISO(opts) {
     if (!this.isValid) return interval_INVALID;
     return `${this.s.toISO(opts)}/${this.e.toISO(opts)}`;
   }
+
   /**
    * Returns an ISO 8601-compliant string representation of date of this Interval.
    * The time components are ignored.
    * @see https://en.wikipedia.org/wiki/ISO_8601#Time_intervals
    * @return {string}
    */
-
-
   toISODate() {
     if (!this.isValid) return interval_INVALID;
     return `${this.s.toISODate()}/${this.e.toISODate()}`;
   }
+
   /**
    * Returns an ISO 8601-compliant string representation of time of this Interval.
    * The date components are ignored.
@@ -5127,12 +4543,11 @@ class Interval {
    * @param {Object} opts - The same options as {@link DateTime#toISO}
    * @return {string}
    */
-
-
   toISOTime(opts) {
     if (!this.isValid) return interval_INVALID;
     return `${this.s.toISOTime(opts)}/${this.e.toISOTime(opts)}`;
   }
+
   /**
    * Returns a string representation of this Interval formatted according to the specified format
    * string. **You may not want this.** See {@link Interval#toLocaleString} for a more flexible
@@ -5144,16 +4559,14 @@ class Interval {
    * representations.
    * @return {string}
    */
-
-
   toFormat(dateFormat) {
-    let _ref4 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-        _ref4$separator = _ref4.separator,
-        separator = _ref4$separator === void 0 ? " – " : _ref4$separator;
-
+    var _ref4 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+      _ref4$separator = _ref4.separator,
+      separator = _ref4$separator === void 0 ? " – " : _ref4$separator;
     if (!this.isValid) return interval_INVALID;
     return `${this.s.toFormat(dateFormat)}${separator}${this.e.toFormat(dateFormat)}`;
   }
+
   /**
    * Return a Duration representing the time spanned by this interval.
    * @param {string|string[]} [unit=['milliseconds']] - the unit or units (such as 'hours' or 'days') to include in the duration.
@@ -5166,15 +4579,13 @@ class Interval {
    * @example Interval.fromDateTimes(dt1, dt2).toDuration('seconds').toObject() //=> { seconds: 88489.257 }
    * @return {Duration}
    */
-
-
   toDuration(unit, opts) {
     if (!this.isValid) {
       return Duration.invalid(this.invalidReason);
     }
-
     return this.e.diff(this.s, unit, opts);
   }
+
   /**
    * Run mapFn on the interval start and end, returning a new Interval from the resulting DateTimes
    * @param {function} mapFn
@@ -5182,14 +4593,12 @@ class Interval {
    * @example Interval.fromDateTimes(dt1, dt2).mapEndpoints(endpoint => endpoint.toUTC())
    * @example Interval.fromDateTimes(dt1, dt2).mapEndpoints(endpoint => endpoint.plus({ hours: 2 }))
    */
-
-
   mapEndpoints(mapFn) {
     return Interval.fromDateTimes(mapFn(this.s), mapFn(this.e));
   }
-
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/info.js
+
 
 
 
@@ -5199,7 +4608,6 @@ class Interval {
 /**
  * The Info class contains static methods for retrieving general time and date related data. For example, it has methods for finding out if a time zone has a DST, for listing the months in any supported locale, and for discovering which of Luxon features are available in the current environment.
  */
-
 class Info {
   /**
    * Return whether the specified zone contains a DST.
@@ -5207,24 +4615,24 @@ class Info {
    * @return {boolean}
    */
   static hasDST() {
-    let zone = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : Settings.defaultZone;
-    const proto = DateTime.now().setZone(zone).set({
+    var zone = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : Settings.defaultZone;
+    var proto = DateTime.now().setZone(zone).set({
       month: 12
     });
     return !zone.isUniversal && proto.offset !== proto.set({
       month: 6
     }).offset;
   }
+
   /**
    * Return whether the specified zone is a valid IANA specifier.
    * @param {string} zone - Zone to check
    * @return {boolean}
    */
-
-
   static isValidIANAZone(zone) {
     return IANAZone.isValidZone(zone);
   }
+
   /**
    * Converts the input into a {@link Zone} instance.
    *
@@ -5239,11 +4647,10 @@ class Info {
    * @param {string|Zone|number} [input] - the value to be converted
    * @return {Zone}
    */
-
-
   static normalizeZone(input) {
     return normalizeZone(input, Settings.defaultZone);
   }
+
   /**
    * Return an array of standalone month names.
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
@@ -5261,23 +4668,20 @@ class Info {
    * @example Info.months('long', { outputCalendar: 'islamic' })[0] //=> 'Rabiʻ I'
    * @return {Array}
    */
-
-
   static months() {
-    let length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "long";
-
-    let _ref = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-        _ref$locale = _ref.locale,
-        locale = _ref$locale === void 0 ? null : _ref$locale,
-        _ref$numberingSystem = _ref.numberingSystem,
-        numberingSystem = _ref$numberingSystem === void 0 ? null : _ref$numberingSystem,
-        _ref$locObj = _ref.locObj,
-        locObj = _ref$locObj === void 0 ? null : _ref$locObj,
-        _ref$outputCalendar = _ref.outputCalendar,
-        outputCalendar = _ref$outputCalendar === void 0 ? "gregory" : _ref$outputCalendar;
-
+    var length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "long";
+    var _ref = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+      _ref$locale = _ref.locale,
+      locale = _ref$locale === void 0 ? null : _ref$locale,
+      _ref$numberingSystem = _ref.numberingSystem,
+      numberingSystem = _ref$numberingSystem === void 0 ? null : _ref$numberingSystem,
+      _ref$locObj = _ref.locObj,
+      locObj = _ref$locObj === void 0 ? null : _ref$locObj,
+      _ref$outputCalendar = _ref.outputCalendar,
+      outputCalendar = _ref$outputCalendar === void 0 ? "gregory" : _ref$outputCalendar;
     return (locObj || Locale.create(locale, numberingSystem, outputCalendar)).months(length);
   }
+
   /**
    * Return an array of format month names.
    * Format months differ from standalone months in that they're meant to appear next to the day of the month. In some languages, that
@@ -5291,23 +4695,20 @@ class Info {
    * @param {string} [opts.outputCalendar='gregory'] - the calendar
    * @return {Array}
    */
-
-
   static monthsFormat() {
-    let length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "long";
-
-    let _ref2 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-        _ref2$locale = _ref2.locale,
-        locale = _ref2$locale === void 0 ? null : _ref2$locale,
-        _ref2$numberingSystem = _ref2.numberingSystem,
-        numberingSystem = _ref2$numberingSystem === void 0 ? null : _ref2$numberingSystem,
-        _ref2$locObj = _ref2.locObj,
-        locObj = _ref2$locObj === void 0 ? null : _ref2$locObj,
-        _ref2$outputCalendar = _ref2.outputCalendar,
-        outputCalendar = _ref2$outputCalendar === void 0 ? "gregory" : _ref2$outputCalendar;
-
+    var length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "long";
+    var _ref2 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+      _ref2$locale = _ref2.locale,
+      locale = _ref2$locale === void 0 ? null : _ref2$locale,
+      _ref2$numberingSystem = _ref2.numberingSystem,
+      numberingSystem = _ref2$numberingSystem === void 0 ? null : _ref2$numberingSystem,
+      _ref2$locObj = _ref2.locObj,
+      locObj = _ref2$locObj === void 0 ? null : _ref2$locObj,
+      _ref2$outputCalendar = _ref2.outputCalendar,
+      outputCalendar = _ref2$outputCalendar === void 0 ? "gregory" : _ref2$outputCalendar;
     return (locObj || Locale.create(locale, numberingSystem, outputCalendar)).months(length, true);
   }
+
   /**
    * Return an array of standalone week names.
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
@@ -5322,21 +4723,18 @@ class Info {
    * @example Info.weekdays('short', { locale: 'ar' })[0] //=> 'الاثنين'
    * @return {Array}
    */
-
-
   static weekdays() {
-    let length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "long";
-
-    let _ref3 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-        _ref3$locale = _ref3.locale,
-        locale = _ref3$locale === void 0 ? null : _ref3$locale,
-        _ref3$numberingSystem = _ref3.numberingSystem,
-        numberingSystem = _ref3$numberingSystem === void 0 ? null : _ref3$numberingSystem,
-        _ref3$locObj = _ref3.locObj,
-        locObj = _ref3$locObj === void 0 ? null : _ref3$locObj;
-
+    var length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "long";
+    var _ref3 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+      _ref3$locale = _ref3.locale,
+      locale = _ref3$locale === void 0 ? null : _ref3$locale,
+      _ref3$numberingSystem = _ref3.numberingSystem,
+      numberingSystem = _ref3$numberingSystem === void 0 ? null : _ref3$numberingSystem,
+      _ref3$locObj = _ref3.locObj,
+      locObj = _ref3$locObj === void 0 ? null : _ref3$locObj;
     return (locObj || Locale.create(locale, numberingSystem, null)).weekdays(length);
   }
+
   /**
    * Return an array of format week names.
    * Format weekdays differ from standalone weekdays in that they're meant to appear next to more date information. In some languages, that
@@ -5349,21 +4747,18 @@ class Info {
    * @param {string} [opts.locObj=null] - an existing locale object to use
    * @return {Array}
    */
-
-
   static weekdaysFormat() {
-    let length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "long";
-
-    let _ref4 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-        _ref4$locale = _ref4.locale,
-        locale = _ref4$locale === void 0 ? null : _ref4$locale,
-        _ref4$numberingSystem = _ref4.numberingSystem,
-        numberingSystem = _ref4$numberingSystem === void 0 ? null : _ref4$numberingSystem,
-        _ref4$locObj = _ref4.locObj,
-        locObj = _ref4$locObj === void 0 ? null : _ref4$locObj;
-
+    var length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "long";
+    var _ref4 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+      _ref4$locale = _ref4.locale,
+      locale = _ref4$locale === void 0 ? null : _ref4$locale,
+      _ref4$numberingSystem = _ref4.numberingSystem,
+      numberingSystem = _ref4$numberingSystem === void 0 ? null : _ref4$numberingSystem,
+      _ref4$locObj = _ref4.locObj,
+      locObj = _ref4$locObj === void 0 ? null : _ref4$locObj;
     return (locObj || Locale.create(locale, numberingSystem, null)).weekdays(length, true);
   }
+
   /**
    * Return an array of meridiems.
    * @param {Object} opts - options
@@ -5372,15 +4767,13 @@ class Info {
    * @example Info.meridiems({ locale: 'my' }) //=> [ 'နံနက်', 'ညနေ' ]
    * @return {Array}
    */
-
-
   static meridiems() {
-    let _ref5 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-        _ref5$locale = _ref5.locale,
-        locale = _ref5$locale === void 0 ? null : _ref5$locale;
-
+    var _ref5 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+      _ref5$locale = _ref5.locale,
+      locale = _ref5$locale === void 0 ? null : _ref5$locale;
     return Locale.create(locale).meridiems();
   }
+
   /**
    * Return an array of eras, such as ['BC', 'AD']. The locale can be specified, but the calendar system is always Gregorian.
    * @param {string} [length='short'] - the length of the era representation, such as "short" or "long".
@@ -5391,17 +4784,14 @@ class Info {
    * @example Info.eras('long', { locale: 'fr' }) //=> [ 'avant Jésus-Christ', 'après Jésus-Christ' ]
    * @return {Array}
    */
-
-
   static eras() {
-    let length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "short";
-
-    let _ref6 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-        _ref6$locale = _ref6.locale,
-        locale = _ref6$locale === void 0 ? null : _ref6$locale;
-
+    var length = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "short";
+    var _ref6 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+      _ref6$locale = _ref6.locale,
+      locale = _ref6$locale === void 0 ? null : _ref6$locale;
     return Locale.create(locale, null, "gregory").eras(length);
   }
+
   /**
    * Return the set of available features in this environment.
    * Some features of Luxon are not available in all environments. For example, on older browsers, relative time formatting support is not available. Use this function to figure out if that's the case.
@@ -5410,58 +4800,43 @@ class Info {
    * @example Info.features() //=> { relative: false }
    * @return {Object}
    */
-
-
   static features() {
     return {
       relative: hasRelative()
     };
   }
-
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/diff.js
 function diff_slicedToArray(arr, i) { return diff_arrayWithHoles(arr) || diff_iterableToArrayLimit(arr, i) || diff_unsupportedIterableToArray(arr, i) || diff_nonIterableRest(); }
-
 function diff_nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
 function diff_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return diff_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return diff_arrayLikeToArray(o, minLen); }
-
 function diff_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-
-function diff_iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
+function diff_iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
 function diff_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
-
-
 function dayDiff(earlier, later) {
-  const utcDayStart = dt => dt.toUTC(0, {
-    keepLocalTime: true
-  }).startOf("day").valueOf(),
-        ms = utcDayStart(later) - utcDayStart(earlier);
-
+  var utcDayStart = dt => dt.toUTC(0, {
+      keepLocalTime: true
+    }).startOf("day").valueOf(),
+    ms = utcDayStart(later) - utcDayStart(earlier);
   return Math.floor(Duration.fromMillis(ms).as("days"));
 }
-
 function highOrderDiffs(cursor, later, units) {
-  const differs = [["years", (a, b) => b.year - a.year], ["quarters", (a, b) => b.quarter - a.quarter + (b.year - a.year) * 4], ["months", (a, b) => b.month - a.month + (b.year - a.year) * 12], ["weeks", (a, b) => {
-    const days = dayDiff(a, b);
+  var differs = [["years", (a, b) => b.year - a.year], ["quarters", (a, b) => b.quarter - a.quarter + (b.year - a.year) * 4], ["months", (a, b) => b.month - a.month + (b.year - a.year) * 12], ["weeks", (a, b) => {
+    var days = dayDiff(a, b);
     return (days - days % 7) / 7;
   }], ["days", dayDiff]];
-  const results = {};
-  const earlier = cursor;
-  let lowestOrder, highWater;
-
+  var results = {};
+  var earlier = cursor;
+  var lowestOrder, highWater;
   for (var _i = 0, _differs = differs; _i < _differs.length; _i++) {
-    const _differs$_i = diff_slicedToArray(_differs[_i], 2),
-          unit = _differs$_i[0],
-          differ = _differs$_i[1];
-
+    var _differs$_i = diff_slicedToArray(_differs[_i], 2),
+      unit = _differs$_i[0],
+      differ = _differs$_i[1];
     if (units.indexOf(unit) >= 0) {
       lowestOrder = unit;
       results[unit] = differ(cursor, later);
       highWater = earlier.plus(results);
-
       if (highWater > later) {
         results[unit]--;
         cursor = earlier.plus(results);
@@ -5470,35 +4845,28 @@ function highOrderDiffs(cursor, later, units) {
       }
     }
   }
-
   return [cursor, results, highWater, lowestOrder];
 }
-
 /* harmony default export */ function diff(earlier, later, units, opts) {
-  let _highOrderDiffs = highOrderDiffs(earlier, later, units),
-      _highOrderDiffs2 = diff_slicedToArray(_highOrderDiffs, 4),
-      cursor = _highOrderDiffs2[0],
-      results = _highOrderDiffs2[1],
-      highWater = _highOrderDiffs2[2],
-      lowestOrder = _highOrderDiffs2[3];
-
-  const remainingMillis = later - cursor;
-  const lowerOrderUnits = units.filter(u => ["hours", "minutes", "seconds", "milliseconds"].indexOf(u) >= 0);
-
+  var _highOrderDiffs = highOrderDiffs(earlier, later, units),
+    _highOrderDiffs2 = diff_slicedToArray(_highOrderDiffs, 4),
+    cursor = _highOrderDiffs2[0],
+    results = _highOrderDiffs2[1],
+    highWater = _highOrderDiffs2[2],
+    lowestOrder = _highOrderDiffs2[3];
+  var remainingMillis = later - cursor;
+  var lowerOrderUnits = units.filter(u => ["hours", "minutes", "seconds", "milliseconds"].indexOf(u) >= 0);
   if (lowerOrderUnits.length === 0) {
     if (highWater < later) {
       highWater = cursor.plus({
         [lowestOrder]: 1
       });
     }
-
     if (highWater !== cursor) {
       results[lowestOrder] = (results[lowestOrder] || 0) + remainingMillis / (highWater - cursor);
     }
   }
-
-  const duration = Duration.fromObject(results, opts);
-
+  var duration = Duration.fromObject(results, opts);
   if (lowerOrderUnits.length > 0) {
     return Duration.fromMillis(remainingMillis, opts).shiftTo(...lowerOrderUnits).plus(duration);
   } else {
@@ -5507,18 +4875,12 @@ function highOrderDiffs(cursor, later, units) {
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/digits.js
 function digits_slicedToArray(arr, i) { return digits_arrayWithHoles(arr) || digits_iterableToArrayLimit(arr, i) || digits_unsupportedIterableToArray(arr, i) || digits_nonIterableRest(); }
-
 function digits_nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
 function digits_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return digits_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return digits_arrayLikeToArray(o, minLen); }
-
 function digits_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-
-function digits_iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
+function digits_iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
 function digits_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
-const numberingSystems = {
+var numberingSystems = {
   arab: "[\u0660-\u0669]",
   arabext: "[\u06F0-\u06F9]",
   bali: "[\u1B50-\u1B59]",
@@ -5541,7 +4903,7 @@ const numberingSystems = {
   tibt: "[\u0F20-\u0F29]",
   latn: "\\d"
 };
-const numberingSystemsUTF16 = {
+var numberingSystemsUTF16 = {
   arab: [1632, 1641],
   arabext: [1776, 1785],
   bali: [6992, 7001],
@@ -5562,52 +4924,42 @@ const numberingSystemsUTF16 = {
   thai: [3664, 3673],
   tibt: [3872, 3881]
 };
-const hanidecChars = numberingSystems.hanidec.replace(/[\[|\]]/g, "").split("");
+var hanidecChars = numberingSystems.hanidec.replace(/[\[|\]]/g, "").split("");
 function parseDigits(str) {
-  let value = parseInt(str, 10);
-
+  var value = parseInt(str, 10);
   if (isNaN(value)) {
     value = "";
-
-    for (let i = 0; i < str.length; i++) {
-      const code = str.charCodeAt(i);
-
+    for (var i = 0; i < str.length; i++) {
+      var code = str.charCodeAt(i);
       if (str[i].search(numberingSystems.hanidec) !== -1) {
         value += hanidecChars.indexOf(str[i]);
       } else {
-        for (const key in numberingSystemsUTF16) {
-          const _numberingSystemsUTF = digits_slicedToArray(numberingSystemsUTF16[key], 2),
-                min = _numberingSystemsUTF[0],
-                max = _numberingSystemsUTF[1];
-
+        for (var key in numberingSystemsUTF16) {
+          var _numberingSystemsUTF = digits_slicedToArray(numberingSystemsUTF16[key], 2),
+            min = _numberingSystemsUTF[0],
+            max = _numberingSystemsUTF[1];
           if (code >= min && code <= max) {
             value += code - min;
           }
         }
       }
     }
-
     return parseInt(value, 10);
   } else {
     return value;
   }
 }
 function digitRegex(_ref) {
-  let numberingSystem = _ref.numberingSystem;
-  let append = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "";
+  var numberingSystem = _ref.numberingSystem;
+  var append = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "";
   return new RegExp(`${numberingSystems[numberingSystem || "latn"]}${append}`);
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/tokenParser.js
 function tokenParser_slicedToArray(arr, i) { return tokenParser_arrayWithHoles(arr) || tokenParser_iterableToArrayLimit(arr, i) || tokenParser_unsupportedIterableToArray(arr, i) || tokenParser_nonIterableRest(); }
-
 function tokenParser_nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
 function tokenParser_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return tokenParser_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return tokenParser_arrayLikeToArray(o, minLen); }
-
 function tokenParser_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-
-function tokenParser_iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
+function tokenParser_iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
 function tokenParser_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
@@ -5616,38 +4968,31 @@ function tokenParser_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
 
-
-const MISSING_FTP = "missing Intl.DateTimeFormat.formatToParts support";
-
+var MISSING_FTP = "missing Intl.DateTimeFormat.formatToParts support";
 function intUnit(regex) {
-  let post = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : i => i;
+  var post = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : i => i;
   return {
     regex,
     deser: _ref => {
-      let _ref2 = tokenParser_slicedToArray(_ref, 1),
-          s = _ref2[0];
-
+      var _ref2 = tokenParser_slicedToArray(_ref, 1),
+        s = _ref2[0];
       return post(parseDigits(s));
     }
   };
 }
-
-const NBSP = String.fromCharCode(160);
-const spaceOrNBSP = `[ ${NBSP}]`;
-const spaceOrNBSPRegExp = new RegExp(spaceOrNBSP, "g");
-
+var NBSP = String.fromCharCode(160);
+var spaceOrNBSP = `[ ${NBSP}]`;
+var spaceOrNBSPRegExp = new RegExp(spaceOrNBSP, "g");
 function fixListRegex(s) {
   // make dots optional and also make them literal
   // make space and non breakable space characters interchangeable
   return s.replace(/\./g, "\\.?").replace(spaceOrNBSPRegExp, spaceOrNBSP);
 }
-
 function stripInsensitivities(s) {
   return s.replace(/\./g, "") // ignore dots that were made optional
   .replace(spaceOrNBSPRegExp, " ") // interchange space and nbsp
   .toLowerCase();
 }
-
 function oneOf(strings, startIndex) {
   if (strings === null) {
     return null;
@@ -5655,242 +5000,184 @@ function oneOf(strings, startIndex) {
     return {
       regex: RegExp(strings.map(fixListRegex).join("|")),
       deser: _ref3 => {
-        let _ref4 = tokenParser_slicedToArray(_ref3, 1),
-            s = _ref4[0];
-
+        var _ref4 = tokenParser_slicedToArray(_ref3, 1),
+          s = _ref4[0];
         return strings.findIndex(i => stripInsensitivities(s) === stripInsensitivities(i)) + startIndex;
       }
     };
   }
 }
-
 function offset(regex, groups) {
   return {
     regex,
     deser: _ref5 => {
-      let _ref6 = tokenParser_slicedToArray(_ref5, 3),
-          h = _ref6[1],
-          m = _ref6[2];
-
+      var _ref6 = tokenParser_slicedToArray(_ref5, 3),
+        h = _ref6[1],
+        m = _ref6[2];
       return signedOffset(h, m);
     },
     groups
   };
 }
-
 function simple(regex) {
   return {
     regex,
     deser: _ref7 => {
-      let _ref8 = tokenParser_slicedToArray(_ref7, 1),
-          s = _ref8[0];
-
+      var _ref8 = tokenParser_slicedToArray(_ref7, 1),
+        s = _ref8[0];
       return s;
     }
   };
 }
-
 function escapeToken(value) {
   return value.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&");
 }
-
 function unitForToken(token, loc) {
-  const one = digitRegex(loc),
-        two = digitRegex(loc, "{2}"),
-        three = digitRegex(loc, "{3}"),
-        four = digitRegex(loc, "{4}"),
-        six = digitRegex(loc, "{6}"),
-        oneOrTwo = digitRegex(loc, "{1,2}"),
-        oneToThree = digitRegex(loc, "{1,3}"),
-        oneToSix = digitRegex(loc, "{1,6}"),
-        oneToNine = digitRegex(loc, "{1,9}"),
-        twoToFour = digitRegex(loc, "{2,4}"),
-        fourToSix = digitRegex(loc, "{4,6}"),
-        literal = t => ({
-    regex: RegExp(escapeToken(t.val)),
-    deser: _ref9 => {
-      let _ref10 = tokenParser_slicedToArray(_ref9, 1),
+  var one = digitRegex(loc),
+    two = digitRegex(loc, "{2}"),
+    three = digitRegex(loc, "{3}"),
+    four = digitRegex(loc, "{4}"),
+    six = digitRegex(loc, "{6}"),
+    oneOrTwo = digitRegex(loc, "{1,2}"),
+    oneToThree = digitRegex(loc, "{1,3}"),
+    oneToSix = digitRegex(loc, "{1,6}"),
+    oneToNine = digitRegex(loc, "{1,9}"),
+    twoToFour = digitRegex(loc, "{2,4}"),
+    fourToSix = digitRegex(loc, "{4,6}"),
+    literal = t => ({
+      regex: RegExp(escapeToken(t.val)),
+      deser: _ref9 => {
+        var _ref10 = tokenParser_slicedToArray(_ref9, 1),
           s = _ref10[0];
-
-      return s;
-    },
-    literal: true
-  }),
-        unitate = t => {
-    if (token.literal) {
-      return literal(t);
-    }
-
-    switch (t.val) {
-      // era
-      case "G":
-        return oneOf(loc.eras("short", false), 0);
-
-      case "GG":
-        return oneOf(loc.eras("long", false), 0);
-      // years
-
-      case "y":
-        return intUnit(oneToSix);
-
-      case "yy":
-        return intUnit(twoToFour, untruncateYear);
-
-      case "yyyy":
-        return intUnit(four);
-
-      case "yyyyy":
-        return intUnit(fourToSix);
-
-      case "yyyyyy":
-        return intUnit(six);
-      // months
-
-      case "M":
-        return intUnit(oneOrTwo);
-
-      case "MM":
-        return intUnit(two);
-
-      case "MMM":
-        return oneOf(loc.months("short", true, false), 1);
-
-      case "MMMM":
-        return oneOf(loc.months("long", true, false), 1);
-
-      case "L":
-        return intUnit(oneOrTwo);
-
-      case "LL":
-        return intUnit(two);
-
-      case "LLL":
-        return oneOf(loc.months("short", false, false), 1);
-
-      case "LLLL":
-        return oneOf(loc.months("long", false, false), 1);
-      // dates
-
-      case "d":
-        return intUnit(oneOrTwo);
-
-      case "dd":
-        return intUnit(two);
-      // ordinals
-
-      case "o":
-        return intUnit(oneToThree);
-
-      case "ooo":
-        return intUnit(three);
-      // time
-
-      case "HH":
-        return intUnit(two);
-
-      case "H":
-        return intUnit(oneOrTwo);
-
-      case "hh":
-        return intUnit(two);
-
-      case "h":
-        return intUnit(oneOrTwo);
-
-      case "mm":
-        return intUnit(two);
-
-      case "m":
-        return intUnit(oneOrTwo);
-
-      case "q":
-        return intUnit(oneOrTwo);
-
-      case "qq":
-        return intUnit(two);
-
-      case "s":
-        return intUnit(oneOrTwo);
-
-      case "ss":
-        return intUnit(two);
-
-      case "S":
-        return intUnit(oneToThree);
-
-      case "SSS":
-        return intUnit(three);
-
-      case "u":
-        return simple(oneToNine);
-
-      case "uu":
-        return simple(oneOrTwo);
-
-      case "uuu":
-        return intUnit(one);
-      // meridiem
-
-      case "a":
-        return oneOf(loc.meridiems(), 0);
-      // weekYear (k)
-
-      case "kkkk":
-        return intUnit(four);
-
-      case "kk":
-        return intUnit(twoToFour, untruncateYear);
-      // weekNumber (W)
-
-      case "W":
-        return intUnit(oneOrTwo);
-
-      case "WW":
-        return intUnit(two);
-      // weekdays
-
-      case "E":
-      case "c":
-        return intUnit(one);
-
-      case "EEE":
-        return oneOf(loc.weekdays("short", false, false), 1);
-
-      case "EEEE":
-        return oneOf(loc.weekdays("long", false, false), 1);
-
-      case "ccc":
-        return oneOf(loc.weekdays("short", true, false), 1);
-
-      case "cccc":
-        return oneOf(loc.weekdays("long", true, false), 1);
-      // offset/zone
-
-      case "Z":
-      case "ZZ":
-        return offset(new RegExp(`([+-]${oneOrTwo.source})(?::(${two.source}))?`), 2);
-
-      case "ZZZ":
-        return offset(new RegExp(`([+-]${oneOrTwo.source})(${two.source})?`), 2);
-      // we don't support ZZZZ (PST) or ZZZZZ (Pacific Standard Time) in parsing
-      // because we don't have any way to figure out what they are
-
-      case "z":
-        return simple(/[a-z_+-/]{1,256}?/i);
-
-      default:
+        return s;
+      },
+      literal: true
+    }),
+    unitate = t => {
+      if (token.literal) {
         return literal(t);
-    }
-  };
-
-  const unit = unitate(token) || {
+      }
+      switch (t.val) {
+        // era
+        case "G":
+          return oneOf(loc.eras("short", false), 0);
+        case "GG":
+          return oneOf(loc.eras("long", false), 0);
+        // years
+        case "y":
+          return intUnit(oneToSix);
+        case "yy":
+          return intUnit(twoToFour, untruncateYear);
+        case "yyyy":
+          return intUnit(four);
+        case "yyyyy":
+          return intUnit(fourToSix);
+        case "yyyyyy":
+          return intUnit(six);
+        // months
+        case "M":
+          return intUnit(oneOrTwo);
+        case "MM":
+          return intUnit(two);
+        case "MMM":
+          return oneOf(loc.months("short", true, false), 1);
+        case "MMMM":
+          return oneOf(loc.months("long", true, false), 1);
+        case "L":
+          return intUnit(oneOrTwo);
+        case "LL":
+          return intUnit(two);
+        case "LLL":
+          return oneOf(loc.months("short", false, false), 1);
+        case "LLLL":
+          return oneOf(loc.months("long", false, false), 1);
+        // dates
+        case "d":
+          return intUnit(oneOrTwo);
+        case "dd":
+          return intUnit(two);
+        // ordinals
+        case "o":
+          return intUnit(oneToThree);
+        case "ooo":
+          return intUnit(three);
+        // time
+        case "HH":
+          return intUnit(two);
+        case "H":
+          return intUnit(oneOrTwo);
+        case "hh":
+          return intUnit(two);
+        case "h":
+          return intUnit(oneOrTwo);
+        case "mm":
+          return intUnit(two);
+        case "m":
+          return intUnit(oneOrTwo);
+        case "q":
+          return intUnit(oneOrTwo);
+        case "qq":
+          return intUnit(two);
+        case "s":
+          return intUnit(oneOrTwo);
+        case "ss":
+          return intUnit(two);
+        case "S":
+          return intUnit(oneToThree);
+        case "SSS":
+          return intUnit(three);
+        case "u":
+          return simple(oneToNine);
+        case "uu":
+          return simple(oneOrTwo);
+        case "uuu":
+          return intUnit(one);
+        // meridiem
+        case "a":
+          return oneOf(loc.meridiems(), 0);
+        // weekYear (k)
+        case "kkkk":
+          return intUnit(four);
+        case "kk":
+          return intUnit(twoToFour, untruncateYear);
+        // weekNumber (W)
+        case "W":
+          return intUnit(oneOrTwo);
+        case "WW":
+          return intUnit(two);
+        // weekdays
+        case "E":
+        case "c":
+          return intUnit(one);
+        case "EEE":
+          return oneOf(loc.weekdays("short", false, false), 1);
+        case "EEEE":
+          return oneOf(loc.weekdays("long", false, false), 1);
+        case "ccc":
+          return oneOf(loc.weekdays("short", true, false), 1);
+        case "cccc":
+          return oneOf(loc.weekdays("long", true, false), 1);
+        // offset/zone
+        case "Z":
+        case "ZZ":
+          return offset(new RegExp(`([+-]${oneOrTwo.source})(?::(${two.source}))?`), 2);
+        case "ZZZ":
+          return offset(new RegExp(`([+-]${oneOrTwo.source})(${two.source})?`), 2);
+        // we don't support ZZZZ (PST) or ZZZZZ (Pacific Standard Time) in parsing
+        // because we don't have any way to figure out what they are
+        case "z":
+          return simple(/[a-z_+-/]{1,256}?/i);
+        default:
+          return literal(t);
+      }
+    };
+  var unit = unitate(token) || {
     invalidReason: MISSING_FTP
   };
   unit.token = token;
   return unit;
 }
-
-const partTypeStyleToTokenVal = {
+var partTypeStyleToTokenVal = {
   year: {
     "2-digit": "yy",
     numeric: "yyyyy"
@@ -5928,132 +5215,100 @@ const partTypeStyleToTokenVal = {
     short: "ZZZ"
   }
 };
-
 function tokenForPart(part, formatOpts) {
-  const type = part.type,
-        value = part.value;
-
+  var type = part.type,
+    value = part.value;
   if (type === "literal") {
     return {
       literal: true,
       val: value
     };
   }
-
-  const style = formatOpts[type];
-  let val = partTypeStyleToTokenVal[type];
-
+  var style = formatOpts[type];
+  var val = partTypeStyleToTokenVal[type];
   if (typeof val === "object") {
     val = val[style];
   }
-
   if (val) {
     return {
       literal: false,
       val
     };
   }
-
   return undefined;
 }
-
 function buildRegex(units) {
-  const re = units.map(u => u.regex).reduce((f, r) => `${f}(${r.source})`, "");
+  var re = units.map(u => u.regex).reduce((f, r) => `${f}(${r.source})`, "");
   return [`^${re}$`, units];
 }
-
 function match(input, regex, handlers) {
-  const matches = input.match(regex);
-
+  var matches = input.match(regex);
   if (matches) {
-    const all = {};
-    let matchIndex = 1;
-
-    for (const i in handlers) {
+    var all = {};
+    var matchIndex = 1;
+    for (var i in handlers) {
       if (util_hasOwnProperty(handlers, i)) {
-        const h = handlers[i],
-              groups = h.groups ? h.groups + 1 : 1;
-
+        var h = handlers[i],
+          groups = h.groups ? h.groups + 1 : 1;
         if (!h.literal && h.token) {
           all[h.token.val[0]] = h.deser(matches.slice(matchIndex, matchIndex + groups));
         }
-
         matchIndex += groups;
       }
     }
-
     return [matches, all];
   } else {
     return [matches, {}];
   }
 }
-
 function dateTimeFromMatches(matches) {
-  const toField = token => {
+  var toField = token => {
     switch (token) {
       case "S":
         return "millisecond";
-
       case "s":
         return "second";
-
       case "m":
         return "minute";
-
       case "h":
       case "H":
         return "hour";
-
       case "d":
         return "day";
-
       case "o":
         return "ordinal";
-
       case "L":
       case "M":
         return "month";
-
       case "y":
         return "year";
-
       case "E":
       case "c":
         return "weekday";
-
       case "W":
         return "weekNumber";
-
       case "k":
         return "weekYear";
-
       case "q":
         return "quarter";
-
       default:
         return null;
     }
   };
-
-  let zone = null;
-  let specificOffset;
-
+  var zone = null;
+  var specificOffset;
   if (!isUndefined(matches.z)) {
     zone = IANAZone.create(matches.z);
   }
-
   if (!isUndefined(matches.Z)) {
     if (!zone) {
       zone = new FixedOffsetZone(matches.Z);
     }
-
     specificOffset = matches.Z;
   }
-
   if (!isUndefined(matches.q)) {
     matches.M = (matches.q - 1) * 3 + 1;
   }
-
   if (!isUndefined(matches.h)) {
     if (matches.h < 12 && matches.a === 1) {
       matches.h += 12;
@@ -6061,64 +5316,51 @@ function dateTimeFromMatches(matches) {
       matches.h = 0;
     }
   }
-
   if (matches.G === 0 && matches.y) {
     matches.y = -matches.y;
   }
-
   if (!isUndefined(matches.u)) {
     matches.S = parseMillis(matches.u);
   }
-
-  const vals = Object.keys(matches).reduce((r, k) => {
-    const f = toField(k);
-
+  var vals = Object.keys(matches).reduce((r, k) => {
+    var f = toField(k);
     if (f) {
       r[f] = matches[k];
     }
-
     return r;
   }, {});
   return [vals, zone, specificOffset];
 }
-
-let dummyDateTimeCache = null;
-
+var dummyDateTimeCache = null;
 function getDummyDateTime() {
   if (!dummyDateTimeCache) {
     dummyDateTimeCache = DateTime.fromMillis(1555555555555);
   }
-
   return dummyDateTimeCache;
 }
-
 function maybeExpandMacroToken(token, locale) {
   if (token.literal) {
     return token;
   }
-
-  const formatOpts = Formatter.macroTokenToFormatOpts(token.val);
-  const tokens = formatOptsToTokens(formatOpts, locale);
-
+  var formatOpts = Formatter.macroTokenToFormatOpts(token.val);
+  var tokens = formatOptsToTokens(formatOpts, locale);
   if (tokens == null || tokens.includes(undefined)) {
     return token;
   }
-
   return tokens;
 }
-
 function expandMacroTokens(tokens, locale) {
   return Array.prototype.concat(...tokens.map(t => maybeExpandMacroToken(t, locale)));
 }
+
 /**
  * @private
  */
 
 function explainFromTokens(locale, input, format) {
-  const tokens = expandMacroTokens(Formatter.parseFormat(format), locale),
-        units = tokens.map(t => unitForToken(t, locale)),
-        disqualifyingUnit = units.find(t => t.invalidReason);
-
+  var tokens = expandMacroTokens(Formatter.parseFormat(format), locale),
+    units = tokens.map(t => unitForToken(t, locale)),
+    disqualifyingUnit = units.find(t => t.invalidReason);
   if (disqualifyingUnit) {
     return {
       input,
@@ -6126,25 +5368,23 @@ function explainFromTokens(locale, input, format) {
       invalidReason: disqualifyingUnit.invalidReason
     };
   } else {
-    const _buildRegex = buildRegex(units),
-          _buildRegex2 = tokenParser_slicedToArray(_buildRegex, 2),
-          regexString = _buildRegex2[0],
-          handlers = _buildRegex2[1],
-          regex = RegExp(regexString, "i"),
-          _match = match(input, regex, handlers),
-          _match2 = tokenParser_slicedToArray(_match, 2),
-          rawMatches = _match2[0],
-          matches = _match2[1],
-          _ref11 = matches ? dateTimeFromMatches(matches) : [null, null, undefined],
-          _ref12 = tokenParser_slicedToArray(_ref11, 3),
-          result = _ref12[0],
-          zone = _ref12[1],
-          specificOffset = _ref12[2];
-
+    var _buildRegex = buildRegex(units),
+      _buildRegex2 = tokenParser_slicedToArray(_buildRegex, 2),
+      regexString = _buildRegex2[0],
+      handlers = _buildRegex2[1],
+      regex = RegExp(regexString, "i"),
+      _match = match(input, regex, handlers),
+      _match2 = tokenParser_slicedToArray(_match, 2),
+      rawMatches = _match2[0],
+      matches = _match2[1],
+      _ref11 = matches ? dateTimeFromMatches(matches) : [null, null, undefined],
+      _ref12 = tokenParser_slicedToArray(_ref11, 3),
+      result = _ref12[0],
+      zone = _ref12[1],
+      specificOffset = _ref12[2];
     if (util_hasOwnProperty(matches, "a") && util_hasOwnProperty(matches, "H")) {
       throw new ConflictingSpecificationError("Can't include meridiem when specifying 24-hour format");
     }
-
     return {
       input,
       tokens,
@@ -6158,77 +5398,67 @@ function explainFromTokens(locale, input, format) {
   }
 }
 function parseFromTokens(locale, input, format) {
-  const _explainFromTokens = explainFromTokens(locale, input, format),
-        result = _explainFromTokens.result,
-        zone = _explainFromTokens.zone,
-        specificOffset = _explainFromTokens.specificOffset,
-        invalidReason = _explainFromTokens.invalidReason;
-
+  var _explainFromTokens = explainFromTokens(locale, input, format),
+    result = _explainFromTokens.result,
+    zone = _explainFromTokens.zone,
+    specificOffset = _explainFromTokens.specificOffset,
+    invalidReason = _explainFromTokens.invalidReason;
   return [result, zone, specificOffset, invalidReason];
 }
 function formatOptsToTokens(formatOpts, locale) {
   if (!formatOpts) {
     return null;
   }
-
-  const formatter = Formatter.create(locale, formatOpts);
-  const parts = formatter.formatDateTimeParts(getDummyDateTime());
+  var formatter = Formatter.create(locale, formatOpts);
+  var parts = formatter.formatDateTimeParts(getDummyDateTime());
   return parts.map(p => tokenForPart(p, formatOpts));
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/impl/conversions.js
-function conversions_ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
+function conversions_ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
+function conversions_objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? conversions_ownKeys(Object(t), !0).forEach(function (r) { conversions_defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : conversions_ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
+function conversions_defineProperty(obj, key, value) { key = conversions_toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function conversions_toPropertyKey(t) { var i = conversions_toPrimitive(t, "string"); return "symbol" == typeof i ? i : i + ""; }
+function conversions_toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
 
-function conversions_objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? conversions_ownKeys(Object(source), !0).forEach(function (key) { conversions_defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : conversions_ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
 
-function conversions_defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
-
-
-const nonLeapLadder = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334],
-      leapLadder = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335];
-
+var nonLeapLadder = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334],
+  leapLadder = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335];
 function unitOutOfRange(unit, value) {
   return new Invalid("unit out of range", `you specified ${value} (of type ${typeof value}) as a ${unit}, which is invalid`);
 }
-
 function dayOfWeek(year, month, day) {
-  const d = new Date(Date.UTC(year, month - 1, day));
-
+  var d = new Date(Date.UTC(year, month - 1, day));
   if (year < 100 && year >= 0) {
     d.setUTCFullYear(d.getUTCFullYear() - 1900);
   }
-
-  const js = d.getUTCDay();
+  var js = d.getUTCDay();
   return js === 0 ? 7 : js;
 }
-
 function computeOrdinal(year, month, day) {
   return day + (isLeapYear(year) ? leapLadder : nonLeapLadder)[month - 1];
 }
-
 function uncomputeOrdinal(year, ordinal) {
-  const table = isLeapYear(year) ? leapLadder : nonLeapLadder,
-        month0 = table.findIndex(i => i < ordinal),
-        day = ordinal - table[month0];
+  var table = isLeapYear(year) ? leapLadder : nonLeapLadder,
+    month0 = table.findIndex(i => i < ordinal),
+    day = ordinal - table[month0];
   return {
     month: month0 + 1,
     day
   };
 }
+
 /**
  * @private
  */
 
-
 function gregorianToWeek(gregObj) {
-  const year = gregObj.year,
-        month = gregObj.month,
-        day = gregObj.day,
-        ordinal = computeOrdinal(year, month, day),
-        weekday = dayOfWeek(year, month, day);
-  let weekNumber = Math.floor((ordinal - weekday + 10) / 7),
-      weekYear;
-
+  var year = gregObj.year,
+    month = gregObj.month,
+    day = gregObj.day,
+    ordinal = computeOrdinal(year, month, day),
+    weekday = dayOfWeek(year, month, day);
+  var weekNumber = Math.floor((ordinal - weekday + 10) / 7),
+    weekYear;
   if (weekNumber < 1) {
     weekYear = year - 1;
     weekNumber = weeksInWeekYear(weekYear);
@@ -6238,7 +5468,6 @@ function gregorianToWeek(gregObj) {
   } else {
     weekYear = year;
   }
-
   return conversions_objectSpread({
     weekYear,
     weekNumber,
@@ -6246,14 +5475,13 @@ function gregorianToWeek(gregObj) {
   }, timeObject(gregObj));
 }
 function weekToGregorian(weekData) {
-  const weekYear = weekData.weekYear,
-        weekNumber = weekData.weekNumber,
-        weekday = weekData.weekday,
-        weekdayOfJan4 = dayOfWeek(weekYear, 1, 4),
-        yearInDays = daysInYear(weekYear);
-  let ordinal = weekNumber * 7 + weekday - weekdayOfJan4 - 3,
-      year;
-
+  var weekYear = weekData.weekYear,
+    weekNumber = weekData.weekNumber,
+    weekday = weekData.weekday,
+    weekdayOfJan4 = dayOfWeek(weekYear, 1, 4),
+    yearInDays = daysInYear(weekYear);
+  var ordinal = weekNumber * 7 + weekday - weekdayOfJan4 - 3,
+    year;
   if (ordinal < 1) {
     year = weekYear - 1;
     ordinal += daysInYear(year);
@@ -6263,11 +5491,9 @@ function weekToGregorian(weekData) {
   } else {
     year = weekYear;
   }
-
-  const _uncomputeOrdinal = uncomputeOrdinal(year, ordinal),
-        month = _uncomputeOrdinal.month,
-        day = _uncomputeOrdinal.day;
-
+  var _uncomputeOrdinal = uncomputeOrdinal(year, ordinal),
+    month = _uncomputeOrdinal.month,
+    day = _uncomputeOrdinal.day;
   return conversions_objectSpread({
     year,
     month,
@@ -6275,23 +5501,21 @@ function weekToGregorian(weekData) {
   }, timeObject(weekData));
 }
 function gregorianToOrdinal(gregData) {
-  const year = gregData.year,
-        month = gregData.month,
-        day = gregData.day;
-  const ordinal = computeOrdinal(year, month, day);
+  var year = gregData.year,
+    month = gregData.month,
+    day = gregData.day;
+  var ordinal = computeOrdinal(year, month, day);
   return conversions_objectSpread({
     year,
     ordinal
   }, timeObject(gregData));
 }
 function ordinalToGregorian(ordinalData) {
-  const year = ordinalData.year,
-        ordinal = ordinalData.ordinal;
-
-  const _uncomputeOrdinal2 = uncomputeOrdinal(year, ordinal),
-        month = _uncomputeOrdinal2.month,
-        day = _uncomputeOrdinal2.day;
-
+  var year = ordinalData.year,
+    ordinal = ordinalData.ordinal;
+  var _uncomputeOrdinal2 = uncomputeOrdinal(year, ordinal),
+    month = _uncomputeOrdinal2.month,
+    day = _uncomputeOrdinal2.day;
   return conversions_objectSpread({
     year,
     month,
@@ -6299,10 +5523,9 @@ function ordinalToGregorian(ordinalData) {
   }, timeObject(ordinalData));
 }
 function hasInvalidWeekData(obj) {
-  const validYear = isInteger(obj.weekYear),
-        validWeek = integerBetween(obj.weekNumber, 1, weeksInWeekYear(obj.weekYear)),
-        validWeekday = integerBetween(obj.weekday, 1, 7);
-
+  var validYear = isInteger(obj.weekYear),
+    validWeek = integerBetween(obj.weekNumber, 1, weeksInWeekYear(obj.weekYear)),
+    validWeekday = integerBetween(obj.weekday, 1, 7);
   if (!validYear) {
     return unitOutOfRange("weekYear", obj.weekYear);
   } else if (!validWeek) {
@@ -6312,9 +5535,8 @@ function hasInvalidWeekData(obj) {
   } else return false;
 }
 function hasInvalidOrdinalData(obj) {
-  const validYear = isInteger(obj.year),
-        validOrdinal = integerBetween(obj.ordinal, 1, daysInYear(obj.year));
-
+  var validYear = isInteger(obj.year),
+    validOrdinal = integerBetween(obj.ordinal, 1, daysInYear(obj.year));
   if (!validYear) {
     return unitOutOfRange("year", obj.year);
   } else if (!validOrdinal) {
@@ -6322,10 +5544,9 @@ function hasInvalidOrdinalData(obj) {
   } else return false;
 }
 function hasInvalidGregorianData(obj) {
-  const validYear = isInteger(obj.year),
-        validMonth = integerBetween(obj.month, 1, 12),
-        validDay = integerBetween(obj.day, 1, daysInMonth(obj.year, obj.month));
-
+  var validYear = isInteger(obj.year),
+    validMonth = integerBetween(obj.month, 1, 12),
+    validDay = integerBetween(obj.day, 1, daysInMonth(obj.year, obj.month));
   if (!validYear) {
     return unitOutOfRange("year", obj.year);
   } else if (!validMonth) {
@@ -6335,15 +5556,14 @@ function hasInvalidGregorianData(obj) {
   } else return false;
 }
 function hasInvalidTimeData(obj) {
-  const hour = obj.hour,
-        minute = obj.minute,
-        second = obj.second,
-        millisecond = obj.millisecond;
-  const validHour = integerBetween(hour, 0, 23) || hour === 24 && minute === 0 && second === 0 && millisecond === 0,
-        validMinute = integerBetween(minute, 0, 59),
-        validSecond = integerBetween(second, 0, 59),
-        validMillisecond = integerBetween(millisecond, 0, 999);
-
+  var hour = obj.hour,
+    minute = obj.minute,
+    second = obj.second,
+    millisecond = obj.millisecond;
+  var validHour = integerBetween(hour, 0, 23) || hour === 24 && minute === 0 && second === 0 && millisecond === 0,
+    validMinute = integerBetween(minute, 0, 59),
+    validSecond = integerBetween(second, 0, 59),
+    validMillisecond = integerBetween(millisecond, 0, 999);
   if (!validHour) {
     return unitOutOfRange("hour", hour);
   } else if (!validMinute) {
@@ -6355,26 +5575,18 @@ function hasInvalidTimeData(obj) {
   } else return false;
 }
 ;// CONCATENATED MODULE: ./node_modules/luxon/src/datetime.js
-function datetime_createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = datetime_unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e2) { throw _e2; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e3) { didErr = true; err = _e3; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-
+function datetime_createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = datetime_unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
 function datetime_slicedToArray(arr, i) { return datetime_arrayWithHoles(arr) || datetime_iterableToArrayLimit(arr, i) || datetime_unsupportedIterableToArray(arr, i) || datetime_nonIterableRest(); }
-
 function datetime_nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
 function datetime_unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return datetime_arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return datetime_arrayLikeToArray(o, minLen); }
-
 function datetime_arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-
-function datetime_iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
+function datetime_iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
 function datetime_arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
-function datetime_ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
-
-function datetime_objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? datetime_ownKeys(Object(source), !0).forEach(function (key) { datetime_defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : datetime_ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
-
-function datetime_defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
+function datetime_ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
+function datetime_objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? datetime_ownKeys(Object(t), !0).forEach(function (r) { datetime_defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : datetime_ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
+function datetime_defineProperty(obj, key, value) { key = datetime_toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function datetime_toPropertyKey(t) { var i = datetime_toPrimitive(t, "string"); return "symbol" == typeof i ? i : i + ""; }
+function datetime_toPrimitive(t, r) { if ("object" != typeof t || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != typeof i) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
 
 
 
@@ -6391,26 +5603,24 @@ function datetime_defineProperty(obj, key, value) { if (key in obj) { Object.def
 
 
 
-const datetime_INVALID = "Invalid DateTime";
-const MAX_DATE = 8.64e15;
-
+var datetime_INVALID = "Invalid DateTime";
+var MAX_DATE = 8.64e15;
 function unsupportedZone(zone) {
   return new Invalid("unsupported zone", `the zone "${zone.name}" is not supported`);
-} // we cache week data on the DT object and this intermediates the cache
+}
 
-
+// we cache week data on the DT object and this intermediates the cache
 function possiblyCachedWeekData(dt) {
   if (dt.weekData === null) {
     dt.weekData = gregorianToWeek(dt.c);
   }
-
   return dt.weekData;
-} // clone really means, "make a new object with these modifications". all "setters" really use this
+}
+
+// clone really means, "make a new object with these modifications". all "setters" really use this
 // to create a new object while only changing some of the properties
-
-
 function datetime_clone(inst, alts) {
-  const current = {
+  var current = {
     ts: inst.ts,
     zone: inst.zone,
     c: inst.c,
@@ -6421,37 +5631,39 @@ function datetime_clone(inst, alts) {
   return new DateTime(datetime_objectSpread(datetime_objectSpread(datetime_objectSpread({}, current), alts), {}, {
     old: current
   }));
-} // find the right offset a given local time. The o input is our guess, which determines which
+}
+
+// find the right offset a given local time. The o input is our guess, which determines which
 // offset we'll pick in ambiguous cases (e.g. there are two 3 AMs b/c Fallback DST)
-
-
 function fixOffset(localTS, o, tz) {
   // Our UTC time is just a guess because our offset is just a guess
-  let utcGuess = localTS - o * 60 * 1000; // Test whether the zone matches the offset for this ts
+  var utcGuess = localTS - o * 60 * 1000;
 
-  const o2 = tz.offset(utcGuess); // If so, offset didn't change and we're done
+  // Test whether the zone matches the offset for this ts
+  var o2 = tz.offset(utcGuess);
 
+  // If so, offset didn't change and we're done
   if (o === o2) {
     return [utcGuess, o];
-  } // If not, change the ts by the difference in the offset
+  }
 
+  // If not, change the ts by the difference in the offset
+  utcGuess -= (o2 - o) * 60 * 1000;
 
-  utcGuess -= (o2 - o) * 60 * 1000; // If that gives us the local time we want, we're done
-
-  const o3 = tz.offset(utcGuess);
-
+  // If that gives us the local time we want, we're done
+  var o3 = tz.offset(utcGuess);
   if (o2 === o3) {
     return [utcGuess, o2];
-  } // If it's different, we're in a hole time. The offset has changed, but the we don't adjust the time
+  }
 
-
+  // If it's different, we're in a hole time. The offset has changed, but the we don't adjust the time
   return [localTS - Math.min(o2, o3) * 60 * 1000, Math.max(o2, o3)];
-} // convert an epoch timestamp into a calendar object with the given offset
+}
 
-
+// convert an epoch timestamp into a calendar object with the given offset
 function tsToObj(ts, offset) {
   ts += offset * 60 * 1000;
-  const d = new Date(ts);
+  var d = new Date(ts);
   return {
     year: d.getUTCFullYear(),
     month: d.getUTCMonth() + 1,
@@ -6461,87 +5673,81 @@ function tsToObj(ts, offset) {
     second: d.getUTCSeconds(),
     millisecond: d.getUTCMilliseconds()
   };
-} // convert a calendar object to a epoch timestamp
+}
 
-
+// convert a calendar object to a epoch timestamp
 function objToTS(obj, offset, zone) {
   return fixOffset(objToLocalTS(obj), offset, zone);
-} // create a new DT instance by adding a duration, adjusting for DSTs
+}
 
-
+// create a new DT instance by adding a duration, adjusting for DSTs
 function adjustTime(inst, dur) {
-  const oPre = inst.o,
-        year = inst.c.year + Math.trunc(dur.years),
-        month = inst.c.month + Math.trunc(dur.months) + Math.trunc(dur.quarters) * 3,
-        c = datetime_objectSpread(datetime_objectSpread({}, inst.c), {}, {
-    year,
-    month,
-    day: Math.min(inst.c.day, daysInMonth(year, month)) + Math.trunc(dur.days) + Math.trunc(dur.weeks) * 7
-  }),
-        millisToAdd = Duration.fromObject({
-    years: dur.years - Math.trunc(dur.years),
-    quarters: dur.quarters - Math.trunc(dur.quarters),
-    months: dur.months - Math.trunc(dur.months),
-    weeks: dur.weeks - Math.trunc(dur.weeks),
-    days: dur.days - Math.trunc(dur.days),
-    hours: dur.hours,
-    minutes: dur.minutes,
-    seconds: dur.seconds,
-    milliseconds: dur.milliseconds
-  }).as("milliseconds"),
-        localTS = objToLocalTS(c);
-
-  let _fixOffset = fixOffset(localTS, oPre, inst.zone),
-      _fixOffset2 = datetime_slicedToArray(_fixOffset, 2),
-      ts = _fixOffset2[0],
-      o = _fixOffset2[1];
-
+  var oPre = inst.o,
+    year = inst.c.year + Math.trunc(dur.years),
+    month = inst.c.month + Math.trunc(dur.months) + Math.trunc(dur.quarters) * 3,
+    c = datetime_objectSpread(datetime_objectSpread({}, inst.c), {}, {
+      year,
+      month,
+      day: Math.min(inst.c.day, daysInMonth(year, month)) + Math.trunc(dur.days) + Math.trunc(dur.weeks) * 7
+    }),
+    millisToAdd = Duration.fromObject({
+      years: dur.years - Math.trunc(dur.years),
+      quarters: dur.quarters - Math.trunc(dur.quarters),
+      months: dur.months - Math.trunc(dur.months),
+      weeks: dur.weeks - Math.trunc(dur.weeks),
+      days: dur.days - Math.trunc(dur.days),
+      hours: dur.hours,
+      minutes: dur.minutes,
+      seconds: dur.seconds,
+      milliseconds: dur.milliseconds
+    }).as("milliseconds"),
+    localTS = objToLocalTS(c);
+  var _fixOffset = fixOffset(localTS, oPre, inst.zone),
+    _fixOffset2 = datetime_slicedToArray(_fixOffset, 2),
+    ts = _fixOffset2[0],
+    o = _fixOffset2[1];
   if (millisToAdd !== 0) {
-    ts += millisToAdd; // that could have changed the offset by going over a DST, but we want to keep the ts the same
-
+    ts += millisToAdd;
+    // that could have changed the offset by going over a DST, but we want to keep the ts the same
     o = inst.zone.offset(ts);
   }
-
   return {
     ts,
     o
   };
-} // helper useful in turning the results of parsing into real dates
+}
+
+// helper useful in turning the results of parsing into real dates
 // by handling the zone options
-
-
 function parseDataToDateTime(parsed, parsedZone, opts, format, text, specificOffset) {
-  const setZone = opts.setZone,
-        zone = opts.zone;
-
+  var setZone = opts.setZone,
+    zone = opts.zone;
   if (parsed && Object.keys(parsed).length !== 0) {
-    const interpretationZone = parsedZone || zone,
-          inst = DateTime.fromObject(parsed, datetime_objectSpread(datetime_objectSpread({}, opts), {}, {
-      zone: interpretationZone,
-      specificOffset
-    }));
+    var interpretationZone = parsedZone || zone,
+      inst = DateTime.fromObject(parsed, datetime_objectSpread(datetime_objectSpread({}, opts), {}, {
+        zone: interpretationZone,
+        specificOffset
+      }));
     return setZone ? inst : inst.setZone(zone);
   } else {
     return DateTime.invalid(new Invalid("unparsable", `the input "${text}" can't be parsed as ${format}`));
   }
-} // if you want to output a technical format (e.g. RFC 2822), this helper
+}
+
+// if you want to output a technical format (e.g. RFC 2822), this helper
 // helps handle the details
-
-
 function toTechFormat(dt, format) {
-  let allowZ = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
+  var allowZ = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
   return dt.isValid ? Formatter.create(Locale.create("en-US"), {
     allowZ,
     forceSimple: true
   }).formatDateTimeFromString(dt, format) : null;
 }
-
 function toISODate(o, extended) {
-  const longFormat = o.c.year > 9999 || o.c.year < 0;
-  let c = "";
+  var longFormat = o.c.year > 9999 || o.c.year < 0;
+  var c = "";
   if (longFormat && o.c.year >= 0) c += "+";
   c += padStart(o.c.year, longFormat ? 6 : 4);
-
   if (extended) {
     c += "-";
     c += padStart(o.c.month);
@@ -6551,33 +5757,26 @@ function toISODate(o, extended) {
     c += padStart(o.c.month);
     c += padStart(o.c.day);
   }
-
   return c;
 }
-
 function toISOTime(o, extended, suppressSeconds, suppressMilliseconds, includeOffset, extendedZone) {
-  let c = padStart(o.c.hour);
-
+  var c = padStart(o.c.hour);
   if (extended) {
     c += ":";
     c += padStart(o.c.minute);
-
     if (o.c.second !== 0 || !suppressSeconds) {
       c += ":";
     }
   } else {
     c += padStart(o.c.minute);
   }
-
   if (o.c.second !== 0 || !suppressSeconds) {
     c += padStart(o.c.second);
-
     if (o.c.millisecond !== 0 || !suppressMilliseconds) {
       c += ".";
       c += padStart(o.c.millisecond, 3);
     }
   }
-
   if (includeOffset) {
     if (o.isOffsetFixed && o.offset === 0 && !extendedZone) {
       c += "Z";
@@ -6593,45 +5792,45 @@ function toISOTime(o, extended, suppressSeconds, suppressMilliseconds, includeOf
       c += padStart(Math.trunc(o.o % 60));
     }
   }
-
   if (extendedZone) {
     c += "[" + o.zone.ianaName + "]";
   }
-
   return c;
-} // defaults for unspecified units in the supported calendars
+}
 
+// defaults for unspecified units in the supported calendars
+var defaultUnitValues = {
+    month: 1,
+    day: 1,
+    hour: 0,
+    minute: 0,
+    second: 0,
+    millisecond: 0
+  },
+  defaultWeekUnitValues = {
+    weekNumber: 1,
+    weekday: 1,
+    hour: 0,
+    minute: 0,
+    second: 0,
+    millisecond: 0
+  },
+  defaultOrdinalUnitValues = {
+    ordinal: 1,
+    hour: 0,
+    minute: 0,
+    second: 0,
+    millisecond: 0
+  };
 
-const defaultUnitValues = {
-  month: 1,
-  day: 1,
-  hour: 0,
-  minute: 0,
-  second: 0,
-  millisecond: 0
-},
-      defaultWeekUnitValues = {
-  weekNumber: 1,
-  weekday: 1,
-  hour: 0,
-  minute: 0,
-  second: 0,
-  millisecond: 0
-},
-      defaultOrdinalUnitValues = {
-  ordinal: 1,
-  hour: 0,
-  minute: 0,
-  second: 0,
-  millisecond: 0
-}; // Units in the supported calendars, sorted by bigness
+// Units in the supported calendars, sorted by bigness
+var datetime_orderedUnits = ["year", "month", "day", "hour", "minute", "second", "millisecond"],
+  orderedWeekUnits = ["weekYear", "weekNumber", "weekday", "hour", "minute", "second", "millisecond"],
+  orderedOrdinalUnits = ["year", "ordinal", "hour", "minute", "second", "millisecond"];
 
-const datetime_orderedUnits = ["year", "month", "day", "hour", "minute", "second", "millisecond"],
-      orderedWeekUnits = ["weekYear", "weekNumber", "weekday", "hour", "minute", "second", "millisecond"],
-      orderedOrdinalUnits = ["year", "ordinal", "hour", "minute", "second", "millisecond"]; // standardize case and plurality in units
-
+// standardize case and plurality in units
 function normalizeUnit(unit) {
-  const normalized = {
+  var normalized = {
     year: "year",
     years: "year",
     month: "month",
@@ -6659,53 +5858,37 @@ function normalizeUnit(unit) {
   }[unit.toLowerCase()];
   if (!normalized) throw new InvalidUnitError(unit);
   return normalized;
-} // this is a dumbed down version of fromObject() that runs about 60% faster
+}
+
+// this is a dumbed down version of fromObject() that runs about 60% faster
 // but doesn't do any validation, makes a bunch of assumptions about what units
 // are present, and so on.
-
-
 function quickDT(obj, opts) {
-  const zone = normalizeZone(opts.zone, Settings.defaultZone),
-        loc = Locale.fromObject(opts),
-        tsNow = Settings.now();
-  let ts, o; // assume we have the higher-order units
+  var zone = normalizeZone(opts.zone, Settings.defaultZone),
+    loc = Locale.fromObject(opts),
+    tsNow = Settings.now();
+  var ts, o;
 
+  // assume we have the higher-order units
   if (!isUndefined(obj.year)) {
-    var _iterator = datetime_createForOfIteratorHelper(datetime_orderedUnits),
-        _step;
-
-    try {
-      for (_iterator.s(); !(_step = _iterator.n()).done;) {
-        const u = _step.value;
-
-        if (isUndefined(obj[u])) {
-          obj[u] = defaultUnitValues[u];
-        }
+    for (var _i = 0, _orderedUnits = datetime_orderedUnits; _i < _orderedUnits.length; _i++) {
+      var u = _orderedUnits[_i];
+      if (isUndefined(obj[u])) {
+        obj[u] = defaultUnitValues[u];
       }
-    } catch (err) {
-      _iterator.e(err);
-    } finally {
-      _iterator.f();
     }
-
-    const invalid = hasInvalidGregorianData(obj) || hasInvalidTimeData(obj);
-
+    var invalid = hasInvalidGregorianData(obj) || hasInvalidTimeData(obj);
     if (invalid) {
       return DateTime.invalid(invalid);
     }
-
-    const offsetProvis = zone.offset(tsNow);
-
+    var offsetProvis = zone.offset(tsNow);
     var _objToTS = objToTS(obj, offsetProvis, zone);
-
     var _objToTS2 = datetime_slicedToArray(_objToTS, 2);
-
     ts = _objToTS2[0];
     o = _objToTS2[1];
   } else {
     ts = tsNow;
   }
-
   return new DateTime({
     ts,
     zone,
@@ -6713,62 +5896,54 @@ function quickDT(obj, opts) {
     o
   });
 }
-
 function diffRelative(start, end, opts) {
-  const round = isUndefined(opts.round) ? true : opts.round,
-        format = (c, unit) => {
-    c = roundTo(c, round || opts.calendary ? 0 : 2, true);
-    const formatter = end.loc.clone(opts).relFormatter(opts);
-    return formatter.format(c, unit);
-  },
-        differ = unit => {
-    if (opts.calendary) {
-      if (!end.hasSame(start, unit)) {
-        return end.startOf(unit).diff(start.startOf(unit), unit).get(unit);
-      } else return 0;
-    } else {
-      return end.diff(start, unit).get(unit);
-    }
-  };
-
+  var round = isUndefined(opts.round) ? true : opts.round,
+    format = (c, unit) => {
+      c = roundTo(c, round || opts.calendary ? 0 : 2, true);
+      var formatter = end.loc.clone(opts).relFormatter(opts);
+      return formatter.format(c, unit);
+    },
+    differ = unit => {
+      if (opts.calendary) {
+        if (!end.hasSame(start, unit)) {
+          return end.startOf(unit).diff(start.startOf(unit), unit).get(unit);
+        } else return 0;
+      } else {
+        return end.diff(start, unit).get(unit);
+      }
+    };
   if (opts.unit) {
     return format(differ(opts.unit), opts.unit);
   }
-
-  var _iterator2 = datetime_createForOfIteratorHelper(opts.units),
-      _step2;
-
+  var _iterator = datetime_createForOfIteratorHelper(opts.units),
+    _step;
   try {
-    for (_iterator2.s(); !(_step2 = _iterator2.n()).done;) {
-      const unit = _step2.value;
-      const count = differ(unit);
-
+    for (_iterator.s(); !(_step = _iterator.n()).done;) {
+      var unit = _step.value;
+      var count = differ(unit);
       if (Math.abs(count) >= 1) {
         return format(count, unit);
       }
     }
   } catch (err) {
-    _iterator2.e(err);
+    _iterator.e(err);
   } finally {
-    _iterator2.f();
+    _iterator.f();
   }
-
   return format(start > end ? -0 : 0, opts.units[opts.units.length - 1]);
 }
-
 function lastOpts(argList) {
-  let opts = {},
-      args;
-
+  var opts = {},
+    args;
   if (argList.length > 0 && typeof argList[argList.length - 1] === "object") {
     opts = argList[argList.length - 1];
     args = Array.from(argList).slice(0, argList.length - 1);
   } else {
     args = Array.from(argList);
   }
-
   return [opts, args];
 }
+
 /**
  * A DateTime is an immutable data structure representing a specific date and time and accompanying methods. It contains class and instance methods for creating, parsing, interrogating, transforming, and formatting them.
  *
@@ -6789,75 +5964,65 @@ function lastOpts(argList) {
  *
  * There's plenty others documented below. In addition, for more information on subtler topics like internationalization, time zones, alternative calendars, validity, and so on, see the external documentation.
  */
-
-
 class DateTime {
   /**
    * @access private
    */
   constructor(config) {
-    const zone = config.zone || Settings.defaultZone;
-    let invalid = config.invalid || (Number.isNaN(config.ts) ? new Invalid("invalid input") : null) || (!zone.isValid ? unsupportedZone(zone) : null);
+    var zone = config.zone || Settings.defaultZone;
+    var invalid = config.invalid || (Number.isNaN(config.ts) ? new Invalid("invalid input") : null) || (!zone.isValid ? unsupportedZone(zone) : null);
     /**
      * @access private
      */
-
     this.ts = isUndefined(config.ts) ? Settings.now() : config.ts;
-    let c = null,
-        o = null;
-
+    var c = null,
+      o = null;
     if (!invalid) {
-      const unchanged = config.old && config.old.ts === this.ts && config.old.zone.equals(zone);
-
+      var unchanged = config.old && config.old.ts === this.ts && config.old.zone.equals(zone);
       if (unchanged) {
         var _ref = [config.old.c, config.old.o];
         c = _ref[0];
         o = _ref[1];
       } else {
-        const ot = zone.offset(this.ts);
+        var ot = zone.offset(this.ts);
         c = tsToObj(this.ts, ot);
         invalid = Number.isNaN(c.year) ? new Invalid("invalid input") : null;
         c = invalid ? null : c;
         o = invalid ? null : ot;
       }
     }
+
     /**
      * @access private
      */
-
-
     this._zone = zone;
     /**
      * @access private
      */
-
     this.loc = config.loc || Locale.create();
     /**
      * @access private
      */
-
     this.invalid = invalid;
     /**
      * @access private
      */
-
     this.weekData = null;
     /**
      * @access private
      */
-
     this.c = c;
     /**
      * @access private
      */
-
     this.o = o;
     /**
      * @access private
      */
-
     this.isLuxonDateTime = true;
-  } // CONSTRUCT
+  }
+
+  // CONSTRUCT
 
   /**
    * Create a DateTime for the current instant, in the system's time zone.
@@ -6866,11 +6031,10 @@ class DateTime {
    * @example DateTime.now().toISO() //~> now in the ISO format
    * @return {DateTime}
    */
-
-
   static now() {
     return new DateTime({});
   }
+
   /**
    * Create a local DateTime
    * @param {number} [year] - The calendar year. If omitted (as in, call `local()` with no arguments), the current time will be used
@@ -6892,22 +6056,19 @@ class DateTime {
    * @example DateTime.local(2017, 3, 12, 5, 45, 10, 765)       //~> 2017-03-12T05:45:10.765
    * @return {DateTime}
    */
-
-
   static local() {
-    const _lastOpts = lastOpts(arguments),
-          _lastOpts2 = datetime_slicedToArray(_lastOpts, 2),
-          opts = _lastOpts2[0],
-          args = _lastOpts2[1],
-          _args = datetime_slicedToArray(args, 7),
-          year = _args[0],
-          month = _args[1],
-          day = _args[2],
-          hour = _args[3],
-          minute = _args[4],
-          second = _args[5],
-          millisecond = _args[6];
-
+    var _lastOpts = lastOpts(arguments),
+      _lastOpts2 = datetime_slicedToArray(_lastOpts, 2),
+      opts = _lastOpts2[0],
+      args = _lastOpts2[1],
+      _args = datetime_slicedToArray(args, 7),
+      year = _args[0],
+      month = _args[1],
+      day = _args[2],
+      hour = _args[3],
+      minute = _args[4],
+      second = _args[5],
+      millisecond = _args[6];
     return quickDT({
       year,
       month,
@@ -6918,6 +6079,7 @@ class DateTime {
       millisecond
     }, opts);
   }
+
   /**
    * Create a DateTime in UTC
    * @param {number} [year] - The calendar year. If omitted (as in, call `utc()` with no arguments), the current time will be used
@@ -6942,22 +6104,19 @@ class DateTime {
    * @example DateTime.utc(2017, 3, 12, 5, 45, 10, 765, { locale: "fr" }) //~> 2017-03-12T05:45:10.765Z with a French locale
    * @return {DateTime}
    */
-
-
   static utc() {
-    const _lastOpts3 = lastOpts(arguments),
-          _lastOpts4 = datetime_slicedToArray(_lastOpts3, 2),
-          opts = _lastOpts4[0],
-          args = _lastOpts4[1],
-          _args2 = datetime_slicedToArray(args, 7),
-          year = _args2[0],
-          month = _args2[1],
-          day = _args2[2],
-          hour = _args2[3],
-          minute = _args2[4],
-          second = _args2[5],
-          millisecond = _args2[6];
-
+    var _lastOpts3 = lastOpts(arguments),
+      _lastOpts4 = datetime_slicedToArray(_lastOpts3, 2),
+      opts = _lastOpts4[0],
+      args = _lastOpts4[1],
+      _args2 = datetime_slicedToArray(args, 7),
+      year = _args2[0],
+      month = _args2[1],
+      day = _args2[2],
+      hour = _args2[3],
+      minute = _args2[4],
+      second = _args2[5],
+      millisecond = _args2[6];
     opts.zone = FixedOffsetZone.utcInstance;
     return quickDT({
       year,
@@ -6969,6 +6128,7 @@ class DateTime {
       millisecond
     }, opts);
   }
+
   /**
    * Create a DateTime from a JavaScript Date object. Uses the default zone.
    * @param {Date} date - a JavaScript Date object
@@ -6976,28 +6136,23 @@ class DateTime {
    * @param {string|Zone} [options.zone='local'] - the zone to place the DateTime into
    * @return {DateTime}
    */
-
-
   static fromJSDate(date) {
-    let options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    const ts = isDate(date) ? date.valueOf() : NaN;
-
+    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var ts = isDate(date) ? date.valueOf() : NaN;
     if (Number.isNaN(ts)) {
       return DateTime.invalid("invalid input");
     }
-
-    const zoneToUse = normalizeZone(options.zone, Settings.defaultZone);
-
+    var zoneToUse = normalizeZone(options.zone, Settings.defaultZone);
     if (!zoneToUse.isValid) {
       return DateTime.invalid(unsupportedZone(zoneToUse));
     }
-
     return new DateTime({
       ts: ts,
       zone: zoneToUse,
       loc: Locale.fromObject(options)
     });
   }
+
   /**
    * Create a DateTime from a number of milliseconds since the epoch (meaning since 1 January 1970 00:00:00 UTC). Uses the default zone.
    * @param {number} milliseconds - a number of milliseconds since 1970 UTC
@@ -7008,11 +6163,8 @@ class DateTime {
    * @param {string} options.numberingSystem - the numbering system to set on the resulting DateTime instance
    * @return {DateTime}
    */
-
-
   static fromMillis(milliseconds) {
-    let options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
+    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     if (!isNumber(milliseconds)) {
       throw new InvalidArgumentError(`fromMillis requires a numerical input, but received a ${typeof milliseconds} with value ${milliseconds}`);
     } else if (milliseconds < -MAX_DATE || milliseconds > MAX_DATE) {
@@ -7026,6 +6178,7 @@ class DateTime {
       });
     }
   }
+
   /**
    * Create a DateTime from a number of seconds since the epoch (meaning since 1 January 1970 00:00:00 UTC). Uses the default zone.
    * @param {number} seconds - a number of seconds since 1970 UTC
@@ -7036,11 +6189,8 @@ class DateTime {
    * @param {string} options.numberingSystem - the numbering system to set on the resulting DateTime instance
    * @return {DateTime}
    */
-
-
   static fromSeconds(seconds) {
-    let options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
+    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     if (!isNumber(seconds)) {
       throw new InvalidArgumentError("fromSeconds requires a numerical input");
     } else {
@@ -7051,6 +6201,7 @@ class DateTime {
       });
     }
   }
+
   /**
    * Create a DateTime from a JavaScript object with keys like 'year' and 'hour' with reasonable defaults.
    * @param {Object} obj - the object to create the DateTime from
@@ -7079,26 +6230,24 @@ class DateTime {
    * @example DateTime.fromObject({ weekYear: 2016, weekNumber: 2, weekday: 3 }).toISODate() //=> '2016-01-13'
    * @return {DateTime}
    */
-
-
   static fromObject(obj) {
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     obj = obj || {};
-    const zoneToUse = normalizeZone(opts.zone, Settings.defaultZone);
-
+    var zoneToUse = normalizeZone(opts.zone, Settings.defaultZone);
     if (!zoneToUse.isValid) {
       return DateTime.invalid(unsupportedZone(zoneToUse));
     }
+    var tsNow = Settings.now(),
+      offsetProvis = !isUndefined(opts.specificOffset) ? opts.specificOffset : zoneToUse.offset(tsNow),
+      normalized = normalizeObject(obj, normalizeUnit),
+      containsOrdinal = !isUndefined(normalized.ordinal),
+      containsGregorYear = !isUndefined(normalized.year),
+      containsGregorMD = !isUndefined(normalized.month) || !isUndefined(normalized.day),
+      containsGregor = containsGregorYear || containsGregorMD,
+      definiteWeekDef = normalized.weekYear || normalized.weekNumber,
+      loc = Locale.fromObject(opts);
 
-    const tsNow = Settings.now(),
-          offsetProvis = !isUndefined(opts.specificOffset) ? opts.specificOffset : zoneToUse.offset(tsNow),
-          normalized = normalizeObject(obj, normalizeUnit),
-          containsOrdinal = !isUndefined(normalized.ordinal),
-          containsGregorYear = !isUndefined(normalized.year),
-          containsGregorMD = !isUndefined(normalized.month) || !isUndefined(normalized.day),
-          containsGregor = containsGregorYear || containsGregorMD,
-          definiteWeekDef = normalized.weekYear || normalized.weekNumber,
-          loc = Locale.fromObject(opts); // cases:
+    // cases:
     // just a weekday -> this week's instance of that weekday, no worries
     // (gregorian data or ordinal) + (weekYear or weekNumber) -> error
     // (gregorian month or day) + ordinal -> error
@@ -7107,17 +6256,15 @@ class DateTime {
     if ((containsGregor || containsOrdinal) && definiteWeekDef) {
       throw new ConflictingSpecificationError("Can't mix weekYear/weekNumber units with year/month/day or ordinals");
     }
-
     if (containsGregorMD && containsOrdinal) {
       throw new ConflictingSpecificationError("Can't mix ordinal dates with month/day");
     }
+    var useWeekData = definiteWeekDef || normalized.weekday && !containsGregor;
 
-    const useWeekData = definiteWeekDef || normalized.weekday && !containsGregor; // configure ourselves to deal with gregorian dates or week stuff
-
-    let units,
-        defaultValues,
-        objNow = tsToObj(tsNow, offsetProvis);
-
+    // configure ourselves to deal with gregorian dates or week stuff
+    var units,
+      defaultValues,
+      objNow = tsToObj(tsNow, offsetProvis);
     if (useWeekData) {
       units = orderedWeekUnits;
       defaultValues = defaultWeekUnitValues;
@@ -7129,19 +6276,16 @@ class DateTime {
     } else {
       units = datetime_orderedUnits;
       defaultValues = defaultUnitValues;
-    } // set default values for missing stuff
+    }
 
-
-    let foundFirst = false;
-
-    var _iterator3 = datetime_createForOfIteratorHelper(units),
-        _step3;
-
+    // set default values for missing stuff
+    var foundFirst = false;
+    var _iterator2 = datetime_createForOfIteratorHelper(units),
+      _step2;
     try {
-      for (_iterator3.s(); !(_step3 = _iterator3.n()).done;) {
-        const u = _step3.value;
-        const v = normalized[u];
-
+      for (_iterator2.s(); !(_step2 = _iterator2.n()).done;) {
+        var u = _step2.value;
+        var v = normalized[u];
         if (!isUndefined(v)) {
           foundFirst = true;
         } else if (foundFirst) {
@@ -7149,41 +6293,40 @@ class DateTime {
         } else {
           normalized[u] = objNow[u];
         }
-      } // make sure the values we have are in range
+      }
 
+      // make sure the values we have are in range
     } catch (err) {
-      _iterator3.e(err);
+      _iterator2.e(err);
     } finally {
-      _iterator3.f();
+      _iterator2.f();
     }
-
-    const higherOrderInvalid = useWeekData ? hasInvalidWeekData(normalized) : containsOrdinal ? hasInvalidOrdinalData(normalized) : hasInvalidGregorianData(normalized),
-          invalid = higherOrderInvalid || hasInvalidTimeData(normalized);
-
+    var higherOrderInvalid = useWeekData ? hasInvalidWeekData(normalized) : containsOrdinal ? hasInvalidOrdinalData(normalized) : hasInvalidGregorianData(normalized),
+      invalid = higherOrderInvalid || hasInvalidTimeData(normalized);
     if (invalid) {
       return DateTime.invalid(invalid);
-    } // compute the actual time
+    }
 
+    // compute the actual time
+    var gregorian = useWeekData ? weekToGregorian(normalized) : containsOrdinal ? ordinalToGregorian(normalized) : normalized,
+      _objToTS3 = objToTS(gregorian, offsetProvis, zoneToUse),
+      _objToTS4 = datetime_slicedToArray(_objToTS3, 2),
+      tsFinal = _objToTS4[0],
+      offsetFinal = _objToTS4[1],
+      inst = new DateTime({
+        ts: tsFinal,
+        zone: zoneToUse,
+        o: offsetFinal,
+        loc
+      });
 
-    const gregorian = useWeekData ? weekToGregorian(normalized) : containsOrdinal ? ordinalToGregorian(normalized) : normalized,
-          _objToTS3 = objToTS(gregorian, offsetProvis, zoneToUse),
-          _objToTS4 = datetime_slicedToArray(_objToTS3, 2),
-          tsFinal = _objToTS4[0],
-          offsetFinal = _objToTS4[1],
-          inst = new DateTime({
-      ts: tsFinal,
-      zone: zoneToUse,
-      o: offsetFinal,
-      loc
-    }); // gregorian data + weekday serves only to validate
-
-
+    // gregorian data + weekday serves only to validate
     if (normalized.weekday && containsGregor && obj.weekday !== inst.weekday) {
       return DateTime.invalid("mismatched weekday", `you can't specify both a weekday of ${normalized.weekday} and a date of ${inst.toISO()}`);
     }
-
     return inst;
   }
+
   /**
    * Create a DateTime from an ISO 8601 string
    * @param {string} text - the ISO string
@@ -7200,18 +6343,15 @@ class DateTime {
    * @example DateTime.fromISO('2016-W05-4')
    * @return {DateTime}
    */
-
-
   static fromISO(text) {
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-    const _parseISODate = parseISODate(text),
-          _parseISODate2 = datetime_slicedToArray(_parseISODate, 2),
-          vals = _parseISODate2[0],
-          parsedZone = _parseISODate2[1];
-
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var _parseISODate = parseISODate(text),
+      _parseISODate2 = datetime_slicedToArray(_parseISODate, 2),
+      vals = _parseISODate2[0],
+      parsedZone = _parseISODate2[1];
     return parseDataToDateTime(vals, parsedZone, opts, "ISO 8601", text);
   }
+
   /**
    * Create a DateTime from an RFC 2822 string
    * @param {string} text - the RFC 2822 string
@@ -7226,18 +6366,15 @@ class DateTime {
    * @example DateTime.fromRFC2822('25 Nov 2016 13:23 Z')
    * @return {DateTime}
    */
-
-
   static fromRFC2822(text) {
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-    const _parseRFC2822Date = parseRFC2822Date(text),
-          _parseRFC2822Date2 = datetime_slicedToArray(_parseRFC2822Date, 2),
-          vals = _parseRFC2822Date2[0],
-          parsedZone = _parseRFC2822Date2[1];
-
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var _parseRFC2822Date = parseRFC2822Date(text),
+      _parseRFC2822Date2 = datetime_slicedToArray(_parseRFC2822Date, 2),
+      vals = _parseRFC2822Date2[0],
+      parsedZone = _parseRFC2822Date2[1];
     return parseDataToDateTime(vals, parsedZone, opts, "RFC 2822", text);
   }
+
   /**
    * Create a DateTime from an HTTP header date
    * @see https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1
@@ -7253,18 +6390,15 @@ class DateTime {
    * @example DateTime.fromHTTP('Sun Nov  6 08:49:37 1994')
    * @return {DateTime}
    */
-
-
   static fromHTTP(text) {
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-    const _parseHTTPDate = parseHTTPDate(text),
-          _parseHTTPDate2 = datetime_slicedToArray(_parseHTTPDate, 2),
-          vals = _parseHTTPDate2[0],
-          parsedZone = _parseHTTPDate2[1];
-
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var _parseHTTPDate = parseHTTPDate(text),
+      _parseHTTPDate2 = datetime_slicedToArray(_parseHTTPDate, 2),
+      vals = _parseHTTPDate2[0],
+      parsedZone = _parseHTTPDate2[1];
     return parseDataToDateTime(vals, parsedZone, opts, "HTTP", opts);
   }
+
   /**
    * Create a DateTime from an input string and format string.
    * Defaults to en-US if no locale has been specified, regardless of the system's locale. For a table of tokens and their interpretations, see [here](https://moment.github.io/luxon/#/parsing?id=table-of-tokens).
@@ -7278,46 +6412,41 @@ class DateTime {
    * @param {string} opts.outputCalendar - the output calendar to set on the resulting DateTime instance
    * @return {DateTime}
    */
-
-
   static fromFormat(text, fmt) {
-    let opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
-
+    var opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
     if (isUndefined(text) || isUndefined(fmt)) {
       throw new InvalidArgumentError("fromFormat requires an input string and a format");
     }
-
-    const _opts$locale = opts.locale,
-          locale = _opts$locale === void 0 ? null : _opts$locale,
-          _opts$numberingSystem = opts.numberingSystem,
-          numberingSystem = _opts$numberingSystem === void 0 ? null : _opts$numberingSystem,
-          localeToUse = Locale.fromOpts({
-      locale,
-      numberingSystem,
-      defaultToEN: true
-    }),
-          _parseFromTokens = parseFromTokens(localeToUse, text, fmt),
-          _parseFromTokens2 = datetime_slicedToArray(_parseFromTokens, 4),
-          vals = _parseFromTokens2[0],
-          parsedZone = _parseFromTokens2[1],
-          specificOffset = _parseFromTokens2[2],
-          invalid = _parseFromTokens2[3];
-
+    var _opts$locale = opts.locale,
+      locale = _opts$locale === void 0 ? null : _opts$locale,
+      _opts$numberingSystem = opts.numberingSystem,
+      numberingSystem = _opts$numberingSystem === void 0 ? null : _opts$numberingSystem,
+      localeToUse = Locale.fromOpts({
+        locale,
+        numberingSystem,
+        defaultToEN: true
+      }),
+      _parseFromTokens = parseFromTokens(localeToUse, text, fmt),
+      _parseFromTokens2 = datetime_slicedToArray(_parseFromTokens, 4),
+      vals = _parseFromTokens2[0],
+      parsedZone = _parseFromTokens2[1],
+      specificOffset = _parseFromTokens2[2],
+      invalid = _parseFromTokens2[3];
     if (invalid) {
       return DateTime.invalid(invalid);
     } else {
       return parseDataToDateTime(vals, parsedZone, opts, `format ${fmt}`, text, specificOffset);
     }
   }
+
   /**
    * @deprecated use fromFormat instead
    */
-
-
   static fromString(text, fmt) {
-    let opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+    var opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
     return DateTime.fromFormat(text, fmt, opts);
   }
+
   /**
    * Create a DateTime from a SQL date, time, or datetime
    * Defaults to en-US if no locale has been specified, regardless of the system's locale
@@ -7338,35 +6467,27 @@ class DateTime {
    * @example DateTime.fromSQL('09:12:34.342')
    * @return {DateTime}
    */
-
-
   static fromSQL(text) {
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
-    const _parseSQL = parseSQL(text),
-          _parseSQL2 = datetime_slicedToArray(_parseSQL, 2),
-          vals = _parseSQL2[0],
-          parsedZone = _parseSQL2[1];
-
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var _parseSQL = parseSQL(text),
+      _parseSQL2 = datetime_slicedToArray(_parseSQL, 2),
+      vals = _parseSQL2[0],
+      parsedZone = _parseSQL2[1];
     return parseDataToDateTime(vals, parsedZone, opts, "SQL", text);
   }
+
   /**
    * Create an invalid DateTime.
    * @param {DateTime} reason - simple string of why this DateTime is invalid. Should not contain parameters or anything else data-dependent
    * @param {string} [explanation=null] - longer explanation, may include parameters and other useful debugging information
    * @return {DateTime}
    */
-
-
   static invalid(reason) {
-    let explanation = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
-
+    var explanation = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
     if (!reason) {
       throw new InvalidArgumentError("need to specify a reason the DateTime is invalid");
     }
-
-    const invalid = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
-
+    var invalid = reason instanceof Invalid ? reason : new Invalid(reason, explanation);
     if (Settings.throwOnInvalid) {
       throw new InvalidDateTimeError(invalid);
     } else {
@@ -7375,29 +6496,28 @@ class DateTime {
       });
     }
   }
+
   /**
    * Check if an object is an instance of DateTime. Works across context boundaries
    * @param {object} o
    * @return {boolean}
    */
-
-
   static isDateTime(o) {
     return o && o.isLuxonDateTime || false;
   }
+
   /**
    * Produce the format string for a set of options
    * @param formatOpts
    * @param localeOpts
    * @returns {string}
    */
-
-
   static parseFormatForOpts(formatOpts) {
-    let localeOpts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    const tokenList = formatOptsToTokens(formatOpts, Locale.fromObject(localeOpts));
+    var localeOpts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var tokenList = formatOptsToTokens(formatOpts, Locale.fromObject(localeOpts));
     return !tokenList ? null : tokenList.map(t => t ? t.val : null).join("");
   }
+
   /**
    * Produce the the fully expanded format token for the locale
    * Does NOT quote characters, so quoted tokens will not round trip correctly
@@ -7405,13 +6525,13 @@ class DateTime {
    * @param localeOpts
    * @returns {string}
    */
-
-
   static expandFormat(fmt) {
-    let localeOpts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    const expanded = expandMacroTokens(Formatter.parseFormat(fmt), Locale.fromObject(localeOpts));
+    var localeOpts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var expanded = expandMacroTokens(Formatter.parseFormat(fmt), Locale.fromObject(localeOpts));
     return expanded.map(t => t.val).join("");
-  } // INFO
+  }
+
+  // INFO
 
   /**
    * Get the value of unit.
@@ -7420,190 +6540,171 @@ class DateTime {
    * @example DateTime.local(2017, 7, 4).get('day'); //=> 4
    * @return {number}
    */
-
-
   get(unit) {
     return this[unit];
   }
+
   /**
    * Returns whether the DateTime is valid. Invalid DateTimes occur when:
    * * The DateTime was created from invalid calendar information, such as the 13th month or February 30
    * * The DateTime was created by an operation on another invalid date
    * @type {boolean}
    */
-
-
   get isValid() {
     return this.invalid === null;
   }
+
   /**
    * Returns an error code if this DateTime is invalid, or null if the DateTime is valid
    * @type {string}
    */
-
-
   get invalidReason() {
     return this.invalid ? this.invalid.reason : null;
   }
+
   /**
    * Returns an explanation of why this DateTime became invalid, or null if the DateTime is valid
    * @type {string}
    */
-
-
   get invalidExplanation() {
     return this.invalid ? this.invalid.explanation : null;
   }
+
   /**
    * Get the locale of a DateTime, such 'en-GB'. The locale is used when formatting the DateTime
    *
    * @type {string}
    */
-
-
   get locale() {
     return this.isValid ? this.loc.locale : null;
   }
+
   /**
    * Get the numbering system of a DateTime, such 'beng'. The numbering system is used when formatting the DateTime
    *
    * @type {string}
    */
-
-
   get numberingSystem() {
     return this.isValid ? this.loc.numberingSystem : null;
   }
+
   /**
    * Get the output calendar of a DateTime, such 'islamic'. The output calendar is used when formatting the DateTime
    *
    * @type {string}
    */
-
-
   get outputCalendar() {
     return this.isValid ? this.loc.outputCalendar : null;
   }
+
   /**
    * Get the time zone associated with this DateTime.
    * @type {Zone}
    */
-
-
   get zone() {
     return this._zone;
   }
+
   /**
    * Get the name of the time zone.
    * @type {string}
    */
-
-
   get zoneName() {
     return this.isValid ? this.zone.name : null;
   }
+
   /**
    * Get the year
    * @example DateTime.local(2017, 5, 25).year //=> 2017
    * @type {number}
    */
-
-
   get year() {
     return this.isValid ? this.c.year : NaN;
   }
+
   /**
    * Get the quarter
    * @example DateTime.local(2017, 5, 25).quarter //=> 2
    * @type {number}
    */
-
-
   get quarter() {
     return this.isValid ? Math.ceil(this.c.month / 3) : NaN;
   }
+
   /**
    * Get the month (1-12).
    * @example DateTime.local(2017, 5, 25).month //=> 5
    * @type {number}
    */
-
-
   get month() {
     return this.isValid ? this.c.month : NaN;
   }
+
   /**
    * Get the day of the month (1-30ish).
    * @example DateTime.local(2017, 5, 25).day //=> 25
    * @type {number}
    */
-
-
   get day() {
     return this.isValid ? this.c.day : NaN;
   }
+
   /**
    * Get the hour of the day (0-23).
    * @example DateTime.local(2017, 5, 25, 9).hour //=> 9
    * @type {number}
    */
-
-
   get hour() {
     return this.isValid ? this.c.hour : NaN;
   }
+
   /**
    * Get the minute of the hour (0-59).
    * @example DateTime.local(2017, 5, 25, 9, 30).minute //=> 30
    * @type {number}
    */
-
-
   get minute() {
     return this.isValid ? this.c.minute : NaN;
   }
+
   /**
    * Get the second of the minute (0-59).
    * @example DateTime.local(2017, 5, 25, 9, 30, 52).second //=> 52
    * @type {number}
    */
-
-
   get second() {
     return this.isValid ? this.c.second : NaN;
   }
+
   /**
    * Get the millisecond of the second (0-999).
    * @example DateTime.local(2017, 5, 25, 9, 30, 52, 654).millisecond //=> 654
    * @type {number}
    */
-
-
   get millisecond() {
     return this.isValid ? this.c.millisecond : NaN;
   }
+
   /**
    * Get the week year
    * @see https://en.wikipedia.org/wiki/ISO_week_date
    * @example DateTime.local(2014, 12, 31).weekYear //=> 2015
    * @type {number}
    */
-
-
   get weekYear() {
     return this.isValid ? possiblyCachedWeekData(this).weekYear : NaN;
   }
+
   /**
    * Get the week number of the week year (1-52ish).
    * @see https://en.wikipedia.org/wiki/ISO_week_date
    * @example DateTime.local(2017, 5, 25).weekNumber //=> 21
    * @type {number}
    */
-
-
   get weekNumber() {
     return this.isValid ? possiblyCachedWeekData(this).weekNumber : NaN;
   }
+
   /**
    * Get the day of the week.
    * 1 is Monday and 7 is Sunday
@@ -7611,91 +6712,82 @@ class DateTime {
    * @example DateTime.local(2014, 11, 31).weekday //=> 4
    * @type {number}
    */
-
-
   get weekday() {
     return this.isValid ? possiblyCachedWeekData(this).weekday : NaN;
   }
+
   /**
    * Get the ordinal (meaning the day of the year)
    * @example DateTime.local(2017, 5, 25).ordinal //=> 145
    * @type {number|DateTime}
    */
-
-
   get ordinal() {
     return this.isValid ? gregorianToOrdinal(this.c).ordinal : NaN;
   }
+
   /**
    * Get the human readable short month name, such as 'Oct'.
    * Defaults to the system's locale if no locale has been specified
    * @example DateTime.local(2017, 10, 30).monthShort //=> Oct
    * @type {string}
    */
-
-
   get monthShort() {
     return this.isValid ? Info.months("short", {
       locObj: this.loc
     })[this.month - 1] : null;
   }
+
   /**
    * Get the human readable long month name, such as 'October'.
    * Defaults to the system's locale if no locale has been specified
    * @example DateTime.local(2017, 10, 30).monthLong //=> October
    * @type {string}
    */
-
-
   get monthLong() {
     return this.isValid ? Info.months("long", {
       locObj: this.loc
     })[this.month - 1] : null;
   }
+
   /**
    * Get the human readable short weekday, such as 'Mon'.
    * Defaults to the system's locale if no locale has been specified
    * @example DateTime.local(2017, 10, 30).weekdayShort //=> Mon
    * @type {string}
    */
-
-
   get weekdayShort() {
     return this.isValid ? Info.weekdays("short", {
       locObj: this.loc
     })[this.weekday - 1] : null;
   }
+
   /**
    * Get the human readable long weekday, such as 'Monday'.
    * Defaults to the system's locale if no locale has been specified
    * @example DateTime.local(2017, 10, 30).weekdayLong //=> Monday
    * @type {string}
    */
-
-
   get weekdayLong() {
     return this.isValid ? Info.weekdays("long", {
       locObj: this.loc
     })[this.weekday - 1] : null;
   }
+
   /**
    * Get the UTC offset of this DateTime in minutes
    * @example DateTime.now().offset //=> -240
    * @example DateTime.utc().offset //=> 0
    * @type {number}
    */
-
-
   get offset() {
     return this.isValid ? +this.o : NaN;
   }
+
   /**
    * Get the short human name for the zone's current offset, for example "EST" or "EDT".
    * Defaults to the system's locale if no locale has been specified
    * @type {string}
    */
-
-
   get offsetNameShort() {
     if (this.isValid) {
       return this.zone.offsetName(this.ts, {
@@ -7706,13 +6798,12 @@ class DateTime {
       return null;
     }
   }
+
   /**
    * Get the long human name for the zone's current offset, for example "Eastern Standard Time" or "Eastern Daylight Time".
    * Defaults to the system's locale if no locale has been specified
    * @type {string}
    */
-
-
   get offsetNameLong() {
     if (this.isValid) {
       return this.zone.offsetName(this.ts, {
@@ -7723,21 +6814,19 @@ class DateTime {
       return null;
     }
   }
+
   /**
    * Get whether this zone's offset ever changes, as in a DST.
    * @type {boolean}
    */
-
-
   get isOffsetFixed() {
     return this.isValid ? this.zone.isUniversal : null;
   }
+
   /**
    * Get whether the DateTime is in a DST.
    * @type {boolean}
    */
-
-
   get isInDST() {
     if (this.isOffsetFixed) {
       return false;
@@ -7750,39 +6839,37 @@ class DateTime {
       }).offset;
     }
   }
+
   /**
    * Returns true if this DateTime is in a leap year, false otherwise
    * @example DateTime.local(2016).isInLeapYear //=> true
    * @example DateTime.local(2013).isInLeapYear //=> false
    * @type {boolean}
    */
-
-
   get isInLeapYear() {
     return isLeapYear(this.year);
   }
+
   /**
    * Returns the number of days in this DateTime's month
    * @example DateTime.local(2016, 2).daysInMonth //=> 29
    * @example DateTime.local(2016, 3).daysInMonth //=> 31
    * @type {number}
    */
-
-
   get daysInMonth() {
     return daysInMonth(this.year, this.month);
   }
+
   /**
    * Returns the number of days in this DateTime's year
    * @example DateTime.local(2016).daysInYear //=> 366
    * @example DateTime.local(2013).daysInYear //=> 365
    * @type {number}
    */
-
-
   get daysInYear() {
     return this.isValid ? daysInYear(this.year) : NaN;
   }
+
   /**
    * Returns the number of weeks in this DateTime's year
    * @see https://en.wikipedia.org/wiki/ISO_week_date
@@ -7790,33 +6877,30 @@ class DateTime {
    * @example DateTime.local(2013).weeksInWeekYear //=> 52
    * @type {number}
    */
-
-
   get weeksInWeekYear() {
     return this.isValid ? weeksInWeekYear(this.weekYear) : NaN;
   }
+
   /**
    * Returns the resolved Intl options for this DateTime.
    * This is useful in understanding the behavior of formatting methods
    * @param {Object} opts - the same options as toLocaleString
    * @return {Object}
    */
-
-
   resolvedLocaleOptions() {
-    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-
-    const _Formatter$create$res = Formatter.create(this.loc.clone(opts), opts).resolvedOptions(this),
-          locale = _Formatter$create$res.locale,
-          numberingSystem = _Formatter$create$res.numberingSystem,
-          calendar = _Formatter$create$res.calendar;
-
+    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var _Formatter$create$res = Formatter.create(this.loc.clone(opts), opts).resolvedOptions(this),
+      locale = _Formatter$create$res.locale,
+      numberingSystem = _Formatter$create$res.numberingSystem,
+      calendar = _Formatter$create$res.calendar;
     return {
       locale,
       numberingSystem,
       outputCalendar: calendar
     };
-  } // TRANSFORM
+  }
+
+  // TRANSFORM
 
   /**
    * "Set" the DateTime's zone to UTC. Returns a newly-constructed DateTime.
@@ -7826,24 +6910,22 @@ class DateTime {
    * @param {Object} [opts={}] - options to pass to `setZone()`
    * @return {DateTime}
    */
-
-
   toUTC() {
-    let offset = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var offset = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     return this.setZone(FixedOffsetZone.instance(offset), opts);
   }
+
   /**
    * "Set" the DateTime's zone to the host's local zone. Returns a newly-constructed DateTime.
    *
    * Equivalent to `setZone('local')`
    * @return {DateTime}
    */
-
-
   toLocal() {
     return this.setZone(Settings.defaultZone);
   }
+
   /**
    * "Set" the DateTime's zone to specified zone. Returns a newly-constructed DateTime.
    *
@@ -7853,56 +6935,45 @@ class DateTime {
    * @param {boolean} [opts.keepLocalTime=false] - If true, adjust the underlying time so that the local time stays the same, but in the target zone. You should rarely need this.
    * @return {DateTime}
    */
-
-
   setZone(zone) {
-    let _ref2 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-        _ref2$keepLocalTime = _ref2.keepLocalTime,
-        keepLocalTime = _ref2$keepLocalTime === void 0 ? false : _ref2$keepLocalTime,
-        _ref2$keepCalendarTim = _ref2.keepCalendarTime,
-        keepCalendarTime = _ref2$keepCalendarTim === void 0 ? false : _ref2$keepCalendarTim;
-
+    var _ref2 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+      _ref2$keepLocalTime = _ref2.keepLocalTime,
+      keepLocalTime = _ref2$keepLocalTime === void 0 ? false : _ref2$keepLocalTime,
+      _ref2$keepCalendarTim = _ref2.keepCalendarTime,
+      keepCalendarTime = _ref2$keepCalendarTim === void 0 ? false : _ref2$keepCalendarTim;
     zone = normalizeZone(zone, Settings.defaultZone);
-
     if (zone.equals(this.zone)) {
       return this;
     } else if (!zone.isValid) {
       return DateTime.invalid(unsupportedZone(zone));
     } else {
-      let newTS = this.ts;
-
+      var newTS = this.ts;
       if (keepLocalTime || keepCalendarTime) {
-        const offsetGuess = zone.offset(this.ts);
-        const asObj = this.toObject();
-
+        var offsetGuess = zone.offset(this.ts);
+        var asObj = this.toObject();
         var _objToTS5 = objToTS(asObj, offsetGuess, zone);
-
         var _objToTS6 = datetime_slicedToArray(_objToTS5, 1);
-
         newTS = _objToTS6[0];
       }
-
       return datetime_clone(this, {
         ts: newTS,
         zone
       });
     }
   }
+
   /**
    * "Set" the locale, numberingSystem, or outputCalendar. Returns a newly-constructed DateTime.
    * @param {Object} properties - the properties to set
    * @example DateTime.local(2017, 5, 25).reconfigure({ locale: 'en-GB' })
    * @return {DateTime}
    */
-
-
   reconfigure() {
-    let _ref3 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-        locale = _ref3.locale,
-        numberingSystem = _ref3.numberingSystem,
-        outputCalendar = _ref3.outputCalendar;
-
-    const loc = this.loc.clone({
+    var _ref3 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+      locale = _ref3.locale,
+      numberingSystem = _ref3.numberingSystem,
+      outputCalendar = _ref3.outputCalendar;
+    var loc = this.loc.clone({
       locale,
       numberingSystem,
       outputCalendar
@@ -7911,19 +6982,19 @@ class DateTime {
       loc
     });
   }
+
   /**
    * "Set" the locale. Returns a newly-constructed DateTime.
    * Just a convenient alias for reconfigure({ locale })
    * @example DateTime.local(2017, 5, 25).setLocale('en-GB')
    * @return {DateTime}
    */
-
-
   setLocale(locale) {
     return this.reconfigure({
       locale
     });
   }
+
   /**
    * "Set" the values of specified units. Returns a newly-constructed DateTime.
    * You can only set units with this method; for "setting" metadata, see {@link DateTime#reconfigure} and {@link DateTime#setZone}.
@@ -7934,51 +7005,45 @@ class DateTime {
    * @example dt.set({ year: 2005, ordinal: 234 })
    * @return {DateTime}
    */
-
-
   set(values) {
     if (!this.isValid) return this;
-    const normalized = normalizeObject(values, normalizeUnit),
-          settingWeekStuff = !isUndefined(normalized.weekYear) || !isUndefined(normalized.weekNumber) || !isUndefined(normalized.weekday),
-          containsOrdinal = !isUndefined(normalized.ordinal),
-          containsGregorYear = !isUndefined(normalized.year),
-          containsGregorMD = !isUndefined(normalized.month) || !isUndefined(normalized.day),
-          containsGregor = containsGregorYear || containsGregorMD,
-          definiteWeekDef = normalized.weekYear || normalized.weekNumber;
-
+    var normalized = normalizeObject(values, normalizeUnit),
+      settingWeekStuff = !isUndefined(normalized.weekYear) || !isUndefined(normalized.weekNumber) || !isUndefined(normalized.weekday),
+      containsOrdinal = !isUndefined(normalized.ordinal),
+      containsGregorYear = !isUndefined(normalized.year),
+      containsGregorMD = !isUndefined(normalized.month) || !isUndefined(normalized.day),
+      containsGregor = containsGregorYear || containsGregorMD,
+      definiteWeekDef = normalized.weekYear || normalized.weekNumber;
     if ((containsGregor || containsOrdinal) && definiteWeekDef) {
       throw new ConflictingSpecificationError("Can't mix weekYear/weekNumber units with year/month/day or ordinals");
     }
-
     if (containsGregorMD && containsOrdinal) {
       throw new ConflictingSpecificationError("Can't mix ordinal dates with month/day");
     }
-
-    let mixed;
-
+    var mixed;
     if (settingWeekStuff) {
       mixed = weekToGregorian(datetime_objectSpread(datetime_objectSpread({}, gregorianToWeek(this.c)), normalized));
     } else if (!isUndefined(normalized.ordinal)) {
       mixed = ordinalToGregorian(datetime_objectSpread(datetime_objectSpread({}, gregorianToOrdinal(this.c)), normalized));
     } else {
-      mixed = datetime_objectSpread(datetime_objectSpread({}, this.toObject()), normalized); // if we didn't set the day but we ended up on an overflow date,
-      // use the last day of the right month
+      mixed = datetime_objectSpread(datetime_objectSpread({}, this.toObject()), normalized);
 
+      // if we didn't set the day but we ended up on an overflow date,
+      // use the last day of the right month
       if (isUndefined(normalized.day)) {
         mixed.day = Math.min(daysInMonth(mixed.year, mixed.month), mixed.day);
       }
     }
-
-    const _objToTS7 = objToTS(mixed, this.o, this.zone),
-          _objToTS8 = datetime_slicedToArray(_objToTS7, 2),
-          ts = _objToTS8[0],
-          o = _objToTS8[1];
-
+    var _objToTS7 = objToTS(mixed, this.o, this.zone),
+      _objToTS8 = datetime_slicedToArray(_objToTS7, 2),
+      ts = _objToTS8[0],
+      o = _objToTS8[1];
     return datetime_clone(this, {
       ts,
       o
     });
   }
+
   /**
    * Add a period of time to this DateTime and return the resulting DateTime
    *
@@ -7992,26 +7057,24 @@ class DateTime {
    * @example DateTime.now().plus(Duration.fromObject({ hours: 3, minutes: 13 })) //~> in 3 hr, 13 min
    * @return {DateTime}
    */
-
-
   plus(duration) {
     if (!this.isValid) return this;
-    const dur = Duration.fromDurationLike(duration);
+    var dur = Duration.fromDurationLike(duration);
     return datetime_clone(this, adjustTime(this, dur));
   }
+
   /**
    * Subtract a period of time to this DateTime and return the resulting DateTime
    * See {@link DateTime#plus}
    * @param {Duration|Object|number} duration - The amount to subtract. Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
    @return {DateTime}
    */
-
-
   minus(duration) {
     if (!this.isValid) return this;
-    const dur = Duration.fromDurationLike(duration).negate();
+    var dur = Duration.fromDurationLike(duration).negate();
     return datetime_clone(this, adjustTime(this, dur));
   }
+
   /**
    * "Set" this DateTime to the beginning of a unit of time.
    * @param {string} unit - The unit to go to the beginning of. Can be 'year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second', or 'millisecond'.
@@ -8022,56 +7085,45 @@ class DateTime {
    * @example DateTime.local(2014, 3, 3, 5, 30).startOf('hour').toISOTime(); //=> '05:00:00.000-05:00'
    * @return {DateTime}
    */
-
-
   startOf(unit) {
     if (!this.isValid) return this;
-    const o = {},
-          normalizedUnit = Duration.normalizeUnit(unit);
-
+    var o = {},
+      normalizedUnit = Duration.normalizeUnit(unit);
     switch (normalizedUnit) {
       case "years":
         o.month = 1;
       // falls through
-
       case "quarters":
       case "months":
         o.day = 1;
       // falls through
-
       case "weeks":
       case "days":
         o.hour = 0;
       // falls through
-
       case "hours":
         o.minute = 0;
       // falls through
-
       case "minutes":
         o.second = 0;
       // falls through
-
       case "seconds":
         o.millisecond = 0;
         break;
-
       case "milliseconds":
         break;
       // no default, invalid units throw in normalizeUnit()
     }
-
     if (normalizedUnit === "weeks") {
       o.weekday = 1;
     }
-
     if (normalizedUnit === "quarters") {
-      const q = Math.ceil(this.month / 3);
+      var q = Math.ceil(this.month / 3);
       o.month = (q - 1) * 3 + 1;
     }
-
     return this.set(o);
   }
+
   /**
    * "Set" this DateTime to the end (meaning the last millisecond) of a unit of time
    * @param {string} unit - The unit to go to the end of. Can be 'year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second', or 'millisecond'.
@@ -8082,13 +7134,13 @@ class DateTime {
    * @example DateTime.local(2014, 3, 3, 5, 30).endOf('hour').toISO(); //=> '2014-03-03T05:59:59.999-05:00'
    * @return {DateTime}
    */
-
-
   endOf(unit) {
     return this.isValid ? this.plus({
       [unit]: 1
     }).startOf(unit).minus(1) : this;
-  } // OUTPUT
+  }
+
+  // OUTPUT
 
   /**
    * Returns a string representation of this DateTime formatted according to the specified format string.
@@ -8102,12 +7154,11 @@ class DateTime {
    * @example DateTime.now().toFormat("HH 'hours and' mm 'minutes'") //=> '20 hours and 55 minutes'
    * @return {string}
    */
-
-
   toFormat(fmt) {
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     return this.isValid ? Formatter.create(this.loc.redefaultToEN(opts)).formatDateTimeFromString(this, fmt) : datetime_INVALID;
   }
+
   /**
    * Returns a localized string representing this date. Accepts the same options as the Intl.DateTimeFormat constructor and any presets defined by Luxon, such as `DateTime.DATE_FULL` or `DateTime.TIME_SIMPLE`.
    * The exact behavior of this method is browser-specific, but in general it will return an appropriate representation
@@ -8127,13 +7178,12 @@ class DateTime {
    * @example DateTime.now().toLocaleString({ hour: '2-digit', minute: '2-digit', hourCycle: 'h23' }); //=> '11:32'
    * @return {string}
    */
-
-
   toLocaleString() {
-    let formatOpts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : DATE_SHORT;
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var formatOpts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : DATE_SHORT;
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     return this.isValid ? Formatter.create(this.loc.clone(opts), formatOpts).formatDateTime(this) : datetime_INVALID;
   }
+
   /**
    * Returns an array of format "parts", meaning individual tokens along with metadata. This is allows callers to post-process individual sections of the formatted output.
    * Defaults to the system's locale if no locale has been specified
@@ -8147,12 +7197,11 @@ class DateTime {
    *                                   //=>   { type: 'year', value: '1982' }
    *                                   //=> ]
    */
-
-
   toLocaleParts() {
-    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     return this.isValid ? Formatter.create(this.loc.clone(opts), opts).formatDateTimeParts(this) : [];
   }
+
   /**
    * Returns an ISO 8601-compliant string representation of this DateTime
    * @param {Object} opts - options
@@ -8167,31 +7216,28 @@ class DateTime {
    * @example DateTime.now().toISO({ format: 'basic' }) //=> '20170422T204705.335-0400'
    * @return {string}
    */
-
-
   toISO() {
-    let _ref4 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-        _ref4$format = _ref4.format,
-        format = _ref4$format === void 0 ? "extended" : _ref4$format,
-        _ref4$suppressSeconds = _ref4.suppressSeconds,
-        suppressSeconds = _ref4$suppressSeconds === void 0 ? false : _ref4$suppressSeconds,
-        _ref4$suppressMillise = _ref4.suppressMilliseconds,
-        suppressMilliseconds = _ref4$suppressMillise === void 0 ? false : _ref4$suppressMillise,
-        _ref4$includeOffset = _ref4.includeOffset,
-        includeOffset = _ref4$includeOffset === void 0 ? true : _ref4$includeOffset,
-        _ref4$extendedZone = _ref4.extendedZone,
-        extendedZone = _ref4$extendedZone === void 0 ? false : _ref4$extendedZone;
-
+    var _ref4 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+      _ref4$format = _ref4.format,
+      format = _ref4$format === void 0 ? "extended" : _ref4$format,
+      _ref4$suppressSeconds = _ref4.suppressSeconds,
+      suppressSeconds = _ref4$suppressSeconds === void 0 ? false : _ref4$suppressSeconds,
+      _ref4$suppressMillise = _ref4.suppressMilliseconds,
+      suppressMilliseconds = _ref4$suppressMillise === void 0 ? false : _ref4$suppressMillise,
+      _ref4$includeOffset = _ref4.includeOffset,
+      includeOffset = _ref4$includeOffset === void 0 ? true : _ref4$includeOffset,
+      _ref4$extendedZone = _ref4.extendedZone,
+      extendedZone = _ref4$extendedZone === void 0 ? false : _ref4$extendedZone;
     if (!this.isValid) {
       return null;
     }
-
-    const ext = format === "extended";
-    let c = toISODate(this, ext);
+    var ext = format === "extended";
+    var c = toISODate(this, ext);
     c += "T";
     c += toISOTime(this, ext, suppressSeconds, suppressMilliseconds, includeOffset, extendedZone);
     return c;
   }
+
   /**
    * Returns an ISO 8601-compliant string representation of this DateTime's date component
    * @param {Object} opts - options
@@ -8200,29 +7246,25 @@ class DateTime {
    * @example DateTime.utc(1982, 5, 25).toISODate({ format: 'basic' }) //=> '19820525'
    * @return {string}
    */
-
-
   toISODate() {
-    let _ref5 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-        _ref5$format = _ref5.format,
-        format = _ref5$format === void 0 ? "extended" : _ref5$format;
-
+    var _ref5 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+      _ref5$format = _ref5.format,
+      format = _ref5$format === void 0 ? "extended" : _ref5$format;
     if (!this.isValid) {
       return null;
     }
-
     return toISODate(this, format === "extended");
   }
+
   /**
    * Returns an ISO 8601-compliant string representation of this DateTime's week date
    * @example DateTime.utc(1982, 5, 25).toISOWeekDate() //=> '1982-W21-2'
    * @return {string}
    */
-
-
   toISOWeekDate() {
     return toTechFormat(this, "kkkk-'W'WW-c");
   }
+
   /**
    * Returns an ISO 8601-compliant string representation of this DateTime's time component
    * @param {Object} opts - options
@@ -8238,41 +7280,37 @@ class DateTime {
    * @example DateTime.utc().set({ hour: 7, minute: 34 }).toISOTime({ includePrefix: true }) //=> 'T07:34:19.361Z'
    * @return {string}
    */
-
-
   toISOTime() {
-    let _ref6 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-        _ref6$suppressMillise = _ref6.suppressMilliseconds,
-        suppressMilliseconds = _ref6$suppressMillise === void 0 ? false : _ref6$suppressMillise,
-        _ref6$suppressSeconds = _ref6.suppressSeconds,
-        suppressSeconds = _ref6$suppressSeconds === void 0 ? false : _ref6$suppressSeconds,
-        _ref6$includeOffset = _ref6.includeOffset,
-        includeOffset = _ref6$includeOffset === void 0 ? true : _ref6$includeOffset,
-        _ref6$includePrefix = _ref6.includePrefix,
-        includePrefix = _ref6$includePrefix === void 0 ? false : _ref6$includePrefix,
-        _ref6$extendedZone = _ref6.extendedZone,
-        extendedZone = _ref6$extendedZone === void 0 ? false : _ref6$extendedZone,
-        _ref6$format = _ref6.format,
-        format = _ref6$format === void 0 ? "extended" : _ref6$format;
-
+    var _ref6 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+      _ref6$suppressMillise = _ref6.suppressMilliseconds,
+      suppressMilliseconds = _ref6$suppressMillise === void 0 ? false : _ref6$suppressMillise,
+      _ref6$suppressSeconds = _ref6.suppressSeconds,
+      suppressSeconds = _ref6$suppressSeconds === void 0 ? false : _ref6$suppressSeconds,
+      _ref6$includeOffset = _ref6.includeOffset,
+      includeOffset = _ref6$includeOffset === void 0 ? true : _ref6$includeOffset,
+      _ref6$includePrefix = _ref6.includePrefix,
+      includePrefix = _ref6$includePrefix === void 0 ? false : _ref6$includePrefix,
+      _ref6$extendedZone = _ref6.extendedZone,
+      extendedZone = _ref6$extendedZone === void 0 ? false : _ref6$extendedZone,
+      _ref6$format = _ref6.format,
+      format = _ref6$format === void 0 ? "extended" : _ref6$format;
     if (!this.isValid) {
       return null;
     }
-
-    let c = includePrefix ? "T" : "";
+    var c = includePrefix ? "T" : "";
     return c + toISOTime(this, format === "extended", suppressSeconds, suppressMilliseconds, includeOffset, extendedZone);
   }
+
   /**
    * Returns an RFC 2822-compatible string representation of this DateTime
    * @example DateTime.utc(2014, 7, 13).toRFC2822() //=> 'Sun, 13 Jul 2014 00:00:00 +0000'
    * @example DateTime.local(2014, 7, 13).toRFC2822() //=> 'Sun, 13 Jul 2014 00:00:00 -0400'
    * @return {string}
    */
-
-
   toRFC2822() {
     return toTechFormat(this, "EEE, dd LLL yyyy HH:mm:ss ZZZ", false);
   }
+
   /**
    * Returns a string representation of this DateTime appropriate for use in HTTP headers. The output is always expressed in GMT.
    * Specifically, the string conforms to RFC 1123.
@@ -8281,25 +7319,22 @@ class DateTime {
    * @example DateTime.utc(2014, 7, 13, 19).toHTTP() //=> 'Sun, 13 Jul 2014 19:00:00 GMT'
    * @return {string}
    */
-
-
   toHTTP() {
     return toTechFormat(this.toUTC(), "EEE, dd LLL yyyy HH:mm:ss 'GMT'");
   }
+
   /**
    * Returns a string representation of this DateTime appropriate for use in SQL Date
    * @example DateTime.utc(2014, 7, 13).toSQLDate() //=> '2014-07-13'
    * @return {string}
    */
-
-
   toSQLDate() {
     if (!this.isValid) {
       return null;
     }
-
     return toISODate(this, true);
   }
+
   /**
    * Returns a string representation of this DateTime appropriate for use in SQL Time
    * @param {Object} opts - options
@@ -8312,33 +7347,28 @@ class DateTime {
    * @example DateTime.now().toSQL({ includeZone: false }) //=> '05:15:16.345 America/New_York'
    * @return {string}
    */
-
-
   toSQLTime() {
-    let _ref7 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-        _ref7$includeOffset = _ref7.includeOffset,
-        includeOffset = _ref7$includeOffset === void 0 ? true : _ref7$includeOffset,
-        _ref7$includeZone = _ref7.includeZone,
-        includeZone = _ref7$includeZone === void 0 ? false : _ref7$includeZone,
-        _ref7$includeOffsetSp = _ref7.includeOffsetSpace,
-        includeOffsetSpace = _ref7$includeOffsetSp === void 0 ? true : _ref7$includeOffsetSp;
-
-    let fmt = "HH:mm:ss.SSS";
-
+    var _ref7 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+      _ref7$includeOffset = _ref7.includeOffset,
+      includeOffset = _ref7$includeOffset === void 0 ? true : _ref7$includeOffset,
+      _ref7$includeZone = _ref7.includeZone,
+      includeZone = _ref7$includeZone === void 0 ? false : _ref7$includeZone,
+      _ref7$includeOffsetSp = _ref7.includeOffsetSpace,
+      includeOffsetSpace = _ref7$includeOffsetSp === void 0 ? true : _ref7$includeOffsetSp;
+    var fmt = "HH:mm:ss.SSS";
     if (includeZone || includeOffset) {
       if (includeOffsetSpace) {
         fmt += " ";
       }
-
       if (includeZone) {
         fmt += "z";
       } else if (includeOffset) {
         fmt += "ZZ";
       }
     }
-
     return toTechFormat(this, fmt, true);
   }
+
   /**
    * Returns a string representation of this DateTime appropriate for use in SQL DateTime
    * @param {Object} opts - options
@@ -8351,80 +7381,70 @@ class DateTime {
    * @example DateTime.local(2014, 7, 13).toSQL({ includeZone: true }) //=> '2014-07-13 00:00:00.000 America/New_York'
    * @return {string}
    */
-
-
   toSQL() {
-    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-
+    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     if (!this.isValid) {
       return null;
     }
-
     return `${this.toSQLDate()} ${this.toSQLTime(opts)}`;
   }
+
   /**
    * Returns a string representation of this DateTime appropriate for debugging
    * @return {string}
    */
-
-
   toString() {
     return this.isValid ? this.toISO() : datetime_INVALID;
   }
+
   /**
    * Returns the epoch milliseconds of this DateTime. Alias of {@link DateTime#toMillis}
    * @return {number}
    */
-
-
   valueOf() {
     return this.toMillis();
   }
+
   /**
    * Returns the epoch milliseconds of this DateTime.
    * @return {number}
    */
-
-
   toMillis() {
     return this.isValid ? this.ts : NaN;
   }
+
   /**
    * Returns the epoch seconds of this DateTime.
    * @return {number}
    */
-
-
   toSeconds() {
     return this.isValid ? this.ts / 1000 : NaN;
   }
+
   /**
    * Returns the epoch seconds (as a whole number) of this DateTime.
    * @return {number}
    */
-
-
   toUnixInteger() {
     return this.isValid ? Math.floor(this.ts / 1000) : NaN;
   }
+
   /**
    * Returns an ISO 8601 representation of this DateTime appropriate for use in JSON.
    * @return {string}
    */
-
-
   toJSON() {
     return this.toISO();
   }
+
   /**
    * Returns a BSON serializable equivalent to this DateTime.
    * @return {Date}
    */
-
-
   toBSON() {
     return this.toJSDate();
   }
+
   /**
    * Returns a JavaScript object with this DateTime's year, month, day, and so on.
    * @param opts - options for generating the object
@@ -8432,31 +7452,27 @@ class DateTime {
    * @example DateTime.now().toObject() //=> { year: 2017, month: 4, day: 22, hour: 20, minute: 49, second: 42, millisecond: 268 }
    * @return {Object}
    */
-
-
   toObject() {
-    let opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     if (!this.isValid) return {};
-
-    const base = datetime_objectSpread({}, this.c);
-
+    var base = datetime_objectSpread({}, this.c);
     if (opts.includeConfig) {
       base.outputCalendar = this.outputCalendar;
       base.numberingSystem = this.loc.numberingSystem;
       base.locale = this.loc.locale;
     }
-
     return base;
   }
+
   /**
    * Returns a JavaScript Date equivalent to this DateTime.
    * @return {Date}
    */
-
-
   toJSDate() {
     return new Date(this.isValid ? this.ts : NaN);
-  } // COMPARE
+  }
+
+  // COMPARE
 
   /**
    * Return the difference between two DateTimes as a Duration.
@@ -8473,28 +7489,24 @@ class DateTime {
    * i2.diff(i1, ['months', 'days', 'hours']).toObject() //=> { months: 16, days: 19, hours: 0.75 }
    * @return {Duration}
    */
-
-
   diff(otherDateTime) {
-    let unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "milliseconds";
-    let opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
-
+    var unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "milliseconds";
+    var opts = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
     if (!this.isValid || !otherDateTime.isValid) {
       return Duration.invalid("created by diffing an invalid DateTime");
     }
-
-    const durOpts = datetime_objectSpread({
+    var durOpts = datetime_objectSpread({
       locale: this.locale,
       numberingSystem: this.numberingSystem
     }, opts);
-
-    const units = maybeArray(unit).map(Duration.normalizeUnit),
-          otherIsLater = otherDateTime.valueOf() > this.valueOf(),
-          earlier = otherIsLater ? this : otherDateTime,
-          later = otherIsLater ? otherDateTime : this,
-          diffed = diff(earlier, later, units, durOpts);
+    var units = maybeArray(unit).map(Duration.normalizeUnit),
+      otherIsLater = otherDateTime.valueOf() > this.valueOf(),
+      earlier = otherIsLater ? this : otherDateTime,
+      later = otherIsLater ? otherDateTime : this,
+      diffed = diff(earlier, later, units, durOpts);
     return otherIsLater ? diffed.negate() : diffed;
   }
+
   /**
    * Return the difference between this DateTime and right now.
    * See {@link DateTime#diff}
@@ -8503,23 +7515,21 @@ class DateTime {
    * @param {string} [opts.conversionAccuracy='casual'] - the conversion system to use
    * @return {Duration}
    */
-
-
   diffNow() {
-    let unit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "milliseconds";
-    let opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var unit = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "milliseconds";
+    var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     return this.diff(DateTime.now(), unit, opts);
   }
+
   /**
    * Return an Interval spanning between this DateTime and another DateTime
    * @param {DateTime} otherDateTime - the other end point of the Interval
    * @return {Interval}
    */
-
-
   until(otherDateTime) {
     return this.isValid ? Interval.fromDateTimes(this, otherDateTime) : this;
   }
+
   /**
    * Return whether this DateTime is in the same unit of time as another DateTime.
    * Higher-order units must also be identical for this function to return `true`.
@@ -8529,16 +7539,15 @@ class DateTime {
    * @example DateTime.now().hasSame(otherDT, 'day'); //~> true if otherDT is in the same current calendar day
    * @return {boolean}
    */
-
-
   hasSame(otherDateTime, unit) {
     if (!this.isValid) return false;
-    const inputMs = otherDateTime.valueOf();
-    const adjustedToZone = this.setZone(otherDateTime.zone, {
+    var inputMs = otherDateTime.valueOf();
+    var adjustedToZone = this.setZone(otherDateTime.zone, {
       keepLocalTime: true
     });
     return adjustedToZone.startOf(unit) <= inputMs && inputMs <= adjustedToZone.endOf(unit);
   }
+
   /**
    * Equality check
    * Two DateTimes are equal if and only if they represent the same millisecond, have the same zone and location, and are both valid.
@@ -8546,11 +7555,10 @@ class DateTime {
    * @param {DateTime} other - the other DateTime
    * @return {boolean}
    */
-
-
   equals(other) {
     return this.isValid && other.isValid && this.valueOf() === other.valueOf() && this.zone.equals(other.zone) && this.loc.equals(other.loc);
   }
+
   /**
    * Returns a string representation of a this time relative to now, such as "in two days". Can only internationalize if your
    * platform supports Intl.RelativeTimeFormat. Rounds down by default.
@@ -8569,29 +7577,26 @@ class DateTime {
    * @example DateTime.now().minus({ days: 2 }).toRelative({ unit: "hours" }) //=> "48 hours ago"
    * @example DateTime.now().minus({ hours: 36 }).toRelative({ round: false }) //=> "1.5 days ago"
    */
-
-
   toRelative() {
-    let options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     if (!this.isValid) return null;
-    const base = options.base || DateTime.fromObject({}, {
-      zone: this.zone
-    }),
-          padding = options.padding ? this < base ? -options.padding : options.padding : 0;
-    let units = ["years", "months", "days", "hours", "minutes", "seconds"];
-    let unit = options.unit;
-
+    var base = options.base || DateTime.fromObject({}, {
+        zone: this.zone
+      }),
+      padding = options.padding ? this < base ? -options.padding : options.padding : 0;
+    var units = ["years", "months", "days", "hours", "minutes", "seconds"];
+    var unit = options.unit;
     if (Array.isArray(options.unit)) {
       units = options.unit;
       unit = undefined;
     }
-
     return diffRelative(base, this.plus(padding), datetime_objectSpread(datetime_objectSpread({}, options), {}, {
       numeric: "always",
       units,
       unit
     }));
   }
+
   /**
    * Returns a string representation of this date relative to today, such as "yesterday" or "next month".
    * Only internationalizes on platforms that supports Intl.RelativeTimeFormat.
@@ -8605,10 +7610,8 @@ class DateTime {
    * @example DateTime.now().plus({ days: 1 }).toRelativeCalendar({ locale: "fr" }) //=> "demain"
    * @example DateTime.now().minus({ days: 2 }).toRelativeCalendar() //=> "2 days ago"
    */
-
-
   toRelativeCalendar() {
-    let options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     if (!this.isValid) return null;
     return diffRelative(options.base || DateTime.fromObject({}, {
       zone: this.zone
@@ -8618,42 +7621,38 @@ class DateTime {
       calendary: true
     }));
   }
+
   /**
    * Return the min of several date times
    * @param {...DateTime} dateTimes - the DateTimes from which to choose the minimum
    * @return {DateTime} the min DateTime, or undefined if called with no argument
    */
-
-
   static min() {
     for (var _len = arguments.length, dateTimes = new Array(_len), _key = 0; _key < _len; _key++) {
       dateTimes[_key] = arguments[_key];
     }
-
     if (!dateTimes.every(DateTime.isDateTime)) {
       throw new InvalidArgumentError("min requires all arguments be DateTimes");
     }
-
     return bestBy(dateTimes, i => i.valueOf(), Math.min);
   }
+
   /**
    * Return the max of several date times
    * @param {...DateTime} dateTimes - the DateTimes from which to choose the maximum
    * @return {DateTime} the max DateTime, or undefined if called with no argument
    */
-
-
   static max() {
     for (var _len2 = arguments.length, dateTimes = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
       dateTimes[_key2] = arguments[_key2];
     }
-
     if (!dateTimes.every(DateTime.isDateTime)) {
       throw new InvalidArgumentError("max requires all arguments be DateTimes");
     }
-
     return bestBy(dateTimes, i => i.valueOf(), Math.max);
-  } // MISC
+  }
+
+  // MISC
 
   /**
    * Explain how a string would be parsed by fromFormat()
@@ -8662,235 +7661,210 @@ class DateTime {
    * @param {Object} options - options taken by fromFormat()
    * @return {Object}
    */
-
-
   static fromFormatExplain(text, fmt) {
-    let options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
-    const _options$locale = options.locale,
-          locale = _options$locale === void 0 ? null : _options$locale,
-          _options$numberingSys = options.numberingSystem,
-          numberingSystem = _options$numberingSys === void 0 ? null : _options$numberingSys,
-          localeToUse = Locale.fromOpts({
-      locale,
-      numberingSystem,
-      defaultToEN: true
-    });
+    var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+    var _options$locale = options.locale,
+      locale = _options$locale === void 0 ? null : _options$locale,
+      _options$numberingSys = options.numberingSystem,
+      numberingSystem = _options$numberingSys === void 0 ? null : _options$numberingSys,
+      localeToUse = Locale.fromOpts({
+        locale,
+        numberingSystem,
+        defaultToEN: true
+      });
     return explainFromTokens(localeToUse, text, fmt);
   }
+
   /**
    * @deprecated use fromFormatExplain instead
    */
-
-
   static fromStringExplain(text, fmt) {
-    let options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+    var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
     return DateTime.fromFormatExplain(text, fmt, options);
-  } // FORMAT PRESETS
+  }
+
+  // FORMAT PRESETS
 
   /**
    * {@link DateTime#toLocaleString} format like 10/14/1983
    * @type {Object}
    */
-
-
   static get DATE_SHORT() {
     return DATE_SHORT;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like 'Oct 14, 1983'
    * @type {Object}
    */
-
-
   static get DATE_MED() {
     return DATE_MED;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like 'Fri, Oct 14, 1983'
    * @type {Object}
    */
-
-
   static get DATE_MED_WITH_WEEKDAY() {
     return DATE_MED_WITH_WEEKDAY;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like 'October 14, 1983'
    * @type {Object}
    */
-
-
   static get DATE_FULL() {
     return DATE_FULL;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like 'Tuesday, October 14, 1983'
    * @type {Object}
    */
-
-
   static get DATE_HUGE() {
     return DATE_HUGE;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like '09:30 AM'. Only 12-hour if the locale is.
    * @type {Object}
    */
-
-
   static get TIME_SIMPLE() {
     return TIME_SIMPLE;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like '09:30:23 AM'. Only 12-hour if the locale is.
    * @type {Object}
    */
-
-
   static get TIME_WITH_SECONDS() {
     return TIME_WITH_SECONDS;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like '09:30:23 AM EDT'. Only 12-hour if the locale is.
    * @type {Object}
    */
-
-
   static get TIME_WITH_SHORT_OFFSET() {
     return TIME_WITH_SHORT_OFFSET;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like '09:30:23 AM Eastern Daylight Time'. Only 12-hour if the locale is.
    * @type {Object}
    */
-
-
   static get TIME_WITH_LONG_OFFSET() {
     return TIME_WITH_LONG_OFFSET;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like '09:30', always 24-hour.
    * @type {Object}
    */
-
-
   static get TIME_24_SIMPLE() {
     return TIME_24_SIMPLE;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like '09:30:23', always 24-hour.
    * @type {Object}
    */
-
-
   static get TIME_24_WITH_SECONDS() {
     return TIME_24_WITH_SECONDS;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like '09:30:23 EDT', always 24-hour.
    * @type {Object}
    */
-
-
   static get TIME_24_WITH_SHORT_OFFSET() {
     return TIME_24_WITH_SHORT_OFFSET;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like '09:30:23 Eastern Daylight Time', always 24-hour.
    * @type {Object}
    */
-
-
   static get TIME_24_WITH_LONG_OFFSET() {
     return TIME_24_WITH_LONG_OFFSET;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like '10/14/1983, 9:30 AM'. Only 12-hour if the locale is.
    * @type {Object}
    */
-
-
   static get DATETIME_SHORT() {
     return DATETIME_SHORT;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like '10/14/1983, 9:30:33 AM'. Only 12-hour if the locale is.
    * @type {Object}
    */
-
-
   static get DATETIME_SHORT_WITH_SECONDS() {
     return DATETIME_SHORT_WITH_SECONDS;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like 'Oct 14, 1983, 9:30 AM'. Only 12-hour if the locale is.
    * @type {Object}
    */
-
-
   static get DATETIME_MED() {
     return DATETIME_MED;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like 'Oct 14, 1983, 9:30:33 AM'. Only 12-hour if the locale is.
    * @type {Object}
    */
-
-
   static get DATETIME_MED_WITH_SECONDS() {
     return DATETIME_MED_WITH_SECONDS;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like 'Fri, 14 Oct 1983, 9:30 AM'. Only 12-hour if the locale is.
    * @type {Object}
    */
-
-
   static get DATETIME_MED_WITH_WEEKDAY() {
     return DATETIME_MED_WITH_WEEKDAY;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like 'October 14, 1983, 9:30 AM EDT'. Only 12-hour if the locale is.
    * @type {Object}
    */
-
-
   static get DATETIME_FULL() {
     return DATETIME_FULL;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like 'October 14, 1983, 9:30:33 AM EDT'. Only 12-hour if the locale is.
    * @type {Object}
    */
-
-
   static get DATETIME_FULL_WITH_SECONDS() {
     return DATETIME_FULL_WITH_SECONDS;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like 'Friday, October 14, 1983, 9:30 AM Eastern Daylight Time'. Only 12-hour if the locale is.
    * @type {Object}
    */
-
-
   static get DATETIME_HUGE() {
     return DATETIME_HUGE;
   }
+
   /**
    * {@link DateTime#toLocaleString} format like 'Friday, October 14, 1983, 9:30:33 AM Eastern Daylight Time'. Only 12-hour if the locale is.
    * @type {Object}
    */
-
-
   static get DATETIME_HUGE_WITH_SECONDS() {
     return DATETIME_HUGE_WITH_SECONDS;
   }
-
 }
+
 /**
  * @private
  */
-
 function friendlyDateTime(dateTimeish) {
   if (DateTime.isDateTime(dateTimeish)) {
     return dateTimeish;
@@ -8913,7 +7887,7 @@ function friendlyDateTime(dateTimeish) {
 
 
 
-const VERSION = "3.2.0";
+var VERSION = "3.2.0";
 
 ;// CONCATENATED MODULE: ./src/3_8/utils.ts
 
@@ -17422,6 +16396,7 @@ class Soup2 {
         this._httpSession.user_agent = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:37.0) Gecko/20100101 Firefox/37.0";
         this._httpSession.timeout = 10;
         this._httpSession.idle_timeout = 10;
+        this._httpSession.use_thread_context = true;
         this._httpSession.add_feature(new ProxyResolverDefault());
     }
     async Send(url, params, headers, method = "GET", cancellable) {
@@ -17438,22 +16413,57 @@ class Soup2 {
             }
             else {
                 AddHeadersToMessage(message, headers);
-                this._httpSession.queue_message(message, (session, message) => {
-                    var _a, _b;
+                const finalCancellable = cancellable !== null && cancellable !== void 0 ? cancellable : soupLib_Cancellable.new();
+                this._httpSession.send_async(message, cancellable, async (session, result) => {
                     const headers = {};
-                    message.response_headers.foreach((name, value) => {
-                        headers[name] = value;
-                    });
+                    let res = null;
+                    try {
+                        const stream = this._httpSession.send_finish(result);
+                        res = await this.read_all_bytes(stream, finalCancellable);
+                        message.response_headers.foreach((name, value) => {
+                            headers[name] = value;
+                        });
+                    }
+                    catch (e) {
+                        logger_Logger.Error("Error reading http request's response: " + e);
+                    }
                     resolve({
                         reason_phrase: message.reason_phrase,
                         status_code: message.status_code,
-                        response_body: (_b = (_a = message.response_body) === null || _a === void 0 ? void 0 : _a.data) !== null && _b !== void 0 ? _b : null,
+                        response_body: res,
                         response_headers: headers
                     });
                 });
             }
         });
         return data;
+    }
+    async read_all_bytes(stream, cancellable) {
+        if (cancellable.is_cancelled())
+            return null;
+        const read_chunk_async = () => {
+            return new Promise((resolve) => {
+                stream.read_bytes_async(8192, 0, cancellable, (source, read_result) => {
+                    resolve(stream.read_bytes_finish(read_result));
+                });
+            });
+        };
+        let res = null;
+        let chunk;
+        chunk = await read_chunk_async();
+        while (chunk.get_size() > 0) {
+            if (cancellable.is_cancelled())
+                return res;
+            const chunkAsString = soupLib_ByteArray.fromGBytes(chunk).toString();
+            if (res === null) {
+                res = chunkAsString;
+            }
+            else {
+                res += chunkAsString;
+            }
+            chunk = await read_chunk_async();
+        }
+        return res;
     }
 }
 const soupLib = imports.gi.Soup.SessionAsync != undefined ? new Soup2() : new Soup3();

--- a/weather@mockturtl/files/weather@mockturtl/metadata.json
+++ b/weather@mockturtl/files/weather@mockturtl/metadata.json
@@ -3,7 +3,7 @@
   "name": "Weather",
   "description": "View your local weather forecast",
   "max-instances": 3,
-  "version": "3.4.1",
+  "version": "3.4.2",
   "multiversion": true,
   "cinnamon-version": ["2.2", "2.4", "2.6", "2.8", "3.0", "3.2", "3.4", "3.6", "3.8", "4.0", "4.2", "4.4", "4.6", "4.8"]
 }

--- a/weather@mockturtl/files/weather@mockturtl/po/ar.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/ar.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-12 12:27-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2021-02-16 11:25+0100\n"
 "Last-Translator: Yaron Sheffer <yaronf@gmx.com>\n"
 "Language-Team: Hebrew <none@example.com>\n"
@@ -18,432 +19,2571 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: applet.js:249
+#: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
+#: 3.8/weather-applet.js:17877
+msgid "Error"
+msgstr ""
+
+#: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
+#: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
+msgid "Service Error"
+msgstr ""
+
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
+msgid "Incorrect API Key"
+msgstr ""
+
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
+msgid "Incorrect Location Format"
+msgstr ""
+
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
+msgid "Key Blocked"
+msgstr ""
+
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
+msgid "Can't find location"
+msgstr ""
+
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
+msgid "No Api Key"
+msgstr ""
+
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
+msgid "No Location"
+msgstr ""
+
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
+msgid "Missing Packages"
+msgstr ""
+
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
+msgid "Location not covered"
+msgstr ""
+
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
+msgid "Weather Applet"
+msgstr ""
+
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: applet.js:250
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr ""
 
-#: applet.js:289
-msgid "Settings"
-msgstr ""
-
-#: applet.js:555
-msgid "Sunrise"
-msgstr "شروق الشمس"
-
-#: applet.js:556
-msgid "Sunset"
-msgstr "غروب الشمس"
-
-#: applet.js:648
-msgid "Loading current weather ..."
-msgstr "يحمل الطقس الحالي..."
-
-#: applet.js:649
-msgid "Loading future weather ..."
-msgstr "يحمل طقس المستقبل..."
-
-#: applet.js:671
-msgid "Loading ..."
-msgstr "يحمل..."
-
-#: applet.js:677
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr ""
 
-#: applet.js:740
-msgid "Temperature:"
+#: 3.0/applet.js:272
+msgid "API returned status code between 400 and 500"
+msgstr ""
+
+#: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
+#: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
+msgid "Location Store"
+msgstr ""
+
+#: 3.0/applet.js:426
+msgid "You can't save a location obtained automatically, sorry"
+msgstr ""
+
+#: 3.0/applet.js:601
+msgid "Could not get weather information"
+msgstr ""
+
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
+msgid ""
+"Unexpected Error While Refreshing Weather, please see log in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
+msgid ""
+"Could not update weather for a while...\n"
+"are you connected to the internet?"
+msgstr ""
+
+#: 3.0/applet.js:684
+msgid "Network Error, please check logs in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:969 3.0/applet.js:1110
+msgid "As of"
+msgstr ""
+
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
+msgid "Powered by"
+msgstr ""
+
+#: 3.0/applet.js:1113
+msgid "from you"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
+msgid "mm"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
+msgid "in"
+msgstr ""
+
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
+msgid "mi"
+msgstr ""
+
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
+msgid "km"
+msgstr ""
+
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
+msgid "Loading current weather ..."
+msgstr "يحمل الطقس الحالي..."
+
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
+msgid "Loading future weather ..."
+msgstr "يحمل طقس المستقبل..."
+
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
+msgid "Loading ..."
+msgstr "يحمل..."
+
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
+#, fuzzy
+msgid "Temperature"
 msgstr "درجة الحرارة:"
 
-#: applet.js:742
-msgid "Humidity:"
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
+#, fuzzy
+msgid "Humidity"
 msgstr "الرطوبة:"
 
-#: applet.js:744
-msgid "Pressure:"
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
+#, fuzzy
+msgid "Pressure"
 msgstr "الضغط:"
 
-#: applet.js:746
-msgid "Wind:"
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
+#, fuzzy
+msgid "Wind"
 msgstr "الريح:"
 
-#: applet.js:748
-msgid "Wind Chill:"
-msgstr "الريح:"
+#: 3.0/applet.js:1639
+msgid "Make sure you entered a location or use Automatic location instead"
+msgstr ""
 
-#: applet.js:953
-msgid "Tornado"
-msgstr "إعصار"
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
+msgid "Could not find location based on address, please check if it's right"
+msgstr ""
 
-#: applet.js:955
-msgid "Tropical storm"
-msgstr "عاصفة مدارية"
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
+msgid "Failed to call Geolocation API, see Looking Glass for errors."
+msgstr ""
 
-#: applet.js:957
-msgid "Hurricane"
-msgstr "إعصار استوائي"
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "Warning"
+msgstr ""
 
-#: applet.js:959
-msgid "Severe thunderstorms"
-msgstr "عواصف رعدية شديدة"
+#: 3.0/applet.js:2032
+msgid "You can only save correct locations when the applet is not refreshing"
+msgstr ""
 
-#: applet.js:961
-msgid "Thunderstorms"
-msgstr "عواصف رعدية"
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "You can't save an incorrect location"
+msgstr ""
 
-#: applet.js:963
-msgid "Mixed rain and snow"
-msgstr "خليط من المطر والثلج"
+#. 3.8->settings-schema.json->logLevel->options
+#: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.8/weather-applet.js:9875
+msgid "Info"
+msgstr ""
 
-#: applet.js:965
-msgid "Mixed rain and sleet"
-msgstr "خليط من المطر والمطر الثلجي"
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
+msgid "Location is already saved"
+msgstr ""
 
-#: applet.js:967
-msgid "Mixed snow and sleet"
-msgstr "خليط من الثلج والمطر الثلجي"
+#: 3.0/applet.js:2049 3.0/applet.js:2083
+msgid "Success"
+msgstr ""
 
-#: applet.js:969
-msgid "Freezing drizzle"
-msgstr "رذاذ متجمد"
+#: 3.0/applet.js:2049
+msgid "Location is saved to library"
+msgstr ""
 
-#: applet.js:971
-msgid "Drizzle"
-msgstr "رذاذ"
+#: 3.0/applet.js:2062
+msgid "You can't remove a location while the applet is refreshing"
+msgstr ""
 
-#: applet.js:973
+#: 3.0/applet.js:2066
+msgid "You can't remove an incorrect location"
+msgstr ""
+
+#: 3.0/applet.js:2070
+msgid "Location is not in storage, can't delete"
+msgstr ""
+
+#: 3.0/applet.js:2083
+msgid "Location is deleted from library"
+msgstr ""
+
+#: 3.0/applet.js:2131
+msgid ""
+"Failed to load in data from location storage, please see the logs for more "
+"information"
+msgstr ""
+
+#: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
+#: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
+msgid "Feels Like"
+msgstr ""
+
+#: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
+#: 3.8/weather-applet.js:15387
+msgid "Failed to Process Weather Info"
+msgstr ""
+
+#: 3.0/climacell.js:224
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://developer.climacell.co/sign-up"
+msgstr ""
+
+#: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
+msgid ""
+"Please Make sure you\n"
+"entered the API key correctly and your account is not locked"
+msgstr ""
+
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Climacell"
+msgstr ""
+
+#: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
+#: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
+#: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
+#, fuzzy
+msgid "Heavy rain"
+msgstr "ثلج كثيف"
+
+#: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
+#: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
+#: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
+msgid "Rain"
+msgstr ""
+
+#: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
+#: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
+#: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
+#, fuzzy
+msgid "Light rain"
+msgstr "مطر متجمد"
+
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
+#, fuzzy
+msgid "Heavy freezing rain"
+msgstr "مطر متجمد"
+
+#: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
+#: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
+#: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "مطر متجمد"
 
-#: applet.js:975 applet.js:977
-msgid "Showers"
-msgstr "رشات مطر"
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
+#, fuzzy
+msgid "Light freezing rain"
+msgstr "مطر متجمد"
 
-#: applet.js:979
-msgid "Snow flurries"
-msgstr "تساقط ثلوج"
+#: 3.0/climacell.js:301
+#, fuzzy
+msgid "Light freezing drizzle"
+msgstr "رذاذ متجمد"
 
-#: applet.js:981
-msgid "Light snow showers"
-msgstr "رشات ثلجية خفيفة"
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
+msgid "Freezing drizzle"
+msgstr "رذاذ متجمد"
 
-#: applet.js:983
-msgid "Blowing snow"
-msgstr "هبوب ثلوج"
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
+#, fuzzy
+msgid "Light drizzle"
+msgstr "رذاذ متجمد"
 
-#: applet.js:985
-msgid "Snow"
-msgstr "ثلج"
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
+msgid "Heavy ice pellets"
+msgstr ""
 
-#: applet.js:987
-msgid "Hail"
-msgstr "بَرَد"
+#: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
+msgid "Ice pellets"
+msgstr ""
 
-#: applet.js:989
-msgid "Sleet"
-msgstr "مطر ثلجي"
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
+msgid "Light ice pellets"
+msgstr ""
 
-#: applet.js:991
-msgid "Dust"
-msgstr "غبار"
-
-#: applet.js:993
-msgid "Foggy"
-msgstr "ضبابي"
-
-#: applet.js:995
-msgid "Haze"
-msgstr "سديم"
-
-#: applet.js:997
-msgid "Smoky"
-msgstr "دخانيّ"
-
-#: applet.js:999
-msgid "Blustery"
-msgstr "ريح عاصف"
-
-#: applet.js:1001
-msgid "Windy"
-msgstr "عاصف"
-
-#: applet.js:1003
-msgid "Cold"
-msgstr "بارد"
-
-#: applet.js:1005
-msgid "Cloudy"
-msgstr "غائم"
-
-#: applet.js:1008
-msgid "Mostly cloudy"
-msgstr "غائم في أغلبه"
-
-#: applet.js:1011 applet.js:1037
-msgid "Partly cloudy"
-msgstr "غائم جزئياً"
-
-#: applet.js:1013
-msgid "Clear"
-msgstr "صافٍ"
-
-#: applet.js:1015
-msgid "Sunny"
-msgstr "مشمس"
-
-#: applet.js:1018
-msgid "Fair"
-msgstr "معتدل"
-
-#: applet.js:1020
-msgid "Mixed rain and hail"
-msgstr "خليط من المطر والبَرَد"
-
-#: applet.js:1022
-msgid "Hot"
-msgstr "حار"
-
-#: applet.js:1024
-msgid "Isolated thunderstorms"
-msgstr "عواصف رعدية معزولة"
-
-#: applet.js:1027
-msgid "Scattered thunderstorms"
-msgstr "סعواصف رعدية متفرقة"
-
-#: applet.js:1029
-msgid "Scattered showers"
-msgstr "رشات متفرقة"
-
-#: applet.js:1031 applet.js:1035
+#: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
+#: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
+#: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "ثلج كثيف"
 
-#: applet.js:1033
-msgid "Scattered snow showers"
+#: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
+#: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
+#: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
+msgid "Snow"
+msgstr "ثلج"
+
+#: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
+#: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
+#: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
+#, fuzzy
+msgid "Light snow"
+msgstr "رشات ثلجية خفيفة"
+
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
+#, fuzzy
+msgid "Flurries"
+msgstr "تساقط ثلوج"
+
+#: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
+#, fuzzy
+msgid "Thunderstorm"
+msgstr "عواصف رعدية"
+
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
+msgid "Light fog"
+msgstr ""
+
+#: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
+#: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
+#: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
+#, fuzzy
+msgid "Fog"
+msgstr "ضبابي"
+
+#: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
+#: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
+msgid "Cloudy"
+msgstr "غائم"
+
+#: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
+msgid "Mostly cloudy"
+msgstr "غائم في أغلبه"
+
+#: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
+#: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
+#: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
+msgid "Partly cloudy"
+msgstr "غائم جزئياً"
+
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
+#, fuzzy
+msgid "Mostly clear"
+msgstr "غائم في أغلبه"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
+#: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
+#: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
+msgid "Clear"
+msgstr "صافٍ"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
+msgid "Sunny"
+msgstr "مشمس"
+
+#: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
+#: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
+#: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
+msgid "Unknown"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "and"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "until"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "Possible"
+msgstr ""
+
+#: 3.0/darkSky.js:211
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://darksky.net/dev/register"
+msgstr ""
+
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from DarkSky"
+msgstr ""
+
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
+msgid "Could not obtain location"
+msgstr ""
+
+#: 3.0/ipApi.js:95
+msgid ""
+"Location Service responded with errors, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
+#, fuzzy
+msgid "Cloudiness"
+msgstr "غائم"
+
+#: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
+#, fuzzy
+msgid "Clear sky"
+msgstr "صافٍ"
+
+#: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
+msgid "Fair"
+msgstr "معتدل"
+
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
+msgid "Heavy rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
+#, fuzzy
+msgid "Heavy rain showers"
+msgstr "ثلج كثيف"
+
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
+msgid "Heavy rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
+#, fuzzy
+msgid "Heavy sleet"
+msgstr "ثلج كثيف"
+
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
+msgid "Heavy sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
+#, fuzzy
+msgid "Heavy sleet showers"
+msgstr "ثلج كثيف"
+
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
+msgid "Heavy sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
+#, fuzzy
+msgid "Heavy snow and thunder"
+msgstr "ثلج كثيف"
+
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
+#, fuzzy
+msgid "Heavy snow showers"
 msgstr "رشات ثلجية متفرقة"
 
-#: applet.js:1039
-msgid "Thundershowers"
-msgstr "وابل رعدي"
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
+msgid "Heavy snow showers and thunder"
+msgstr ""
 
-#: applet.js:1041
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
+msgid "Light rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
+#, fuzzy
+msgid "Light rain showers"
+msgstr "رشات ثلجية خفيفة"
+
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
+#, fuzzy
+msgid "Light rain showers and thunder"
+msgstr "رشات ثلجية خفيفة"
+
+#: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
+msgid "Light sleet"
+msgstr ""
+
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
+msgid "Light sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
+#, fuzzy
+msgid "Light sleet showers"
+msgstr "رشات ثلجية خفيفة"
+
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
+#, fuzzy
+msgid "Light sleet showers and thunder"
+msgstr "رشات ثلجية خفيفة"
+
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
+#, fuzzy
+msgid "Light snow and thunder"
+msgstr "رشات ثلجية خفيفة"
+
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
+msgid "Light snow showers"
+msgstr "رشات ثلجية خفيفة"
+
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
+#, fuzzy
+msgid "Light snow showers and thunder"
+msgstr "رشات ثلجية خفيفة"
+
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
+msgid "Rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
+#, fuzzy
+msgid "Rain showers"
+msgstr "رشات ثلجية متفرقة"
+
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
+msgid "Rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:511 3.0/met_norway.js:512 3.0/met_norway.js:518
+#: 3.0/met_norway.js:525 3.0/met_norway.js:532 3.0/met_uk.js:638
+#: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
+#: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
+#: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
+msgid "Sleet"
+msgstr "مطر ثلجي"
+
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
+#, fuzzy
+msgid "Sleet and thunder"
+msgstr "סعواصف رعدية متفرقة"
+
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
+#, fuzzy
+msgid "Sleet showers"
+msgstr "رشات متفرقة"
+
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
+msgid "Sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
+msgid "Snow and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "رشات ثلجية متفرقة"
 
-#: applet.js:1043
-msgid "Isolated thundershowers"
-msgstr "وابل ثلجي معزول"
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
+#, fuzzy
+msgid "Snow showers and thunder"
+msgstr "رشات ثلجية متفرقة"
 
-#: applet.js:1046
-msgid "Not available"
-msgstr "غير متاح"
+#: 3.0/met_uk.js:162 3.0/met_uk.js:192 3.0/met_uk.js:239 3.0/us_weather.js:151
+#: 3.0/us_weather.js:179
+msgid "Unexpected response from API"
+msgstr ""
 
-#: applet.js:1051
-msgid "Monday"
-msgstr "الإثنين"
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
+msgid "Visibility"
+msgstr ""
 
-#: applet.js:1051
-msgid "Tuesday"
-msgstr "الثلاثاء"
+#: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
+msgid "Failed to Process Current Weather Info"
+msgstr ""
 
-#: applet.js:1051
-msgid "Wednesday"
-msgstr "الأربعاء"
+#: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
+msgid "Failed to Process Forecast Info"
+msgstr ""
 
-#: applet.js:1051
-msgid "Thursday"
-msgstr "الخميس"
+#: 3.0/met_uk.js:408
+msgid "Very poor - Less than"
+msgstr ""
 
-#: applet.js:1051
-msgid "Friday"
-msgstr "الجمعة"
+#: 3.0/met_uk.js:410
+msgid "Poor - Between"
+msgstr ""
 
-#: applet.js:1051
-msgid "Saturday"
-msgstr "السبت"
+#: 3.0/met_uk.js:412
+msgid "Moderate - Between"
+msgstr ""
 
-#: applet.js:1051
+#: 3.0/met_uk.js:414
+msgid "Good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:416
+msgid "Very good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:417
+msgid "Excellent - More than"
+msgstr ""
+
+#: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
+msgid "Mist"
+msgstr ""
+
+#: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
+msgid "Overcast"
+msgstr ""
+
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
+#, fuzzy
+msgid "Light rain shower"
+msgstr "رشات ثلجية خفيفة"
+
+#: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
+msgid "Drizzle"
+msgstr "رذاذ"
+
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
+#, fuzzy
+msgid "Heavy rain shower"
+msgstr "ثلج كثيف"
+
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
+#, fuzzy
+msgid "Sleet shower"
+msgstr "رشات متفرقة"
+
+#: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
+msgid "Hail"
+msgstr "بَرَد"
+
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
+#, fuzzy
+msgid "Hail shower"
+msgstr "رشات ثلجية متفرقة"
+
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
+#, fuzzy
+msgid "Light snow shower"
+msgstr "رشات ثلجية خفيفة"
+
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
+#, fuzzy
+msgid "Heavy snow shower"
+msgstr "ثلج كثيف"
+
+#: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
+#, fuzzy
+msgid "Thunder"
+msgstr "عواصف رعدية"
+
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
+#, fuzzy
+msgid "Thunder shower"
+msgstr "وابل رعدي"
+
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
+msgid "Please make sure Location is in the correct format in the Settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
+msgid "Make sure you entered the correct key in settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
+msgid ""
+"Location not found, make sure location is available or it is in the correct "
+"format"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
+msgid "If this problem persists, please contact the Author of this applet"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
+msgid "Unknown Error, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
+msgid "Thunderstorm with light rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
+#, fuzzy
+msgid "Thunderstorm with rain"
+msgstr "عواصف رعدية"
+
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
+msgid "Thunderstorm with heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
+#, fuzzy
+msgid "Light thunderstorm"
+msgstr "عواصف رعدية"
+
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
+#, fuzzy
+msgid "Heavy thunderstorm"
+msgstr "عواصف رعدية شديدة"
+
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
+#, fuzzy
+msgid "Ragged thunderstorm"
+msgstr "عواصف رعدية معزولة"
+
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
+msgid "Thunderstorm with light drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
+#, fuzzy
+msgid "Thunderstorm with drizzle"
+msgstr "عواصف رعدية"
+
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
+msgid "Thunderstorm with heavy drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
+msgid "Light intensity drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
+msgid "Heavy intensity drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
+msgid "Light intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Drizzle rain"
+msgstr "رذاذ"
+
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
+msgid "Heavy intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
+#, fuzzy
+msgid "Shower rain and drizzle"
+msgstr "خليط من المطر والبَرَد"
+
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
+msgid "Heavy shower rain and drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
+#, fuzzy
+msgid "Shower drizzle"
+msgstr "رذاذ متجمد"
+
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
+msgid "Moderate rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
+msgid "Heavy intensity rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
+msgid "Very heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
+#, fuzzy
+msgid "Extreme rain"
+msgstr "مطر متجمد"
+
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
+#, fuzzy
+msgid "Light intensity shower rain"
+msgstr "رشات ثلجية خفيفة"
+
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
+#, fuzzy
+msgid "Shower rain"
+msgstr "رشات مطر"
+
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
+msgid "Heavy intensity shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
+msgid "Ragged shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
+#, fuzzy
+msgid "Shower sleet"
+msgstr "رشات مطر"
+
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
+#, fuzzy
+msgid "Light rain and snow"
+msgstr "خليط من المطر والثلج"
+
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
+#, fuzzy
+msgid "Rain and snow"
+msgstr "خليط من المطر والثلج"
+
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
+#, fuzzy
+msgid "Light shower snow"
+msgstr "رشات ثلجية خفيفة"
+
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
+#, fuzzy
+msgid "Shower snow"
+msgstr "رشات مطر"
+
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
+#, fuzzy
+msgid "Heavy shower snow"
+msgstr "ثلج كثيف"
+
+#: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
+#, fuzzy
+msgid "Smoke"
+msgstr "دخانيّ"
+
+#: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
+msgid "Haze"
+msgstr "سديم"
+
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
+msgid "Sand, dust whirls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
+msgid "Sand"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
+msgid "Dust"
+msgstr "غبار"
+
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
+msgid "Volcanic ash"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
+msgid "Squalls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
+msgid "Tornado"
+msgstr "إعصار"
+
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
+msgid "Sky is clear"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
+#, fuzzy
+msgid "Clouds"
+msgstr "غائم"
+
+#: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
+msgid "Few clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
+#, fuzzy
+msgid "Scattered clouds"
+msgstr "رشات متفرقة"
+
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
+msgid "Broken clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
+msgid "Overcast clouds"
+msgstr ""
+
+#: 3.0/us_weather.js:120
+msgid "Could not get forecast for your area"
+msgstr ""
+
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
+msgid "Location is outside US, please use a different provider."
+msgstr ""
+
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
+msgid "Failed to Process Hourly Forecast Info"
+msgstr ""
+
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
+msgid "Clear and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
+msgid "Few clouds and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
+#, fuzzy
+msgid "Partly cloudy and windy"
+msgstr "غائم جزئياً"
+
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
+#, fuzzy
+msgid "Mostly cloudy and windy"
+msgstr "غائم في أغلبه"
+
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
+msgid "Overcast and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
+#, fuzzy
+msgid "Snowy rain"
+msgstr "تساقط ثلوج"
+
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
+#, fuzzy
+msgid "Freezing rain and snow"
+msgstr "مطر متجمد"
+
+#: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
+msgid "Hurricane"
+msgstr "إعصار استوائي"
+
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
+msgid "Storm"
+msgstr ""
+
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
+msgid "Tropical storm"
+msgstr "عاصفة مدارية"
+
+#: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
+msgid "Hot"
+msgstr "حار"
+
+#: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
+msgid "Cold"
+msgstr "بارد"
+
+#: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
+msgid "Blizzard"
+msgstr ""
+
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
+msgid "Today"
+msgstr "اليوم"
+
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
+msgid "Tomorrow"
+msgstr "غداً"
+
+#: 3.0/utils.js:204
 msgid "Sunday"
 msgstr "الأحد"
 
-#: applet.js:1056
+#: 3.0/utils.js:204
+msgid "Monday"
+msgstr "الإثنين"
+
+#: 3.0/utils.js:204
+msgid "Tuesday"
+msgstr "الثلاثاء"
+
+#: 3.0/utils.js:204
+msgid "Wednesday"
+msgstr "الأربعاء"
+
+#: 3.0/utils.js:204
+msgid "Thursday"
+msgstr "الخميس"
+
+#: 3.0/utils.js:204
+msgid "Friday"
+msgstr "الجمعة"
+
+#: 3.0/utils.js:204
+msgid "Saturday"
+msgstr "السبت"
+
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
+msgid "Calm"
+msgstr ""
+
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
+msgid "Light air"
+msgstr ""
+
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
+msgid "Light breeze"
+msgstr ""
+
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
+msgid "Gentle breeze"
+msgstr ""
+
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
+msgid "Moderate breeze"
+msgstr ""
+
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
+msgid "Fresh breeze"
+msgstr ""
+
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
+msgid "Strong breeze"
+msgstr ""
+
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
+msgid "Near gale"
+msgstr ""
+
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
+msgid "Gale"
+msgstr ""
+
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
+msgid "Strong gale"
+msgstr ""
+
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
+msgid "Violent storm"
+msgstr ""
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "ش"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "ش ق"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "ق"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "ج ق"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "ج"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "ج غ"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "غ"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "ش غ"
 
-#. cinnamon-weather->settings-schema.json->woeidLookup->description
-msgid "Get WOEID"
+#: 3.0/weatherbit.js:312
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://www.weatherbit.io/account/create"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->verticalOrientation->description
-msgid "Vertical orientation"
+#: 3.0/yahoo.js:78
+msgid ""
+"Unknown Error happened while calling Yahoo bridge,\n"
+" see Looking Glass log for errors"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showTextInPanel->description
-msgid "Display current temperature in panel"
+#: 3.0/yahoo.js:91
+msgid ""
+"Yahoo bridge responded in bad format,\n"
+" see Looking Glass log for errors"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeid->description
-msgid "WOEID"
+#: 3.0/yahoo.js:177
+msgid "Missing package"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeid->tooltip
-msgid "Where On Earth ID"
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+#, fuzzy
+msgid "Please install '"
+msgstr "انتظر رجاءً"
+
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+msgid "', then refresh manually."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->description
+#: 3.0/yahoo.js:182
+msgid "Could not connect to Yahoo API."
+msgstr ""
+
+#: 3.0/yahoo.js:186
+msgid ""
+"Unknown error happened while obtaining weather, see Looking Glass logs for "
+"more information"
+msgstr ""
+
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
+#, fuzzy
+msgid "Tropical Storm"
+msgstr "عاصفة مدارية"
+
+#: 3.0/yahoo.js:439
+#, fuzzy
+msgid "Severe Thunderstorms"
+msgstr "عواصف رعدية شديدة"
+
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
+msgid "Thunderstorms"
+msgstr "عواصف رعدية"
+
+#: 3.0/yahoo.js:441
+#, fuzzy
+msgid "Mixed Rain and Snow"
+msgstr "خليط من المطر والثلج"
+
+#: 3.0/yahoo.js:442
+#, fuzzy
+msgid "Mixed Rain and Sleet"
+msgstr "خليط من المطر والمطر الثلجي"
+
+#: 3.0/yahoo.js:443
+#, fuzzy
+msgid "Mixed Snow and Sleet"
+msgstr "خليط من الثلج والمطر الثلجي"
+
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
+#, fuzzy
+msgid "Freezing Drizzle"
+msgstr "رذاذ متجمد"
+
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
+#, fuzzy
+msgid "Freezing Rain"
+msgstr "مطر متجمد"
+
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
+msgid "Showers"
+msgstr "رشات مطر"
+
+#: 3.0/yahoo.js:449
+#, fuzzy
+msgid "Snow Flurries"
+msgstr "تساقط ثلوج"
+
+#: 3.0/yahoo.js:450
+#, fuzzy
+msgid "Light Snow Showers"
+msgstr "رشات ثلجية خفيفة"
+
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
+#, fuzzy
+msgid "Blowing Snow"
+msgstr "هبوب ثلوج"
+
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
+msgid "Foggy"
+msgstr "ضبابي"
+
+#: 3.0/yahoo.js:458
+msgid "Smoky"
+msgstr "دخانيّ"
+
+#: 3.0/yahoo.js:459
+msgid "Blustery"
+msgstr "ريح عاصف"
+
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
+msgid "Windy"
+msgstr "عاصف"
+
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
+#, fuzzy
+msgid "Mostly Cloudy"
+msgstr "غائم في أغلبه"
+
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
+#, fuzzy
+msgid "Partly Cloudy"
+msgstr "غائم جزئياً"
+
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
+#, fuzzy
+msgid "Mostly Sunny"
+msgstr "غائم في أغلبه"
+
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
+#, fuzzy
+msgid "Mixed Rain and Hail"
+msgstr "خليط من المطر والبَرَد"
+
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
+#, fuzzy
+msgid "Isolated Thunderstorms"
+msgstr "عواصف رعدية معزولة"
+
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
+#, fuzzy
+msgid "Scattered Thunderstorms"
+msgstr "סعواصف رعدية متفرقة"
+
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
+#, fuzzy
+msgid "Scattered Showers"
+msgstr "رشات متفرقة"
+
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
+#, fuzzy
+msgid "Heavy Rain"
+msgstr "ثلج كثيف"
+
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
+#, fuzzy
+msgid "Scattered Snow Showers"
+msgstr "رشات ثلجية متفرقة"
+
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
+#, fuzzy
+msgid "Heavy Snow"
+msgstr "ثلج كثيف"
+
+#: 3.0/yahoo.js:478
+#, fuzzy
+msgid "Not Available"
+msgstr "غير متاح"
+
+#: 3.0/yahoo.js:479
+#, fuzzy
+msgid "Scattered Thundershowers"
+msgstr "סعواصف رعدية متفرقة"
+
+#: 3.8/weather-applet.js:9638
+msgid ""
+"Could not retrieve logs, log file was not found under path\n"
+" {logFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:9642
+msgid ""
+"Could not get contents of log file under path\n"
+" {logFilePath}"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10283
+msgid "Met Office UK"
+msgstr ""
+
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
+msgstr ""
+
+#: 3.8/weather-applet.js:10476
+msgid "Data was not found for location"
+msgstr ""
+
+#: 3.8/weather-applet.js:10557
+msgid "Very poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10557
+msgid "Less than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "Excellent"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "More than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566
+msgid "Poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
+msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10571
+msgid "Moderate"
+msgstr ""
+
+#: 3.8/weather-applet.js:10576
+msgid "Good"
+msgstr ""
+
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
+msgid "Very good"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10942
+msgid "OpenWeatherMap"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:11396
+msgid "MET Norway"
+msgstr ""
+
+#: 3.8/weather-applet.js:11955
+msgid "WeatherBit"
+msgstr ""
+
+#: 3.8/weather-applet.js:12386
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "غداً"
+
+#: 3.8/weather-applet.js:12561
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12575
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12723
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:13292
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13474
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "هبوب ثلوج"
+
+#: 3.8/weather-applet.js:13478
+#, fuzzy
+msgid "Heavy drizzle"
+msgstr "رذاذ متجمد"
+
+#: 3.8/weather-applet.js:13482
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13484
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13486
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:13490
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "رذاذ متجمد"
+
+#: 3.8/weather-applet.js:13492
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13494
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13496
+#, fuzzy
+msgid "Freezing fog"
+msgstr "مطر متجمد"
+
+#: 3.8/weather-applet.js:13502
+msgid "Funnel cloud/tornado"
+msgstr ""
+
+#: 3.8/weather-applet.js:13504
+#, fuzzy
+msgid "Hail showers"
+msgstr "رشات ثلجية متفرقة"
+
+#: 3.8/weather-applet.js:13506
+msgid "Ice"
+msgstr ""
+
+#: 3.8/weather-applet.js:13508
+msgid "Lightning without thunder"
+msgstr ""
+
+#: 3.8/weather-applet.js:13512
+msgid "Precipitation in vicinity"
+msgstr ""
+
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
+#, fuzzy
+msgid "Heavy rain and snow"
+msgstr "خليط من المطر والثلج"
+
+#: 3.8/weather-applet.js:13518
+#, fuzzy
+msgid "Light rain And snow"
+msgstr "خليط من المطر والثلج"
+
+#: 3.8/weather-applet.js:13526
+msgid "Sky coverage decreasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13528
+msgid "Sky coverage increasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13530
+msgid "Sky unchanged"
+msgstr ""
+
+#: 3.8/weather-applet.js:13532
+msgid "Smoke or haze"
+msgstr ""
+
+#: 3.8/weather-applet.js:13536
+#, fuzzy
+msgid "Snow and rain showers"
+msgstr "رشات ثلجية متفرقة"
+
+#: 3.8/weather-applet.js:13548
+msgid "Thunderstorm without precipitation"
+msgstr ""
+
+#: 3.8/weather-applet.js:13550
+msgid "Diamond dust"
+msgstr ""
+
+#: 3.8/weather-applet.js:13556
+#, fuzzy
+msgid "Partially cloudy"
+msgstr "غائم جزئياً"
+
+#: 3.8/weather-applet.js:13578
+msgid "Please make sure you entered the API key correctly"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:13595
+msgid "DMI Denmark"
+msgstr ""
+
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
+msgid "NOT FOUND"
+msgstr ""
+
+#: 3.8/weather-applet.js:13779
+msgid "Blowing snow"
+msgstr "هبوب ثلوج"
+
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
+#, fuzzy
+msgid "Slight snow"
+msgstr "هبوب ثلوج"
+
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
+#, fuzzy
+msgid "Moderate snow"
+msgstr "ثلج كثيف"
+
+#: 3.8/weather-applet.js:13842
+#, fuzzy
+msgid "Moderate rain showers"
+msgstr "رشات متفرقة"
+
+#: 3.8/weather-applet.js:13849
+msgid "Mixed rain and snow"
+msgstr "خليط من المطر والثلج"
+
+#: 3.8/weather-applet.js:13856
+#, fuzzy
+msgid "Heavy mixed rain and snow"
+msgstr "خليط من المطر والثلج"
+
+#: 3.8/weather-applet.js:14024
+msgid "AccuWeather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+msgid "Weather Underground"
+msgstr ""
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+msgid "The location you provided was not found."
+msgstr ""
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+msgid "Strong Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "خليط من المطر والثلج"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "خليط من المطر والمطر الثلجي"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "رشات ثلجية متفرقة"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "غائم في أغلبه"
+
+#: 3.8/weather-applet.js:15247
+msgid "Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:15603
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+
+#: 3.8/weather-applet.js:15831
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+
+#: 3.8/weather-applet.js:15968
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:15975
+msgid ""
+"Could not get contents of config file under path\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr ""
+
+#: 3.8/weather-applet.js:16675
+msgid "Dew Point"
+msgstr ""
+
+#: 3.8/weather-applet.js:16747
+msgid "Precipitation will end in {precipEnd} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16749
+msgid "Precipitation won't end in within an hour"
+msgstr ""
+
+#: 3.8/weather-applet.js:16752
+msgid "Precipitation will start within {precipStart} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16964
+msgid "Forecast parsing failed, see logs for more details."
+msgstr ""
+
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
+msgid "As of {lastUpdatedTime}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17502
+msgid "{distance} {distanceUnit} from you"
+msgstr ""
+
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
+msgid "Error Saving Debug Information"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Debug Information saved successfully"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Saved to {filePath}"
+msgstr ""
+
+#: 3.8/LogSaver.py:16
+msgid "Save to File"
+msgstr ""
+
+#: 3.8/LogSaver.py:29
+msgid "Select a destination"
+msgstr ""
+
+#. metadata.json->name
+#. 3.8->settings-schema.json->providers->title
+msgid "Weather"
+msgstr ""
+
+#. metadata.json->description
+msgid "View your local weather forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->head->description
+msgid "Settings for weather@mockturtl 3.0+"
+msgstr ""
+
+#. 3.0->settings-schema.json->keybinding->description
+#. 3.8->settings-schema.json->keybinding->description
+msgid "Set the keybinding to call the menu"
+msgstr ""
+
+#. 3.0->settings-schema.json->descriptions->description
+msgid "Weather service information"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->description
+msgid "Click here for detailed description"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->tooltip
+#. 3.0->settings-schema.json->getLocation->tooltip
+#. 3.8->settings-schema.json->getLocation->tooltip
+msgid "Opens webpage guide"
+msgstr ""
+
+#. 3.0->settings-schema.json->providerSettings->description
+#. 3.8->settings-schema.json->provider-options->title
+msgid "Weather Provider Options"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->description
+#. 3.8->settings-schema.json->dataService->description
+msgid "Data service"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "DarkSky (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weatherbit (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Yahoo"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Climacell (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->description
+#. 3.8->settings-schema.json->apiKey->description
+msgid "API Key"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->tooltip
+#. 3.8->settings-schema.json->apiKey->tooltip
+msgid "Copy this from your account of the used Data service and paste it here."
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->description
+#. 3.8->settings-schema.json->manualLocation->description
+msgid "Manual Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->tooltip
+#. 3.8->settings-schema.json->manualLocation->tooltip
+msgid "Enable this if your location is not accurate"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->description
+msgid "Location - Coordinates"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->tooltip
+msgid ""
+"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an "
+"address.\n"
+"Waits for 3 seconds after you stop typing before refreshes the weather."
+msgstr ""
+
+#. 3.0->settings-schema.json->getLocation->description
+msgid "Setup API Key and Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->units
+#. 3.8->settings-schema.json->refreshInterval->units
+msgid "minutes"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->description
+#. 3.8->settings-schema.json->refreshInterval->description
+msgid "Update interval"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastDays->units
+#. 3.8->settings-schema.json->forecastDays->units
+msgid "days"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastDays->description
+#. 3.8->settings-schema.json->forecastDays->description
+msgid "Forecast length"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastHours->units
+#. 3.8->settings-schema.json->forecastHours->units
+msgid "hours"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastHours->description
+#. 3.8->settings-schema.json->forecastHours->description
+msgid "Hourly Forecast length"
+msgstr ""
+
+#. 3.0->settings-schema.json->unitSettings->description
+msgid "Units"
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureUnit->description
+#. 3.8->settings-schema.json->temperatureUnit->description
 #, fuzzy
 msgid "Temperature unit"
 msgstr "درجة الحرارة:"
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "fahrenheit"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Automatic"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "celsius"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+msgid "Celsius"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->translateCondition->description
-msgid "Translate condition"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+msgid "Fahrenheit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->locationLabelOverride->description
-msgid "Override location label"
+#. 3.0->settings-schema.json->temperatureUnit->tooltip
+#. 3.0->settings-schema.json->distanceUnit->tooltip
+#. 3.8->settings-schema.json->temperatureUnit->tooltip
+#. 3.8->settings-schema.json->distanceUnit->tooltip
+msgid ""
+"Automatic will try to guess your preference based your current display "
+"language."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->show24Hours->description
-msgid "Display time in 24 hour format"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->forecastDays->description
-msgid "Forecast length"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->forecastDays->units
-msgid "days"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->showSunrise->description
-msgid "Show sunrise / sunset times"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->description
+#. 3.0->settings-schema.json->windSpeedUnit->description
+#. 3.8->settings-schema.json->windSpeedUnit->description
 msgid "Wind speed unit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
 msgid "kph"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "m/s"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "knots"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
 msgid "mph"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showCommentInPanel->description
-msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "m/s"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->description
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "knots"
+msgstr ""
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "Beaufort"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->description
+#. 3.8->settings-schema.json->pressureUnit->description
 msgid "Atmospheric pressure unit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "psi"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "hPa"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "atm"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "kPa"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "Pa"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mm Hg"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "at"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mbar"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
 msgid "in Hg"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->description
-msgid "Update interval"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "mm Hg"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->units
-msgid "minutes"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "psi"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->useSymbolicIcons->description
-msgid "Symbolic icons"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "at"
 msgstr ""
 
-#. cinnamon-weather->metadata.json->description
-msgid "View your local weather forecast"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "atm"
 msgstr ""
 
-#. cinnamon-weather->metadata.json->name
-msgid "Weather"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "Pa"
 msgstr ""
 
-#~ msgid "Please wait"
-#~ msgstr "انتظر رجاءً"
+#. 3.0->settings-schema.json->distanceUnit->description
+#. 3.8->settings-schema.json->distanceUnit->description
+msgid "Distance unit"
+msgstr ""
 
-#~ msgid "Today"
-#~ msgstr "اليوم"
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Metric"
+msgstr ""
 
-#~ msgid "Tomorrow"
-#~ msgstr "غداً"
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Imperial"
+msgstr ""
+
+#. 3.0->settings-schema.json->panelSettings->description
+msgid "Panel options"
+msgstr ""
+
+#. 3.0->settings-schema.json->showTextInPanel->description
+#. 3.8->settings-schema.json->showTextInPanel->description
+msgid "Display current temperature in panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->showCommentInPanel->description
+#. 3.8->settings-schema.json->showCommentInPanel->description
+msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->showCommentInPanel->tooltip
+#. 3.8->settings-schema.json->showCommentInPanel->tooltip
+msgid "Only works with horizontal panels"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempTextOverride->description
+#. 3.8->settings-schema.json->tempTextOverride->description
+msgid "Override label on panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.0->settings-schema.json->useCustomMenuIcons->tooltip
+#. 3.8->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.8->settings-schema.json->useCustomMenuIcons->tooltip
+msgid "Iconset is weather-icons by Erik Flowers"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->description
+#. 3.8->settings-schema.json->useCustomAppletIcons->description
+msgid "Use custom icons on the panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->displaySettings->description
+#. 3.8->settings-schema.json->presentation-section->title
+msgid "Presentation"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->description
+#. 3.8->settings-schema.json->verticalOrientation->description
+msgid "Show forecast vertically"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->units
+#. 3.8->settings-schema.json->forecastColumns->units
+msgid "columns"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->description
+#. 3.8->settings-schema.json->forecastColumns->description
+msgid "Maximum number of columns for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->units
+#. 3.8->settings-schema.json->forecastRows->units
+msgid "rows"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->description
+#. 3.8->settings-schema.json->forecastRows->description
+msgid "Maximum number of rows for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->showSunrise->description
+#. 3.8->settings-schema.json->showSunrise->description
+msgid "Show sunrise / sunset times"
+msgstr ""
+
+#. 3.0->settings-schema.json->show24Hours->description
+#. 3.8->settings-schema.json->show24Hours->description
+msgid "Display time in 24 hour format"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->description
+#. 3.8->settings-schema.json->shortHourlyTime->description
+msgid "Only display hours for hourly forecast time"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->tooltip
+#. 3.8->settings-schema.json->shortHourlyTime->tooltip
+msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->description
+#. 3.8->settings-schema.json->showForecastDates->description
+msgid "Display date for daily forecasts"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->tooltip
+#. 3.8->settings-schema.json->showForecastDates->tooltip
+msgid "Like \"Friday 15\""
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureHighFirst->description
+#. 3.8->settings-schema.json->temperatureHighFirst->description
+msgid "Show high temperature first in forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempRussianStyle->description
+#. 3.8->settings-schema.json->tempRussianStyle->description
+#, fuzzy
+msgid "Show temperature Russian style"
+msgstr "درجة الحرارة:"
+
+#. 3.0->settings-schema.json->locationLabelOverride->description
+#. 3.8->settings-schema.json->locationLabelOverride->description
+msgid "Override location label"
+msgstr ""
+
+#. 3.0->settings-schema.json->conditionSettings->description
+#. 3.8->settings-schema.json->weather-conditions->title
+msgid "Weather conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->translateCondition->description
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Translate conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortConditions->description
+#. 3.8->settings-schema.json->shortConditions->description
+msgid "Less verbose conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->iconSettings->description
+#. 3.8->settings-schema.json->icons->title
+msgid "Icons"
+msgstr ""
+
+#. 3.0->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons in the applet"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomMenuIcons->description
+#. 3.8->settings-schema.json->useCustomMenuIcons->description
+msgid "Use custom icons in the popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->locations-page->title
+#. 3.8->settings-schema.json->location->description
+msgid "Location"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-page->title
+msgid "Other options"
+msgstr ""
+
+#. 3.8->settings-schema.json->info-section->title
+msgid "Help"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-section->title
+msgid "Location settings"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-store->title
+msgid "Saved Locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->panel-options->title
+msgid "Panel (Taskbar)"
+msgstr ""
+
+#. 3.8->settings-schema.json->presentation->title
+msgid "Popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-section->title
+msgid "Other Units"
+msgstr ""
+
+#. 3.8->settings-schema.json->temp-unit-section->title
+#, fuzzy
+msgid "Temperature Unit"
+msgstr "درجة الحرارة:"
+
+#. 3.8->settings-schema.json->keybindings->title
+msgid "Keybindings"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info->title
+msgid "More about the Weather applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->submit-issue->title
+msgid "Report an issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->debug-options->title
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Debug"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->tooltip
+msgid ""
+"You can choose between several different weather forecast providers. Some "
+"providers require a API key to work, some have regional limits, differ in "
+"forecast length, and they all need a functional internet connection to work. "
+"The options are described in detail on the Cinnamon Spices Website which you "
+"can access with the button on the Help tab."
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Met Office UK (UK only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "US National Weather (US only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Pirate Weather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Visual Crossing (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Tomorrow.io (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "AccuWeather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weather Underground (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->location->tooltip
+msgid ""
+"You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use "
+"'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street} "
+"{City/Town} {Postcode} {Country}. The search algorithm is very flexible with "
+"the format. After 3 seconds without typing the address you entered is "
+"replaced automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->description
+msgid "Save current location to storage"
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->tooltip
+msgid ""
+"Saves location information to file so you can switch between them with "
+"buttons in the applet, which will appear if you have more than one."
+msgstr ""
+
+#. 3.8->settings-schema.json->getLocation->description
+msgid "Weather Applet at Cinnamon Spices Website"
+msgstr ""
+
+#. 3.8->settings-schema.json->refreshInterval->tooltip
+msgid ""
+"If you are using a provider with API keys set it to an interval you won't "
+"run out of your quota with."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastDays->tooltip
+msgid ""
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->description
+msgid "Enable minutely precipitation forecast"
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->tooltip
+msgid ""
+"If you'd like to use this make sure you use your exact coordinates/address "
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
+msgstr ""
+
+#. 3.8->settings-schema.json->showBothTempUnits->description
+msgid "Show both temperature units at the same time"
+msgstr ""
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+msgid "Override tooltip on panel"
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
+msgid "Always show Hourly Weather"
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->tooltip
+msgid ""
+"Hide/Show button will be hidden and Hourly weather will be permanently "
+"visible."
+msgstr ""
+
+#. 3.8->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->description
+msgid "Your saved locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->tooltip
+msgid ""
+"You have to make sure the Search entry field is unique and your Timezone is "
+"in the IANA time zone format (e.g. 'Europe/London')"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Latitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Longitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "City"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Country"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Timezone"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Search entry"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->description
+msgid "Display wind direction as text"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->tooltip
+msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->tooltip
+msgid "Does not apply to custom iconset, that is symbolic by default"
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons throughout the applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info-label->description
+msgid ""
+"For detailed information about the applet please go to the Spices Website to "
+"find info about known issues, troubleshooting, changelog and more by "
+"clicking the button below. Here you can ask questions etc in the comment "
+"section by logging in with your Github account."
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->description
+msgid "Submit an Issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->tooltip
+msgid ""
+"Opens webpage where you can fill out a new issue for the applet, needs a "
+"GitHub account.\n"
+" Please make sure that the issue is not already submitted."
+msgstr ""
+
+#. 3.8->settings-schema.json->maintainer->description
+msgid "Current maintainer: Gr3q"
+msgstr ""
+
+#. 3.8->settings-schema.json->issue-reporting-explanation->description
+msgid ""
+"If you find an issue with this applet please make a report by clicking on "
+"the button below and login in with your Github account.\n"
+"\n"
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
+msgstr ""
+
+#. 3.8->settings-schema.json->loc-info->description
+msgid ""
+"Your location in most cases work automatically but you can enter it manually "
+"by coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,"
+"Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/"
+"Town} {Postcode} {Country}. The search algorithm is very flexible with the "
+"format. After 3 seconds without typing the address you entered is replaced "
+"automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->description
+msgid "Log Level"
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->tooltip
+msgid ""
+"Info is the regular logging, Debug is debug, and Verbose also logs network "
+"request payloads. Changing this will only be effective on future logs. Only "
+"change it you are instructed or you know what you are doing."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Verbose"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->description
+msgid "Click Save to save debug information to a file"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->tooltip
+msgid ""
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
+msgstr ""
+
+#. 3.8->settings-schema.json->selectedLogPath->description
+msgid "Selected path to save Logs"
+msgstr ""

--- a/weather@mockturtl/files/weather@mockturtl/po/be.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/be.po
@@ -3,8 +3,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-04 08:45+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2023-02-03 18:53+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,65 +18,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:16977
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Памылка"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:16978 3.8/weather-applet.js:16980
-#: 3.8/weather-applet.js:16982 3.8/weather-applet.js:16985
-#: 3.8/weather-applet.js:16988 3.8/weather-applet.js:16989
-#: 3.8/weather-applet.js:16990 3.8/weather-applet.js:16991
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Памылка сэрвіса"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:16979
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Няправільны ключ API"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:16981
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Няправільны фармат месцазнаходжаньня"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:16983
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Ключ заблякаваны"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:16984
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Немагчыма знайсьці месцазнаходжаньне"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:16986
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Няма ключу API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:16987
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Няма месцазнаходжаньня"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:16992
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Адсутнічаюць пакункі"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:16993
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Месцазнаходжаньне не падтрымліваецца"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9309
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Надвор'е"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17312
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17313
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Націсьніце каб адкрыць"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:15699
-#: 3.8/weather-applet.js:17316
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Абнавіць"
 
@@ -85,8 +86,8 @@ msgstr "API вярнуў код статусу між 400 і 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9475
-#: 3.8/weather-applet.js:9479 3.8/weather-applet.js:9483
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Захаваньне месцазнаходжаньня"
 
@@ -99,13 +100,13 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr "Немагчыма атрымаць інфармацыі пра надвор'е"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17139
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Нечаканая памылка падчас абнаўленьня надвор'я, гл. логі ў Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:17394
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -121,7 +122,7 @@ msgstr "Памылка сеткі, гл. логі ў Looking Glass"
 msgid "As of"
 msgstr "У стане на"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:16392
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "З дапамогай"
 
@@ -129,93 +130,91 @@ msgstr "З дапамогай"
 msgid "from you"
 msgstr "ад вас"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16313
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "мм"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:10273
-#: 3.8/weather-applet.js:16313
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "у"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:9911
-#: 3.8/weather-applet.js:16470
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "міляў"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:9912
-#: 3.8/weather-applet.js:16471
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "км"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:16650
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Загрузка бягучага надвор'я ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:16653
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Загрузка прагнозу надвор'я ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:15652
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Загрузка ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:15673
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Тэмпэратура"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:15674
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Вільготнасьць"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:15675
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Ціск"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12143 3.8/weather-applet.js:12150
-#: 3.8/weather-applet.js:12151 3.8/weather-applet.js:12157
-#: 3.8/weather-applet.js:14103 3.8/weather-applet.js:14104
-#: 3.8/weather-applet.js:15524
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Вецер"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:14935
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Пераканайцеся, што Вы ўвялі месцазнаходжаньне, ці скарыстайцеся аўтаматычным "
 "месцазнаходжаньнем"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9555
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Немагчыма знайсьці месцазнаходжаньне па адрасе, праверце дакладнасьць даных"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9576
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "Не атрымалася выклікаць Geolocation API, гл. логі ў Looking Glass."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9475
-#: 3.8/weather-applet.js:9479
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Увага"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9475
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Вы можаце захаваць правільныя месцазнаходжаньні толькі калі аплет не "
 "абнаўляецца"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9479
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Вы ня можаце захаваць няправільнае месцазнаходжаньне"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9483
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Інфармацыя"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9483
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Месцазнаходжаньне ўжо захаванае"
 
@@ -253,15 +252,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10353 3.8/weather-applet.js:10645
-#: 3.8/weather-applet.js:11608 3.8/weather-applet.js:12046
-#: 3.8/weather-applet.js:12551 3.8/weather-applet.js:12913
-#: 3.8/weather-applet.js:14272
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Адчуваецца як"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:10398
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Не атрымалася апрацаваць інфармацыю пра надвор'е"
 
@@ -274,7 +273,7 @@ msgstr ""
 "ці спачатку атрымайце яго на https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:10282 3.8/weather-applet.js:11778
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -282,7 +281,7 @@ msgstr ""
 "Калі ласка, пераканайцеся, што\n"
 "уведзены ключ API правільны і ваш акаўнт не заблякаваны"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12012
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -293,60 +292,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10112 3.8/weather-applet.js:10119
-#: 3.8/weather-applet.js:10126 3.8/weather-applet.js:10127
-#: 3.8/weather-applet.js:11282 3.8/weather-applet.js:11283
-#: 3.8/weather-applet.js:11289 3.8/weather-applet.js:11296
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12186
-#: 3.8/weather-applet.js:13079
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Моцны дождж"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11457 3.8/weather-applet.js:11458
-#: 3.8/weather-applet.js:11464 3.8/weather-applet.js:12171
-#: 3.8/weather-applet.js:12172 3.8/weather-applet.js:12178
-#: 3.8/weather-applet.js:12185 3.8/weather-applet.js:12227
-#: 3.8/weather-applet.js:12234 3.8/weather-applet.js:12241
-#: 3.8/weather-applet.js:12695 3.8/weather-applet.js:12744
-#: 3.8/weather-applet.js:12745 3.8/weather-applet.js:12752
-#: 3.8/weather-applet.js:13071 3.8/weather-applet.js:13338
-#: 3.8/weather-applet.js:13339 3.8/weather-applet.js:13380
-#: 3.8/weather-applet.js:14075 3.8/weather-applet.js:14076
-#: 3.8/weather-applet.js:14438 3.8/weather-applet.js:14439
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Дождж"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10084
-#: 3.8/weather-applet.js:10091 3.8/weather-applet.js:10105
-#: 3.8/weather-applet.js:10106 3.8/weather-applet.js:10914
-#: 3.8/weather-applet.js:11366 3.8/weather-applet.js:11367
-#: 3.8/weather-applet.js:11373 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:11387 3.8/weather-applet.js:12179
-#: 3.8/weather-applet.js:13081
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Лёгкі дождж"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12242 3.8/weather-applet.js:13055
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Моцны ледзяны дождж"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:10919
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12716
-#: 3.8/weather-applet.js:12717 3.8/weather-applet.js:12723
-#: 3.8/weather-applet.js:12724 3.8/weather-applet.js:12730
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Ледзяны дождж"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12235 3.8/weather-applet.js:13057
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Лёгкі ледзяны дождж"
 
@@ -354,189 +353,189 @@ msgstr "Лёгкі ледзяны дождж"
 msgid "Light freezing drizzle"
 msgstr "Лёгкая ледзяная імжа"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12221
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Ледзяная імжа"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13037
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Лёгкая імжа"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12256
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Моцны град"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12248 3.8/weather-applet.js:12249
-#: 3.8/weather-applet.js:12255 3.8/weather-applet.js:12262
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Град"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12263
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Лёгкі град"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10196
-#: 3.8/weather-applet.js:10203 3.8/weather-applet.js:10210
-#: 3.8/weather-applet.js:10211 3.8/weather-applet.js:10926
-#: 3.8/weather-applet.js:11338 3.8/weather-applet.js:11339
-#: 3.8/weather-applet.js:11345 3.8/weather-applet.js:11352
-#: 3.8/weather-applet.js:11359 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:13097 3.8/weather-applet.js:13415
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Моцны сьнегапад"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:10925 3.8/weather-applet.js:11513
-#: 3.8/weather-applet.js:11514 3.8/weather-applet.js:11520
-#: 3.8/weather-applet.js:12192 3.8/weather-applet.js:12193
-#: 3.8/weather-applet.js:12206 3.8/weather-applet.js:12213
-#: 3.8/weather-applet.js:12688 3.8/weather-applet.js:12689
-#: 3.8/weather-applet.js:13091 3.8/weather-applet.js:13324
-#: 3.8/weather-applet.js:13408 3.8/weather-applet.js:14089
-#: 3.8/weather-applet.js:14090 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14467
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Сьнегапад"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10175
-#: 3.8/weather-applet.js:10182 3.8/weather-applet.js:10189
-#: 3.8/weather-applet.js:10190 3.8/weather-applet.js:10924
-#: 3.8/weather-applet.js:11422 3.8/weather-applet.js:11423
-#: 3.8/weather-applet.js:11429 3.8/weather-applet.js:11436
-#: 3.8/weather-applet.js:11443 3.8/weather-applet.js:12207
-#: 3.8/weather-applet.js:13099
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Лёгкі сьнегапад"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12199
-#: 3.8/weather-applet.js:12200 3.8/weather-applet.js:14445
-#: 3.8/weather-applet.js:14446
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Кароткачасовыя сьнегапады"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10899
-#: 3.8/weather-applet.js:12269 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12761 3.8/weather-applet.js:12762
-#: 3.8/weather-applet.js:13103 3.8/weather-applet.js:13422
-#: 3.8/weather-applet.js:13423 3.8/weather-applet.js:14096
-#: 3.8/weather-applet.js:14097
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Навальніца"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12137
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Лёгкі туман"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10063 3.8/weather-applet.js:10064
-#: 3.8/weather-applet.js:10938 3.8/weather-applet.js:11275
-#: 3.8/weather-applet.js:11276 3.8/weather-applet.js:12129
-#: 3.8/weather-applet.js:12130 3.8/weather-applet.js:12136
-#: 3.8/weather-applet.js:12831 3.8/weather-applet.js:12832
-#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:14047
-#: 3.8/weather-applet.js:14048 3.8/weather-applet.js:14494
-#: 3.8/weather-applet.js:14495
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Туман"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10070 3.8/weather-applet.js:10071
-#: 3.8/weather-applet.js:11261 3.8/weather-applet.js:11262
-#: 3.8/weather-applet.js:12101 3.8/weather-applet.js:12102
-#: 3.8/weather-applet.js:13317 3.8/weather-applet.js:13318
-#: 3.8/weather-applet.js:14040 3.8/weather-applet.js:14041
-#: 3.8/weather-applet.js:14536 3.8/weather-applet.js:14537
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Пахмурна"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12122
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:12639
-#: 3.8/weather-applet.js:12640 3.8/weather-applet.js:12674
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Пераважна воблачна"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10035
-#: 3.8/weather-applet.js:10036 3.8/weather-applet.js:10042
-#: 3.8/weather-applet.js:10043 3.8/weather-applet.js:11450
-#: 3.8/weather-applet.js:11451 3.8/weather-applet.js:12115
-#: 3.8/weather-applet.js:12116 3.8/weather-applet.js:12632
-#: 3.8/weather-applet.js:12633 3.8/weather-applet.js:12667
-#: 3.8/weather-applet.js:13310 3.8/weather-applet.js:13311
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Малавоблачна"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12108
-#: 3.8/weather-applet.js:12109
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Пераважна ясна"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10021 3.8/weather-applet.js:10022
-#: 3.8/weather-applet.js:10944 3.8/weather-applet.js:12094
-#: 3.8/weather-applet.js:12095 3.8/weather-applet.js:12618
-#: 3.8/weather-applet.js:12619 3.8/weather-applet.js:12653
-#: 3.8/weather-applet.js:13115 3.8/weather-applet.js:13303
-#: 3.8/weather-applet.js:13304 3.8/weather-applet.js:14026
-#: 3.8/weather-applet.js:14027 3.8/weather-applet.js:14033
-#: 3.8/weather-applet.js:14034 3.8/weather-applet.js:14571
-#: 3.8/weather-applet.js:14572
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Ясна"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10028
-#: 3.8/weather-applet.js:10029 3.8/weather-applet.js:12094
-#: 3.8/weather-applet.js:12095 3.8/weather-applet.js:14578
-#: 3.8/weather-applet.js:14579
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Сонечна"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10014
-#: 3.8/weather-applet.js:10015 3.8/weather-applet.js:10049
-#: 3.8/weather-applet.js:10050 3.8/weather-applet.js:10238
-#: 3.8/weather-applet.js:10239 3.8/weather-applet.js:11244
-#: 3.8/weather-applet.js:11245 3.8/weather-applet.js:11542
-#: 3.8/weather-applet.js:11543 3.8/weather-applet.js:12086
-#: 3.8/weather-applet.js:12087 3.8/weather-applet.js:12609
-#: 3.8/weather-applet.js:12610 3.8/weather-applet.js:12838
-#: 3.8/weather-applet.js:12839 3.8/weather-applet.js:13959
-#: 3.8/weather-applet.js:13960 3.8/weather-applet.js:14110
-#: 3.8/weather-applet.js:14111 3.8/weather-applet.js:14682
-#: 3.8/weather-applet.js:14684
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Невядома"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10273
+#: 3.0/darkSky.js:71
 msgid "and"
 msgstr "і"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10273
+#: 3.0/darkSky.js:71
 msgid "until"
 msgstr "да"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10273
+#: 3.0/darkSky.js:71
 msgid "Possible"
 msgstr "Магчыма"
 
@@ -548,7 +547,7 @@ msgstr ""
 "Калі ласка, увядзіце ключ API у наладах,\n"
 "ці спачатку атрымайце яго на https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:10292
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -556,130 +555,130 @@ msgstr ""
 "Калі ласка, пераканайцеся, што\n"
 "вы ўвялі ключ API, атрыманы ад DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:9254
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Не атрымалася знайсьці месцазнаходжаньне"
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:9260
+#: 3.0/ipApi.js:95
 msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr "Сэрвіс месцазнаходжаньня адказаў з памылкамі, гл. логі ў Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11106
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Воблачна"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:10945 3.8/weather-applet.js:11254
-#: 3.8/weather-applet.js:11255
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Ясна"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11268 3.8/weather-applet.js:11269
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Пагода"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11290
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Моцны дождж з навальніцай"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11297
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Моцныя залевы"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11304
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Моцныя залевы з навальніцай"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11310
-#: 3.8/weather-applet.js:11311 3.8/weather-applet.js:11317
-#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:11331
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Моцны мокры сьнегапад"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11318
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Моцны мокры сьнегапад з навальніцай"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11325
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Моцны дождж з мокрым сьнегам"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11332
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Моцны дождж з мокрым сьнегам і навальніцай"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11346
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Моцны сьнегапад з навальніцай"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11353
-#: 3.8/weather-applet.js:13416
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Моцны сьнегапад"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11360
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Моцны сьнегапад з навальніцай"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11374
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Лёгкі дождж з навальніцай"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11381
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Кароткачасовыя залевы"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11388
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Кароткачасовыя залевы з навальніцай"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11394
-#: 3.8/weather-applet.js:11395 3.8/weather-applet.js:11401
-#: 3.8/weather-applet.js:11408 3.8/weather-applet.js:11415
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Невялікі мокры сьнег"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11402
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Невялікі мокры сьнег з навальніцай"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11409
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Кароткачасовыя залевы з мокрым сьнегам"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11416
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Кароткачасовыя залевы з мокрым сьнегам і навальніцай"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11430
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Лёгкі сьнег з навальніцай"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11437
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Кароткачасовыя сьнегапады"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11444
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Кароткачасовыя сьнегапады з навальніцай"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11465
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Дождж з навальніцай"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11471
-#: 3.8/weather-applet.js:11472 3.8/weather-applet.js:11478
-#: 3.8/weather-applet.js:12753 3.8/weather-applet.js:13077
-#: 3.8/weather-applet.js:13381 3.8/weather-applet.js:13387
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Залевы"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11479
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Залевы з навальніцай"
 
@@ -688,44 +687,44 @@ msgstr "Залевы з навальніцай"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10133
-#: 3.8/weather-applet.js:10140 3.8/weather-applet.js:10147
-#: 3.8/weather-applet.js:10148 3.8/weather-applet.js:10927
-#: 3.8/weather-applet.js:11485 3.8/weather-applet.js:11486
-#: 3.8/weather-applet.js:11492 3.8/weather-applet.js:11499
-#: 3.8/weather-applet.js:11506 3.8/weather-applet.js:12702
-#: 3.8/weather-applet.js:12703 3.8/weather-applet.js:12709
-#: 3.8/weather-applet.js:12710 3.8/weather-applet.js:12737
-#: 3.8/weather-applet.js:12738 3.8/weather-applet.js:14082
-#: 3.8/weather-applet.js:14083 3.8/weather-applet.js:14480
-#: 3.8/weather-applet.js:14481
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Мокры сьнег"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11493
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Мокры сьнег з навальніцай"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11500
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Залева з мокрым сьнегам"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11507
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Залева з мокрым сьнегам і навальніцай"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11521
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Сьнег з навальніцай"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11527 3.8/weather-applet.js:11528
-#: 3.8/weather-applet.js:11534 3.8/weather-applet.js:13095
-#: 3.8/weather-applet.js:13409
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Сьнег"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11535
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Сьнегапад з навальніцай"
 
@@ -734,20 +733,21 @@ msgstr "Сьнегапад з навальніцай"
 msgid "Unexpected response from API"
 msgstr "Нечаканы адказ ад API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:9836
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Бачнасьць"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:9864 3.8/weather-applet.js:10722
-#: 3.8/weather-applet.js:11619 3.8/weather-applet.js:12564
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Не атрымалася апрацаваць інфармацыю пра бягучае надвор'е"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:9655
-#: 3.8/weather-applet.js:9689 3.8/weather-applet.js:11645
-#: 3.8/weather-applet.js:11679 3.8/weather-applet.js:12366
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Не атрымалася апрацаваць прагноз надвор'я"
 
@@ -776,90 +776,90 @@ msgid "Excellent - More than"
 msgstr "Выдатная - больш за"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10056 3.8/weather-applet.js:10057
-#: 3.8/weather-applet.js:10934 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Туман"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10077
-#: 3.8/weather-applet.js:10078 3.8/weather-applet.js:12646
-#: 3.8/weather-applet.js:12647 3.8/weather-applet.js:12681
-#: 3.8/weather-applet.js:13111
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Пахмурна"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10085
-#: 3.8/weather-applet.js:10092
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Кароткачасовая залева"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10098 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10906 3.8/weather-applet.js:12164
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12220
-#: 3.8/weather-applet.js:13033 3.8/weather-applet.js:14417
-#: 3.8/weather-applet.js:14418
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Імжа"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10113
-#: 3.8/weather-applet.js:10120
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Моцная залева"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10134
-#: 3.8/weather-applet.js:10141
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Дождж са сьнегам"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10154 3.8/weather-applet.js:10161
-#: 3.8/weather-applet.js:10168 3.8/weather-applet.js:10169
-#: 3.8/weather-applet.js:13109 3.8/weather-applet.js:14054
-#: 3.8/weather-applet.js:14055 3.8/weather-applet.js:14473
-#: 3.8/weather-applet.js:14474
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Град"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10155
-#: 3.8/weather-applet.js:10162
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Моцны град"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10176
-#: 3.8/weather-applet.js:10183
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Лёгкі сьнегапад"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10197
-#: 3.8/weather-applet.js:10204
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Моцны сьнегапад"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10217 3.8/weather-applet.js:10224
-#: 3.8/weather-applet.js:10231 3.8/weather-applet.js:10232
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Навальніца"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10218
-#: 3.8/weather-applet.js:10225
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Залева з навальніцай"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10777
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Калі ласка, пераканайцеся, што месцазнаходжаньне ў наладах у правільным "
 "фармаце"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10781
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Пераканайцеся, што вы ўвялі правільны ключ у наладах"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10785
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -867,212 +867,212 @@ msgstr ""
 "Месцазнаходжаньне ня знойдзена, пераканайцеся, што яно даступна і ў "
 "правільным фармаце"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10789
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 "Калі гэтая праблема паўтараецца, калі ласка, зьвярніцеся да аўтара аплета"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10793
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Нечаканая памылка, гл. логі ў Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10895
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Навальніца зь лэгкім дажджом"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10896
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Навальніца з дажджом"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10897
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Навальніца з моцным дажджом"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10898
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Лёгкая навальніца"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10900
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Моцная навальніца"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10901
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Ірваная навальніца"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10902
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Навальніца зь лёгкай імжою"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10903
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Навальніца зь імжою"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10904
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Навальніца з моцнай імжою"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:10905
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Слабая імжа"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:10907
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Моцная імжа"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:10908
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Лёгкі імжысты дождж"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:10909
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Імжысты дождж"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:10910
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Моцны імжысты дождж"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:10911
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Залева зь імжой"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:10912
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Моцная залева зь імжой"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:10913
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Імжыстая залева"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:10915
-#: 3.8/weather-applet.js:13345 3.8/weather-applet.js:13346
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Сярэдні дождж"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:10916
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Моцны дождж"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:10917
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Вельмі моцны дождж"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:10918
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Вельмі моцны дождж"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:10920
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Лёгкая залева"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:10921
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Залева"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:10922
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Моцная залева"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:10923
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Месцамі залева"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:10928
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Мокры сьнег"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:10929
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Лёгкі дождж са сьнегам"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:10930
-#: 3.8/weather-applet.js:13352 3.8/weather-applet.js:13353
-#: 3.8/weather-applet.js:13359 3.8/weather-applet.js:13394
-#: 3.8/weather-applet.js:13401
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Дождж са сьнегам"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:10931
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Лёгкі сьнег"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:10932
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Сьнегапад"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:10933
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Моцны сьнегапад"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:10935 3.8/weather-applet.js:12796
-#: 3.8/weather-applet.js:12797 3.8/weather-applet.js:14508
-#: 3.8/weather-applet.js:14509
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Дым"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:10936 3.8/weather-applet.js:12803
-#: 3.8/weather-applet.js:12804 3.8/weather-applet.js:14501
-#: 3.8/weather-applet.js:14502
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Туман"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:10937
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Пясок, пылавыя віхры"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:10939
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Пясок"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:10940 3.8/weather-applet.js:12789
-#: 3.8/weather-applet.js:12790 3.8/weather-applet.js:14487
-#: 3.8/weather-applet.js:14488
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Пыл"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:10941
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Вулканічны попел"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:10942
-#: 3.8/weather-applet.js:13101
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Шквал"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:10943 3.8/weather-applet.js:12768
-#: 3.8/weather-applet.js:12769 3.8/weather-applet.js:14360
-#: 3.8/weather-applet.js:14361
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Сьмерч"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:10946
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Яснае неба"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:10947
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Воблачна"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:10948
-#: 3.8/weather-applet.js:12625 3.8/weather-applet.js:12626
-#: 3.8/weather-applet.js:12660
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Месцамі воблачна"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:10949
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Рассыпістыя аблокі"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:10950
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Перарывістыя аблокі"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:10951
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Хмарна"
 
@@ -1080,80 +1080,80 @@ msgstr "Хмарна"
 msgid "Could not get forecast for your area"
 msgstr "Не ўдалося атрымаць прагноз для вашай мясцовасьці"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12323
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "Месцазнаходжаньне па-за ЗША, скарыстайцеся іншым сэрвісам."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12387
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Не атрымалася апрацаваць пагадзінны прагноз"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12654
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Ясна і ветрана"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12661
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Месцамі воблачна і ветрана"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12668
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Перарывістыя аблокі і ветрана"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12675
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Пераважна воблачна і ветрана"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12682
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Пахмурна і ветрана"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12696
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Сьнег з дажджом"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12731
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Імжысты дождж са сьнегам"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:8715 3.8/weather-applet.js:12775
-#: 3.8/weather-applet.js:12776 3.8/weather-applet.js:14374
-#: 3.8/weather-applet.js:14375
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Ураган"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:8710
-#: 3.8/weather-applet.js:12782
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Шторм"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12783
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Трапічны шторм"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12810 3.8/weather-applet.js:12811
-#: 3.8/weather-applet.js:14606 3.8/weather-applet.js:14607
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Сьпякотна"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12817 3.8/weather-applet.js:12818
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Халодна"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12824 3.8/weather-applet.js:12825
-#: 3.8/weather-applet.js:14655 3.8/weather-applet.js:14656
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Завіруха"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:8588
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Сёньня"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:8590
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Заўтра"
 
@@ -1185,79 +1185,79 @@ msgstr "Пятніца"
 msgid "Saturday"
 msgstr "Субота"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:8680
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Штыль"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:8683
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Лёгкі ветрык"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:8686
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Лёгкі вецер"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:8689
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Слабы вецер"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:8692
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Умераны вецер"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:8695
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Сьвежы вецер"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:8698
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Моцны вецер"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:8701
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Амаль шторм"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:8704
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Шторм"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:8707
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Моцны шторм"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:8713
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Вельмі моцны шторм"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8863
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "Пн"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8863
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "ПнУ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8863
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "У"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8863
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "ПдУ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8863
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "Пд"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8863
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "ПдЗ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8863
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "З"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8863
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "ПнЗ"
 
@@ -1308,7 +1308,7 @@ msgid ""
 msgstr ""
 "Нечаканая памылка падчас абнаўленьня надвор'я, гл. логі ў Looking Glass"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14367 3.8/weather-applet.js:14368
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Трапічны шторм"
 
@@ -1316,7 +1316,7 @@ msgstr "Трапічны шторм"
 msgid "Severe Thunderstorms"
 msgstr "Моцныя навальніцы"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14388 3.8/weather-applet.js:14389
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Навальніцы"
 
@@ -1332,15 +1332,15 @@ msgstr "Дождж з мокрым сьнегам"
 msgid "Mixed Snow and Sleet"
 msgstr "Сьнег з мокрым сьнегам"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14410 3.8/weather-applet.js:14411
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Ледзяная імжа"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14424 3.8/weather-applet.js:14425
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Ледзяны дождж"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14431 3.8/weather-applet.js:14432
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Залевы"
 
@@ -1352,11 +1352,11 @@ msgstr "Сьнежныя парывы"
 msgid "Light Snow Showers"
 msgstr "Невялікія сьнегапады"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14459 3.8/weather-applet.js:14460
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Завіруха"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13331 3.8/weather-applet.js:13332
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Туманна"
 
@@ -1368,54 +1368,54 @@ msgstr "Дымна"
 msgid "Blustery"
 msgstr "Парывісты вецер"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14522 3.8/weather-applet.js:14523
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Ветрана"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:14543 3.8/weather-applet.js:14544
-#: 3.8/weather-applet.js:14550 3.8/weather-applet.js:14551
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Пераважна воблачна"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14061 3.8/weather-applet.js:14062
-#: 3.8/weather-applet.js:14068 3.8/weather-applet.js:14069
-#: 3.8/weather-applet.js:14557 3.8/weather-applet.js:14558
-#: 3.8/weather-applet.js:14564 3.8/weather-applet.js:14565
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Малавоблачна"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:14592 3.8/weather-applet.js:14593
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Пераважна сонечна"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:14599 3.8/weather-applet.js:14600
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Дождж с градам"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:14613 3.8/weather-applet.js:14614
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Асобныя навальніцы"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:14620 3.8/weather-applet.js:14621
-#: 3.8/weather-applet.js:14676 3.8/weather-applet.js:14677
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Месцамі навальніцы"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:14627 3.8/weather-applet.js:14628
-#: 3.8/weather-applet.js:14662 3.8/weather-applet.js:14663
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Месцамі залевы"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:14634 3.8/weather-applet.js:14635
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Моцны дождж"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:14641 3.8/weather-applet.js:14642
-#: 3.8/weather-applet.js:14669 3.8/weather-applet.js:14670
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Месцамі сьнегавыя залевы"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:14648 3.8/weather-applet.js:14649
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Моцны сьнег"
 
@@ -1427,7 +1427,7 @@ msgstr "Не доступна"
 msgid "Scattered Thundershowers"
 msgstr "Месцамі навальнічныя залевы"
 
-#: 3.8/weather-applet.js:9193
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1435,7 +1435,7 @@ msgstr ""
 "Немагчыма атрымаць логі, файл логаў ня знойдзены па шляху\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9197
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1444,11 +1444,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:9616
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:9718
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1456,287 +1456,299 @@ msgstr ""
 "MET Office UK пакрывае толькі тэрыторыю Велікабрытаніі, калі ласка, "
 "пераканайцеся, што вашае месцазнаходжаньне ў гэтай краіне"
 
-#: 3.8/weather-applet.js:9796
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Ня знойдзены даныя для месцазнаходжаньня"
 
-#: 3.8/weather-applet.js:9877
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Вельмі слабая"
 
-#: 3.8/weather-applet.js:9877
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Менш за {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:9881
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Выдатная"
 
-#: 3.8/weather-applet.js:9881
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Больш за {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:9886
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Слабая"
 
-#: 3.8/weather-applet.js:9886 3.8/weather-applet.js:9891
-#: 3.8/weather-applet.js:9896 3.8/weather-applet.js:9901
-#: 3.8/weather-applet.js:9906
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Між {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:9891
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Сярэдняя"
 
-#: 3.8/weather-applet.js:9896
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Добрая"
 
-#: 3.8/weather-applet.js:9901 3.8/weather-applet.js:9906
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Вельмі добрая"
 
-#: 3.8/weather-applet.js:10258
-msgid "DarkSky"
-msgstr "DarkSky"
-
-#: 3.8/weather-applet.js:10308
-msgid "This API has ceased to function, please use another one."
-msgstr "Гэты API спыніў працу, скарыстайцеся іншым."
-
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10569
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11015
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:11558
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:11981
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12144
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Лёгкі вецер"
 
-#: 3.8/weather-applet.js:12158
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Моцны вецер"
 
-#: 3.8/weather-applet.js:12305
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:13031
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Завіруха"
 
-#: 3.8/weather-applet.js:13035
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Моцная імжа"
 
-#: 3.8/weather-applet.js:13039
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Моцны імжысты дождж"
 
-#: 3.8/weather-applet.js:13041
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Лёгкі імжысты дождж"
 
-#: 3.8/weather-applet.js:13043
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Пылавая бура"
 
-#: 3.8/weather-applet.js:13047
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Ледзяны імжысты дождж"
 
-#: 3.8/weather-applet.js:13049
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Моцны ледзяны імжысты дождж"
 
-#: 3.8/weather-applet.js:13051
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Лёгкая ледзяны імжысты дождж"
 
-#: 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Марозны туман"
 
-#: 3.8/weather-applet.js:13059
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Сьмерч"
 
-#: 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Залева з градам"
 
-#: 3.8/weather-applet.js:13063
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Лёд"
 
-#: 3.8/weather-applet.js:13065
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Маланкі бяз грому"
 
-#: 3.8/weather-applet.js:13069
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Ападкі побач"
 
-#: 3.8/weather-applet.js:13073 3.8/weather-applet.js:13360
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Моцны дождж са сьнегам"
 
-#: 3.8/weather-applet.js:13075
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Лёгкі дождж са сьнегам"
 
-#: 3.8/weather-applet.js:13083
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Неба прасьвятляецца"
 
-#: 3.8/weather-applet.js:13085
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Неба цямнее"
 
-#: 3.8/weather-applet.js:13087
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Неба бязь зьменаў"
 
-#: 3.8/weather-applet.js:13089
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Дым ці смуга"
 
-#: 3.8/weather-applet.js:13093
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Сьнег і залевы"
 
-#: 3.8/weather-applet.js:13105
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Навальніца без ападкаў"
 
-#: 3.8/weather-applet.js:13107
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Алмазны пыл"
 
-#: 3.8/weather-applet.js:13113
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Пераменная воблачнасьць"
 
-#: 3.8/weather-applet.js:13135
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Калі ласка, пераканайцеся, што уведзены ключ API правільны"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:13293
-#: 3.8/weather-applet.js:13429 3.8/weather-applet.js:13430
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "НЯ ЗНОЙДЗЕНА"
 
-#: 3.8/weather-applet.js:13325
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Замеці"
 
-#: 3.8/weather-applet.js:13366 3.8/weather-applet.js:13367
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Лёгкі сьнегапад"
 
-#: 3.8/weather-applet.js:13373 3.8/weather-applet.js:13374
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Умераны сьнегапад"
 
-#: 3.8/weather-applet.js:13388
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Умераныя залевы"
 
-#: 3.8/weather-applet.js:13395
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Дождж са сьнегам"
 
-#: 3.8/weather-applet.js:13402
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Моцны дождж са сьнегам"
 
-#: 3.8/weather-applet.js:13499
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:13841
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:13852
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "Калі ласка, абярыце іншы сэрвіс ці іншые месцазнаходжаньне"
 
-#: 3.8/weather-applet.js:14149
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14338
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "Уведзены ключ API нядзейсны."
 
-#: 3.8/weather-applet.js:14345
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "Уведзенае месцазнаходжаньне ня знойдзена."
 
-#: 3.8/weather-applet.js:14381 3.8/weather-applet.js:14382
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Моцны шторм"
 
-#: 3.8/weather-applet.js:14396 3.8/weather-applet.js:14397
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Дождж са сьнегам"
 
-#: 3.8/weather-applet.js:14403 3.8/weather-applet.js:14404
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Дождж з мокрым сьнегам"
 
-#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14453
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Сьнегапады"
 
-#: 3.8/weather-applet.js:14515 3.8/weather-applet.js:14516
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "Брыз"
 
-#: 3.8/weather-applet.js:14529 3.8/weather-applet.js:14530
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr "Халодна"
 
-#: 3.8/weather-applet.js:14585 3.8/weather-applet.js:14586
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Пераважна ясна"
 
-#: 3.8/weather-applet.js:15064
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:15603
+#, fuzzy
 msgid ""
-"Could not retrieve config, file was not found under path\n"
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr "Сэрвіс месцазнаходжаньня адказаў з памылкамі, гл. логі ў Looking Glass"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+"Пераканайцеся, што Вы ўвялі месцазнаходжаньне, ці скарыстайцеся аўтаматычным "
+"месцазнаходжаньнем"
+
+#: 3.8/weather-applet.js:15968
+#, fuzzy
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 "Немагчыма атрымаць налады, файл ня знойдзены па шляху\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15068
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1744,57 +1756,57 @@ msgstr ""
 "Немагчыма атрымаць зьмест файлу наладаў па шляху\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15676
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Гэты сэрвіс патрабуе ключ API для працы"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Кропка расы"
 
-#: 3.8/weather-applet.js:15748
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Ападкі скончацца на працягу {precipEnd} хвілінаў"
 
-#: 3.8/weather-applet.js:15750
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "Ападкі ня скончацца на працягу гадзіны"
 
-#: 3.8/weather-applet.js:15753
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Ападкі пачнуцца на працягу {precipStart} хвілінаў"
 
-#: 3.8/weather-applet.js:15961
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Памылка загрузкі прагнозу, глядзіце логі, каб даведацца падрабязьней"
 
-#: 3.8/weather-applet.js:16399 3.8/weather-applet.js:17147
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "У стане на {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:16405
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance}{distanceUnit} ад вас"
 
-#: 3.8/weather-applet.js:16409
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "Назва станцыі: {stationName}"
 
-#: 3.8/weather-applet.js:16412
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "Лакацыя: {stationArea}"
 
-#: 3.8/weather-applet.js:16944 3.8/weather-applet.js:16954
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Памылка захаваньня інфармацыі пра адладку"
 
-#: 3.8/weather-applet.js:16965
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Інфармацыя пра адладку пасьпяхова захаваная"
 
-#: 3.8/weather-applet.js:16965
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Захавана у {filePath}"
-
-#: 3.8/weather-applet.js:17106
-msgid "This provider requires an API key to operate"
-msgstr "Гэты сэрвіс патрабуе ключ API для працы"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -1848,7 +1860,6 @@ msgid "Data service"
 msgstr "Сэрвіс даных"
 
 #. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
 msgid "DarkSky (key needed)"
 msgstr "DarkSky (патрабуе ключ)"
 
@@ -2295,6 +2306,11 @@ msgid "US National Weather (US only)"
 msgstr "US National Weather (толькі ЗША)"
 
 #. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Pirate Weather (key needed)"
+msgstr "Weatherbit (патрабуе ключ)"
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Visual Crossing (key needed)"
 msgstr "Visual Crossing (патрабуе ключ)"
 
@@ -2323,6 +2339,12 @@ msgstr ""
 "дому} {Вуліца} {Горад} {Паштовы індэкс} {Краіна}. Альгарытм пошуку вельмі "
 "гібкі датычна фармату. Пасьля 3 сэкундаў бяз уводу адрас аўтаматычна "
 "замяняецца для валідацыі."
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
 
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"
@@ -2371,10 +2393,11 @@ msgid "Enable minutely precipitation forecast"
 msgstr "Уключыць штохвілінны прагноз ападкаў"
 
 #. 3.8->settings-schema.json->immediatePrecip->tooltip
+#, fuzzy
 msgid ""
 "If you'd like to use this make sure you use your exact coordinates/address "
-"as location to help its accuracy. Currently implemented with OpenWeatherMap "
-"and MET Norway only."
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
 msgstr ""
 "Калі вы хочаце гэтым скарыстацца, пераканайцеся, што вы выкарыстоўваеце "
 "дакладныя каардынаты/адрас як месцазнаходжаньне, каб павялічыць "
@@ -2395,6 +2418,16 @@ msgstr ""
 "вымярэньня.\n"
 "Можа быць выкарыстана, калі метка не зьмяшчаецца на вертыкальнай панэлі з "
 "улікам іншых дробязяў."
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+#, fuzzy
+msgid "Override tooltip on panel"
+msgstr "Перавызначыць метку на панэлі"
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
 
 #. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
 msgid "Always show Hourly Weather"
@@ -2567,21 +2600,3 @@ msgstr ""
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr "Абраны шлях захаваньня логаў"
-
-#~ msgid "Climacell"
-#~ msgstr "Climacell"
-
-#~ msgid "Light Snow"
-#~ msgstr "Небольшой снегопад"
-
-#~ msgid "API key doesn't provide access to Hourly Weather, skipping"
-#~ msgstr "Ключ API не предоставляет доступ к почасовому прогнозу. Пропущено."
-
-#~ msgid "Instead of 15:00 or 3 pm it will show up as 15 or 3 pm"
-#~ msgstr "Вместо 15:00 или 3 pm дня будет отображаться 15 или 3 pm"
-
-#~ msgid "ClimacellV4 (key needed)"
-#~ msgstr "ClimacellV4 (требуется ключ)"
-
-#~ msgid "ClimacellV3 (key needed)"
-#~ msgstr "ClimacellV3 (требуется ключ)"

--- a/weather@mockturtl/files/weather@mockturtl/po/bg.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/bg.po
@@ -8,8 +8,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: weather@mockturtl 2.4.3\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-24 09:42+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2023-03-23 12:17+0200\n"
 "Last-Translator: Angel Ivanov <angel.ivanov@outlook.com>\n"
 "Language-Team: български <>\n"
@@ -20,65 +21,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17472
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Грешка"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17473 3.8/weather-applet.js:17475
-#: 3.8/weather-applet.js:17477 3.8/weather-applet.js:17480
-#: 3.8/weather-applet.js:17483 3.8/weather-applet.js:17484
-#: 3.8/weather-applet.js:17485 3.8/weather-applet.js:17486
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Грешка в услугата"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17474
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Неправилен API ключ"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17476
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Неправилен формат на местоположението"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17478
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Блокиран ключ"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17479
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Местоположението не е открито"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17481
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Не е въведен API ключ"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17482
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Не е въведено местоположение"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17487
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Липсващи пакети"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17488
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Местоположението не се поддържа от избрания доставчик на прогноза"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9748
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Аплет за Времето"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17797
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17798
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Натиснете за да се отвори"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16181
-#: 3.8/weather-applet.js:17801
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Обнови"
 
@@ -88,8 +89,8 @@ msgstr "API отговори със статус код между 400 и 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9914
-#: 3.8/weather-applet.js:9918 3.8/weather-applet.js:9922
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Запазване на Местоположение"
 
@@ -102,14 +103,14 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr "Неуспешно зареждане на прогнозата"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17636
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Възникна неизвестна грешка при обновлението на аплета за Времето, \n"
 "моля проверете лога в Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:17879
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -125,7 +126,7 @@ msgstr "Мрежова грешка, моля проверете логовет�
 msgid "As of"
 msgstr "Обновена в"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:16885
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Благодарение на"
 
@@ -133,96 +134,94 @@ msgstr "Благодарение на"
 msgid "from you"
 msgstr "от вас"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16798
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "мм"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:10721
-#: 3.8/weather-applet.js:16798
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "инча"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10354
-#: 3.8/weather-applet.js:16963
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "мили"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10355
-#: 3.8/weather-applet.js:16964
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "км"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17143
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Зареждане на текущата прогноза ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17146
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Зареждане на прогнозата за времето ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16134
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Зареждане ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16155
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Температура"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16156
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Влажност"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16157
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Налягане"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12599 3.8/weather-applet.js:12606
-#: 3.8/weather-applet.js:12607 3.8/weather-applet.js:12613
-#: 3.8/weather-applet.js:14569 3.8/weather-applet.js:14570
-#: 3.8/weather-applet.js:16006
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Вятър"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:15403
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Проверете дали сте въвели местоположение или използвайте\n"
 "Автоматичното му определяне"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9994
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Местоположението не може да бъде намерено по зададения адрес. Моля, "
 "проверете дали адреса е верен"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10015
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Повикването на API за определяне на местоположението не беше успешно. "
 "Проверете Looking Glass за грешки."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9914
-#: 3.8/weather-applet.js:9918
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Предупреждение"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9914
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Запазването на правилно зададено местоположение е възможно само когато "
 "аплета не се обновява"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9918
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Запазването на грешно местоположение е невъзможно"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9922
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Инфo"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9922
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Местоположението вече е запазено"
 
@@ -260,15 +259,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10801 3.8/weather-applet.js:11095
-#: 3.8/weather-applet.js:12062 3.8/weather-applet.js:12502
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13373
-#: 3.8/weather-applet.js:14740
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Усеща се като"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:10846
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Неуспешна обработка на прогнозата"
 
@@ -281,7 +280,7 @@ msgstr ""
 "или вземете такъв от https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:10730 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -289,7 +288,7 @@ msgstr ""
 "Моля проверете дали сте\n"
 "въвели правилния API ключ"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12468
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -300,60 +299,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:11734 3.8/weather-applet.js:11735
-#: 3.8/weather-applet.js:11741 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11755 3.8/weather-applet.js:12642
-#: 3.8/weather-applet.js:13539
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Силен дъжд"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11909 3.8/weather-applet.js:11910
-#: 3.8/weather-applet.js:11916 3.8/weather-applet.js:12627
-#: 3.8/weather-applet.js:12628 3.8/weather-applet.js:12634
-#: 3.8/weather-applet.js:12641 3.8/weather-applet.js:12683
-#: 3.8/weather-applet.js:12690 3.8/weather-applet.js:12697
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:13202
-#: 3.8/weather-applet.js:13203 3.8/weather-applet.js:13210
-#: 3.8/weather-applet.js:13531 3.8/weather-applet.js:13800
-#: 3.8/weather-applet.js:13801 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:14541 3.8/weather-applet.js:14542
-#: 3.8/weather-applet.js:14906 3.8/weather-applet.js:14907
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Дъжд"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10530
-#: 3.8/weather-applet.js:10537 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11364
-#: 3.8/weather-applet.js:11818 3.8/weather-applet.js:11819
-#: 3.8/weather-applet.js:11825 3.8/weather-applet.js:11832
-#: 3.8/weather-applet.js:11839 3.8/weather-applet.js:12635
-#: 3.8/weather-applet.js:13541
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Слаб дъжд"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12698 3.8/weather-applet.js:13515
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Силен леден дъжд"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11369
-#: 3.8/weather-applet.js:12684 3.8/weather-applet.js:13174
-#: 3.8/weather-applet.js:13175 3.8/weather-applet.js:13181
-#: 3.8/weather-applet.js:13182 3.8/weather-applet.js:13188
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Леден дъжд"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12691 3.8/weather-applet.js:13517
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Слаб леден дъжд"
 
@@ -361,189 +360,189 @@ msgstr "Слаб леден дъжд"
 msgid "Light freezing drizzle"
 msgstr "Леко ледено ръмене"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12677
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Ледено ръмене"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13497
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Слабо ръмене"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12712
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Град"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12704 3.8/weather-applet.js:12705
-#: 3.8/weather-applet.js:12711 3.8/weather-applet.js:12718
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Градушка"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12719
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Градушка"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10649 3.8/weather-applet.js:10656
-#: 3.8/weather-applet.js:10657 3.8/weather-applet.js:11376
-#: 3.8/weather-applet.js:11790 3.8/weather-applet.js:11791
-#: 3.8/weather-applet.js:11797 3.8/weather-applet.js:11804
-#: 3.8/weather-applet.js:11811 3.8/weather-applet.js:12670
-#: 3.8/weather-applet.js:13557 3.8/weather-applet.js:13877
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Силен сняг"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11375 3.8/weather-applet.js:11965
-#: 3.8/weather-applet.js:11966 3.8/weather-applet.js:11972
-#: 3.8/weather-applet.js:12648 3.8/weather-applet.js:12649
-#: 3.8/weather-applet.js:12662 3.8/weather-applet.js:12669
-#: 3.8/weather-applet.js:13146 3.8/weather-applet.js:13147
-#: 3.8/weather-applet.js:13551 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13870 3.8/weather-applet.js:14555
-#: 3.8/weather-applet.js:14556 3.8/weather-applet.js:14934
-#: 3.8/weather-applet.js:14935
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Сняг"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10621
-#: 3.8/weather-applet.js:10628 3.8/weather-applet.js:10635
-#: 3.8/weather-applet.js:10636 3.8/weather-applet.js:11374
-#: 3.8/weather-applet.js:11874 3.8/weather-applet.js:11875
-#: 3.8/weather-applet.js:11881 3.8/weather-applet.js:11888
-#: 3.8/weather-applet.js:11895 3.8/weather-applet.js:12663
-#: 3.8/weather-applet.js:13559
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Слаб сняг"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12655
-#: 3.8/weather-applet.js:12656 3.8/weather-applet.js:14913
-#: 3.8/weather-applet.js:14914
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Лек снеговалеж"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11349
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12726
-#: 3.8/weather-applet.js:13219 3.8/weather-applet.js:13220
-#: 3.8/weather-applet.js:13563 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:14562
-#: 3.8/weather-applet.js:14563
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Гръмотевици"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12593
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Слаба мъгла"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10509 3.8/weather-applet.js:10510
-#: 3.8/weather-applet.js:11388 3.8/weather-applet.js:11727
-#: 3.8/weather-applet.js:11728 3.8/weather-applet.js:12585
-#: 3.8/weather-applet.js:12586 3.8/weather-applet.js:12592
-#: 3.8/weather-applet.js:13289 3.8/weather-applet.js:13290
-#: 3.8/weather-applet.js:13505 3.8/weather-applet.js:14513
-#: 3.8/weather-applet.js:14514 3.8/weather-applet.js:14962
-#: 3.8/weather-applet.js:14963
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Мъгла"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10516 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:11713 3.8/weather-applet.js:11714
-#: 3.8/weather-applet.js:12557 3.8/weather-applet.js:12558
-#: 3.8/weather-applet.js:13779 3.8/weather-applet.js:13780
-#: 3.8/weather-applet.js:14506 3.8/weather-applet.js:14507
-#: 3.8/weather-applet.js:15004 3.8/weather-applet.js:15005
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Облачно"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12578
-#: 3.8/weather-applet.js:12579 3.8/weather-applet.js:13097
-#: 3.8/weather-applet.js:13098 3.8/weather-applet.js:13132
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Облачно"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10489 3.8/weather-applet.js:11902
-#: 3.8/weather-applet.js:11903 3.8/weather-applet.js:12571
-#: 3.8/weather-applet.js:12572 3.8/weather-applet.js:13090
-#: 3.8/weather-applet.js:13091 3.8/weather-applet.js:13125
-#: 3.8/weather-applet.js:13772 3.8/weather-applet.js:13773
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Разкъсана облачност"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12564
-#: 3.8/weather-applet.js:12565
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Ясно"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11394 3.8/weather-applet.js:12550
-#: 3.8/weather-applet.js:12551 3.8/weather-applet.js:13076
-#: 3.8/weather-applet.js:13077 3.8/weather-applet.js:13111
-#: 3.8/weather-applet.js:13575 3.8/weather-applet.js:13765
-#: 3.8/weather-applet.js:13766 3.8/weather-applet.js:14492
-#: 3.8/weather-applet.js:14493 3.8/weather-applet.js:14499
-#: 3.8/weather-applet.js:14500 3.8/weather-applet.js:15039
-#: 3.8/weather-applet.js:15040
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Ясно"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10474
-#: 3.8/weather-applet.js:10475 3.8/weather-applet.js:12550
-#: 3.8/weather-applet.js:12551 3.8/weather-applet.js:15046
-#: 3.8/weather-applet.js:15047
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Слънчево"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10460
-#: 3.8/weather-applet.js:10461 3.8/weather-applet.js:10495
-#: 3.8/weather-applet.js:10496 3.8/weather-applet.js:10684
-#: 3.8/weather-applet.js:10685 3.8/weather-applet.js:11696
-#: 3.8/weather-applet.js:11697 3.8/weather-applet.js:11994
-#: 3.8/weather-applet.js:11995 3.8/weather-applet.js:12542
-#: 3.8/weather-applet.js:12543 3.8/weather-applet.js:13067
-#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13296
-#: 3.8/weather-applet.js:13297 3.8/weather-applet.js:14425
-#: 3.8/weather-applet.js:14426 3.8/weather-applet.js:14576
-#: 3.8/weather-applet.js:14577 3.8/weather-applet.js:15150
-#: 3.8/weather-applet.js:15152
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10721
+#: 3.0/darkSky.js:71
 msgid "and"
 msgstr "и"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10721
+#: 3.0/darkSky.js:71
 msgid "until"
 msgstr "до"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10721
+#: 3.0/darkSky.js:71
 msgid "Possible"
 msgstr "Възможно"
 
@@ -555,7 +554,7 @@ msgstr ""
 "Моля въведете API ключ в Настройките\n"
 "или вземете такъв от https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:10740
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -563,132 +562,132 @@ msgstr ""
 "Моля проверете, че сте\n"
 "въвели правилния API ключ от DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:9693
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Неуспешно получаване на местоположението"
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:9699
+#: 3.0/ipApi.js:95
 msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 "Услугата за получаване на местоположението отговори с грешка, моля проверете "
 "логовете в Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11558
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Облачност"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11395 3.8/weather-applet.js:11706
-#: 3.8/weather-applet.js:11707
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Ясно небе"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11720 3.8/weather-applet.js:11721
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Ясно"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11742
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Силен дъжд с гръмотевици"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11749
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Силен дъжд"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11756
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Силен дъжд с гръмотевици"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11762
-#: 3.8/weather-applet.js:11763 3.8/weather-applet.js:11769
-#: 3.8/weather-applet.js:11776 3.8/weather-applet.js:11783
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Силна суграшица"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11770
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Силна суграшица с гръмотевици"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11777
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Силна суграшица"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11784
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Силна суграшица с гръмотевици"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11798
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Силен сняг с гръмотевици"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11805
-#: 3.8/weather-applet.js:13878
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Силен сняг"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11812
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Силен сняг с гръмотевици"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11826
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Слаб дъжд с гръмотевици"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11833
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Слаб дъжд"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11840
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Слаб дъжд с гръмотевици"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11846
-#: 3.8/weather-applet.js:11847 3.8/weather-applet.js:11853
-#: 3.8/weather-applet.js:11860 3.8/weather-applet.js:11867
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Суграшица"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11854
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Суграшица с гръмотевици"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11861
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Суграшица"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11868
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Суграшица с гръмотевици"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11882
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Слаб сняг с гръмотевици"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11889
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Слаб сняг"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11896
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Слаб сняг с гръмотевици"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11917
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Дъжд и гръмотевици"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11923
-#: 3.8/weather-applet.js:11924 3.8/weather-applet.js:11930
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13537
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Дъжд"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11931
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Дъжд и гръмотевици"
 
@@ -697,44 +696,44 @@ msgstr "Дъжд и гръмотевици"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11377
-#: 3.8/weather-applet.js:11937 3.8/weather-applet.js:11938
-#: 3.8/weather-applet.js:11944 3.8/weather-applet.js:11951
-#: 3.8/weather-applet.js:11958 3.8/weather-applet.js:13160
-#: 3.8/weather-applet.js:13161 3.8/weather-applet.js:13167
-#: 3.8/weather-applet.js:13168 3.8/weather-applet.js:13195
-#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:14548
-#: 3.8/weather-applet.js:14549 3.8/weather-applet.js:14948
-#: 3.8/weather-applet.js:14949
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Суграшица"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11945
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Суграшица с гръмотевици"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11952
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Суграшица"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11959
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Суграшица с гръмотевици"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11973
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Сняг с гръмотевици"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11979 3.8/weather-applet.js:11980
-#: 3.8/weather-applet.js:11986 3.8/weather-applet.js:13555
-#: 3.8/weather-applet.js:13871
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Сняг"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11987
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Сняг с гръмотевици"
 
@@ -743,21 +742,21 @@ msgstr "Сняг с гръмотевици"
 msgid "Unexpected response from API"
 msgstr "Неочаквано съобщение от API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10279
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Видимост"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10307
-#: 3.8/weather-applet.js:11172 3.8/weather-applet.js:12073
-#: 3.8/weather-applet.js:13022
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Неуспешна обработка на текущата прогноза"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10097
-#: 3.8/weather-applet.js:10131 3.8/weather-applet.js:12099
-#: 3.8/weather-applet.js:12133 3.8/weather-applet.js:12824
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Неуспешна обработка на прогнозата"
 
@@ -786,90 +785,90 @@ msgid "Excellent - More than"
 msgstr "Отлична - Повече от"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11384 3.8/weather-applet.js:13527
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Мъгла"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10524 3.8/weather-applet.js:13104
-#: 3.8/weather-applet.js:13105 3.8/weather-applet.js:13139
-#: 3.8/weather-applet.js:13571
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Облачно"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:10538
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Слаб дъжд"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10544 3.8/weather-applet.js:10545
-#: 3.8/weather-applet.js:11356 3.8/weather-applet.js:12620
-#: 3.8/weather-applet.js:12621 3.8/weather-applet.js:12676
-#: 3.8/weather-applet.js:13493 3.8/weather-applet.js:14885
-#: 3.8/weather-applet.js:14886
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Ръмене"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Силен дъжд"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Суграшица"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10600 3.8/weather-applet.js:10607
-#: 3.8/weather-applet.js:10614 3.8/weather-applet.js:10615
-#: 3.8/weather-applet.js:13569 3.8/weather-applet.js:14520
-#: 3.8/weather-applet.js:14521 3.8/weather-applet.js:14941
-#: 3.8/weather-applet.js:14942
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Градушка"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Градушка"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Слаб сняг"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10643
-#: 3.8/weather-applet.js:10650
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Силен сняг"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10663 3.8/weather-applet.js:10670
-#: 3.8/weather-applet.js:10677 3.8/weather-applet.js:10678
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Гръмотевици"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10664
-#: 3.8/weather-applet.js:10671
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Гръмотевици"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11227
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Моля, проверете дали местоположението е въведено в правилния формат в "
 "Настройките"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11231
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Проверете дали сте въвели правилния ключ в Настройките"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11235
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -877,211 +876,211 @@ msgstr ""
 "Местоположението не е намерено, проверете дали съществува и че е въведено в "
 "правилният формат"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11239
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Ако проблема продължавате, моля свържете се с автора на този аплет"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11243
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Неизвестна грешка, моля проверете логовете в Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11345
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Гръмотевици с слаб дъжд"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11346
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Гръмотевици с дъжд"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11347
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Гръмотевици със силен дъжд"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11348
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Слаби гръмотевици"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11350
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Силни гръмотевици"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11351
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Частични гръмотевици"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11352
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Гръмотевици с леко ръмене"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11353
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Гръмотевици с ръмене"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11354
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Гръмотевици със силно ръмене"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11355
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Леко ръмене"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11357
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Силен дъжд"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11358
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Леко ръмене"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11359
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Ситен дъжд"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11360
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Силен дъжд"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11361
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Силине дъжд"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11362
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Силен дъжд"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11363
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Силен дъжд"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11365
-#: 3.8/weather-applet.js:13807 3.8/weather-applet.js:13808
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Умерен дъжд"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11366
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Силен дъжд"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11367
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Много силен дъжд"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11368
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Порой"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11370
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Слаб дъжд"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11371
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Дъжд"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11372
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Силен дъжд"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11373
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Частичен дъжд"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11378
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Суграшица"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11379
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Слаб дъжд и сняг"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:13814 3.8/weather-applet.js:13815
-#: 3.8/weather-applet.js:13821 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13863
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Дъжд и сняг"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11381
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Слаб сняг"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11382
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Силен сняг"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11383
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Силен сняг"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11385 3.8/weather-applet.js:13254
-#: 3.8/weather-applet.js:13255 3.8/weather-applet.js:14976
-#: 3.8/weather-applet.js:14977
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Дим"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11386 3.8/weather-applet.js:13261
-#: 3.8/weather-applet.js:13262 3.8/weather-applet.js:14969
-#: 3.8/weather-applet.js:14970
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Лека мъгла"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11387
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Пясък, пепел и вятър"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11389
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Пясък"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11390 3.8/weather-applet.js:13247
-#: 3.8/weather-applet.js:13248 3.8/weather-applet.js:14955
-#: 3.8/weather-applet.js:14956
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Пепел"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11391
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Вулканичен прах"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11392
-#: 3.8/weather-applet.js:13561
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Шквалове"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11393 3.8/weather-applet.js:13226
-#: 3.8/weather-applet.js:13227 3.8/weather-applet.js:14828
-#: 3.8/weather-applet.js:14829
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Торнадо"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11396
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Ясно небе"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11397
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Облачно"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11398
-#: 3.8/weather-applet.js:13083 3.8/weather-applet.js:13084
-#: 3.8/weather-applet.js:13118
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Лека облачност"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11399
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Разкъсана облачност"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11400
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Разкъсана облачност"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11401
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Облачно"
 
@@ -1089,81 +1088,81 @@ msgstr "Облачно"
 msgid "Could not get forecast for your area"
 msgstr "Няма прогноза за вашето местоположение"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 "Местоположението е извън САЩ. Моля, използвайте друг доставчик на прогноза."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12845
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Неуспешна обработка на Почасовата Прогноза"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13112
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Ясно и ветровито"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13119
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Лека облачност и вятър"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13126
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Разкъсана облачност и вятър"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13133
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Облачно и ветровито"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13140
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Облачно и ветровито"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13154
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Сняг"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13189
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Леден дъжд и сняг"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9148 3.8/weather-applet.js:13233
-#: 3.8/weather-applet.js:13234 3.8/weather-applet.js:14842
-#: 3.8/weather-applet.js:14843
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Ураган"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9143
-#: 3.8/weather-applet.js:13240
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Буря"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13241
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Тропическа буря"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13268 3.8/weather-applet.js:13269
-#: 3.8/weather-applet.js:15074 3.8/weather-applet.js:15075
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Горещо"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13275 3.8/weather-applet.js:13276
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Студено"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13282 3.8/weather-applet.js:13283
-#: 3.8/weather-applet.js:15123 3.8/weather-applet.js:15124
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Виелица"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9021
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Днес"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9023
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Утре"
 
@@ -1195,79 +1194,79 @@ msgstr "Петък"
 msgid "Saturday"
 msgstr "Събота"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9113
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Спокойно"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9116
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Лек вятър"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9119
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Лек вятър"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9122
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Лек вятър"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9125
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Умерен вятър"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9128
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Освежаващ вятър"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9131
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Силен вятър"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9134
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Вятър"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9137
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Вятър"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9140
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Силен вятър"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9146
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Силна буря"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "С"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "СИ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "И"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "ЮИ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "Ю"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "ЮЗ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "З"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "СЗ"
 
@@ -1319,7 +1318,7 @@ msgstr ""
 "Неизвестна грешка при получаване на прогнозата, проверете Looking Glass за "
 "повече информация"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14835 3.8/weather-applet.js:14836
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Тропическа буря"
 
@@ -1327,7 +1326,7 @@ msgstr "Тропическа буря"
 msgid "Severe Thunderstorms"
 msgstr "Силни гръмотевици"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14856 3.8/weather-applet.js:14857
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Гръмотевици"
 
@@ -1343,15 +1342,15 @@ msgstr "Дъжд и суграшица"
 msgid "Mixed Snow and Sleet"
 msgstr "Сняг и суграшица"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14878 3.8/weather-applet.js:14879
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Леден дъжд"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14892 3.8/weather-applet.js:14893
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Леден дъжд"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14899 3.8/weather-applet.js:14900
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Дъжд"
 
@@ -1363,11 +1362,11 @@ msgstr "Лек снеговалеж"
 msgid "Light Snow Showers"
 msgstr "Слаб сняг"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14927 3.8/weather-applet.js:14928
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Сняг и вятър"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13793 3.8/weather-applet.js:13794
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Мъгла"
 
@@ -1379,54 +1378,54 @@ msgstr "Дим"
 msgid "Blustery"
 msgstr "Силен вятър"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14990 3.8/weather-applet.js:14991
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Ветровито"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15011 3.8/weather-applet.js:15012
-#: 3.8/weather-applet.js:15018 3.8/weather-applet.js:15019
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Облачно"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14527 3.8/weather-applet.js:14528
-#: 3.8/weather-applet.js:14534 3.8/weather-applet.js:14535
-#: 3.8/weather-applet.js:15025 3.8/weather-applet.js:15026
-#: 3.8/weather-applet.js:15032 3.8/weather-applet.js:15033
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Разкъсана облачност"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15060 3.8/weather-applet.js:15061
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Слънчево"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15067 3.8/weather-applet.js:15068
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Дъжд и градушка"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15081 3.8/weather-applet.js:15082
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Частични гръмотевици"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15088 3.8/weather-applet.js:15089
-#: 3.8/weather-applet.js:15144 3.8/weather-applet.js:15145
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Частични гръмотевици"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15095 3.8/weather-applet.js:15096
-#: 3.8/weather-applet.js:15130 3.8/weather-applet.js:15131
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Частични валижи"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15102 3.8/weather-applet.js:15103
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Силен дъжд"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15109 3.8/weather-applet.js:15110
-#: 3.8/weather-applet.js:15137 3.8/weather-applet.js:15138
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Частичен снеговалеж"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15116 3.8/weather-applet.js:15117
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Силен сняг"
 
@@ -1438,7 +1437,7 @@ msgstr "Не е наличен"
 msgid "Scattered Thundershowers"
 msgstr "Частични гръмотевици"
 
-#: 3.8/weather-applet.js:9632
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1447,7 +1446,7 @@ msgstr ""
 "намерени в\n"
 "  {logFilePath}"
 
-#: 3.8/weather-applet.js:9636
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1457,11 +1456,11 @@ msgstr ""
 "  {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10055
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10160
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1469,279 +1468,292 @@ msgstr ""
 "Met Office UK работи само за Обединеното Кралство. Потвърдете, че вашето "
 "местоположение е в тази страна"
 
-#: 3.8/weather-applet.js:10239
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Прогнозата за това местоположението не е налична"
 
-#: 3.8/weather-applet.js:10320
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Много лоша"
 
-#: 3.8/weather-applet.js:10320
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "По-малко от {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10324
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Отлична"
 
-#: 3.8/weather-applet.js:10324
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Повече от {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10329
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Лоша"
 
-#: 3.8/weather-applet.js:10329 3.8/weather-applet.js:10334
-#: 3.8/weather-applet.js:10339 3.8/weather-applet.js:10344
-#: 3.8/weather-applet.js:10349
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Между {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10334
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Умерена"
 
-#: 3.8/weather-applet.js:10339
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Добра"
 
-#: 3.8/weather-applet.js:10344 3.8/weather-applet.js:10349
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Много добра"
 
-#: 3.8/weather-applet.js:10704
-msgid "DarkSky"
-msgstr "DarkSky"
-
-#: 3.8/weather-applet.js:10756
-msgid "This API has ceased to function, please use another one."
-msgstr "Този API вече не функционира, моля използвайте друг."
-
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11017
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11465
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12010
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12435
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12600
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Слаб вятър"
 
-#: 3.8/weather-applet.js:12614
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Силен вятър"
 
-#: 3.8/weather-applet.js:12761
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:13314
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:13491
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Навяващ сняг"
 
-#: 3.8/weather-applet.js:13495
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Силно ръмене"
 
-#: 3.8/weather-applet.js:13499
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Силно ръмене/дъжд"
 
-#: 3.8/weather-applet.js:13501
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Леко ръмене/дъжд"
 
-#: 3.8/weather-applet.js:13503
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Пясъчна буря"
 
-#: 3.8/weather-applet.js:13507
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Ледено ръмене/леден дъжд"
 
-#: 3.8/weather-applet.js:13509
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Силно ледено ръмене/леден дъжд"
 
-#: 3.8/weather-applet.js:13511
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Слабо ледено ръмене/леден дъжд"
 
-#: 3.8/weather-applet.js:13513
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Замръзнала мъгла"
 
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Фуниеобразен облак/торнадо"
 
-#: 3.8/weather-applet.js:13521
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Градушка"
 
-#: 3.8/weather-applet.js:13523
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Лед"
 
-#: 3.8/weather-applet.js:13525
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Светкавици без гръмотевици"
 
-#: 3.8/weather-applet.js:13529
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Очаквани валежи"
 
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:13822
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Силен дъжд и сняг"
 
-#: 3.8/weather-applet.js:13535
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Слаб дъжд и сняг"
 
-#: 3.8/weather-applet.js:13543
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Изчезващи облаци"
 
-#: 3.8/weather-applet.js:13545
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Увеличаващи се облаци"
 
-#: 3.8/weather-applet.js:13547
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Без промяна"
 
-#: 3.8/weather-applet.js:13549
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Дим"
 
-#: 3.8/weather-applet.js:13553
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Сняг и дъжд"
 
-#: 3.8/weather-applet.js:13565
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Гръмотевици без валежи"
 
-#: 3.8/weather-applet.js:13567
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Диамантен прах"
 
-#: 3.8/weather-applet.js:13573
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Разкъсана облачност"
 
-#: 3.8/weather-applet.js:13595
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Проверете дали сте въвели правилния API ключ"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13611
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:13754 3.8/weather-applet.js:13755
-#: 3.8/weather-applet.js:13891 3.8/weather-applet.js:13892
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "Не е открито"
 
-#: 3.8/weather-applet.js:13787
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Сняг и вятър"
 
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Слаб сняг"
 
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13836
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Умерен снеговалеж"
 
-#: 3.8/weather-applet.js:13850
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Умерен дъжд"
 
-#: 3.8/weather-applet.js:13857
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Дъжд и сняг"
 
-#: 3.8/weather-applet.js:13864
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Силен дъжд и сняг"
 
-#: 3.8/weather-applet.js:13961
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:14305
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:14318
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "Моля, изберете друг доставчик на прогноза или местоположение"
 
-#: 3.8/weather-applet.js:14615
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14806
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "API ключа, който използвате е невалиден."
 
-#: 3.8/weather-applet.js:14813
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "Местоположение, което указахте не е намерено."
 
-#: 3.8/weather-applet.js:14849 3.8/weather-applet.js:14850
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Силна буря"
 
-#: 3.8/weather-applet.js:14864 3.8/weather-applet.js:14865
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Дъжд и сняг"
 
-#: 3.8/weather-applet.js:14871 3.8/weather-applet.js:14872
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Дъжд и суграшица"
 
-#: 3.8/weather-applet.js:14920 3.8/weather-applet.js:14921
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Сняг"
 
-#: 3.8/weather-applet.js:14983 3.8/weather-applet.js:14984
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "Ветровито"
 
-#: 3.8/weather-applet.js:14997 3.8/weather-applet.js:14998
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr "Студено"
 
-#: 3.8/weather-applet.js:15053 3.8/weather-applet.js:15054
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Предимно ясно"
 
-#: 3.8/weather-applet.js:15541
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:15603
+#, fuzzy
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+"Услугата за получаване на местоположението отговори с грешка, моля проверете "
+"логовете в Looking Glass"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+"Проверете дали сте въвели местоположение или използвайте\n"
+"Автоматичното му определяне"
+
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1749,7 +1761,7 @@ msgstr ""
 "Настройките не бяха извлечени. Файлът не беше открит в\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15546
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1757,59 +1769,59 @@ msgstr ""
 "Настройките не бяха извлечени от файлът, който се намира в\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:16158
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Избраният доставчик на прогноза изисква API ключ за да работи"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Точка на оросяване"
 
-#: 3.8/weather-applet.js:16230
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Валежът ще спре след {precipEnd} минути"
 
-#: 3.8/weather-applet.js:16232
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "Валежът няма да спре до час"
 
-#: 3.8/weather-applet.js:16235
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Валежът ще започне след {precipStart} минути"
 
-#: 3.8/weather-applet.js:16443
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Обработката на данните за прогнозата беше неуспешна. Вижте лог файла за "
 "повече информация."
 
-#: 3.8/weather-applet.js:16892 3.8/weather-applet.js:17678
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "Обновена в {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:16898
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} от вас"
 
-#: 3.8/weather-applet.js:16902
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "Име на станцията: {stationName}"
 
-#: 3.8/weather-applet.js:16905
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "Област: {stationArea}"
 
-#: 3.8/weather-applet.js:17438 3.8/weather-applet.js:17448
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Грешка при запазването на дебъг информацията"
 
-#: 3.8/weather-applet.js:17460
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Дебъг информацията е запазена успешно"
 
-#: 3.8/weather-applet.js:17460
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Запазен в {filePath}"
-
-#: 3.8/weather-applet.js:17603
-msgid "This provider requires an API key to operate"
-msgstr "Избраният доставчик на прогноза изисква API ключ за да работи"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -1862,7 +1874,6 @@ msgid "Data service"
 msgstr "Доставчик на прогнозата"
 
 #. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
 msgid "DarkSky (key needed)"
 msgstr "DarkSky (необходим е ключ)"
 
@@ -2314,6 +2325,11 @@ msgid "US National Weather (US only)"
 msgstr "US National Weather (само за САЩ)"
 
 #. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Pirate Weather (key needed)"
+msgstr "Weatherbit (необходим е ключ)"
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Visual Crossing (key needed)"
 msgstr "Visual Crossing (необходим е ключ)"
 
@@ -2337,12 +2353,18 @@ msgid ""
 "the format. After 3 seconds without typing the address you entered is "
 "replaced automatically for validating your choice."
 msgstr ""
-"Може да въведете координати 'Географска Ширина, Географска "
-"Дължина' (например 51.5085,-0.1257) или 'Град,Код на Държава' (например "
-"София, БГ) или опитайте да въведете {Номер} {Улица} {Град} {Пощенски код} "
-"{Държава}. Алгоритъмът за търсене е много гъвкав спрямо използвания формат. "
-"3 секунди след спирането на въвеждане на данни, адреса който сте въвели ще "
-"бъде автоматично променен и ще можете да го потвърдите."
+"Може да въведете координати 'Географска Ширина, Географска Дължина' "
+"(например 51.5085,-0.1257) или 'Град,Код на Държава' (например София, БГ) "
+"или опитайте да въведете {Номер} {Улица} {Град} {Пощенски код} {Държава}. "
+"Алгоритъмът за търсене е много гъвкав спрямо използвания формат. 3 секунди "
+"след спирането на въвеждане на данни, адреса който сте въвели ще бъде "
+"автоматично променен и ще можете да го потвърдите."
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
 
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"
@@ -2391,10 +2413,11 @@ msgid "Enable minutely precipitation forecast"
 msgstr "Включи минутно обновление на валежите"
 
 #. 3.8->settings-schema.json->immediatePrecip->tooltip
+#, fuzzy
 msgid ""
 "If you'd like to use this make sure you use your exact coordinates/address "
-"as location to help its accuracy. Currently implemented with OpenWeatherMap "
-"and MET Norway only."
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
 msgstr ""
 "Ако желаете да използвате това, използвайте точни координати/адрес като "
 "местоположение с цел подобряване на точността. За момента се поддържа само "
@@ -2556,8 +2579,8 @@ msgid ""
 msgstr ""
 "Определянето на местоположението ви в повечето случай ще е автоматично. Може "
 "да го въведете и ръчно, като въведете координати 'Географска Ширина, "
-"Географска Дължина' (например 51.5085,-0.1257) или 'Град,Код на "
-"Държава' (например София,БГ) или опитайте да въведете {Номер} {Улица} {Град} "
+"Географска Дължина' (например 51.5085,-0.1257) или 'Град,Код на Държава' "
+"(например София,БГ) или опитайте да въведете {Номер} {Улица} {Град} "
 "{Пощенски код} {Държава}. Алгоритъмът за търсене е много гъвкав спрямо "
 "използвания формат. 3 секунди след спирането на въвеждане на данни, адреса "
 "който сте въвели ще бъде автоматично променен и ще можете да го потвърдите."
@@ -2597,168 +2620,3 @@ msgstr ""
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr "Изберете път за запазване на лог файловете"
-
-#~ msgid "Settings"
-#~ msgstr "Настройки"
-
-#~ msgid "Cloudiness:"
-#~ msgstr "Облачност:"
-
-#~ msgid "Sunrise"
-#~ msgstr "Изгрев"
-
-#~ msgid "Sunset"
-#~ msgstr "Залез"
-
-#~ msgid "Service Unavailable"
-#~ msgstr "Услугата е недостъпна"
-
-#~ msgid "Wrong API Key"
-#~ msgstr "Неправилен API ключ"
-
-#~ msgid "City Not found"
-#~ msgstr "Градът не е намерен"
-
-#~ msgid "Key Temp. Blocked"
-#~ msgstr "Ключът е временно блокиран"
-
-#~ msgid "Drizzle with Thunderstorms"
-#~ msgstr "Гръмотевици с ръмене"
-
-#~ msgid "Mostly Drizzle"
-#~ msgstr "Ръмене"
-
-#~ msgid "Mostly Drizzle with Thunderstorms"
-#~ msgstr "Гръмотевици с ръмене"
-
-#~ msgid "Mostly Heavy Sleet"
-#~ msgstr "Силна суграшица"
-
-#~ msgid "Mostly Heavy Sleet with Thunderstorms"
-#~ msgstr "Силна суграшица с гръмотевици"
-
-#~ msgid "Few Clouds"
-#~ msgstr "Лека облачност"
-
-#~ msgid "Mostly Ligh Rain with Thunderstorms"
-#~ msgstr "Гръмотевици с лек дъжд"
-
-#~ msgid "Mostly Light Sleet"
-#~ msgstr "Суграшица"
-
-#~ msgid "Mostly Light Sleet with Thunderstorms"
-#~ msgstr "Лека суграшица с гръмотевици"
-
-#~ msgid "Mostly Light Snow"
-#~ msgstr "Слаб сняг"
-
-#~ msgid "Mostly Light Snow with Thunderstorms"
-#~ msgstr "Слаб сняг с гръмотевици"
-
-#~ msgid "Rain with Thunderstorms"
-#~ msgstr "Дъжд с гръмотевици"
-
-#~ msgid "Mostly Rainy with Thunderstorms"
-#~ msgstr "Дъжд с гръмотевици"
-
-#~ msgid "Mostly Sleet with Thunderstorms"
-#~ msgstr "Суграшица с гръмотевици"
-
-#~ msgid "Snowy"
-#~ msgstr "Сняг"
-
-#~ msgid "Mostly Snowy with Thunderstorms"
-#~ msgstr "Сняг с гръмотевици"
-
-#~ msgid "Updated"
-#~ msgstr "Обновен"
-
-#~ msgid "Settings for weather@mockturtl 1.8+"
-#~ msgstr "Настройки за weather@mockturtl 1.8+"
-
-#~ msgid "Weather Provider Settings"
-#~ msgstr "Настройки за доставчика на прогноза"
-
-#~ msgid ""
-#~ "Acceptable inputs: City,CountryCode or Zipcode,CountryCode or Latitude,"
-#~ "Longtitude"
-#~ msgstr ""
-#~ "Разрешен формат: Град, Код на страната или пощенски код, Код на страната "
-#~ "или Географска ширина, дължина"
-
-#~ msgid "Personal Settings"
-#~ msgstr "Лични настройки"
-
-#~ msgid "Vertical orientation"
-#~ msgstr "Вертикална ориентация"
-
-#~ msgid "Translate condition"
-#~ msgstr "Превеждане на метеорологичните условия"
-
-#~ msgid "Symbolic icons"
-#~ msgstr "Символични икони"
-
-#~ msgid "OpenWeatherMap - The default, works out of the box."
-#~ msgstr ""
-#~ "OpenWeatherMap - Доставчик по-подразбиране, работи без нужда от "
-#~ "допълнителни настройки."
-
-#~ msgid ""
-#~ "DarkSky - Needs key, please click on 'Setup API Key and Location' for the "
-#~ "steps how to obtain one."
-#~ msgstr ""
-#~ "DarkSky - Необходим е ключ, моля натиснитете на 'Настройка на API Ключ и "
-#~ "Местоположение' за да разберете как да получите такъв."
-
-#~ msgid ""
-#~ "MET Norway - Current weather is shown for the next hour, and the daily "
-#~ "forecasts \n"
-#~ "are generated from 6 hour forecasts, so it can look incorrect sometimes."
-#~ msgstr ""
-#~ "MET Norway - Текущата прогноза се показва за следващия час, а дневната "
-#~ "прогноза\n"
-#~ "се определя от прогнозата за 6 час, поради което може понякога да "
-#~ "изглежда неправилна."
-
-#~ msgid ""
-#~ "WeatherBit - Minimum of 10min refresh rate is recommended or you might "
-#~ "exceed you daily quota.\n"
-#~ "Needs a key, please click on 'Setup API Key and Location' for the steps "
-#~ "how to obtain one."
-#~ msgstr ""
-#~ "WeatherBit - За да не натхвърлите дневния си лимит, се препоръчва периода "
-#~ "на обновяване на прогнозата да е поне 10 мин.\n"
-#~ "Необходим е ключ, моля натистнете на 'Настройка на API Ключ и "
-#~ "Местоположение' за да разберете как да получите такъв."
-
-#~ msgid "Currently only used with DarkSky "
-#~ msgstr "В момента се използва само от DarkSky "
-
-#~ msgid ""
-#~ "powered by: OpenWeatherMap, DarkSky, ipapi. Big Thanks to OpenWeatherMap "
-#~ "for their support!"
-#~ msgstr ""
-#~ "Услугата е предоставена от: OpenWeatherMap, DarkSky, ipapi. Огромна "
-#~ "благодарност на OpenWeatherMap за тяхната поддръжка!"
-
-#~ msgid "Settings for weather@mockturtl 3.8+"
-#~ msgstr "Настройки за weather@mockturtl 3.8+"
-
-#~ msgid ""
-#~ "MET Norway - Current weather is shown for the next hour, and the daily "
-#~ "forecasts are generated from 6 hour forecasts, so it can look incorrect "
-#~ "sometimes."
-#~ msgstr ""
-#~ "MET Norway - Текущата прогноза се показва за следващия час, а дневната се "
-#~ "определя от прогнозата за 6 последователни часа, поради което може "
-#~ "понякога да изглежда неправилна."
-
-#~ msgid ""
-#~ "WeatherBit - Minimum of 10min refresh rate is recommended or you might "
-#~ "exceed you daily quota. Needs a key, please click on 'Setup API Key and "
-#~ "Location' for the steps how to obtain one."
-#~ msgstr ""
-#~ "WeatherBit - За да не натхвърлите дневния си лимит, се препоръчва периода "
-#~ "на обновяване на прогнозата да е поне 10 мин.\n"
-#~ "Необходим е ключ, моля натистнете на 'Настройка на API Ключ и "
-#~ "Местоположение' за да разберете как да получите такъв."

--- a/weather@mockturtl/files/weather@mockturtl/po/ca.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/ca.po
@@ -5,8 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 3.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-12 12:27-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2011-06-15 00:41+0200\n"
 "Last-Translator: Pau Iranzo <paugnu@gmail.com>\n"
 "Language-Team: Softcatalà\n"
@@ -18,432 +19,2571 @@ msgstr ""
 "X-Generator: Virtaal 0.7.0-rc1\n"
 "X-Project-Style: default\n"
 
-#: applet.js:249
+#: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
+#: 3.8/weather-applet.js:17877
+msgid "Error"
+msgstr ""
+
+#: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
+#: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
+msgid "Service Error"
+msgstr ""
+
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
+msgid "Incorrect API Key"
+msgstr ""
+
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
+msgid "Incorrect Location Format"
+msgstr ""
+
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
+msgid "Key Blocked"
+msgstr ""
+
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
+msgid "Can't find location"
+msgstr ""
+
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
+msgid "No Api Key"
+msgstr ""
+
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
+msgid "No Location"
+msgstr ""
+
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
+msgid "Missing Packages"
+msgstr ""
+
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
+msgid "Location not covered"
+msgstr ""
+
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
+msgid "Weather Applet"
+msgstr ""
+
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: applet.js:250
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr ""
 
-#: applet.js:289
-msgid "Settings"
-msgstr ""
-
-#: applet.js:555
-msgid "Sunrise"
-msgstr ""
-
-#: applet.js:556
-msgid "Sunset"
-msgstr ""
-
-#: applet.js:648
-msgid "Loading current weather ..."
-msgstr "S'està carregant el temps actual..."
-
-#: applet.js:649
-msgid "Loading future weather ..."
-msgstr "S'està carregant el temps futur..."
-
-#: applet.js:671
-msgid "Loading ..."
-msgstr "S'està carregant..."
-
-#: applet.js:677
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr ""
 
-#: applet.js:740
-msgid "Temperature:"
+#: 3.0/applet.js:272
+msgid "API returned status code between 400 and 500"
+msgstr ""
+
+#: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
+#: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
+msgid "Location Store"
+msgstr ""
+
+#: 3.0/applet.js:426
+msgid "You can't save a location obtained automatically, sorry"
+msgstr ""
+
+#: 3.0/applet.js:601
+msgid "Could not get weather information"
+msgstr ""
+
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
+msgid ""
+"Unexpected Error While Refreshing Weather, please see log in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
+msgid ""
+"Could not update weather for a while...\n"
+"are you connected to the internet?"
+msgstr ""
+
+#: 3.0/applet.js:684
+msgid "Network Error, please check logs in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:969 3.0/applet.js:1110
+msgid "As of"
+msgstr ""
+
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
+msgid "Powered by"
+msgstr ""
+
+#: 3.0/applet.js:1113
+msgid "from you"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
+msgid "mm"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
+msgid "in"
+msgstr ""
+
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
+msgid "mi"
+msgstr ""
+
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
+msgid "km"
+msgstr ""
+
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
+msgid "Loading current weather ..."
+msgstr "S'està carregant el temps actual..."
+
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
+msgid "Loading future weather ..."
+msgstr "S'està carregant el temps futur..."
+
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
+msgid "Loading ..."
+msgstr "S'està carregant..."
+
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
+#, fuzzy
+msgid "Temperature"
 msgstr "Temperatura:"
 
-#: applet.js:742
-msgid "Humidity:"
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
+#, fuzzy
+msgid "Humidity"
 msgstr "Humitat:"
 
-#: applet.js:744
-msgid "Pressure:"
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
+#, fuzzy
+msgid "Pressure"
 msgstr "Pressió:"
 
-#: applet.js:746
-msgid "Wind:"
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
+#, fuzzy
+msgid "Wind"
 msgstr "Vent:"
 
-#: applet.js:748
-msgid "Wind Chill:"
-msgstr "Vent:"
+#: 3.0/applet.js:1639
+msgid "Make sure you entered a location or use Automatic location instead"
+msgstr ""
 
-#: applet.js:953
-msgid "Tornado"
-msgstr "Tornado"
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
+msgid "Could not find location based on address, please check if it's right"
+msgstr ""
 
-#: applet.js:955
-msgid "Tropical storm"
-msgstr "Tempesta tropical"
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
+msgid "Failed to call Geolocation API, see Looking Glass for errors."
+msgstr ""
 
-#: applet.js:957
-msgid "Hurricane"
-msgstr "Huracà"
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "Warning"
+msgstr ""
 
-#: applet.js:959
-msgid "Severe thunderstorms"
-msgstr "Tempestes elèctriques severes"
+#: 3.0/applet.js:2032
+msgid "You can only save correct locations when the applet is not refreshing"
+msgstr ""
 
-#: applet.js:961
-msgid "Thunderstorms"
-msgstr "Tempestes"
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "You can't save an incorrect location"
+msgstr ""
 
-#: applet.js:963
-msgid "Mixed rain and snow"
-msgstr "Barreja de pluja i neu"
+#. 3.8->settings-schema.json->logLevel->options
+#: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.8/weather-applet.js:9875
+msgid "Info"
+msgstr ""
 
-#: applet.js:965
-msgid "Mixed rain and sleet"
-msgstr "Barreja de pluja i calamarsa"
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
+msgid "Location is already saved"
+msgstr ""
 
-#: applet.js:967
-msgid "Mixed snow and sleet"
-msgstr "Barreja de neu i calamarsa"
+#: 3.0/applet.js:2049 3.0/applet.js:2083
+msgid "Success"
+msgstr ""
 
-#: applet.js:969
-msgid "Freezing drizzle"
-msgstr "Plugims gelats"
+#: 3.0/applet.js:2049
+msgid "Location is saved to library"
+msgstr ""
 
-#: applet.js:971
-msgid "Drizzle"
-msgstr "Plugim"
+#: 3.0/applet.js:2062
+msgid "You can't remove a location while the applet is refreshing"
+msgstr ""
 
-#: applet.js:973
+#: 3.0/applet.js:2066
+msgid "You can't remove an incorrect location"
+msgstr ""
+
+#: 3.0/applet.js:2070
+msgid "Location is not in storage, can't delete"
+msgstr ""
+
+#: 3.0/applet.js:2083
+msgid "Location is deleted from library"
+msgstr ""
+
+#: 3.0/applet.js:2131
+msgid ""
+"Failed to load in data from location storage, please see the logs for more "
+"information"
+msgstr ""
+
+#: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
+#: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
+msgid "Feels Like"
+msgstr ""
+
+#: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
+#: 3.8/weather-applet.js:15387
+msgid "Failed to Process Weather Info"
+msgstr ""
+
+#: 3.0/climacell.js:224
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://developer.climacell.co/sign-up"
+msgstr ""
+
+#: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
+msgid ""
+"Please Make sure you\n"
+"entered the API key correctly and your account is not locked"
+msgstr ""
+
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Climacell"
+msgstr ""
+
+#: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
+#: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
+#: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
+#, fuzzy
+msgid "Heavy rain"
+msgstr "Nevada forta"
+
+#: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
+#: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
+#: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
+msgid "Rain"
+msgstr ""
+
+#: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
+#: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
+#: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
+#, fuzzy
+msgid "Light rain"
+msgstr "Pluja glaçada"
+
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
+#, fuzzy
+msgid "Heavy freezing rain"
+msgstr "Pluja glaçada"
+
+#: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
+#: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
+#: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Pluja glaçada"
 
-#: applet.js:975 applet.js:977
-msgid "Showers"
-msgstr "Ruixats"
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
+#, fuzzy
+msgid "Light freezing rain"
+msgstr "Pluja glaçada"
 
-#: applet.js:979
-msgid "Snow flurries"
-msgstr "Ràfegues de neu"
+#: 3.0/climacell.js:301
+#, fuzzy
+msgid "Light freezing drizzle"
+msgstr "Plugims gelats"
 
-#: applet.js:981
-msgid "Light snow showers"
-msgstr "Precipitacions lleugeres de neu"
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
+msgid "Freezing drizzle"
+msgstr "Plugims gelats"
 
-#: applet.js:983
-msgid "Blowing snow"
-msgstr "Neu aixecada pel vent"
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
+#, fuzzy
+msgid "Light drizzle"
+msgstr "Plugims gelats"
 
-#: applet.js:985
-msgid "Snow"
-msgstr "Neu"
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
+msgid "Heavy ice pellets"
+msgstr ""
 
-#: applet.js:987
-msgid "Hail"
-msgstr "Calamarsa"
+#: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
+msgid "Ice pellets"
+msgstr ""
 
-#: applet.js:989
-msgid "Sleet"
-msgstr "Aiguaneu"
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
+msgid "Light ice pellets"
+msgstr ""
 
-#: applet.js:991
-msgid "Dust"
-msgstr "Pols"
-
-#: applet.js:993
-msgid "Foggy"
-msgstr "Boirós"
-
-#: applet.js:995
-msgid "Haze"
-msgstr "Boirina"
-
-#: applet.js:997
-msgid "Smoky"
-msgstr "Fumat"
-
-#: applet.js:999
-msgid "Blustery"
-msgstr "Tempestuós"
-
-#: applet.js:1001
-msgid "Windy"
-msgstr "Ventades"
-
-#: applet.js:1003
-msgid "Cold"
-msgstr "Fred"
-
-#: applet.js:1005
-msgid "Cloudy"
-msgstr "Ennuvolat"
-
-#: applet.js:1008
-msgid "Mostly cloudy"
-msgstr "Majoritàriament ennuvolat"
-
-#: applet.js:1011 applet.js:1037
-msgid "Partly cloudy"
-msgstr "Parcialment ennuvolat"
-
-#: applet.js:1013
-msgid "Clear"
-msgstr "Clar"
-
-#: applet.js:1015
-msgid "Sunny"
-msgstr "Assolellat"
-
-#: applet.js:1018
-msgid "Fair"
-msgstr "Bon temps"
-
-#: applet.js:1020
-msgid "Mixed rain and hail"
-msgstr "Barreja de pluja i calamarsa"
-
-#: applet.js:1022
-msgid "Hot"
-msgstr "Calor"
-
-#: applet.js:1024
-msgid "Isolated thunderstorms"
-msgstr "Tempestes aïllades"
-
-#: applet.js:1027
-msgid "Scattered thunderstorms"
-msgstr "Tempestes elèctriques aïllades"
-
-#: applet.js:1029
-msgid "Scattered showers"
-msgstr "Pluges aïllades"
-
-#: applet.js:1031 applet.js:1035
+#: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
+#: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
+#: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Nevada forta"
 
-#: applet.js:1033
-msgid "Scattered snow showers"
-msgstr "Xàfecs de neu dispersos"
+#: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
+#: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
+#: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
+msgid "Snow"
+msgstr "Neu"
 
-#: applet.js:1039
-msgid "Thundershowers"
+#: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
+#: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
+#: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
+#, fuzzy
+msgid "Light snow"
+msgstr "Precipitacions lleugeres de neu"
+
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
+#, fuzzy
+msgid "Flurries"
+msgstr "Ràfegues de neu"
+
+#: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
+#, fuzzy
+msgid "Thunderstorm"
 msgstr "Tempestes"
 
-#: applet.js:1041
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
+msgid "Light fog"
+msgstr ""
+
+#: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
+#: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
+#: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
+#, fuzzy
+msgid "Fog"
+msgstr "Boirós"
+
+#: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
+#: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
+msgid "Cloudy"
+msgstr "Ennuvolat"
+
+#: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
+msgid "Mostly cloudy"
+msgstr "Majoritàriament ennuvolat"
+
+#: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
+#: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
+#: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
+msgid "Partly cloudy"
+msgstr "Parcialment ennuvolat"
+
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
+#, fuzzy
+msgid "Mostly clear"
+msgstr "Majoritàriament ennuvolat"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
+#: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
+#: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
+msgid "Clear"
+msgstr "Clar"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
+msgid "Sunny"
+msgstr "Assolellat"
+
+#: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
+#: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
+#: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
+msgid "Unknown"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "and"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "until"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "Possible"
+msgstr ""
+
+#: 3.0/darkSky.js:211
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://darksky.net/dev/register"
+msgstr ""
+
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from DarkSky"
+msgstr ""
+
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
+msgid "Could not obtain location"
+msgstr ""
+
+#: 3.0/ipApi.js:95
+msgid ""
+"Location Service responded with errors, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
+#, fuzzy
+msgid "Cloudiness"
+msgstr "Ennuvolat"
+
+#: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
+#, fuzzy
+msgid "Clear sky"
+msgstr "Clar"
+
+#: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
+msgid "Fair"
+msgstr "Bon temps"
+
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
+msgid "Heavy rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
+#, fuzzy
+msgid "Heavy rain showers"
+msgstr "Nevada forta"
+
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
+msgid "Heavy rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
+#, fuzzy
+msgid "Heavy sleet"
+msgstr "Nevada forta"
+
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
+msgid "Heavy sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
+#, fuzzy
+msgid "Heavy sleet showers"
+msgstr "Nevada forta"
+
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
+msgid "Heavy sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
+#, fuzzy
+msgid "Heavy snow and thunder"
+msgstr "Nevada forta"
+
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
+#, fuzzy
+msgid "Heavy snow showers"
+msgstr "Cobert"
+
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
+msgid "Heavy snow showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
+msgid "Light rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
+#, fuzzy
+msgid "Light rain showers"
+msgstr "Precipitacions lleugeres de neu"
+
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
+#, fuzzy
+msgid "Light rain showers and thunder"
+msgstr "Precipitacions lleugeres de neu"
+
+#: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
+msgid "Light sleet"
+msgstr ""
+
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
+msgid "Light sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
+#, fuzzy
+msgid "Light sleet showers"
+msgstr "Precipitacions lleugeres de neu"
+
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
+#, fuzzy
+msgid "Light sleet showers and thunder"
+msgstr "Precipitacions lleugeres de neu"
+
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
+#, fuzzy
+msgid "Light snow and thunder"
+msgstr "Precipitacions lleugeres de neu"
+
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
+msgid "Light snow showers"
+msgstr "Precipitacions lleugeres de neu"
+
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
+#, fuzzy
+msgid "Light snow showers and thunder"
+msgstr "Precipitacions lleugeres de neu"
+
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
+msgid "Rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
+#, fuzzy
+msgid "Rain showers"
+msgstr "Cobert"
+
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
+msgid "Rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:511 3.0/met_norway.js:512 3.0/met_norway.js:518
+#: 3.0/met_norway.js:525 3.0/met_norway.js:532 3.0/met_uk.js:638
+#: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
+#: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
+#: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
+msgid "Sleet"
+msgstr "Aiguaneu"
+
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
+#, fuzzy
+msgid "Sleet and thunder"
+msgstr "Tempestes elèctriques aïllades"
+
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
+#, fuzzy
+msgid "Sleet showers"
+msgstr "Pluges aïllades"
+
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
+msgid "Sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
+msgid "Snow and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Cobert"
 
-#: applet.js:1043
-msgid "Isolated thundershowers"
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
+#, fuzzy
+msgid "Snow showers and thunder"
+msgstr "Cobert"
+
+#: 3.0/met_uk.js:162 3.0/met_uk.js:192 3.0/met_uk.js:239 3.0/us_weather.js:151
+#: 3.0/us_weather.js:179
+msgid "Unexpected response from API"
+msgstr ""
+
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
+msgid "Visibility"
+msgstr ""
+
+#: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
+msgid "Failed to Process Current Weather Info"
+msgstr ""
+
+#: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
+msgid "Failed to Process Forecast Info"
+msgstr ""
+
+#: 3.0/met_uk.js:408
+msgid "Very poor - Less than"
+msgstr ""
+
+#: 3.0/met_uk.js:410
+msgid "Poor - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:412
+msgid "Moderate - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:414
+msgid "Good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:416
+msgid "Very good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:417
+msgid "Excellent - More than"
+msgstr ""
+
+#: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
+msgid "Mist"
+msgstr ""
+
+#: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
+msgid "Overcast"
+msgstr ""
+
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
+#, fuzzy
+msgid "Light rain shower"
+msgstr "Precipitacions lleugeres de neu"
+
+#: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
+msgid "Drizzle"
+msgstr "Plugim"
+
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
+#, fuzzy
+msgid "Heavy rain shower"
+msgstr "Nevada forta"
+
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
+#, fuzzy
+msgid "Sleet shower"
+msgstr "Pluges aïllades"
+
+#: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
+msgid "Hail"
+msgstr "Calamarsa"
+
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
+#, fuzzy
+msgid "Hail shower"
+msgstr "Cobert"
+
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
+#, fuzzy
+msgid "Light snow shower"
+msgstr "Precipitacions lleugeres de neu"
+
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
+#, fuzzy
+msgid "Heavy snow shower"
+msgstr "Nevada forta"
+
+#: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
+#, fuzzy
+msgid "Thunder"
+msgstr "Tempestes"
+
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
+#, fuzzy
+msgid "Thunder shower"
+msgstr "Tempestes"
+
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
+msgid "Please make sure Location is in the correct format in the Settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
+msgid "Make sure you entered the correct key in settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
+msgid ""
+"Location not found, make sure location is available or it is in the correct "
+"format"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
+msgid "If this problem persists, please contact the Author of this applet"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
+msgid "Unknown Error, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
+msgid "Thunderstorm with light rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
+#, fuzzy
+msgid "Thunderstorm with rain"
+msgstr "Tempestes"
+
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
+msgid "Thunderstorm with heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
+#, fuzzy
+msgid "Light thunderstorm"
+msgstr "Tempestes"
+
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
+#, fuzzy
+msgid "Heavy thunderstorm"
+msgstr "Tempestes elèctriques severes"
+
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
+#, fuzzy
+msgid "Ragged thunderstorm"
 msgstr "Tempestes aïllades"
 
-#: applet.js:1046
-msgid "Not available"
-msgstr "No disponible"
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
+msgid "Thunderstorm with light drizzle"
+msgstr ""
 
-#: applet.js:1051
-msgid "Monday"
-msgstr "Dilluns"
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
+#, fuzzy
+msgid "Thunderstorm with drizzle"
+msgstr "Tempestes"
 
-#: applet.js:1051
-msgid "Tuesday"
-msgstr "Dimarts"
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
+msgid "Thunderstorm with heavy drizzle"
+msgstr ""
 
-#: applet.js:1051
-msgid "Wednesday"
-msgstr "Dimecres"
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
+msgid "Light intensity drizzle"
+msgstr ""
 
-#: applet.js:1051
-msgid "Thursday"
-msgstr "Dijous"
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
+msgid "Heavy intensity drizzle"
+msgstr ""
 
-#: applet.js:1051
-msgid "Friday"
-msgstr "Divendres"
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
+msgid "Light intensity drizzle rain"
+msgstr ""
 
-#: applet.js:1051
-msgid "Saturday"
-msgstr "Dissabte"
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Drizzle rain"
+msgstr "Plugim"
 
-#: applet.js:1051
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
+msgid "Heavy intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
+#, fuzzy
+msgid "Shower rain and drizzle"
+msgstr "Barreja de pluja i calamarsa"
+
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
+msgid "Heavy shower rain and drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
+#, fuzzy
+msgid "Shower drizzle"
+msgstr "Plugims gelats"
+
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
+msgid "Moderate rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
+msgid "Heavy intensity rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
+msgid "Very heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
+#, fuzzy
+msgid "Extreme rain"
+msgstr "Pluja glaçada"
+
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
+#, fuzzy
+msgid "Light intensity shower rain"
+msgstr "Precipitacions lleugeres de neu"
+
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
+#, fuzzy
+msgid "Shower rain"
+msgstr "Ruixats"
+
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
+msgid "Heavy intensity shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
+msgid "Ragged shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
+#, fuzzy
+msgid "Shower sleet"
+msgstr "Ruixats"
+
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
+#, fuzzy
+msgid "Light rain and snow"
+msgstr "Barreja de pluja i neu"
+
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
+#, fuzzy
+msgid "Rain and snow"
+msgstr "Barreja de pluja i neu"
+
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
+#, fuzzy
+msgid "Light shower snow"
+msgstr "Precipitacions lleugeres de neu"
+
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
+#, fuzzy
+msgid "Shower snow"
+msgstr "Ruixats"
+
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
+#, fuzzy
+msgid "Heavy shower snow"
+msgstr "Nevada forta"
+
+#: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
+#, fuzzy
+msgid "Smoke"
+msgstr "Fumat"
+
+#: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
+msgid "Haze"
+msgstr "Boirina"
+
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
+msgid "Sand, dust whirls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
+msgid "Sand"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
+msgid "Dust"
+msgstr "Pols"
+
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
+msgid "Volcanic ash"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
+msgid "Squalls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
+msgid "Tornado"
+msgstr "Tornado"
+
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
+msgid "Sky is clear"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
+#, fuzzy
+msgid "Clouds"
+msgstr "Ennuvolat"
+
+#: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
+msgid "Few clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
+#, fuzzy
+msgid "Scattered clouds"
+msgstr "Pluges aïllades"
+
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
+msgid "Broken clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
+msgid "Overcast clouds"
+msgstr ""
+
+#: 3.0/us_weather.js:120
+msgid "Could not get forecast for your area"
+msgstr ""
+
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
+msgid "Location is outside US, please use a different provider."
+msgstr ""
+
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
+msgid "Failed to Process Hourly Forecast Info"
+msgstr ""
+
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
+msgid "Clear and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
+msgid "Few clouds and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
+#, fuzzy
+msgid "Partly cloudy and windy"
+msgstr "Parcialment ennuvolat"
+
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
+#, fuzzy
+msgid "Mostly cloudy and windy"
+msgstr "Majoritàriament ennuvolat"
+
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
+msgid "Overcast and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
+#, fuzzy
+msgid "Snowy rain"
+msgstr "Ràfegues de neu"
+
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
+#, fuzzy
+msgid "Freezing rain and snow"
+msgstr "Pluja glaçada"
+
+#: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
+msgid "Hurricane"
+msgstr "Huracà"
+
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
+msgid "Storm"
+msgstr ""
+
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
+msgid "Tropical storm"
+msgstr "Tempesta tropical"
+
+#: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
+msgid "Hot"
+msgstr "Calor"
+
+#: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
+msgid "Cold"
+msgstr "Fred"
+
+#: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
+msgid "Blizzard"
+msgstr ""
+
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
+msgid "Today"
+msgstr "Avui"
+
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
+msgid "Tomorrow"
+msgstr "Demà"
+
+#: 3.0/utils.js:204
 msgid "Sunday"
 msgstr "Diumenge"
 
-#: applet.js:1056
+#: 3.0/utils.js:204
+msgid "Monday"
+msgstr "Dilluns"
+
+#: 3.0/utils.js:204
+msgid "Tuesday"
+msgstr "Dimarts"
+
+#: 3.0/utils.js:204
+msgid "Wednesday"
+msgstr "Dimecres"
+
+#: 3.0/utils.js:204
+msgid "Thursday"
+msgstr "Dijous"
+
+#: 3.0/utils.js:204
+msgid "Friday"
+msgstr "Divendres"
+
+#: 3.0/utils.js:204
+msgid "Saturday"
+msgstr "Dissabte"
+
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
+msgid "Calm"
+msgstr ""
+
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
+msgid "Light air"
+msgstr ""
+
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
+msgid "Light breeze"
+msgstr ""
+
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
+msgid "Gentle breeze"
+msgstr ""
+
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
+msgid "Moderate breeze"
+msgstr ""
+
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
+msgid "Fresh breeze"
+msgstr ""
+
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
+msgid "Strong breeze"
+msgstr ""
+
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
+msgid "Near gale"
+msgstr ""
+
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
+msgid "Gale"
+msgstr ""
+
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
+msgid "Strong gale"
+msgstr ""
+
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
+msgid "Violent storm"
+msgstr ""
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeidLookup->description
-msgid "Get WOEID"
+#: 3.0/weatherbit.js:312
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://www.weatherbit.io/account/create"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->verticalOrientation->description
-msgid "Vertical orientation"
+#: 3.0/yahoo.js:78
+msgid ""
+"Unknown Error happened while calling Yahoo bridge,\n"
+" see Looking Glass log for errors"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showTextInPanel->description
-msgid "Display current temperature in panel"
+#: 3.0/yahoo.js:91
+msgid ""
+"Yahoo bridge responded in bad format,\n"
+" see Looking Glass log for errors"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeid->description
-msgid "WOEID"
+#: 3.0/yahoo.js:177
+msgid "Missing package"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeid->tooltip
-msgid "Where On Earth ID"
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+#, fuzzy
+msgid "Please install '"
+msgstr "Espereu"
+
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+msgid "', then refresh manually."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->description
+#: 3.0/yahoo.js:182
+msgid "Could not connect to Yahoo API."
+msgstr ""
+
+#: 3.0/yahoo.js:186
+msgid ""
+"Unknown error happened while obtaining weather, see Looking Glass logs for "
+"more information"
+msgstr ""
+
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
+#, fuzzy
+msgid "Tropical Storm"
+msgstr "Tempesta tropical"
+
+#: 3.0/yahoo.js:439
+#, fuzzy
+msgid "Severe Thunderstorms"
+msgstr "Tempestes elèctriques severes"
+
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
+msgid "Thunderstorms"
+msgstr "Tempestes"
+
+#: 3.0/yahoo.js:441
+#, fuzzy
+msgid "Mixed Rain and Snow"
+msgstr "Barreja de pluja i neu"
+
+#: 3.0/yahoo.js:442
+#, fuzzy
+msgid "Mixed Rain and Sleet"
+msgstr "Barreja de pluja i calamarsa"
+
+#: 3.0/yahoo.js:443
+#, fuzzy
+msgid "Mixed Snow and Sleet"
+msgstr "Barreja de neu i calamarsa"
+
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
+#, fuzzy
+msgid "Freezing Drizzle"
+msgstr "Plugims gelats"
+
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
+#, fuzzy
+msgid "Freezing Rain"
+msgstr "Pluja glaçada"
+
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
+msgid "Showers"
+msgstr "Ruixats"
+
+#: 3.0/yahoo.js:449
+#, fuzzy
+msgid "Snow Flurries"
+msgstr "Ràfegues de neu"
+
+#: 3.0/yahoo.js:450
+#, fuzzy
+msgid "Light Snow Showers"
+msgstr "Precipitacions lleugeres de neu"
+
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
+#, fuzzy
+msgid "Blowing Snow"
+msgstr "Neu aixecada pel vent"
+
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
+msgid "Foggy"
+msgstr "Boirós"
+
+#: 3.0/yahoo.js:458
+msgid "Smoky"
+msgstr "Fumat"
+
+#: 3.0/yahoo.js:459
+msgid "Blustery"
+msgstr "Tempestuós"
+
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
+msgid "Windy"
+msgstr "Ventades"
+
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
+#, fuzzy
+msgid "Mostly Cloudy"
+msgstr "Majoritàriament ennuvolat"
+
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
+#, fuzzy
+msgid "Partly Cloudy"
+msgstr "Parcialment ennuvolat"
+
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
+#, fuzzy
+msgid "Mostly Sunny"
+msgstr "Majoritàriament ennuvolat"
+
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
+#, fuzzy
+msgid "Mixed Rain and Hail"
+msgstr "Barreja de pluja i calamarsa"
+
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
+#, fuzzy
+msgid "Isolated Thunderstorms"
+msgstr "Tempestes aïllades"
+
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
+#, fuzzy
+msgid "Scattered Thunderstorms"
+msgstr "Tempestes elèctriques aïllades"
+
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
+#, fuzzy
+msgid "Scattered Showers"
+msgstr "Pluges aïllades"
+
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
+#, fuzzy
+msgid "Heavy Rain"
+msgstr "Nevada forta"
+
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
+#, fuzzy
+msgid "Scattered Snow Showers"
+msgstr "Xàfecs de neu dispersos"
+
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
+#, fuzzy
+msgid "Heavy Snow"
+msgstr "Nevada forta"
+
+#: 3.0/yahoo.js:478
+#, fuzzy
+msgid "Not Available"
+msgstr "No disponible"
+
+#: 3.0/yahoo.js:479
+#, fuzzy
+msgid "Scattered Thundershowers"
+msgstr "Tempestes elèctriques aïllades"
+
+#: 3.8/weather-applet.js:9638
+msgid ""
+"Could not retrieve logs, log file was not found under path\n"
+" {logFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:9642
+msgid ""
+"Could not get contents of log file under path\n"
+" {logFilePath}"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10283
+msgid "Met Office UK"
+msgstr ""
+
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
+msgstr ""
+
+#: 3.8/weather-applet.js:10476
+msgid "Data was not found for location"
+msgstr ""
+
+#: 3.8/weather-applet.js:10557
+msgid "Very poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10557
+msgid "Less than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "Excellent"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "More than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566
+msgid "Poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
+msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10571
+msgid "Moderate"
+msgstr ""
+
+#: 3.8/weather-applet.js:10576
+msgid "Good"
+msgstr ""
+
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
+msgid "Very good"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10942
+msgid "OpenWeatherMap"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:11396
+msgid "MET Norway"
+msgstr ""
+
+#: 3.8/weather-applet.js:11955
+msgid "WeatherBit"
+msgstr ""
+
+#: 3.8/weather-applet.js:12386
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Demà"
+
+#: 3.8/weather-applet.js:12561
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12575
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12723
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:13292
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13474
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "Neu aixecada pel vent"
+
+#: 3.8/weather-applet.js:13478
+#, fuzzy
+msgid "Heavy drizzle"
+msgstr "Plugims gelats"
+
+#: 3.8/weather-applet.js:13482
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13484
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13486
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:13490
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "Plugims gelats"
+
+#: 3.8/weather-applet.js:13492
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13494
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13496
+#, fuzzy
+msgid "Freezing fog"
+msgstr "Pluja glaçada"
+
+#: 3.8/weather-applet.js:13502
+msgid "Funnel cloud/tornado"
+msgstr ""
+
+#: 3.8/weather-applet.js:13504
+#, fuzzy
+msgid "Hail showers"
+msgstr "Cobert"
+
+#: 3.8/weather-applet.js:13506
+msgid "Ice"
+msgstr ""
+
+#: 3.8/weather-applet.js:13508
+msgid "Lightning without thunder"
+msgstr ""
+
+#: 3.8/weather-applet.js:13512
+msgid "Precipitation in vicinity"
+msgstr ""
+
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
+#, fuzzy
+msgid "Heavy rain and snow"
+msgstr "Barreja de pluja i neu"
+
+#: 3.8/weather-applet.js:13518
+#, fuzzy
+msgid "Light rain And snow"
+msgstr "Barreja de pluja i neu"
+
+#: 3.8/weather-applet.js:13526
+msgid "Sky coverage decreasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13528
+msgid "Sky coverage increasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13530
+msgid "Sky unchanged"
+msgstr ""
+
+#: 3.8/weather-applet.js:13532
+msgid "Smoke or haze"
+msgstr ""
+
+#: 3.8/weather-applet.js:13536
+#, fuzzy
+msgid "Snow and rain showers"
+msgstr "Cobert"
+
+#: 3.8/weather-applet.js:13548
+msgid "Thunderstorm without precipitation"
+msgstr ""
+
+#: 3.8/weather-applet.js:13550
+msgid "Diamond dust"
+msgstr ""
+
+#: 3.8/weather-applet.js:13556
+#, fuzzy
+msgid "Partially cloudy"
+msgstr "Parcialment ennuvolat"
+
+#: 3.8/weather-applet.js:13578
+msgid "Please make sure you entered the API key correctly"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:13595
+msgid "DMI Denmark"
+msgstr ""
+
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
+msgid "NOT FOUND"
+msgstr ""
+
+#: 3.8/weather-applet.js:13779
+msgid "Blowing snow"
+msgstr "Neu aixecada pel vent"
+
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
+#, fuzzy
+msgid "Slight snow"
+msgstr "Neu aixecada pel vent"
+
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
+#, fuzzy
+msgid "Moderate snow"
+msgstr "Nevada forta"
+
+#: 3.8/weather-applet.js:13842
+#, fuzzy
+msgid "Moderate rain showers"
+msgstr "Pluges aïllades"
+
+#: 3.8/weather-applet.js:13849
+msgid "Mixed rain and snow"
+msgstr "Barreja de pluja i neu"
+
+#: 3.8/weather-applet.js:13856
+#, fuzzy
+msgid "Heavy mixed rain and snow"
+msgstr "Barreja de pluja i neu"
+
+#: 3.8/weather-applet.js:14024
+msgid "AccuWeather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+msgid "Weather Underground"
+msgstr ""
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+msgid "The location you provided was not found."
+msgstr ""
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+msgid "Strong Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "Barreja de pluja i neu"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "Barreja de pluja i calamarsa"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "Cobert"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "Majoritàriament ennuvolat"
+
+#: 3.8/weather-applet.js:15247
+msgid "Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:15603
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+
+#: 3.8/weather-applet.js:15831
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+
+#: 3.8/weather-applet.js:15968
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:15975
+msgid ""
+"Could not get contents of config file under path\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr ""
+
+#: 3.8/weather-applet.js:16675
+msgid "Dew Point"
+msgstr ""
+
+#: 3.8/weather-applet.js:16747
+msgid "Precipitation will end in {precipEnd} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16749
+msgid "Precipitation won't end in within an hour"
+msgstr ""
+
+#: 3.8/weather-applet.js:16752
+msgid "Precipitation will start within {precipStart} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16964
+msgid "Forecast parsing failed, see logs for more details."
+msgstr ""
+
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
+msgid "As of {lastUpdatedTime}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17502
+msgid "{distance} {distanceUnit} from you"
+msgstr ""
+
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
+msgid "Error Saving Debug Information"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Debug Information saved successfully"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Saved to {filePath}"
+msgstr ""
+
+#: 3.8/LogSaver.py:16
+msgid "Save to File"
+msgstr ""
+
+#: 3.8/LogSaver.py:29
+msgid "Select a destination"
+msgstr ""
+
+#. metadata.json->name
+#. 3.8->settings-schema.json->providers->title
+msgid "Weather"
+msgstr ""
+
+#. metadata.json->description
+msgid "View your local weather forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->head->description
+msgid "Settings for weather@mockturtl 3.0+"
+msgstr ""
+
+#. 3.0->settings-schema.json->keybinding->description
+#. 3.8->settings-schema.json->keybinding->description
+msgid "Set the keybinding to call the menu"
+msgstr ""
+
+#. 3.0->settings-schema.json->descriptions->description
+msgid "Weather service information"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->description
+msgid "Click here for detailed description"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->tooltip
+#. 3.0->settings-schema.json->getLocation->tooltip
+#. 3.8->settings-schema.json->getLocation->tooltip
+msgid "Opens webpage guide"
+msgstr ""
+
+#. 3.0->settings-schema.json->providerSettings->description
+#. 3.8->settings-schema.json->provider-options->title
+msgid "Weather Provider Options"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->description
+#. 3.8->settings-schema.json->dataService->description
+msgid "Data service"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "DarkSky (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weatherbit (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Yahoo"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Climacell (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->description
+#. 3.8->settings-schema.json->apiKey->description
+msgid "API Key"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->tooltip
+#. 3.8->settings-schema.json->apiKey->tooltip
+msgid "Copy this from your account of the used Data service and paste it here."
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->description
+#. 3.8->settings-schema.json->manualLocation->description
+msgid "Manual Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->tooltip
+#. 3.8->settings-schema.json->manualLocation->tooltip
+msgid "Enable this if your location is not accurate"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->description
+msgid "Location - Coordinates"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->tooltip
+msgid ""
+"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an "
+"address.\n"
+"Waits for 3 seconds after you stop typing before refreshes the weather."
+msgstr ""
+
+#. 3.0->settings-schema.json->getLocation->description
+msgid "Setup API Key and Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->units
+#. 3.8->settings-schema.json->refreshInterval->units
+msgid "minutes"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->description
+#. 3.8->settings-schema.json->refreshInterval->description
+msgid "Update interval"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastDays->units
+#. 3.8->settings-schema.json->forecastDays->units
+msgid "days"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastDays->description
+#. 3.8->settings-schema.json->forecastDays->description
+msgid "Forecast length"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastHours->units
+#. 3.8->settings-schema.json->forecastHours->units
+msgid "hours"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastHours->description
+#. 3.8->settings-schema.json->forecastHours->description
+msgid "Hourly Forecast length"
+msgstr ""
+
+#. 3.0->settings-schema.json->unitSettings->description
+msgid "Units"
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureUnit->description
+#. 3.8->settings-schema.json->temperatureUnit->description
 #, fuzzy
 msgid "Temperature unit"
 msgstr "Temperatura:"
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "fahrenheit"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Automatic"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "celsius"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+msgid "Celsius"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->translateCondition->description
-msgid "Translate condition"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+msgid "Fahrenheit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->locationLabelOverride->description
-msgid "Override location label"
+#. 3.0->settings-schema.json->temperatureUnit->tooltip
+#. 3.0->settings-schema.json->distanceUnit->tooltip
+#. 3.8->settings-schema.json->temperatureUnit->tooltip
+#. 3.8->settings-schema.json->distanceUnit->tooltip
+msgid ""
+"Automatic will try to guess your preference based your current display "
+"language."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->show24Hours->description
-msgid "Display time in 24 hour format"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->forecastDays->description
-msgid "Forecast length"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->forecastDays->units
-msgid "days"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->showSunrise->description
-msgid "Show sunrise / sunset times"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->description
+#. 3.0->settings-schema.json->windSpeedUnit->description
+#. 3.8->settings-schema.json->windSpeedUnit->description
 msgid "Wind speed unit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
 msgid "kph"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "m/s"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "knots"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
 msgid "mph"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showCommentInPanel->description
-msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "m/s"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->description
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "knots"
+msgstr ""
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "Beaufort"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->description
+#. 3.8->settings-schema.json->pressureUnit->description
 msgid "Atmospheric pressure unit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "psi"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "hPa"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "atm"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "kPa"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "Pa"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mm Hg"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "at"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mbar"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
 msgid "in Hg"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->description
-msgid "Update interval"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "mm Hg"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->units
-msgid "minutes"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "psi"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->useSymbolicIcons->description
-msgid "Symbolic icons"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "at"
 msgstr ""
 
-#. cinnamon-weather->metadata.json->description
-msgid "View your local weather forecast"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "atm"
 msgstr ""
 
-#. cinnamon-weather->metadata.json->name
-msgid "Weather"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "Pa"
 msgstr ""
 
-#~ msgid "Please wait"
-#~ msgstr "Espereu"
+#. 3.0->settings-schema.json->distanceUnit->description
+#. 3.8->settings-schema.json->distanceUnit->description
+msgid "Distance unit"
+msgstr ""
 
-#~ msgid "Today"
-#~ msgstr "Avui"
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Metric"
+msgstr ""
 
-#~ msgid "Tomorrow"
-#~ msgstr "Demà"
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Imperial"
+msgstr ""
+
+#. 3.0->settings-schema.json->panelSettings->description
+msgid "Panel options"
+msgstr ""
+
+#. 3.0->settings-schema.json->showTextInPanel->description
+#. 3.8->settings-schema.json->showTextInPanel->description
+msgid "Display current temperature in panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->showCommentInPanel->description
+#. 3.8->settings-schema.json->showCommentInPanel->description
+msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->showCommentInPanel->tooltip
+#. 3.8->settings-schema.json->showCommentInPanel->tooltip
+msgid "Only works with horizontal panels"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempTextOverride->description
+#. 3.8->settings-schema.json->tempTextOverride->description
+msgid "Override label on panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.0->settings-schema.json->useCustomMenuIcons->tooltip
+#. 3.8->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.8->settings-schema.json->useCustomMenuIcons->tooltip
+msgid "Iconset is weather-icons by Erik Flowers"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->description
+#. 3.8->settings-schema.json->useCustomAppletIcons->description
+msgid "Use custom icons on the panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->displaySettings->description
+#. 3.8->settings-schema.json->presentation-section->title
+msgid "Presentation"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->description
+#. 3.8->settings-schema.json->verticalOrientation->description
+msgid "Show forecast vertically"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->units
+#. 3.8->settings-schema.json->forecastColumns->units
+msgid "columns"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->description
+#. 3.8->settings-schema.json->forecastColumns->description
+msgid "Maximum number of columns for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->units
+#. 3.8->settings-schema.json->forecastRows->units
+msgid "rows"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->description
+#. 3.8->settings-schema.json->forecastRows->description
+msgid "Maximum number of rows for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->showSunrise->description
+#. 3.8->settings-schema.json->showSunrise->description
+msgid "Show sunrise / sunset times"
+msgstr ""
+
+#. 3.0->settings-schema.json->show24Hours->description
+#. 3.8->settings-schema.json->show24Hours->description
+msgid "Display time in 24 hour format"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->description
+#. 3.8->settings-schema.json->shortHourlyTime->description
+msgid "Only display hours for hourly forecast time"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->tooltip
+#. 3.8->settings-schema.json->shortHourlyTime->tooltip
+msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->description
+#. 3.8->settings-schema.json->showForecastDates->description
+msgid "Display date for daily forecasts"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->tooltip
+#. 3.8->settings-schema.json->showForecastDates->tooltip
+msgid "Like \"Friday 15\""
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureHighFirst->description
+#. 3.8->settings-schema.json->temperatureHighFirst->description
+msgid "Show high temperature first in forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempRussianStyle->description
+#. 3.8->settings-schema.json->tempRussianStyle->description
+#, fuzzy
+msgid "Show temperature Russian style"
+msgstr "Temperatura:"
+
+#. 3.0->settings-schema.json->locationLabelOverride->description
+#. 3.8->settings-schema.json->locationLabelOverride->description
+msgid "Override location label"
+msgstr ""
+
+#. 3.0->settings-schema.json->conditionSettings->description
+#. 3.8->settings-schema.json->weather-conditions->title
+msgid "Weather conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->translateCondition->description
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Translate conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortConditions->description
+#. 3.8->settings-schema.json->shortConditions->description
+msgid "Less verbose conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->iconSettings->description
+#. 3.8->settings-schema.json->icons->title
+msgid "Icons"
+msgstr ""
+
+#. 3.0->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons in the applet"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomMenuIcons->description
+#. 3.8->settings-schema.json->useCustomMenuIcons->description
+msgid "Use custom icons in the popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->locations-page->title
+#. 3.8->settings-schema.json->location->description
+msgid "Location"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-page->title
+msgid "Other options"
+msgstr ""
+
+#. 3.8->settings-schema.json->info-section->title
+msgid "Help"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-section->title
+msgid "Location settings"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-store->title
+msgid "Saved Locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->panel-options->title
+msgid "Panel (Taskbar)"
+msgstr ""
+
+#. 3.8->settings-schema.json->presentation->title
+msgid "Popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-section->title
+msgid "Other Units"
+msgstr ""
+
+#. 3.8->settings-schema.json->temp-unit-section->title
+#, fuzzy
+msgid "Temperature Unit"
+msgstr "Temperatura:"
+
+#. 3.8->settings-schema.json->keybindings->title
+msgid "Keybindings"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info->title
+msgid "More about the Weather applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->submit-issue->title
+msgid "Report an issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->debug-options->title
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Debug"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->tooltip
+msgid ""
+"You can choose between several different weather forecast providers. Some "
+"providers require a API key to work, some have regional limits, differ in "
+"forecast length, and they all need a functional internet connection to work. "
+"The options are described in detail on the Cinnamon Spices Website which you "
+"can access with the button on the Help tab."
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Met Office UK (UK only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "US National Weather (US only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Pirate Weather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Visual Crossing (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Tomorrow.io (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "AccuWeather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weather Underground (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->location->tooltip
+msgid ""
+"You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use "
+"'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street} "
+"{City/Town} {Postcode} {Country}. The search algorithm is very flexible with "
+"the format. After 3 seconds without typing the address you entered is "
+"replaced automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->description
+msgid "Save current location to storage"
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->tooltip
+msgid ""
+"Saves location information to file so you can switch between them with "
+"buttons in the applet, which will appear if you have more than one."
+msgstr ""
+
+#. 3.8->settings-schema.json->getLocation->description
+msgid "Weather Applet at Cinnamon Spices Website"
+msgstr ""
+
+#. 3.8->settings-schema.json->refreshInterval->tooltip
+msgid ""
+"If you are using a provider with API keys set it to an interval you won't "
+"run out of your quota with."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastDays->tooltip
+msgid ""
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->description
+msgid "Enable minutely precipitation forecast"
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->tooltip
+msgid ""
+"If you'd like to use this make sure you use your exact coordinates/address "
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
+msgstr ""
+
+#. 3.8->settings-schema.json->showBothTempUnits->description
+msgid "Show both temperature units at the same time"
+msgstr ""
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+msgid "Override tooltip on panel"
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
+msgid "Always show Hourly Weather"
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->tooltip
+msgid ""
+"Hide/Show button will be hidden and Hourly weather will be permanently "
+"visible."
+msgstr ""
+
+#. 3.8->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->description
+msgid "Your saved locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->tooltip
+msgid ""
+"You have to make sure the Search entry field is unique and your Timezone is "
+"in the IANA time zone format (e.g. 'Europe/London')"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Latitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Longitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "City"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Country"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Timezone"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Search entry"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->description
+msgid "Display wind direction as text"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->tooltip
+msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->tooltip
+msgid "Does not apply to custom iconset, that is symbolic by default"
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons throughout the applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info-label->description
+msgid ""
+"For detailed information about the applet please go to the Spices Website to "
+"find info about known issues, troubleshooting, changelog and more by "
+"clicking the button below. Here you can ask questions etc in the comment "
+"section by logging in with your Github account."
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->description
+msgid "Submit an Issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->tooltip
+msgid ""
+"Opens webpage where you can fill out a new issue for the applet, needs a "
+"GitHub account.\n"
+" Please make sure that the issue is not already submitted."
+msgstr ""
+
+#. 3.8->settings-schema.json->maintainer->description
+msgid "Current maintainer: Gr3q"
+msgstr ""
+
+#. 3.8->settings-schema.json->issue-reporting-explanation->description
+msgid ""
+"If you find an issue with this applet please make a report by clicking on "
+"the button below and login in with your Github account.\n"
+"\n"
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
+msgstr ""
+
+#. 3.8->settings-schema.json->loc-info->description
+msgid ""
+"Your location in most cases work automatically but you can enter it manually "
+"by coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,"
+"Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/"
+"Town} {Postcode} {Country}. The search algorithm is very flexible with the "
+"format. After 3 seconds without typing the address you entered is replaced "
+"automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->description
+msgid "Log Level"
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->tooltip
+msgid ""
+"Info is the regular logging, Debug is debug, and Verbose also logs network "
+"request payloads. Changing this will only be effective on future logs. Only "
+"change it you are instructed or you know what you are doing."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Verbose"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->description
+msgid "Click Save to save debug information to a file"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->tooltip
+msgid ""
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
+msgstr ""
+
+#. 3.8->settings-schema.json->selectedLogPath->description
+msgid "Selected path to save Logs"
+msgstr ""

--- a/weather@mockturtl/files/weather@mockturtl/po/cs.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/cs.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 3.4.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-30 08:55+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2024-02-04 19:07+0100\n"
 "Last-Translator: Bohuslav Kotál <fotobob1@centrum.cz>\n"
 "Language-Team: \n"
@@ -19,65 +20,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17607
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Chyba"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17608 3.8/weather-applet.js:17610
-#: 3.8/weather-applet.js:17612 3.8/weather-applet.js:17615
-#: 3.8/weather-applet.js:17618 3.8/weather-applet.js:17619
-#: 3.8/weather-applet.js:17620 3.8/weather-applet.js:17621
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Chyba služby"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17609
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Nesprávný API klíč"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17611
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Chybný lokační formát"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17613
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Klíč je blokován"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17614
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Místo se nedaří najít"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17616
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Chybí API klíč"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17617
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Poloha není k dispozici"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17622
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Chybějící balíky"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17623
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Lokalita nemá pokrytí"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9711
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Applet Počasí"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17921
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17922
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Klikněte pro zobrazení"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16215
-#: 3.8/weather-applet.js:17925
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Znovunačtení"
 
@@ -87,8 +88,8 @@ msgstr "API vrátilo stavový kód mezi 400 a 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Uložení lokace"
 
@@ -100,14 +101,14 @@ msgstr "Automaticky zjištěná lokace nemůže být uložena, je nám líto"
 msgid "Could not get weather information"
 msgstr "Nelze zjistit informace o počasí"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17760
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Neočekávaná chyba při získávání předpovědi, detaily jsou dostupné v logu "
 "Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:18003
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -123,7 +124,7 @@ msgstr "Chyba připojení. Zkotroluj log pro více detailů"
 msgid "As of"
 msgstr "Naposledy v"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:17006
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Zdoj předpovědi"
 
@@ -131,52 +132,52 @@ msgstr "Zdoj předpovědi"
 msgid "from you"
 msgstr "od vás"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16919
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:16919
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "v"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10312
-#: 3.8/weather-applet.js:17084
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mil"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10313
-#: 3.8/weather-applet.js:17085
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17262
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Načítání aktuálního počasí ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17265
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Načítání předpovědi počasí ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16168
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Načítá se ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16189
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Teplota"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16190
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Vlhkost"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16191
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Tlak"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12257 3.8/weather-applet.js:12263
-#: 3.8/weather-applet.js:14217 3.8/weather-applet.js:14218
-#: 3.8/weather-applet.js:16037
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Vítr"
 
@@ -185,37 +186,36 @@ msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Ujistěte se, že je zadána lokalita nebo zapnuto její automatické nastavení"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9952
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Nedaří se zjistit lokalitu podle zadané adresy, zkontrolujte správnost zadání"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9973
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Nepodařilo se kontaktovat geolokační API. Detaily jsou v Looking Glass logu."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Varování"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9872
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Uložit lze pouze validní lokace a to v době, kdy se applet neaktualizuje"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Nelze uložit neplatnou lokalitu"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9880
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Informace"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Lokalita je již uložena"
 
@@ -253,15 +253,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10740 3.8/weather-applet.js:11711
-#: 3.8/weather-applet.js:12150 3.8/weather-applet.js:12659
-#: 3.8/weather-applet.js:13021 3.8/weather-applet.js:14388
-#: 3.8/weather-applet.js:14929
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Pocitově"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:14991
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Nepodařilo se zpracovat informace o počasí"
 
@@ -274,7 +274,7 @@ msgstr ""
 "nebo nejdříve získejte na https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:14871
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -282,7 +282,7 @@ msgstr ""
 "Ujistěte se, že klíč API\n"
 "je vložen správně a váš účet není uzamčen"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12113
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -293,60 +293,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10516 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10530 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:11379 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:11386 3.8/weather-applet.js:11393
-#: 3.8/weather-applet.js:11400 3.8/weather-applet.js:12292
-#: 3.8/weather-applet.js:13187
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Průtrž mračen"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11554 3.8/weather-applet.js:11555
-#: 3.8/weather-applet.js:11561 3.8/weather-applet.js:12277
-#: 3.8/weather-applet.js:12278 3.8/weather-applet.js:12284
-#: 3.8/weather-applet.js:12291 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12340 3.8/weather-applet.js:12347
-#: 3.8/weather-applet.js:12801 3.8/weather-applet.js:12850
-#: 3.8/weather-applet.js:12851 3.8/weather-applet.js:12858
-#: 3.8/weather-applet.js:13179 3.8/weather-applet.js:13448
-#: 3.8/weather-applet.js:13449 3.8/weather-applet.js:13490
-#: 3.8/weather-applet.js:14189 3.8/weather-applet.js:14190
-#: 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Déšť"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10495 3.8/weather-applet.js:10509
-#: 3.8/weather-applet.js:10510 3.8/weather-applet.js:11009
-#: 3.8/weather-applet.js:11463 3.8/weather-applet.js:11464
-#: 3.8/weather-applet.js:11470 3.8/weather-applet.js:11477
-#: 3.8/weather-applet.js:11484 3.8/weather-applet.js:12285
-#: 3.8/weather-applet.js:13189
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Slabý déšť"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12348 3.8/weather-applet.js:13163
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Silný mrznoucí déšť"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11014
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12822
-#: 3.8/weather-applet.js:12823 3.8/weather-applet.js:12829
-#: 3.8/weather-applet.js:12830 3.8/weather-applet.js:12836
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Mrznoucí déšť"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12341 3.8/weather-applet.js:13165
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Slabý mrznoucí déšť"
 
@@ -354,177 +354,177 @@ msgstr "Slabý mrznoucí déšť"
 msgid "Light freezing drizzle"
 msgstr "Slabé mrznoucí mrholení"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12327
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Mrznoucí mrholení"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13145
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Slabé mrholení"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12362
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Silný zmrzlý déšť"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12354 3.8/weather-applet.js:12355
-#: 3.8/weather-applet.js:12361 3.8/weather-applet.js:12368
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Zmrzlý déšť"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12369
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Slabý zmrzlý déšť"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10600
-#: 3.8/weather-applet.js:10607 3.8/weather-applet.js:10614
-#: 3.8/weather-applet.js:10615 3.8/weather-applet.js:11021
-#: 3.8/weather-applet.js:11435 3.8/weather-applet.js:11436
-#: 3.8/weather-applet.js:11442 3.8/weather-applet.js:11449
-#: 3.8/weather-applet.js:11456 3.8/weather-applet.js:12320
-#: 3.8/weather-applet.js:13205 3.8/weather-applet.js:13525
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Silné sněžení"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:11610
-#: 3.8/weather-applet.js:11611 3.8/weather-applet.js:11617
-#: 3.8/weather-applet.js:12298 3.8/weather-applet.js:12299
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12795
-#: 3.8/weather-applet.js:13199 3.8/weather-applet.js:13434
-#: 3.8/weather-applet.js:13518 3.8/weather-applet.js:14203
-#: 3.8/weather-applet.js:14204 3.8/weather-applet.js:14581
-#: 3.8/weather-applet.js:14582
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Sněžení"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11019
-#: 3.8/weather-applet.js:11519 3.8/weather-applet.js:11520
-#: 3.8/weather-applet.js:11526 3.8/weather-applet.js:11533
-#: 3.8/weather-applet.js:11540 3.8/weather-applet.js:12313
-#: 3.8/weather-applet.js:13207
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Lehké sněžení"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12305
-#: 3.8/weather-applet.js:12306 3.8/weather-applet.js:14560
-#: 3.8/weather-applet.js:14561
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Sněhový poprašek"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:12375 3.8/weather-applet.js:12376
-#: 3.8/weather-applet.js:12867 3.8/weather-applet.js:12868
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13532
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:14210
-#: 3.8/weather-applet.js:14211
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Bouřka"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12243
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Slabá mlha"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11372
-#: 3.8/weather-applet.js:11373 3.8/weather-applet.js:12235
-#: 3.8/weather-applet.js:12236 3.8/weather-applet.js:12242
-#: 3.8/weather-applet.js:12937 3.8/weather-applet.js:12938
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:14161
-#: 3.8/weather-applet.js:14162 3.8/weather-applet.js:14609
-#: 3.8/weather-applet.js:14610
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Mlha"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10474 3.8/weather-applet.js:10475
-#: 3.8/weather-applet.js:11358 3.8/weather-applet.js:11359
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:12208
-#: 3.8/weather-applet.js:13427 3.8/weather-applet.js:13428
-#: 3.8/weather-applet.js:14154 3.8/weather-applet.js:14155
-#: 3.8/weather-applet.js:14651 3.8/weather-applet.js:14652
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Zataženo"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12228
-#: 3.8/weather-applet.js:12229 3.8/weather-applet.js:12745
-#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:12780
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Převážně zataženo"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10439
-#: 3.8/weather-applet.js:10440 3.8/weather-applet.js:10446
-#: 3.8/weather-applet.js:10447 3.8/weather-applet.js:11547
-#: 3.8/weather-applet.js:11548 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12222 3.8/weather-applet.js:12738
-#: 3.8/weather-applet.js:12739 3.8/weather-applet.js:12773
-#: 3.8/weather-applet.js:13420 3.8/weather-applet.js:13421
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Polojasno"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Převážně jasno"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10425 3.8/weather-applet.js:10426
-#: 3.8/weather-applet.js:11039 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:12724
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12759
-#: 3.8/weather-applet.js:13223 3.8/weather-applet.js:13413
-#: 3.8/weather-applet.js:13414 3.8/weather-applet.js:14140
-#: 3.8/weather-applet.js:14141 3.8/weather-applet.js:14147
-#: 3.8/weather-applet.js:14148 3.8/weather-applet.js:14686
-#: 3.8/weather-applet.js:14687
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Jasno"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10432
-#: 3.8/weather-applet.js:10433 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:14693
-#: 3.8/weather-applet.js:14694
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Slunečno"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10418
-#: 3.8/weather-applet.js:10419 3.8/weather-applet.js:10453
-#: 3.8/weather-applet.js:10454 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10643 3.8/weather-applet.js:11341
-#: 3.8/weather-applet.js:11342 3.8/weather-applet.js:11639
-#: 3.8/weather-applet.js:11640 3.8/weather-applet.js:12192
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12715
-#: 3.8/weather-applet.js:12716 3.8/weather-applet.js:12944
-#: 3.8/weather-applet.js:12945 3.8/weather-applet.js:14073
-#: 3.8/weather-applet.js:14074 3.8/weather-applet.js:14224
-#: 3.8/weather-applet.js:14225 3.8/weather-applet.js:14797
-#: 3.8/weather-applet.js:14799
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Neznámo"
 
@@ -548,7 +548,7 @@ msgstr ""
 "Vložte klíč API v nastavení\n"
 "nebo jej získejte na https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:14881
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -556,7 +556,7 @@ msgstr ""
 "Ujistěte se, že je\n"
 "vložen API klič získaný na DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:15197
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Nedaří se zjistit polohu"
 
@@ -566,121 +566,121 @@ msgid ""
 msgstr ""
 "Lokační služba odpověděla s chybami, detaily jsou v logu v Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11203
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Oblačnost"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11351
-#: 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Jasno"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11365 3.8/weather-applet.js:11366
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Hezky"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11387
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Průtrž mračen s bouřkou"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11394
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Silné dešťové přeháňky"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11401
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Bouřka a intenzivní přeháňky"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11407
-#: 3.8/weather-applet.js:11408 3.8/weather-applet.js:11414
-#: 3.8/weather-applet.js:11421 3.8/weather-applet.js:11428
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Silný mrznoucí déšť"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11415
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Silný mrznoucí déšť déšť s bouřkou"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11422
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Přeháňky silného mrznoucího deště"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11429
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Přeháňky silného deště se sněhem a bouřka"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11443
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Sněhová vánice s bouřkou"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11450
-#: 3.8/weather-applet.js:13526
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Přeháňky sněhové vánice"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11457
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Přeháňky sněhové vánice a bouřka"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11471
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Slabý déšť a bouřka"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11478
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Slabé dešťové přeháňky"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11485
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Slabé dešťové přeháňky a bouřka"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11491
-#: 3.8/weather-applet.js:11492 3.8/weather-applet.js:11498
-#: 3.8/weather-applet.js:11505 3.8/weather-applet.js:11512
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Slabý déšť se sněhem"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11499
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Slabý déšť se sněhem a bouřka"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11506
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Lehké přeháňky deště se sněhem"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11513
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Lehké přeháňky deště se sněhem a bouřka"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11527
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Slabé sněžení a bouřka"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11534
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Slabé sněhové přeháňky"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11541
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Slabé sněhové přeháňky a bouřka"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11562
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Bouřka s deštěm"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11568
-#: 3.8/weather-applet.js:11569 3.8/weather-applet.js:11575
-#: 3.8/weather-applet.js:12859 3.8/weather-applet.js:13185
-#: 3.8/weather-applet.js:13491 3.8/weather-applet.js:13497
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Dešťové přeháňky"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11576
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Dešťové přeháňky a bouřka"
 
@@ -689,44 +689,44 @@ msgstr "Dešťové přeháňky a bouřka"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10537
-#: 3.8/weather-applet.js:10544 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11582 3.8/weather-applet.js:11583
-#: 3.8/weather-applet.js:11589 3.8/weather-applet.js:11596
-#: 3.8/weather-applet.js:11603 3.8/weather-applet.js:12808
-#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12815
-#: 3.8/weather-applet.js:12816 3.8/weather-applet.js:12843
-#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14196
-#: 3.8/weather-applet.js:14197 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Plískanice"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11590
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Déšť se sněhem a bouřka"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11597
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Přeháňky deště se sněhem"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11604
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Přeháňky deště se sněhem a bouřka"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11618
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Sněžení s bouřkou"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11624 3.8/weather-applet.js:11625
-#: 3.8/weather-applet.js:11631 3.8/weather-applet.js:13203
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Sněhové přeháňky"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11632
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Sněhové přeháňky s bouřkou"
 
@@ -735,21 +735,21 @@ msgstr "Sněhové přeháňky s bouřkou"
 msgid "Unexpected response from API"
 msgstr "Neočekávaná odpověď z API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10237
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Dohlednost"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10265
-#: 3.8/weather-applet.js:10817 3.8/weather-applet.js:11722
-#: 3.8/weather-applet.js:12672
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Zpracování informací o aktuálním počasí selhalo"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10055
-#: 3.8/weather-applet.js:10089 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11782 3.8/weather-applet.js:12474
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Zpracování informací s předpovědí selhalo"
 
@@ -778,89 +778,89 @@ msgid "Excellent - More than"
 msgstr "Vynikající - více než"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10460 3.8/weather-applet.js:10461
-#: 3.8/weather-applet.js:11029 3.8/weather-applet.js:13175
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Opar"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:12752
-#: 3.8/weather-applet.js:12753 3.8/weather-applet.js:12787
-#: 3.8/weather-applet.js:13219
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Zataženo"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10489
-#: 3.8/weather-applet.js:10496
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Slabá dešťová přeháňka"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:12326
-#: 3.8/weather-applet.js:13141 3.8/weather-applet.js:14532
-#: 3.8/weather-applet.js:14533
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Mrholení"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:10524
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Silná dešťová přeháňka"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10538
-#: 3.8/weather-applet.js:10545
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Přeháňka mrznoucího deště"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:13217 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14169 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:14589
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Kroupy"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Přeháňka krupobití"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Slabá sněhová přeháňka"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Silná sněhová přeháňka"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10621 3.8/weather-applet.js:10628
-#: 3.8/weather-applet.js:10635 3.8/weather-applet.js:10636
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Bouřka"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Bouřková přeháňka"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10872
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Ujistěte se prosím, že je v nastaveních lokalita zadána ve správném formátu"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10876
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Ujistěte se, že je zadán správný klíč v nastavení"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10681 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -868,211 +868,211 @@ msgstr ""
 "Lokalita nenalezena. Ujistěte se, že je zvolená lokalita dostupná a je ve "
 "správném formátu"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10884
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Pokud problém přetrvává, kontaktujte prosím autora appletu"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10888
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Neznámá chyba, detaily jsou v logu Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10990
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Bouřka se slabým deštěm"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10991
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Bouřka s deštěm"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10992
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Bouřka s přívalovým deštěm"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10993
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Slabá bouřka"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10995
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Silná bouřka"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10996
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Roztroušené bouřky"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10997
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Bouřka s mírným mrholením"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10998
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Bouřka s mrholením"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10999
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Bouřka se silným mžením"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11000
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Slabé mrholení"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11002
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Silné mžení"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11003
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Slabé mrholení"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11004
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Mrholení"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11005
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Intenzivní mrholení"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11006
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Přeháňky a mrholení"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11007
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Průtrže a mrholení"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11008
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Občasné mrholení"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11010
-#: 3.8/weather-applet.js:13455 3.8/weather-applet.js:13456
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Mírný déšť"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11011
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Velmi silný déšť"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11012
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Průtrž mračen"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11013
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Extrémní dešťové srážky"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11015
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Slabé přeháňky"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11016
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Dešťové přeháňky"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11017
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Vydatné dešťové přeháňky"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11018
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Lokální přeháňky"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11023
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Plískanice"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11024
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Slabý déšť se sněhem"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11025
-#: 3.8/weather-applet.js:13462 3.8/weather-applet.js:13463
-#: 3.8/weather-applet.js:13469 3.8/weather-applet.js:13504
-#: 3.8/weather-applet.js:13511
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Déšť se sněhem"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11026
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Lehké sněhové přeháňky"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11027
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Sněhové přeháňky"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11028
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Silné sněhové přeháňky"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:12902
-#: 3.8/weather-applet.js:12903 3.8/weather-applet.js:14623
-#: 3.8/weather-applet.js:14624
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Kouř"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11031 3.8/weather-applet.js:12909
-#: 3.8/weather-applet.js:12910 3.8/weather-applet.js:14616
-#: 3.8/weather-applet.js:14617
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Kouřmo"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11032
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Víření prachu a písku"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11034
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Písek"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11035 3.8/weather-applet.js:12895
-#: 3.8/weather-applet.js:12896 3.8/weather-applet.js:14602
-#: 3.8/weather-applet.js:14603
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Prach"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11036
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Sopečný popílek"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:13209
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Nárazy větru"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11038 3.8/weather-applet.js:12874
-#: 3.8/weather-applet.js:12875 3.8/weather-applet.js:14475
-#: 3.8/weather-applet.js:14476
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Tornádo"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11041
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Bezoblačná obloha"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11042
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Zataženo"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11043
-#: 3.8/weather-applet.js:12731 3.8/weather-applet.js:12732
-#: 3.8/weather-applet.js:12766
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Skoro jasno"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11044
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Polojasno"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11045
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Skoro zataženo"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11046
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Zataženo"
 
@@ -1080,80 +1080,80 @@ msgstr "Zataženo"
 msgid "Could not get forecast for your area"
 msgstr "Nepodařilo se získat předpověď pro vaší oblast"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12431
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "Lokalita leží mimo území USA, použijte jiného poskytovatele."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12495
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Zpracování hodinových předpovědí selhalo"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12760
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Jasno a větrno"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12767
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Skoro jasno a větrno"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12774
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Částečně zataženo a větrno"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Převážně zataženo a větrno"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12788
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Zataženo a větrno"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12802
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Déšť se sněhem"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12837
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Mrznoucí déšť a sněžení"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9153 3.8/weather-applet.js:12881
-#: 3.8/weather-applet.js:12882 3.8/weather-applet.js:14489
-#: 3.8/weather-applet.js:14490
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Hurikán"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9148
-#: 3.8/weather-applet.js:12888
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Bouře"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12889
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Tropická bouře"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12916 3.8/weather-applet.js:12917
-#: 3.8/weather-applet.js:14721 3.8/weather-applet.js:14722
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Horko"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12923 3.8/weather-applet.js:12924
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Zima"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12930 3.8/weather-applet.js:12931
-#: 3.8/weather-applet.js:14770 3.8/weather-applet.js:14771
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Sněhová bouře"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9025
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Dnes"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9027
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Zítra"
 
@@ -1185,79 +1185,79 @@ msgstr "Pátek"
 msgid "Saturday"
 msgstr "Sobota"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9118
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Bezvětří"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9121
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Vánek"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9124
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Lehká bríza"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9127
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Mírná bríza"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9130
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Střední bríza"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9133
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Svěží bríza"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9136
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Silná bríza"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9139
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Vítr dosahující síly vichřice"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9142
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Vichřice"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9145
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Silná vichřice"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9151
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Ničivá bouře"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "SV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "V"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "JV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "J"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "JZ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "Z"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "SZ"
 
@@ -1309,7 +1309,7 @@ msgstr ""
 "Nastala neznámá chyba při pokusu získat předpověď.\n"
 "Detaily jsou v Looking Glass logu"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14482 3.8/weather-applet.js:14483
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Tropická bouře"
 
@@ -1317,7 +1317,7 @@ msgstr "Tropická bouře"
 msgid "Severe Thunderstorms"
 msgstr "Extrémní bouřky"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14503 3.8/weather-applet.js:14504
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Bouřky"
 
@@ -1333,15 +1333,15 @@ msgstr "Déšť a zmrzlý déšť"
 msgid "Mixed Snow and Sleet"
 msgstr "Sněžení a mrznoucí déšť"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Mrznoucí mrholení"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Mrznoucí déšť"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Přeháňky"
 
@@ -1353,11 +1353,11 @@ msgstr "Sněhový poprašek"
 msgid "Light Snow Showers"
 msgstr "Mírné sněhové přeháňky"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14574 3.8/weather-applet.js:14575
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Přízemní sníh"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13441 3.8/weather-applet.js:13442
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Mlhavo"
 
@@ -1369,54 +1369,54 @@ msgstr "Kouřmo"
 msgid "Blustery"
 msgstr "Větrno"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14637 3.8/weather-applet.js:14638
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Větrno"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:14658 3.8/weather-applet.js:14659
-#: 3.8/weather-applet.js:14665 3.8/weather-applet.js:14666
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Převážně zataženo"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14175 3.8/weather-applet.js:14176
-#: 3.8/weather-applet.js:14182 3.8/weather-applet.js:14183
-#: 3.8/weather-applet.js:14672 3.8/weather-applet.js:14673
-#: 3.8/weather-applet.js:14679 3.8/weather-applet.js:14680
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Částečně zataženo"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Převážně slunečno"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:14714 3.8/weather-applet.js:14715
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Déšť a kroupy"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:14728 3.8/weather-applet.js:14729
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Ojedinělé bouřky"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:14735 3.8/weather-applet.js:14736
-#: 3.8/weather-applet.js:14791 3.8/weather-applet.js:14792
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Rozptýlené bouřky"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:14742 3.8/weather-applet.js:14743
-#: 3.8/weather-applet.js:14777 3.8/weather-applet.js:14778
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Rozptýlené přeháňky"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:14749 3.8/weather-applet.js:14750
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Průtrž mračen"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:14756 3.8/weather-applet.js:14757
-#: 3.8/weather-applet.js:14784 3.8/weather-applet.js:14785
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Rozptýlené sněhové přeháňky"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:14763 3.8/weather-applet.js:14764
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Sněhová vánice"
 
@@ -1428,7 +1428,7 @@ msgstr "Nedostupné"
 msgid "Scattered Thundershowers"
 msgstr "Lokální bouřky"
 
-#: 3.8/weather-applet.js:9637
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1436,7 +1436,7 @@ msgstr ""
 "Nepodařilo se načíst logy, soubor nebyl nalezen v umístění\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9641
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1445,11 +1445,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10013
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office Velká Británie"
 
-#: 3.8/weather-applet.js:10118
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1457,277 +1457,277 @@ msgstr ""
 "MET Office UK zajišťuje předpověď pouze pro Vekou Británii, ujistěte se, že "
 "je zadaná lokalita v této zemi"
 
-#: 3.8/weather-applet.js:10197
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Data pro lokalitu se nedaří najít"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Velmi špatná"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Méně než {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Vynikající"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Více než {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10287
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Špatná"
 
-#: 3.8/weather-applet.js:10287 3.8/weather-applet.js:10292
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:10302
-#: 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Mezi {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10292
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Průměrná"
 
-#: 3.8/weather-applet.js:10297
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Dobrá"
 
-#: 3.8/weather-applet.js:10302 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Velmi dobrá"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10662
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:11659
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12080
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12250
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Slabý vítr"
 
-#: 3.8/weather-applet.js:12264
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Silný vítr"
 
-#: 3.8/weather-applet.js:12411
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:12962
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:13139
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Sněhové jazyky"
 
-#: 3.8/weather-applet.js:13143
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Silné mžení"
 
-#: 3.8/weather-applet.js:13147
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Silné mrholení/déšť"
 
-#: 3.8/weather-applet.js:13149
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Slabé mrholení/déšť"
 
-#: 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Prachová bouře"
 
-#: 3.8/weather-applet.js:13155
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Mrznoucí mrholení/déšť"
 
-#: 3.8/weather-applet.js:13157
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Silné mrznoucí mrholení/déšť"
 
-#: 3.8/weather-applet.js:13159
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Slabé mrznoucí mrholení/déšť"
 
-#: 3.8/weather-applet.js:13161
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Namrzající mlha"
 
-#: 3.8/weather-applet.js:13167
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Trychtýřový mrak/tornádo"
 
-#: 3.8/weather-applet.js:13169
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Přeháňky s kroupami"
 
-#: 3.8/weather-applet.js:13171
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Náledí"
 
-#: 3.8/weather-applet.js:13173
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Blesky bez bouřky"
 
-#: 3.8/weather-applet.js:13177
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Srážky poblíž"
 
-#: 3.8/weather-applet.js:13181 3.8/weather-applet.js:13470
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Silný déšť a sněžení"
 
-#: 3.8/weather-applet.js:13183
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Slabý déšť a sněžení"
 
-#: 3.8/weather-applet.js:13191
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Ubývání oblačnosti"
 
-#: 3.8/weather-applet.js:13193
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Přibývání oblačnosti"
 
-#: 3.8/weather-applet.js:13195
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Oblačnost stabilní"
 
-#: 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Kouř nebo opar"
 
-#: 3.8/weather-applet.js:13201
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Sněhové a dešťové přeháňky"
 
-#: 3.8/weather-applet.js:13213
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Bouřka bez srážek"
 
-#: 3.8/weather-applet.js:13215
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Diamantový prach"
 
-#: 3.8/weather-applet.js:13221
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Částečné zataženo"
 
-#: 3.8/weather-applet.js:13243
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 "Ujistěte se, že je\n"
 "API klič vložen správně"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13259
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:13402 3.8/weather-applet.js:13403
-#: 3.8/weather-applet.js:13539 3.8/weather-applet.js:13540
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "NENALEZENO"
 
-#: 3.8/weather-applet.js:13435
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Přízemní sníh"
 
-#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:13477
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Lehké sněžení"
 
-#: 3.8/weather-applet.js:13483 3.8/weather-applet.js:13484
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Mírné sněžení"
 
-#: 3.8/weather-applet.js:13498
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Mírné dešťové přeháňky"
 
-#: 3.8/weather-applet.js:13505
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Déšť se sněhem"
 
-#: 3.8/weather-applet.js:13512
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Silný déšť a sněžení"
 
-#: 3.8/weather-applet.js:13657
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:13953
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:13966
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "Vyberte prosím jiného poskytovatele předpovědi"
 
-#: 3.8/weather-applet.js:14263
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14453
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "Zadaný API klíč není platný."
 
-#: 3.8/weather-applet.js:14460
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "Zadaná lokalita nebyla nalezena."
 
-#: 3.8/weather-applet.js:14496 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Silná bouře"
 
-#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:14512
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Déšť se sněhem"
 
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Déšť a zmrzlý déšť"
 
-#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Sněhové přeháňky"
 
-#: 3.8/weather-applet.js:14630 3.8/weather-applet.js:14631
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "Větrno"
 
-#: 3.8/weather-applet.js:14644 3.8/weather-applet.js:14645
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr "Mráz"
 
-#: 3.8/weather-applet.js:14700 3.8/weather-applet.js:14701
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Skoro jasno"
 
-#: 3.8/weather-applet.js:14853
+#: 3.8/weather-applet.js:15247
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:15206
+#: 3.8/weather-applet.js:15603
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
@@ -1735,13 +1735,13 @@ msgstr ""
 "Lokační služba nedokázala najít polohu počítače, detaily jsou v logu v "
 "Looking Glass"
 
-#: 3.8/weather-applet.js:15428
+#: 3.8/weather-applet.js:15831
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Ujistěte se, že je lokalita zadána nebo místo toho přepněte na automatické "
 "zjištění lokace."
 
-#: 3.8/weather-applet.js:15565
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1749,7 +1749,7 @@ msgstr ""
 "Nepodařilo se načíst nastavení, soubor nebyl nebyl nalezen v umístění\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15572
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1757,57 +1757,57 @@ msgstr ""
 "Nepodařilo se načíst obsah nastavení z umístění\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Poskytovatel předpovědi k činnosti vyžaduje API klíč"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Rosný bod"
 
-#: 3.8/weather-applet.js:16264
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Srážky ustanou za {precipEnd} minut"
 
-#: 3.8/weather-applet.js:16266
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "Srážky lze očekávat po celou následující hodinu"
 
-#: 3.8/weather-applet.js:16269
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Za {precipStart} minut začnou padat srážky"
 
-#: 3.8/weather-applet.js:16481
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Selhala analýza předpovědi, více detailů je v Záznamech."
 
-#: 3.8/weather-applet.js:17013 3.8/weather-applet.js:17802
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "Aktualizováno {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:17019
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} od vás"
 
-#: 3.8/weather-applet.js:17023
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "Jméno stanice: {stationName}"
 
-#: 3.8/weather-applet.js:17026
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "Oblast: {stationArea}"
 
-#: 3.8/weather-applet.js:17573 3.8/weather-applet.js:17583
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Nepodařilo se uložit debug informace"
 
-#: 3.8/weather-applet.js:17595
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Debug informace úspěšně uloženy"
 
-#: 3.8/weather-applet.js:17595
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Uloženo do {filePath}"
-
-#: 3.8/weather-applet.js:17726
-msgid "This provider requires an API key to operate"
-msgstr "Poskytovatel předpovědi k činnosti vyžaduje API klíč"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"

--- a/weather@mockturtl/files/weather@mockturtl/po/da.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/da.po
@@ -7,8 +7,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.4.2\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-21 09:37+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2023-12-25 11:54+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: dansk <dansk@dansk-gruppen.dk>\n"
@@ -20,65 +21,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17519
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Fejl"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17520 3.8/weather-applet.js:17522
-#: 3.8/weather-applet.js:17524 3.8/weather-applet.js:17527
-#: 3.8/weather-applet.js:17530 3.8/weather-applet.js:17531
-#: 3.8/weather-applet.js:17532 3.8/weather-applet.js:17533
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Tjenestefejl"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17521
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Forkert API-nøgle"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17523
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Forkert lokalitetsformat"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17525
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Nøgle blokeret"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17526
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Kan ikke finde lokaliteten"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17528
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Ingen API-nøgle"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17529
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Ingen lokalitet"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17534
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Manglende pakker"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17535
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Lokaliteten er ikke dækket"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9711
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Vejret"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17833
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "…"
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17834
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Klik for at åbne"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16129
-#: 3.8/weather-applet.js:17837
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Opdatér"
 
@@ -88,8 +89,8 @@ msgstr "API'en returnerede statuskode mellem 400 og 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Lokalitetslager"
 
@@ -101,12 +102,12 @@ msgstr "Du kan desværre ikke gemme en automatisk indhentet lokalitet"
 msgid "Could not get weather information"
 msgstr "Kunne ikke hente oplysninger om vejret"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17672
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr "Uventet fejl under genindlæsning af vejret. Se loggene i Luppen"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:17915
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -122,7 +123,7 @@ msgstr "Netværksfejl. Se loggene i Luppen"
 msgid "As of"
 msgstr "Fra"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:16920
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Leveret af"
 
@@ -130,90 +131,89 @@ msgstr "Leveret af"
 msgid "from you"
 msgstr "fra dig"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16833
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:16833
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "i"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10312
-#: 3.8/weather-applet.js:16998
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10313
-#: 3.8/weather-applet.js:16999
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17176
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Henter nuværende vejrdata …"
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17179
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Henter fremtidige vejrdata …"
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16082
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Indlæser …"
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16103
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Temperatur"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16104
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Luftfugtighed"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16105
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Tryk"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12257 3.8/weather-applet.js:12263
-#: 3.8/weather-applet.js:14217 3.8/weather-applet.js:14218
-#: 3.8/weather-applet.js:15951
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Vind"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:15343
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Sikr dig, at du har angivet en lokalitet eller brug automatisk lokalitet i "
 "stedet"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9952
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr "Kunne ikke finde lokalitet baseret på adressen. Tjek, om den er rigtig"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9973
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "Kunne ikke kalde Geolocation-API'en. Se loggene i Luppen for fejl."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Advarsel"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9872
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Du kan kun gemme korrekte lokaliteter, når panelprogrammet ikke genindlæser"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Du kan ikke gemme en forkert lokalitet"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9880
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Information"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Lokaliteten er allerede gemt"
 
@@ -250,15 +250,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10740 3.8/weather-applet.js:11711
-#: 3.8/weather-applet.js:12150 3.8/weather-applet.js:12659
-#: 3.8/weather-applet.js:13021 3.8/weather-applet.js:14388
-#: 3.8/weather-applet.js:14978
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Føles som"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:15040
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Kunne ikke behandle vejrinformation"
 
@@ -271,7 +271,7 @@ msgstr ""
 "eller hent først en på https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:14920
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -279,7 +279,7 @@ msgstr ""
 "Sikr dig, at du har indtastet\n"
 "API-nøglen korrekt og din konto ikke er låst"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12113
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -290,60 +290,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10516 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10530 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:11379 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:11386 3.8/weather-applet.js:11393
-#: 3.8/weather-applet.js:11400 3.8/weather-applet.js:12292
-#: 3.8/weather-applet.js:13187
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Kraftig regn"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11554 3.8/weather-applet.js:11555
-#: 3.8/weather-applet.js:11561 3.8/weather-applet.js:12277
-#: 3.8/weather-applet.js:12278 3.8/weather-applet.js:12284
-#: 3.8/weather-applet.js:12291 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12340 3.8/weather-applet.js:12347
-#: 3.8/weather-applet.js:12801 3.8/weather-applet.js:12850
-#: 3.8/weather-applet.js:12851 3.8/weather-applet.js:12858
-#: 3.8/weather-applet.js:13179 3.8/weather-applet.js:13448
-#: 3.8/weather-applet.js:13449 3.8/weather-applet.js:13490
-#: 3.8/weather-applet.js:14189 3.8/weather-applet.js:14190
-#: 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Regn"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10495 3.8/weather-applet.js:10509
-#: 3.8/weather-applet.js:10510 3.8/weather-applet.js:11009
-#: 3.8/weather-applet.js:11463 3.8/weather-applet.js:11464
-#: 3.8/weather-applet.js:11470 3.8/weather-applet.js:11477
-#: 3.8/weather-applet.js:11484 3.8/weather-applet.js:12285
-#: 3.8/weather-applet.js:13189
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Let regn"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12348 3.8/weather-applet.js:13163
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Kraftig isslag"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11014
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12822
-#: 3.8/weather-applet.js:12823 3.8/weather-applet.js:12829
-#: 3.8/weather-applet.js:12830 3.8/weather-applet.js:12836
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Isslag"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12341 3.8/weather-applet.js:13165
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Let isslag"
 
@@ -351,177 +351,177 @@ msgstr "Let isslag"
 msgid "Light freezing drizzle"
 msgstr "Let isslag"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12327
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Isslag"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13145
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Let støvregn"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12362
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Stor mængde ispiller"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12354 3.8/weather-applet.js:12355
-#: 3.8/weather-applet.js:12361 3.8/weather-applet.js:12368
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Ispiller"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12369
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Lille mængde ispiller"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10600
-#: 3.8/weather-applet.js:10607 3.8/weather-applet.js:10614
-#: 3.8/weather-applet.js:10615 3.8/weather-applet.js:11021
-#: 3.8/weather-applet.js:11435 3.8/weather-applet.js:11436
-#: 3.8/weather-applet.js:11442 3.8/weather-applet.js:11449
-#: 3.8/weather-applet.js:11456 3.8/weather-applet.js:12320
-#: 3.8/weather-applet.js:13205 3.8/weather-applet.js:13525
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Kraftig sne"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:11610
-#: 3.8/weather-applet.js:11611 3.8/weather-applet.js:11617
-#: 3.8/weather-applet.js:12298 3.8/weather-applet.js:12299
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12795
-#: 3.8/weather-applet.js:13199 3.8/weather-applet.js:13434
-#: 3.8/weather-applet.js:13518 3.8/weather-applet.js:14203
-#: 3.8/weather-applet.js:14204 3.8/weather-applet.js:14581
-#: 3.8/weather-applet.js:14582
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Sne"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11019
-#: 3.8/weather-applet.js:11519 3.8/weather-applet.js:11520
-#: 3.8/weather-applet.js:11526 3.8/weather-applet.js:11533
-#: 3.8/weather-applet.js:11540 3.8/weather-applet.js:12313
-#: 3.8/weather-applet.js:13207
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Let sne"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12305
-#: 3.8/weather-applet.js:12306 3.8/weather-applet.js:14560
-#: 3.8/weather-applet.js:14561
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Lette snebyger"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:12375 3.8/weather-applet.js:12376
-#: 3.8/weather-applet.js:12867 3.8/weather-applet.js:12868
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13532
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:14210
-#: 3.8/weather-applet.js:14211
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Tordenvejr"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12243
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Let tåge"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11372
-#: 3.8/weather-applet.js:11373 3.8/weather-applet.js:12235
-#: 3.8/weather-applet.js:12236 3.8/weather-applet.js:12242
-#: 3.8/weather-applet.js:12937 3.8/weather-applet.js:12938
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:14161
-#: 3.8/weather-applet.js:14162 3.8/weather-applet.js:14609
-#: 3.8/weather-applet.js:14610
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Tåge"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10474 3.8/weather-applet.js:10475
-#: 3.8/weather-applet.js:11358 3.8/weather-applet.js:11359
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:12208
-#: 3.8/weather-applet.js:13427 3.8/weather-applet.js:13428
-#: 3.8/weather-applet.js:14154 3.8/weather-applet.js:14155
-#: 3.8/weather-applet.js:14651 3.8/weather-applet.js:14652
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Overskyet"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12228
-#: 3.8/weather-applet.js:12229 3.8/weather-applet.js:12745
-#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:12780
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Næsten overskyet"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10439
-#: 3.8/weather-applet.js:10440 3.8/weather-applet.js:10446
-#: 3.8/weather-applet.js:10447 3.8/weather-applet.js:11547
-#: 3.8/weather-applet.js:11548 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12222 3.8/weather-applet.js:12738
-#: 3.8/weather-applet.js:12739 3.8/weather-applet.js:12773
-#: 3.8/weather-applet.js:13420 3.8/weather-applet.js:13421
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Delvist skyet"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Overvejende klart"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10425 3.8/weather-applet.js:10426
-#: 3.8/weather-applet.js:11039 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:12724
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12759
-#: 3.8/weather-applet.js:13223 3.8/weather-applet.js:13413
-#: 3.8/weather-applet.js:13414 3.8/weather-applet.js:14140
-#: 3.8/weather-applet.js:14141 3.8/weather-applet.js:14147
-#: 3.8/weather-applet.js:14148 3.8/weather-applet.js:14686
-#: 3.8/weather-applet.js:14687
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Klart"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10432
-#: 3.8/weather-applet.js:10433 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:14693
-#: 3.8/weather-applet.js:14694
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Solrigt"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10418
-#: 3.8/weather-applet.js:10419 3.8/weather-applet.js:10453
-#: 3.8/weather-applet.js:10454 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10643 3.8/weather-applet.js:11341
-#: 3.8/weather-applet.js:11342 3.8/weather-applet.js:11639
-#: 3.8/weather-applet.js:11640 3.8/weather-applet.js:12192
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12715
-#: 3.8/weather-applet.js:12716 3.8/weather-applet.js:12944
-#: 3.8/weather-applet.js:12945 3.8/weather-applet.js:14073
-#: 3.8/weather-applet.js:14074 3.8/weather-applet.js:14224
-#: 3.8/weather-applet.js:14225 3.8/weather-applet.js:14797
-#: 3.8/weather-applet.js:14799
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Ukendt"
 
@@ -545,7 +545,7 @@ msgstr ""
 "Indtast API-nøglen under indstillinger,\n"
 "eller hent først en på https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:14930
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -553,130 +553,130 @@ msgstr ""
 "Sikr dig, at du har indtastet\n"
 "API-nøglen, som du har fra DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:14878
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Kunne ikke hente lokalitet"
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:14884
+#: 3.0/ipApi.js:95
 msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr "Lokalitetstjenesten svarede med fejl. Se loggene i Luppen"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11203
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Skydække"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11351
-#: 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Klart vejr"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11365 3.8/weather-applet.js:11366
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Opholdsvejr"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11387
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Kraftig regn og torden"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11394
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Kraftige regnbyger"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11401
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Kraftig regnbyger og torden"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11407
-#: 3.8/weather-applet.js:11408 3.8/weather-applet.js:11414
-#: 3.8/weather-applet.js:11421 3.8/weather-applet.js:11428
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Kraftig slud"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11415
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Kraftig slud og torden"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11422
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Kraftige sludbyger"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11429
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Kraftige sludbyger og torden"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11443
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Kraftig sne og torden"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11450
-#: 3.8/weather-applet.js:13526
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Kraftige snebyger"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11457
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Kraftig snebyger og torden"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11471
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Let regn og torden"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11478
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Lette regnbyger"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11485
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Lette regnbyger og torden"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11491
-#: 3.8/weather-applet.js:11492 3.8/weather-applet.js:11498
-#: 3.8/weather-applet.js:11505 3.8/weather-applet.js:11512
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Let slud"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11499
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Let slud og torden"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11506
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Lette sludbyger"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11513
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Lette sludbyger og torden"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11527
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Let sne og torden"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11534
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Lette snebyger"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11541
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Lette snebyger og torden"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11562
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Regn og torden"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11568
-#: 3.8/weather-applet.js:11569 3.8/weather-applet.js:11575
-#: 3.8/weather-applet.js:12859 3.8/weather-applet.js:13185
-#: 3.8/weather-applet.js:13491 3.8/weather-applet.js:13497
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Regnbyger"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11576
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Regnbyger og torden"
 
@@ -685,44 +685,44 @@ msgstr "Regnbyger og torden"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10537
-#: 3.8/weather-applet.js:10544 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11582 3.8/weather-applet.js:11583
-#: 3.8/weather-applet.js:11589 3.8/weather-applet.js:11596
-#: 3.8/weather-applet.js:11603 3.8/weather-applet.js:12808
-#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12815
-#: 3.8/weather-applet.js:12816 3.8/weather-applet.js:12843
-#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14196
-#: 3.8/weather-applet.js:14197 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Slud"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11590
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Slud og torden"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11597
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Sludbyger"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11604
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Sludbyger og torden"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11618
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Sne og torden"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11624 3.8/weather-applet.js:11625
-#: 3.8/weather-applet.js:11631 3.8/weather-applet.js:13203
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Snebyger"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11632
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Snebyger og torden"
 
@@ -731,21 +731,21 @@ msgstr "Snebyger og torden"
 msgid "Unexpected response from API"
 msgstr "Uventet svar fra API'en"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10237
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Sigtbarhed"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10265
-#: 3.8/weather-applet.js:10817 3.8/weather-applet.js:11722
-#: 3.8/weather-applet.js:12672
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Kunne ikke behandle aktuelle vejrinformation"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10055
-#: 3.8/weather-applet.js:10089 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11782 3.8/weather-applet.js:12474
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Kunne ikke behandle vejrudsigtsinformation"
 
@@ -774,88 +774,88 @@ msgid "Excellent - More than"
 msgstr "Fremragende - mere end"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10460 3.8/weather-applet.js:10461
-#: 3.8/weather-applet.js:11029 3.8/weather-applet.js:13175
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Dis"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:12752
-#: 3.8/weather-applet.js:12753 3.8/weather-applet.js:12787
-#: 3.8/weather-applet.js:13219
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Overskyet"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10489
-#: 3.8/weather-applet.js:10496
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Lette regnbyger"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:12326
-#: 3.8/weather-applet.js:13141 3.8/weather-applet.js:14532
-#: 3.8/weather-applet.js:14533
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Støvregn"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:10524
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Kraftige regnbyger"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10538
-#: 3.8/weather-applet.js:10545
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Sludbyger"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:13217 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14169 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:14589
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Hagl"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Haglbyger"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Lette snebyger"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Kraftige snebyger"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10621 3.8/weather-applet.js:10628
-#: 3.8/weather-applet.js:10635 3.8/weather-applet.js:10636
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Tordenvejr"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Tordenbyger"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10872
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Sikr dig, at lokalitet er i det rigtige format under indstillinger"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10876
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Sikr dig, at du har indtastet den rigtige nøgle under indstillinger"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10681 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -863,211 +863,211 @@ msgstr ""
 "Lokalitet ikke fundet. Sikr dig, at lokaliteten er tilgængelig eller er i "
 "det rigtige format"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10884
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Kontakt forfatteren af panelprogrammet, hvis problemet varer ved"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10888
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Ukendt fejl. Se loggene i Luppen"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10990
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Tordenvejr med let regn"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10991
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Tordenvejr med regn"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10992
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Tordenvejr med kraftig regn"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10993
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Let tordenvejr"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10995
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Kraftigt tordenvejr"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10996
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Ujævnt tordenvejr"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10997
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Tordenvejr med let støvregn"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10998
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Tordenvejr med støvregn"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10999
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Tordenvejr med kraftig støvregn"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11000
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Let støvregn"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11002
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Kraftig støvregn"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11003
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Let finregn"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11004
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Finregn"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11005
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Kraftig finregn"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11006
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Bygeregn og støvregn"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11007
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Kraftig bygeregn og støvregn"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11008
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Bygestøvregn"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11010
-#: 3.8/weather-applet.js:13455 3.8/weather-applet.js:13456
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Moderat regn"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11011
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Kraftig regn"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11012
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Meget kraftig regn"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11013
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Ekstrem regn"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11015
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Lette regnbyger"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11016
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Regnbyger"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11017
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Kraftige regnbyger"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11018
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Ujævne regnbyger"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11023
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Sludbyger"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11024
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Let regn og sne"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11025
-#: 3.8/weather-applet.js:13462 3.8/weather-applet.js:13463
-#: 3.8/weather-applet.js:13469 3.8/weather-applet.js:13504
-#: 3.8/weather-applet.js:13511
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Regn og sne"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11026
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Lette snebyger"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11027
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Snebyger"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11028
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Kraftige snebyger"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:12902
-#: 3.8/weather-applet.js:12903 3.8/weather-applet.js:14623
-#: 3.8/weather-applet.js:14624
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Røg"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11031 3.8/weather-applet.js:12909
-#: 3.8/weather-applet.js:12910 3.8/weather-applet.js:14616
-#: 3.8/weather-applet.js:14617
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Dis"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11032
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Sand, støvhvirvler"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11034
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Sand"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11035 3.8/weather-applet.js:12895
-#: 3.8/weather-applet.js:12896 3.8/weather-applet.js:14602
-#: 3.8/weather-applet.js:14603
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Støv"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11036
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Vulkansk aske"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:13209
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Vindstød"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11038 3.8/weather-applet.js:12874
-#: 3.8/weather-applet.js:12875 3.8/weather-applet.js:14475
-#: 3.8/weather-applet.js:14476
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11041
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Skyfrit"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11042
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Skyer"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11043
-#: 3.8/weather-applet.js:12731 3.8/weather-applet.js:12732
-#: 3.8/weather-applet.js:12766
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Få skyer"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11044
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Spredte skyer"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11045
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Spredt skydække"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11046
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Overskyet"
 
@@ -1075,80 +1075,80 @@ msgstr "Overskyet"
 msgid "Could not get forecast for your area"
 msgstr "Kunne ikke hente vejrudsigten for dit område"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12431
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "Området er uden for USA - brug en anden udbyder."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12495
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Kunne ikke behandle timebaseret vejrudsigtsinformation"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12760
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Klart og blæsende"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12767
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Få skyer og blæsende"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12774
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Delvist skyet og blæsende"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Næsten overskyet og blæsende"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12788
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Overskyet og blæsende"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12802
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Slud"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12837
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Isslag og sne"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9153 3.8/weather-applet.js:12881
-#: 3.8/weather-applet.js:12882 3.8/weather-applet.js:14489
-#: 3.8/weather-applet.js:14490
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Tyfon"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9148
-#: 3.8/weather-applet.js:12888
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Storm"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12889
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Tropisk storm"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12916 3.8/weather-applet.js:12917
-#: 3.8/weather-applet.js:14721 3.8/weather-applet.js:14722
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Varmt"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12923 3.8/weather-applet.js:12924
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Koldt"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12930 3.8/weather-applet.js:12931
-#: 3.8/weather-applet.js:14770 3.8/weather-applet.js:14771
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Snestorm"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9025
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "I dag"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9027
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "I morgen"
 
@@ -1180,79 +1180,79 @@ msgstr "Fredag"
 msgid "Saturday"
 msgstr "Lørdag"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9118
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Stille"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9121
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Let luft"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9124
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Let brise"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9127
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Blid brise"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9130
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Moderat brise"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9133
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Frisk brise"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9136
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Stærk brise"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9139
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Tæt på kuling"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9142
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Kuling"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9145
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Stormende kuling"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9151
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Kraftig storm"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "NØ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "Ø"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "SØ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "SV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "V"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "NV"
 
@@ -1304,7 +1304,7 @@ msgstr ""
 "Ukendt fejl opstod i forsøget på at hente vejret. Se Lup-loggen for mere "
 "information"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14482 3.8/weather-applet.js:14483
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Tropisk storm"
 
@@ -1312,7 +1312,7 @@ msgstr "Tropisk storm"
 msgid "Severe Thunderstorms"
 msgstr "Kraftige tordenbyger"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14503 3.8/weather-applet.js:14504
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Tordenvejr"
 
@@ -1328,15 +1328,15 @@ msgstr "Blandet regn og slud"
 msgid "Mixed Snow and Sleet"
 msgstr "Blandet sne og slud"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Isslag"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Isslag"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Byger"
 
@@ -1348,11 +1348,11 @@ msgstr "Lette snebyger"
 msgid "Light Snow Showers"
 msgstr "Lette snebyger"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14574 3.8/weather-applet.js:14575
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Fygesne"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13441 3.8/weather-applet.js:13442
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Tåget"
 
@@ -1364,54 +1364,54 @@ msgstr "Røg"
 msgid "Blustery"
 msgstr "Susende"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14637 3.8/weather-applet.js:14638
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Blæsende"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:14658 3.8/weather-applet.js:14659
-#: 3.8/weather-applet.js:14665 3.8/weather-applet.js:14666
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Næsten overskyet"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14175 3.8/weather-applet.js:14176
-#: 3.8/weather-applet.js:14182 3.8/weather-applet.js:14183
-#: 3.8/weather-applet.js:14672 3.8/weather-applet.js:14673
-#: 3.8/weather-applet.js:14679 3.8/weather-applet.js:14680
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Delvist skyet"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Overvejende solrigt"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:14714 3.8/weather-applet.js:14715
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Blandet regn og hagl"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:14728 3.8/weather-applet.js:14729
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Lokale tordenbyger"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:14735 3.8/weather-applet.js:14736
-#: 3.8/weather-applet.js:14791 3.8/weather-applet.js:14792
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Spredte tordenbyger"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:14742 3.8/weather-applet.js:14743
-#: 3.8/weather-applet.js:14777 3.8/weather-applet.js:14778
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Spredte byger"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:14749 3.8/weather-applet.js:14750
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Kraftig regn"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:14756 3.8/weather-applet.js:14757
-#: 3.8/weather-applet.js:14784 3.8/weather-applet.js:14785
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Spredte snebyger"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:14763 3.8/weather-applet.js:14764
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Kraftig sne"
 
@@ -1423,7 +1423,7 @@ msgstr "Ikke tilgængelig"
 msgid "Scattered Thundershowers"
 msgstr "Spredte tordenbyger"
 
-#: 3.8/weather-applet.js:9637
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1431,7 +1431,7 @@ msgstr ""
 "Kunne ikke hente logge. Logfilen blev ikke fundet under stien\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9641
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1440,285 +1440,299 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10013
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10118
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr "Met Office UK dækker kun UK. Sikr dig, at din lokalitet er i landet"
 
-#: 3.8/weather-applet.js:10197
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Data blev ikke fundet for lokaliteten"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Meget dårlig"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Mindre end {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Fremragende"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Mere end {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10287
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Dårlig"
 
-#: 3.8/weather-applet.js:10287 3.8/weather-applet.js:10292
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:10302
-#: 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Mellem {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10292
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Moderat"
 
-#: 3.8/weather-applet.js:10297
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "God"
 
-#: 3.8/weather-applet.js:10302 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Meget god"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10662
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "Meteorologisk institutt Norge"
 
-#: 3.8/weather-applet.js:11659
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12080
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12250
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Let vind"
 
-#: 3.8/weather-applet.js:12264
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Stærk vind"
 
-#: 3.8/weather-applet.js:12411
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:12962
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:13139
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Fygesne"
 
-#: 3.8/weather-applet.js:13143
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Kraftig støvregn"
 
-#: 3.8/weather-applet.js:13147
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Kraftig støvregn/regn"
 
-#: 3.8/weather-applet.js:13149
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Let støvregn/regn"
 
-#: 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Støvstorm"
 
-#: 3.8/weather-applet.js:13155
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Isslag"
 
-#: 3.8/weather-applet.js:13157
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Kraftig isslag"
 
-#: 3.8/weather-applet.js:13159
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Let isslag"
 
-#: 3.8/weather-applet.js:13161
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Iståge"
 
-#: 3.8/weather-applet.js:13167
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Tragtskt/tornado"
 
-#: 3.8/weather-applet.js:13169
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Haglbyger"
 
-#: 3.8/weather-applet.js:13171
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Is"
 
-#: 3.8/weather-applet.js:13173
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Lyn uden torden"
 
-#: 3.8/weather-applet.js:13177
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Nedbør i nærheden"
 
-#: 3.8/weather-applet.js:13181 3.8/weather-applet.js:13470
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Kraftig regn og sne"
 
-#: 3.8/weather-applet.js:13183
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Let regn og sne"
 
-#: 3.8/weather-applet.js:13191
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Aftagende skydække"
 
-#: 3.8/weather-applet.js:13193
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Tiltagende skydække"
 
-#: 3.8/weather-applet.js:13195
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Uændret skydække"
 
-#: 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Røg eller dis"
 
-#: 3.8/weather-applet.js:13201
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Sne- og regnbyger"
 
-#: 3.8/weather-applet.js:13213
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Tordenvejr uden nedbør"
 
-#: 3.8/weather-applet.js:13215
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Isnåle"
 
-#: 3.8/weather-applet.js:13221
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Delvist skyet"
 
-#: 3.8/weather-applet.js:13243
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Sikr dig, at du har indtastet API-nøglen korrekt"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13259
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Danmark"
 
-#: 3.8/weather-applet.js:13402 3.8/weather-applet.js:13403
-#: 3.8/weather-applet.js:13539 3.8/weather-applet.js:13540
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "IKKE FUNDET"
 
-#: 3.8/weather-applet.js:13435
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Fygesne"
 
-#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:13477
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Let sne"
 
-#: 3.8/weather-applet.js:13483 3.8/weather-applet.js:13484
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Moderat sne"
 
-#: 3.8/weather-applet.js:13498
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Moderate regnbyger"
 
-#: 3.8/weather-applet.js:13505
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Blandet regn og sne"
 
-#: 3.8/weather-applet.js:13512
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Kraftig regn og sne"
 
-#: 3.8/weather-applet.js:13657
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:13953
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:13966
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "Vælg en anden udbyder eller lokalitet"
 
-#: 3.8/weather-applet.js:14263
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14453
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "Den angivne API-nøgle er ugyldig."
 
-#: 3.8/weather-applet.js:14460
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "Dn angivne lokalitet blev ikke fundet."
 
-#: 3.8/weather-applet.js:14496 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Stærk storm"
 
-#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:14512
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Rain and Snow"
 
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Regn og slud"
 
-#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Snebyger"
 
-#: 3.8/weather-applet.js:14630 3.8/weather-applet.js:14631
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "Let blæsende"
 
-#: 3.8/weather-applet.js:14644 3.8/weather-applet.js:14645
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr "Køligt"
 
-#: 3.8/weather-applet.js:14700 3.8/weather-applet.js:14701
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Overvejende klart"
 
-#: 3.8/weather-applet.js:14902
+#: 3.8/weather-applet.js:15247
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:15481
+#: 3.8/weather-applet.js:15603
+#, fuzzy
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr "Lokalitetstjenesten svarede med fejl. Se loggene i Luppen"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+"Sikr dig, at du har angivet en lokalitet eller brug automatisk lokalitet i "
+"stedet"
+
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1726,7 +1740,7 @@ msgstr ""
 "Kunne ikke hente konfigurationen. Filen blev ikke fundet under stien\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15486
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1734,57 +1748,57 @@ msgstr ""
 "Kunne ikke hente indholdet af konfigurationsfilen under stien\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:16106
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Denne udbyder kræver en API-nøgle for at virke"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Dugpunkt"
 
-#: 3.8/weather-applet.js:16178
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Nedbøren vil ophøre om {precipEnd} minutter"
 
-#: 3.8/weather-applet.js:16180
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "Nedbøren vil ikke ophøre den næste time"
 
-#: 3.8/weather-applet.js:16183
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Nedbøren vil begynde om {precipStart} minutter"
 
-#: 3.8/weather-applet.js:16395
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Tolkning af vejrudsigt mislykkedes. Se loggen for flere detaljer."
 
-#: 3.8/weather-applet.js:16927 3.8/weather-applet.js:17714
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "Fra"
 
-#: 3.8/weather-applet.js:16933
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} fra dig"
 
-#: 3.8/weather-applet.js:16937
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "Stationsnavn: {stationName}"
 
-#: 3.8/weather-applet.js:16940
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "Område: {stationArea}"
 
-#: 3.8/weather-applet.js:17485 3.8/weather-applet.js:17495
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Der opstod en fejl, da fejlsøgningsinformation skulle gemmes"
 
-#: 3.8/weather-applet.js:17507
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Fejlsøgningsinformation blev gemt"
 
-#: 3.8/weather-applet.js:17507
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Gemt i {filePath}"
-
-#: 3.8/weather-applet.js:17638
-msgid "This provider requires an API key to operate"
-msgstr "Denne udbyder kræver en API-nøgle for at virke"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -2312,6 +2326,12 @@ msgstr ""
 "at skrive {Husnummer} {Gade} {By} {Postnummer} {Land}. Søgealgoritmen er "
 "meget fleksibel mht. formatet. Tre sekunder efter, du har tastet, erstattes "
 "den indtastede adresse automatisk for at validere din indtastning."
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
 
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"

--- a/weather@mockturtl/files/weather@mockturtl/po/de.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/de.po
@@ -9,8 +9,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: weather@mockturtl 2.6.5\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-24 09:42+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2023-03-18 21:50+0100\n"
 "Last-Translator: bigjr slade <bigjrslade@gmail.com>\n"
 "Language-Team: \n"
@@ -21,65 +22,65 @@ msgstr ""
 "X-Generator: Poedit 3.1.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17472
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Fehler"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17473 3.8/weather-applet.js:17475
-#: 3.8/weather-applet.js:17477 3.8/weather-applet.js:17480
-#: 3.8/weather-applet.js:17483 3.8/weather-applet.js:17484
-#: 3.8/weather-applet.js:17485 3.8/weather-applet.js:17486
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Dienst Fehler"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17474
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Falscher API-Schlüssel"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17476
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Falsches Standort-Format"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17478
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Schlüssel blockiert"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17479
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Kann Standort nicht ermitteln"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17481
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Kein Api-Schlüssel"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17482
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Kein Standort"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17487
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Fehlende Pakete"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17488
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Standort nicht abgedeckt"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9748
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Wetter-Applet"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17797
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "…"
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17798
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Zum Öffnen anklicken"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16181
-#: 3.8/weather-applet.js:17801
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Neu laden"
 
@@ -89,8 +90,8 @@ msgstr "Die API lieferte einen Statuscode zwischen 400 und 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9914
-#: 3.8/weather-applet.js:9918 3.8/weather-applet.js:9922
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Standortspeicher"
 
@@ -102,14 +103,14 @@ msgstr "Sie können einen automatisch erhaltenen Ort leider nicht speichern"
 msgid "Could not get weather information"
 msgstr "Konnte keine Wetterinformationen abrufen"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17636
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Unerwarteter Fehler beim Aktualisieren des Wetters, siehe Logs in Looking "
 "Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:17879
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -125,7 +126,7 @@ msgstr "Netzwerkfehler, bitte überprüfen Sie die Protokolle in Looking Glass"
 msgid "As of"
 msgstr "Stand"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:16885
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Unterstützt von"
 
@@ -133,95 +134,93 @@ msgstr "Unterstützt von"
 msgid "from you"
 msgstr "Von dir"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16798
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:10721
-#: 3.8/weather-applet.js:16798
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10354
-#: 3.8/weather-applet.js:16963
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10355
-#: 3.8/weather-applet.js:16964
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17143
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Aktuelles Wetter wird geladen ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17146
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Zukünftiges Wetter wird geladen ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16134
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Wird geladen ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16155
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Temperatur"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16156
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Luftfeuchtigkeit"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16157
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Luftdruck"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12599 3.8/weather-applet.js:12606
-#: 3.8/weather-applet.js:12607 3.8/weather-applet.js:12613
-#: 3.8/weather-applet.js:14569 3.8/weather-applet.js:14570
-#: 3.8/weather-applet.js:16006
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Wind"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:15403
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Stellen sie sicher, dass ein Ort eingegeben wurde oder verwenden sie die "
 "Ortserkennung"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9994
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Kann keinen Ort basierend auf der Adresse finden, bitte überprüfen sie ihre "
 "Angaben"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10015
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Aufruf der Geolocation API fehlgeschlagen, siehe Looking Glass für Fehler."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9914
-#: 3.8/weather-applet.js:9918
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Warnung"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9914
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Sie können nur korrekte Orte speichern, wenn das Applet gerade nicht "
 "aktualisiert wird"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9918
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Sie können einen falschen Ort nicht speichern"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9922
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Info"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9922
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Ort ist bereits gespeichert"
 
@@ -260,15 +259,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10801 3.8/weather-applet.js:11095
-#: 3.8/weather-applet.js:12062 3.8/weather-applet.js:12502
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13373
-#: 3.8/weather-applet.js:14740
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Fühlt sich an wie"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:10846
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Verarbeitung der Wetterinformationen fehlgeschlagen"
 
@@ -281,7 +280,7 @@ msgstr ""
 "oder holen Sie sich zuerst eine auf https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:10730 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -289,7 +288,7 @@ msgstr ""
 "Bitte stellen Sie sicher, dass Sie\n"
 "den API-Schlüssel korrekt eingegeben haben und Ihr Konto nicht gesperrt ist"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12468
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -300,60 +299,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:11734 3.8/weather-applet.js:11735
-#: 3.8/weather-applet.js:11741 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11755 3.8/weather-applet.js:12642
-#: 3.8/weather-applet.js:13539
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Starker Regen"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11909 3.8/weather-applet.js:11910
-#: 3.8/weather-applet.js:11916 3.8/weather-applet.js:12627
-#: 3.8/weather-applet.js:12628 3.8/weather-applet.js:12634
-#: 3.8/weather-applet.js:12641 3.8/weather-applet.js:12683
-#: 3.8/weather-applet.js:12690 3.8/weather-applet.js:12697
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:13202
-#: 3.8/weather-applet.js:13203 3.8/weather-applet.js:13210
-#: 3.8/weather-applet.js:13531 3.8/weather-applet.js:13800
-#: 3.8/weather-applet.js:13801 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:14541 3.8/weather-applet.js:14542
-#: 3.8/weather-applet.js:14906 3.8/weather-applet.js:14907
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Regen"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10530
-#: 3.8/weather-applet.js:10537 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11364
-#: 3.8/weather-applet.js:11818 3.8/weather-applet.js:11819
-#: 3.8/weather-applet.js:11825 3.8/weather-applet.js:11832
-#: 3.8/weather-applet.js:11839 3.8/weather-applet.js:12635
-#: 3.8/weather-applet.js:13541
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Leichter Regen"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12698 3.8/weather-applet.js:13515
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Starker Eisregen"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11369
-#: 3.8/weather-applet.js:12684 3.8/weather-applet.js:13174
-#: 3.8/weather-applet.js:13175 3.8/weather-applet.js:13181
-#: 3.8/weather-applet.js:13182 3.8/weather-applet.js:13188
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Eisregen"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12691 3.8/weather-applet.js:13517
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Leichter Eisregen"
 
@@ -361,189 +360,189 @@ msgstr "Leichter Eisregen"
 msgid "Light freezing drizzle"
 msgstr "Leichter Frostnieselregen"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12677
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Frostnieselregen"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13497
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Leichter Nieselregen"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12712
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Schwere Eiskörner"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12704 3.8/weather-applet.js:12705
-#: 3.8/weather-applet.js:12711 3.8/weather-applet.js:12718
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Eiskörner"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12719
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Leichte Eiskörner"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10649 3.8/weather-applet.js:10656
-#: 3.8/weather-applet.js:10657 3.8/weather-applet.js:11376
-#: 3.8/weather-applet.js:11790 3.8/weather-applet.js:11791
-#: 3.8/weather-applet.js:11797 3.8/weather-applet.js:11804
-#: 3.8/weather-applet.js:11811 3.8/weather-applet.js:12670
-#: 3.8/weather-applet.js:13557 3.8/weather-applet.js:13877
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Starker Schneefall"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11375 3.8/weather-applet.js:11965
-#: 3.8/weather-applet.js:11966 3.8/weather-applet.js:11972
-#: 3.8/weather-applet.js:12648 3.8/weather-applet.js:12649
-#: 3.8/weather-applet.js:12662 3.8/weather-applet.js:12669
-#: 3.8/weather-applet.js:13146 3.8/weather-applet.js:13147
-#: 3.8/weather-applet.js:13551 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13870 3.8/weather-applet.js:14555
-#: 3.8/weather-applet.js:14556 3.8/weather-applet.js:14934
-#: 3.8/weather-applet.js:14935
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Schneefall"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10621
-#: 3.8/weather-applet.js:10628 3.8/weather-applet.js:10635
-#: 3.8/weather-applet.js:10636 3.8/weather-applet.js:11374
-#: 3.8/weather-applet.js:11874 3.8/weather-applet.js:11875
-#: 3.8/weather-applet.js:11881 3.8/weather-applet.js:11888
-#: 3.8/weather-applet.js:11895 3.8/weather-applet.js:12663
-#: 3.8/weather-applet.js:13559
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Leichter Schneefall"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12655
-#: 3.8/weather-applet.js:12656 3.8/weather-applet.js:14913
-#: 3.8/weather-applet.js:14914
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Gestöber"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11349
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12726
-#: 3.8/weather-applet.js:13219 3.8/weather-applet.js:13220
-#: 3.8/weather-applet.js:13563 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:14562
-#: 3.8/weather-applet.js:14563
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Gewitter"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12593
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Leichter Nebel"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10509 3.8/weather-applet.js:10510
-#: 3.8/weather-applet.js:11388 3.8/weather-applet.js:11727
-#: 3.8/weather-applet.js:11728 3.8/weather-applet.js:12585
-#: 3.8/weather-applet.js:12586 3.8/weather-applet.js:12592
-#: 3.8/weather-applet.js:13289 3.8/weather-applet.js:13290
-#: 3.8/weather-applet.js:13505 3.8/weather-applet.js:14513
-#: 3.8/weather-applet.js:14514 3.8/weather-applet.js:14962
-#: 3.8/weather-applet.js:14963
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Nebel"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10516 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:11713 3.8/weather-applet.js:11714
-#: 3.8/weather-applet.js:12557 3.8/weather-applet.js:12558
-#: 3.8/weather-applet.js:13779 3.8/weather-applet.js:13780
-#: 3.8/weather-applet.js:14506 3.8/weather-applet.js:14507
-#: 3.8/weather-applet.js:15004 3.8/weather-applet.js:15005
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Bewölkt"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12578
-#: 3.8/weather-applet.js:12579 3.8/weather-applet.js:13097
-#: 3.8/weather-applet.js:13098 3.8/weather-applet.js:13132
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Grösstenteils bewölkt"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10489 3.8/weather-applet.js:11902
-#: 3.8/weather-applet.js:11903 3.8/weather-applet.js:12571
-#: 3.8/weather-applet.js:12572 3.8/weather-applet.js:13090
-#: 3.8/weather-applet.js:13091 3.8/weather-applet.js:13125
-#: 3.8/weather-applet.js:13772 3.8/weather-applet.js:13773
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Teilweise bewölkt"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12564
-#: 3.8/weather-applet.js:12565
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Weitgehend klar"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11394 3.8/weather-applet.js:12550
-#: 3.8/weather-applet.js:12551 3.8/weather-applet.js:13076
-#: 3.8/weather-applet.js:13077 3.8/weather-applet.js:13111
-#: 3.8/weather-applet.js:13575 3.8/weather-applet.js:13765
-#: 3.8/weather-applet.js:13766 3.8/weather-applet.js:14492
-#: 3.8/weather-applet.js:14493 3.8/weather-applet.js:14499
-#: 3.8/weather-applet.js:14500 3.8/weather-applet.js:15039
-#: 3.8/weather-applet.js:15040
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Klar"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10474
-#: 3.8/weather-applet.js:10475 3.8/weather-applet.js:12550
-#: 3.8/weather-applet.js:12551 3.8/weather-applet.js:15046
-#: 3.8/weather-applet.js:15047
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Sonnig"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10460
-#: 3.8/weather-applet.js:10461 3.8/weather-applet.js:10495
-#: 3.8/weather-applet.js:10496 3.8/weather-applet.js:10684
-#: 3.8/weather-applet.js:10685 3.8/weather-applet.js:11696
-#: 3.8/weather-applet.js:11697 3.8/weather-applet.js:11994
-#: 3.8/weather-applet.js:11995 3.8/weather-applet.js:12542
-#: 3.8/weather-applet.js:12543 3.8/weather-applet.js:13067
-#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13296
-#: 3.8/weather-applet.js:13297 3.8/weather-applet.js:14425
-#: 3.8/weather-applet.js:14426 3.8/weather-applet.js:14576
-#: 3.8/weather-applet.js:14577 3.8/weather-applet.js:15150
-#: 3.8/weather-applet.js:15152
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10721
+#: 3.0/darkSky.js:71
 msgid "and"
 msgstr "und"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10721
+#: 3.0/darkSky.js:71
 msgid "until"
 msgstr "bis"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10721
+#: 3.0/darkSky.js:71
 msgid "Possible"
 msgstr "Möglich"
 
@@ -555,137 +554,137 @@ msgstr ""
 "Bitte geben Sie den API-Schlüssel in den Einstellungen ein,\n"
 "oder holen Sie sich zuerst eine auf https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:10740
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
 msgstr "Bitte verwenden Sie den API-Schlüssel, den Sie von DarkSky haben"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:9693
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Konnte den Standort nicht ermitteln"
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:9699
+#: 3.0/ipApi.js:95
 msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 "Location Service antwortede mit Fehler, bitte sehen Sie in Looking Glass Logs"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11558
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Bewölkung"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11395 3.8/weather-applet.js:11706
-#: 3.8/weather-applet.js:11707
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Klarer Himmel"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11720 3.8/weather-applet.js:11721
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Schön"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11742
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Starker Regen und Gewitter"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11749
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Starke Regenschauer"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11756
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Starke Regenschauer und Gewitter"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11762
-#: 3.8/weather-applet.js:11763 3.8/weather-applet.js:11769
-#: 3.8/weather-applet.js:11776 3.8/weather-applet.js:11783
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Schwerer Schneeregen"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11770
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Starker Schneeregen und Donner"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11777
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Starke Graupelschauer"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11784
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Heftige Graupelschauer und Gewitter"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11798
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Starker Schnee und Gewitter"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11805
-#: 3.8/weather-applet.js:13878
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Starke Schneeschauer"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11812
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Heftige Schneeschauer und Gewitter"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11826
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Leichter Regen und Donner"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11833
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Leichte Regenschauer"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11840
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Leichte Regenschauer und Gewitter"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11846
-#: 3.8/weather-applet.js:11847 3.8/weather-applet.js:11853
-#: 3.8/weather-applet.js:11860 3.8/weather-applet.js:11867
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Leichter Schneeregen"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11854
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Leichter Schneeregen und Donner"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11861
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Leichte Graupelschauer"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11868
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Leichte Graupelschauer und Gewitter"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11882
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Leichter Schneefall und Gewitter"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11889
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Leichte Schneeschauer"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11896
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Leichte Schneeschauer und Gewitter"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11917
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Regen und Donner"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11923
-#: 3.8/weather-applet.js:11924 3.8/weather-applet.js:11930
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13537
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Regenschauer"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11931
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Regenschauer und Gewitter"
 
@@ -694,44 +693,44 @@ msgstr "Regenschauer und Gewitter"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11377
-#: 3.8/weather-applet.js:11937 3.8/weather-applet.js:11938
-#: 3.8/weather-applet.js:11944 3.8/weather-applet.js:11951
-#: 3.8/weather-applet.js:11958 3.8/weather-applet.js:13160
-#: 3.8/weather-applet.js:13161 3.8/weather-applet.js:13167
-#: 3.8/weather-applet.js:13168 3.8/weather-applet.js:13195
-#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:14548
-#: 3.8/weather-applet.js:14549 3.8/weather-applet.js:14948
-#: 3.8/weather-applet.js:14949
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Graupel"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11945
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Graupel und Donner"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11952
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Graupelschauer"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11959
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Graupelschauer und Gewitter"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11973
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Schnee und Donner"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11979 3.8/weather-applet.js:11980
-#: 3.8/weather-applet.js:11986 3.8/weather-applet.js:13555
-#: 3.8/weather-applet.js:13871
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Schneeschauer"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11987
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Schneeschauer und Gewitter"
 
@@ -740,21 +739,21 @@ msgstr "Schneeschauer und Gewitter"
 msgid "Unexpected response from API"
 msgstr "Unerwartete Antwort von API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10279
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Sichtweite"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10307
-#: 3.8/weather-applet.js:11172 3.8/weather-applet.js:12073
-#: 3.8/weather-applet.js:13022
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Verarbeitung aktueller Wetterinformationen fehlgeschlagen"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10097
-#: 3.8/weather-applet.js:10131 3.8/weather-applet.js:12099
-#: 3.8/weather-applet.js:12133 3.8/weather-applet.js:12824
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Fehler bei der Verarbeitung der Vorhersage"
 
@@ -783,88 +782,88 @@ msgid "Excellent - More than"
 msgstr "Ausgezeichnet - Mehr als"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11384 3.8/weather-applet.js:13527
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Nebel"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10524 3.8/weather-applet.js:13104
-#: 3.8/weather-applet.js:13105 3.8/weather-applet.js:13139
-#: 3.8/weather-applet.js:13571
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Bewölkt"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:10538
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Leichter Regenschauer"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10544 3.8/weather-applet.js:10545
-#: 3.8/weather-applet.js:11356 3.8/weather-applet.js:12620
-#: 3.8/weather-applet.js:12621 3.8/weather-applet.js:12676
-#: 3.8/weather-applet.js:13493 3.8/weather-applet.js:14885
-#: 3.8/weather-applet.js:14886
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Niesel"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Starker Regenschauer"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Graupelschauer"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10600 3.8/weather-applet.js:10607
-#: 3.8/weather-applet.js:10614 3.8/weather-applet.js:10615
-#: 3.8/weather-applet.js:13569 3.8/weather-applet.js:14520
-#: 3.8/weather-applet.js:14521 3.8/weather-applet.js:14941
-#: 3.8/weather-applet.js:14942
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Hagel"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Hagelschauer"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Leichter Schneeschauer"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10643
-#: 3.8/weather-applet.js:10650
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Starker Schneeschauer"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10663 3.8/weather-applet.js:10670
-#: 3.8/weather-applet.js:10677 3.8/weather-applet.js:10678
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Donner"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10664
-#: 3.8/weather-applet.js:10671
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Gewitterschauer"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11227
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Bitte stellen Sie sicher, dass der Ort das richtige Format hat"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11231
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Vergewissern Sie sich, dass Sie den richtigen Schlüssel verwenden"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11235
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -872,213 +871,213 @@ msgstr ""
 "Ort nicht gefunden, stellen Sie sicher, dass der Ort verfügbar ist oder im "
 "richtigen Format vorliegt"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11239
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 "Falls dieses Problem weiterhin besteht, kontaktieren Sie den Autor dieses "
 "Applets"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11243
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Unbekannter Fehler, bitte schauen sie in die Looking Glass Protokolle"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11345
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Gewitter mit leichtem Regen"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11346
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Gewitter mit Regen"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11347
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Gewitter mit starkem Regen"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11348
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Leichtes Gewitter"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11350
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Starkes Gewitter"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11351
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Immer wieder Gewitter"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11352
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Gewitter mit leichtem Nieselregen"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11353
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Gewitter mit Nieselregen"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11354
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Gewitter mit starkem Nieselregen"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11355
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Leichter Sprühregen"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11357
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Starker Nieselregen"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11358
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Leichter Nieselregen"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11359
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Nieselregen"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11360
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Starker Nieselregen"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11361
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Schauer- und Nieselregen"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11362
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Starker Regenschauer und Niesel"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11363
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Nieselregenschauer"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11365
-#: 3.8/weather-applet.js:13807 3.8/weather-applet.js:13808
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Mäßiger Regen"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11366
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Starker Regen"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11367
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Sehr starker Regen"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11368
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Extremer Regen"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11370
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Leichte Regenschauer"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11371
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Regenschauer"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11372
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Starker Regenschauer"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11373
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Immer wieder Regenschauer"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11378
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Graupelschauer"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11379
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Leichter Regen und Schnee"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:13814 3.8/weather-applet.js:13815
-#: 3.8/weather-applet.js:13821 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13863
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Regen und Schnee"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11381
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Leichter Schneeschauer"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11382
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Schneeschauer"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11383
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Starker Schneeschauer"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11385 3.8/weather-applet.js:13254
-#: 3.8/weather-applet.js:13255 3.8/weather-applet.js:14976
-#: 3.8/weather-applet.js:14977
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Rauch"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11386 3.8/weather-applet.js:13261
-#: 3.8/weather-applet.js:13262 3.8/weather-applet.js:14969
-#: 3.8/weather-applet.js:14970
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Dunst"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11387
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Sand, Staubwirbel"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11389
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Sand"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11390 3.8/weather-applet.js:13247
-#: 3.8/weather-applet.js:13248 3.8/weather-applet.js:14955
-#: 3.8/weather-applet.js:14956
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Staub"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11391
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Vulkanasche"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11392
-#: 3.8/weather-applet.js:13561
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Böen"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11393 3.8/weather-applet.js:13226
-#: 3.8/weather-applet.js:13227 3.8/weather-applet.js:14828
-#: 3.8/weather-applet.js:14829
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11396
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Klarer Himmel"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11397
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Wolken"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11398
-#: 3.8/weather-applet.js:13083 3.8/weather-applet.js:13084
-#: 3.8/weather-applet.js:13118
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Wenige Wolken"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11399
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Zerstreute Wolken"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11400
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Aufgelockert bewölkt"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11401
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Wolenverhangen"
 
@@ -1086,81 +1085,81 @@ msgstr "Wolenverhangen"
 msgid "Could not get forecast for your area"
 msgstr "Konnte keine Vorhersage für ihre Gegen abrufen"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 "Standort außerhalb der USA, bitte verwenden Sie einen anderen Anbieter."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12845
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Verarbeitung der stündlichen Vorhersage fehlgeschlagen"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13112
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Klar und windig"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13119
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Wenig Wolken und windig"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13126
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Teilweise bewölkt und windig"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13133
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Meist bewölkt und windig"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13140
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Bewölkt und windig"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13154
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Schneeregen"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13189
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Eisregen und Schnee"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9148 3.8/weather-applet.js:13233
-#: 3.8/weather-applet.js:13234 3.8/weather-applet.js:14842
-#: 3.8/weather-applet.js:14843
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Hurrikan"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9143
-#: 3.8/weather-applet.js:13240
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Sturm"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13241
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Tropischer Sturm"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13268 3.8/weather-applet.js:13269
-#: 3.8/weather-applet.js:15074 3.8/weather-applet.js:15075
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Heiß"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13275 3.8/weather-applet.js:13276
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Kalt"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13282 3.8/weather-applet.js:13283
-#: 3.8/weather-applet.js:15123 3.8/weather-applet.js:15124
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Blizzard"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9021
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Heute"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9023
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Morgen"
 
@@ -1192,79 +1191,79 @@ msgstr "Freitag"
 msgid "Saturday"
 msgstr "Samstag"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9113
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Ruhig"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9116
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Leichter Wind"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9119
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Leichte Brise"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9122
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Sanfte Brise"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9125
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Mäßige Brise"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9128
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Frische Brise"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9131
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Starke Brise"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9134
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Nahe Sturm"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9137
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Sturm"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9140
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Starker Sturm"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9146
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Heftiger Sturm"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "NO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "O"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "SO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "SW"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "W"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "NW"
 
@@ -1316,7 +1315,7 @@ msgstr ""
 "Unbekannter Fehler bei der Wettervorhersage, siehe Looking Glass logs für "
 "weitere Informationen"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14835 3.8/weather-applet.js:14836
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Tropischer Sturm"
 
@@ -1324,7 +1323,7 @@ msgstr "Tropischer Sturm"
 msgid "Severe Thunderstorms"
 msgstr "Schwere Gewitter"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14856 3.8/weather-applet.js:14857
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Gewitter"
 
@@ -1340,15 +1339,15 @@ msgstr "Gemischter Regen und Schneeregen"
 msgid "Mixed Snow and Sleet"
 msgstr "Gemischter Schnee und Schneeregen"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14878 3.8/weather-applet.js:14879
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Frostnieselregen"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14892 3.8/weather-applet.js:14893
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Eisregen"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14899 3.8/weather-applet.js:14900
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Schauer"
 
@@ -1360,11 +1359,11 @@ msgstr "Schneegestöber"
 msgid "Light Snow Showers"
 msgstr "Leichte Schneeschauer"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14927 3.8/weather-applet.js:14928
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Schneetreiben"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13793 3.8/weather-applet.js:13794
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Neblig"
 
@@ -1376,54 +1375,54 @@ msgstr "Rauchig"
 msgid "Blustery"
 msgstr "Stürmisch"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14990 3.8/weather-applet.js:14991
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Windig"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15011 3.8/weather-applet.js:15012
-#: 3.8/weather-applet.js:15018 3.8/weather-applet.js:15019
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Meist bewölkt"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14527 3.8/weather-applet.js:14528
-#: 3.8/weather-applet.js:14534 3.8/weather-applet.js:14535
-#: 3.8/weather-applet.js:15025 3.8/weather-applet.js:15026
-#: 3.8/weather-applet.js:15032 3.8/weather-applet.js:15033
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Teilweise wolkig"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15060 3.8/weather-applet.js:15061
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Größtenteils sonnig"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15067 3.8/weather-applet.js:15068
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Gemischter Regen und Hagel"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15081 3.8/weather-applet.js:15082
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Lokale Gewitter"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15088 3.8/weather-applet.js:15089
-#: 3.8/weather-applet.js:15144 3.8/weather-applet.js:15145
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Vereinzelt Gewitter"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15095 3.8/weather-applet.js:15096
-#: 3.8/weather-applet.js:15130 3.8/weather-applet.js:15131
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Vereinzelte Schauer"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15102 3.8/weather-applet.js:15103
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Starker Regen"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15109 3.8/weather-applet.js:15110
-#: 3.8/weather-applet.js:15137 3.8/weather-applet.js:15138
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Vereinzelt Schneeschauer"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15116 3.8/weather-applet.js:15117
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Schwerer Schnee"
 
@@ -1435,372 +1434,384 @@ msgstr "Nicht verfügbar"
 msgid "Scattered Thundershowers"
 msgstr "Vereinzelt Gewitterschauer"
 
-#: 3.8/weather-applet.js:9632
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:9636
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10055
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10160
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10239
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Keine Daten für dein Standort"
 
-#: 3.8/weather-applet.js:10320
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Sehr schlecht"
 
-#: 3.8/weather-applet.js:10320
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Weniger als {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10324
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Ausgezeichnet"
 
-#: 3.8/weather-applet.js:10324
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Mehr als {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10329
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Schlecht"
 
-#: 3.8/weather-applet.js:10329 3.8/weather-applet.js:10334
-#: 3.8/weather-applet.js:10339 3.8/weather-applet.js:10344
-#: 3.8/weather-applet.js:10349
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Zwischen {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10334
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Mäßig"
 
-#: 3.8/weather-applet.js:10339
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Gut"
 
-#: 3.8/weather-applet.js:10344 3.8/weather-applet.js:10349
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Sehr gut"
 
-#: 3.8/weather-applet.js:10704
-msgid "DarkSky"
-msgstr ""
-
-#: 3.8/weather-applet.js:10756
-msgid "This API has ceased to function, please use another one."
-msgstr ""
-
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11017
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11465
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norway"
 
 # https://www.weatherbit.io/
 # is a weather plattform
-#: 3.8/weather-applet.js:12010
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "weatherbit.io"
 
 # https://www.tomorrow.io/
 # is a weather plattform
-#: 3.8/weather-applet.js:12435
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "tomorrow.io"
 
-#: 3.8/weather-applet.js:12600
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Schwacher Wind"
 
-#: 3.8/weather-applet.js:12614
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Kräftiger Wind"
 
-#: 3.8/weather-applet.js:12761
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US National Weather (nur US)"
 
 # https://www.visualcrossing.com/
-#: 3.8/weather-applet.js:13314
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "visualcrossing.com"
 
-#: 3.8/weather-applet.js:13491
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Schneeverwehungen"
 
-#: 3.8/weather-applet.js:13495
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Starker Nieselregen"
 
-#: 3.8/weather-applet.js:13499
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Starker (Niesel-)Regen"
 
-#: 3.8/weather-applet.js:13501
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Leichter (Niesel-)Regen"
 
-#: 3.8/weather-applet.js:13503
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Sandsturm"
 
-#: 3.8/weather-applet.js:13507
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Frostnieselregen/Eisregen"
 
-#: 3.8/weather-applet.js:13509
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Starker Frostnieselregen/Eisregen"
 
-#: 3.8/weather-applet.js:13511
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Leichter Frostnieselregen/Eisregen"
 
-#: 3.8/weather-applet.js:13513
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Eisnebel"
 
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Trichterwolke/Tornado"
 
-#: 3.8/weather-applet.js:13521
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Hagelschauer"
 
-#: 3.8/weather-applet.js:13523
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Eis"
 
-#: 3.8/weather-applet.js:13525
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Blitzschlag ohne Donner"
 
-#: 3.8/weather-applet.js:13529
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Niederschlag in der Umgebung"
 
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:13822
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Starker Regen und Gewitter"
 
-#: 3.8/weather-applet.js:13535
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Leichter Regen und Schnee"
 
-#: 3.8/weather-applet.js:13543
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Abnehmende Bewölkung"
 
-#: 3.8/weather-applet.js:13545
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Zunehmende Bewölkung"
 
-#: 3.8/weather-applet.js:13547
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Himmel unverändert"
 
-#: 3.8/weather-applet.js:13549
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Rauch oder Dunst"
 
-#: 3.8/weather-applet.js:13553
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Schnee- und Regenschauer"
 
-#: 3.8/weather-applet.js:13565
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Gewitter ohne Niederschlag"
 
-#: 3.8/weather-applet.js:13567
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Polarschnee"
 
-#: 3.8/weather-applet.js:13573
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Teilweise bewölkt"
 
-#: 3.8/weather-applet.js:13595
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 "Bitte stellen Sie sicher, dass Sie den API-Schlüssel korrekt eingegeben haben"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13611
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Dänemark"
 
-#: 3.8/weather-applet.js:13754 3.8/weather-applet.js:13755
-#: 3.8/weather-applet.js:13891 3.8/weather-applet.js:13892
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "NICHT GEFUNDEN"
 
-#: 3.8/weather-applet.js:13787
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Schneewehen"
 
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Leichter Schneefall"
 
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13836
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Mäßiger Schneefall"
 
-#: 3.8/weather-applet.js:13850
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Mäßige Regenschauer"
 
-#: 3.8/weather-applet.js:13857
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Regen und Schnee gemischt"
 
-#: 3.8/weather-applet.js:13864
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Starker Regen und Schnee gemischt"
 
-#: 3.8/weather-applet.js:13961
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:14305
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:14318
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr ""
 
 # https://www.wunderground.com/
 # is a weatherplattform
-#: 3.8/weather-applet.js:14615
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14806
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:14813
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "Keine Daten für dein Standort"
 
-#: 3.8/weather-applet.js:14849 3.8/weather-applet.js:14850
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Kräftiger Wind"
 
-#: 3.8/weather-applet.js:14864 3.8/weather-applet.js:14865
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Regen und Schnee"
 
-#: 3.8/weather-applet.js:14871 3.8/weather-applet.js:14872
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Regen und Graupel"
 
-#: 3.8/weather-applet.js:14920 3.8/weather-applet.js:14921
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Schneeschauer"
 
-#: 3.8/weather-applet.js:14983 3.8/weather-applet.js:14984
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:14997 3.8/weather-applet.js:14998
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15053 3.8/weather-applet.js:15054
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Überwegend klar"
 
-#: 3.8/weather-applet.js:15541
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "US National Weather (nur US)"
+
+#: 3.8/weather-applet.js:15603
+#, fuzzy
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+"Location Service antwortede mit Fehler, bitte sehen Sie in Looking Glass Logs"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+"Stellen sie sicher, dass ein Ort eingegeben wurde oder verwenden sie die "
+"Ortserkennung"
+
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:15546
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:16158
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Dieser Anbieter benötigt einen API-Schlüssel um zu funktionieren"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Taupunkt"
 
-#: 3.8/weather-applet.js:16230
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Niederschlag wird innerhalb von {precipEnd} Minuten aufhören"
 
-#: 3.8/weather-applet.js:16232
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "Niederschlag wird nicht innerhalb einer Stunde aufhören"
 
-#: 3.8/weather-applet.js:16235
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Niederschlag wird innerhalb von {precipStart} Minuten beginnen"
 
-#: 3.8/weather-applet.js:16443
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:16892 3.8/weather-applet.js:17678
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "Stand {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:16898
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance}{distanceUnit} von Ihnen"
 
-#: 3.8/weather-applet.js:16902
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:16905
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17438 3.8/weather-applet.js:17448
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:17460
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:17460
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr ""
-
-#: 3.8/weather-applet.js:17603
-msgid "This provider requires an API key to operate"
-msgstr "Dieser Anbieter benötigt einen API-Schlüssel um zu funktionieren"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -1853,7 +1864,6 @@ msgid "Data service"
 msgstr "Vorhersagedienst"
 
 #. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
 msgid "DarkSky (key needed)"
 msgstr "DarkSky (Schlüssel erforderlich)"
 
@@ -2302,6 +2312,11 @@ msgid "US National Weather (US only)"
 msgstr "US National Weather (nur US)"
 
 #. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Pirate Weather (key needed)"
+msgstr "Weatherbit (Schlüssel erforderlich)"
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Visual Crossing (key needed)"
 msgstr "Visual Crossing (Schlüssel erforderlich)"
 
@@ -2331,6 +2346,12 @@ msgstr ""
 "Suchalgorithmus ist sehr flexibel, was das Format angeht. Nach 3 Sekunden "
 "ohne Eingabe wird die eingegebene Adresse automatisch ersetzt, um Ihre "
 "Auswahl zu überprüfen."
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
 
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"
@@ -2381,10 +2402,11 @@ msgid "Enable minutely precipitation forecast"
 msgstr "Detaillierte Niederschlagsvorhersage aktivieren"
 
 #. 3.8->settings-schema.json->immediatePrecip->tooltip
+#, fuzzy
 msgid ""
 "If you'd like to use this make sure you use your exact coordinates/address "
-"as location to help its accuracy. Currently implemented with OpenWeatherMap "
-"and MET Norway only."
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
 msgstr ""
 "Wenn Sie dies verwenden möchten, stellen Sie sicher, dass Sie Ihre genaue\n"
 " Koordinaten / Adresse als Standort verwenden, um die Genauigkeit zu "
@@ -2578,117 +2600,3 @@ msgstr ""
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr ""
-
-#~ msgid "Light Snow"
-#~ msgstr "Leichter Schneefall"
-
-#~ msgid "API key doesn't provide access to Hourly Weather, skipping"
-#~ msgstr ""
-#~ "API-Schlüssel bietet keinen Zugriff auf stündliches Wetter, überspringen"
-
-#~ msgid "Please install '{missingPackage}', then refresh manually."
-#~ msgstr ""
-#~ "Bitte »{missingPackage}« installieren, danach manuell aktualisieren."
-
-#~ msgid "Instead of 15:00 or 3 pm it will show up as 15 or 3 pm"
-#~ msgstr "Anstelle von 15:00 oder 3:00 pm wird 15 oder 3 pm angezeigt"
-
-#~ msgid "Currently only used with DarkSky."
-#~ msgstr "Derzeit nur mit DarkSky verwendet."
-
-#~ msgid "ClimacellV4 (key needed)"
-#~ msgstr "ClimacellV4 (Schlüssel erforderlich)"
-
-#~ msgid "ClimacellV3 (key needed)"
-#~ msgstr "ClimacellV3 (Schlüssel erforderlich)"
-
-#~ msgid "Settings"
-#~ msgstr "Einstellungen"
-
-#~ msgid "Cloudiness:"
-#~ msgstr "Bewölktheit:"
-
-#~ msgid "Sunrise"
-#~ msgstr "Sonnenaufgang"
-
-#~ msgid "Sunset"
-#~ msgstr "Sonnenuntergang"
-
-#~ msgid "Service Unavailable"
-#~ msgstr "Dienst nicht verfügbar"
-
-#~ msgid "Wrong API Key"
-#~ msgstr "API-Schlüssel falsch"
-
-#~ msgid "City Not found"
-#~ msgstr "Der Ort wurde nicht gefunden"
-
-#~ msgid "Key Temp. Blocked"
-#~ msgstr "Der API-Schlüssel wurde gesperrt"
-
-#~ msgid "Clear Sky"
-#~ msgstr "Klarer Himmel"
-
-#~ msgid "Light Rain"
-#~ msgstr "Leichter Regen"
-
-#~ msgid "Rain Showers"
-#~ msgstr "Regenschauer"
-
-#~ msgid "Few Clouds"
-#~ msgstr "Wenige Wolken"
-
-#~ msgid "Substantial Rain"
-#~ msgstr "Erheblicher Regen"
-
-#~ msgid "Substantial Freezing Rain"
-#~ msgstr "Erheblicher gefrierender Regen"
-
-#~ msgid "Substantial Ice Pellets"
-#~ msgstr "Erhebliche Eis-Pellets"
-
-#~ msgid "Substantial Snow"
-#~ msgstr "Erheblicher Schneefall"
-
-#~ msgid "Weather Provider Settings"
-#~ msgstr "Einstellungen für den Vorhersagedienst"
-
-#~ msgid ""
-#~ "Acceptable inputs: City,CountryCode or Zipcode,CountryCode or Latitude,"
-#~ "Longitude"
-#~ msgstr ""
-#~ "Zulässige Angaben: Ort,Ländercode oder Postleitzahl,Ländercode oder "
-#~ "Breitengrad,Längengrad"
-
-#~ msgid "Personal Settings"
-#~ msgstr "Persönliche Einstellungen"
-
-#~ msgid "Vertical orientation"
-#~ msgstr "Vertikale Ausrichtung"
-
-#~ msgid "Translate condition"
-#~ msgstr "Wetterbedingungen übersetzt anzeigen"
-
-#~ msgid "Symbolic icons"
-#~ msgstr "Wettersymbole anzeigen"
-
-#~ msgid "Acceptable inputs is Latitude,Longitude"
-#~ msgstr "Gültige Eingaben sind Breitengrad, Längengrad"
-
-#~ msgid "Units, Icons and Keys"
-#~ msgstr "Einheiten, Icons & Schlüssel"
-
-#~ msgid "How to choose a weather provider"
-#~ msgstr "Wie du einen Wetterprovider auswählst"
-
-#~ msgid "Allowed location formats"
-#~ msgstr "Zulässige Ortsformate"
-
-#~ msgid "View additional information"
-#~ msgstr "Zeige zusätzliche Infos"
-
-#~ msgid "Delete current location from storage"
-#~ msgstr "Aktuellen Ort löschen"
-
-#~ msgid "Removes location information from storage file."
-#~ msgstr "Entfernt Standortinformationen aus der Speicherdatei."

--- a/weather@mockturtl/files/weather@mockturtl/po/el.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/el.po
@@ -8,8 +8,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 3.0.5\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-12 12:27-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2021-04-14 15:52+0200\n"
 "Last-Translator: Vasilis Kosmidis <skyhirules@gmail.com>\n"
 "Language-Team: Ελληνικά <>\n"
@@ -20,440 +21,2589 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: applet.js:249
+#: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
+#: 3.8/weather-applet.js:17877
+msgid "Error"
+msgstr ""
+
+#: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
+#: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
+msgid "Service Error"
+msgstr ""
+
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
+msgid "Incorrect API Key"
+msgstr ""
+
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
+msgid "Incorrect Location Format"
+msgstr ""
+
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
+msgid "Key Blocked"
+msgstr ""
+
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
+msgid "Can't find location"
+msgstr ""
+
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
+msgid "No Api Key"
+msgstr ""
+
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
+msgid "No Location"
+msgstr ""
+
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
+msgid "Missing Packages"
+msgstr ""
+
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
+msgid "Location not covered"
+msgstr ""
+
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
+#, fuzzy
+msgid "Weather Applet"
+msgstr "Καιρός"
+
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr ""
 
-#: applet.js:250
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Κάντε κλικ για να ανοίξει"
 
-#: applet.js:289
-msgid "Settings"
-msgstr "Ρυθμίσεις"
-
-#: applet.js:555
-msgid "Sunrise"
-msgstr "Ανατολή"
-
-#: applet.js:556
-msgid "Sunset"
-msgstr "Δύση"
-
-#: applet.js:648
-msgid "Loading current weather ..."
-msgstr "Φόρτωση τρέχοντος καιρού ..."
-
-#: applet.js:649
-msgid "Loading future weather ..."
-msgstr "Φόρτωση μελλοντικού καιρού ..."
-
-#: applet.js:671
-msgid "Loading ..."
-msgstr "Φόρτωση ..."
-
-#: applet.js:677
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Ανανέωση"
 
-#: applet.js:740
-msgid "Temperature:"
+#: 3.0/applet.js:272
+msgid "API returned status code between 400 and 500"
+msgstr ""
+
+#: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
+#: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
+msgid "Location Store"
+msgstr ""
+
+#: 3.0/applet.js:426
+msgid "You can't save a location obtained automatically, sorry"
+msgstr ""
+
+#: 3.0/applet.js:601
+msgid "Could not get weather information"
+msgstr ""
+
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
+msgid ""
+"Unexpected Error While Refreshing Weather, please see log in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
+msgid ""
+"Could not update weather for a while...\n"
+"are you connected to the internet?"
+msgstr ""
+
+#: 3.0/applet.js:684
+msgid "Network Error, please check logs in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:969 3.0/applet.js:1110
+msgid "As of"
+msgstr ""
+
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
+msgid "Powered by"
+msgstr ""
+
+#: 3.0/applet.js:1113
+msgid "from you"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
+msgid "mm"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
+msgid "in"
+msgstr ""
+
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
+msgid "mi"
+msgstr ""
+
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
+msgid "km"
+msgstr ""
+
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
+msgid "Loading current weather ..."
+msgstr "Φόρτωση τρέχοντος καιρού ..."
+
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
+msgid "Loading future weather ..."
+msgstr "Φόρτωση μελλοντικού καιρού ..."
+
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
+msgid "Loading ..."
+msgstr "Φόρτωση ..."
+
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
+#, fuzzy
+msgid "Temperature"
 msgstr "Θερμοκρασία:"
 
-#: applet.js:742
-msgid "Humidity:"
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
+#, fuzzy
+msgid "Humidity"
 msgstr "Υγρασία:"
 
-#: applet.js:744
-msgid "Pressure:"
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
+#, fuzzy
+msgid "Pressure"
 msgstr "Πίεση:"
 
-#: applet.js:746
-msgid "Wind:"
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
+#, fuzzy
+msgid "Wind"
 msgstr "Άνεμος:"
 
-#: applet.js:748
-msgid "Wind Chill:"
-msgstr "Αισθητή θερμοκρασία:"
+#: 3.0/applet.js:1639
+msgid "Make sure you entered a location or use Automatic location instead"
+msgstr ""
 
-#: applet.js:953
-msgid "Tornado"
-msgstr "Ανεμοστρόβιλος"
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
+msgid "Could not find location based on address, please check if it's right"
+msgstr ""
 
-#: applet.js:955
-msgid "Tropical storm"
-msgstr "Τροπική καταιγίδα"
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
+msgid "Failed to call Geolocation API, see Looking Glass for errors."
+msgstr ""
 
-#: applet.js:957
-msgid "Hurricane"
-msgstr "Τυφώνας"
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "Warning"
+msgstr ""
 
-#: applet.js:959
-msgid "Severe thunderstorms"
-msgstr "Ισχυρές καταιγίδες"
+#: 3.0/applet.js:2032
+msgid "You can only save correct locations when the applet is not refreshing"
+msgstr ""
 
-#: applet.js:961
-msgid "Thunderstorms"
-msgstr "Καταιγίδες"
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "You can't save an incorrect location"
+msgstr ""
 
-#: applet.js:963
-msgid "Mixed rain and snow"
-msgstr "Βροχή και χιόνι"
+#. 3.8->settings-schema.json->logLevel->options
+#: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.8/weather-applet.js:9875
+msgid "Info"
+msgstr ""
 
-#: applet.js:965
-msgid "Mixed rain and sleet"
-msgstr "Βροχή και χιονόνερο"
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
+msgid "Location is already saved"
+msgstr ""
 
-#: applet.js:967
-msgid "Mixed snow and sleet"
-msgstr "Χιόνι και χιονόνερο"
+#: 3.0/applet.js:2049 3.0/applet.js:2083
+msgid "Success"
+msgstr ""
 
-#: applet.js:969
-msgid "Freezing drizzle"
-msgstr "Παγωμένο ψιλόβροχο"
+#: 3.0/applet.js:2049
+msgid "Location is saved to library"
+msgstr ""
 
-#: applet.js:971
-msgid "Drizzle"
-msgstr "Ψιλόβροχο"
+#: 3.0/applet.js:2062
+msgid "You can't remove a location while the applet is refreshing"
+msgstr ""
 
-#: applet.js:973
+#: 3.0/applet.js:2066
+msgid "You can't remove an incorrect location"
+msgstr ""
+
+#: 3.0/applet.js:2070
+msgid "Location is not in storage, can't delete"
+msgstr ""
+
+#: 3.0/applet.js:2083
+msgid "Location is deleted from library"
+msgstr ""
+
+#: 3.0/applet.js:2131
+msgid ""
+"Failed to load in data from location storage, please see the logs for more "
+"information"
+msgstr ""
+
+#: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
+#: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
+msgid "Feels Like"
+msgstr ""
+
+#: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
+#: 3.8/weather-applet.js:15387
+msgid "Failed to Process Weather Info"
+msgstr ""
+
+#: 3.0/climacell.js:224
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://developer.climacell.co/sign-up"
+msgstr ""
+
+#: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
+msgid ""
+"Please Make sure you\n"
+"entered the API key correctly and your account is not locked"
+msgstr ""
+
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Climacell"
+msgstr ""
+
+#: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
+#: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
+#: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
+#, fuzzy
+msgid "Heavy rain"
+msgstr "Ισχυρή χιονόπτωση"
+
+#: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
+#: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
+#: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
+msgid "Rain"
+msgstr ""
+
+#: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
+#: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
+#: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
+#, fuzzy
+msgid "Light rain"
+msgstr "Παγωμένη βροχή"
+
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
+#, fuzzy
+msgid "Heavy freezing rain"
+msgstr "Παγωμένη βροχή"
+
+#: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
+#: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
+#: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Παγωμένη βροχή"
 
-#: applet.js:975 applet.js:977
-msgid "Showers"
-msgstr "Ισχυρές βροχοπτώσεις"
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
+#, fuzzy
+msgid "Light freezing rain"
+msgstr "Παγωμένη βροχή"
 
-#: applet.js:979
-msgid "Snow flurries"
-msgstr "Νυφάδες χιονιού"
+#: 3.0/climacell.js:301
+#, fuzzy
+msgid "Light freezing drizzle"
+msgstr "Παγωμένο ψιλόβροχο"
 
-#: applet.js:981
-msgid "Light snow showers"
-msgstr "Ελαφριά χιονόπτωση"
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
+msgid "Freezing drizzle"
+msgstr "Παγωμένο ψιλόβροχο"
 
-#: applet.js:983
-msgid "Blowing snow"
-msgstr "Χιονοθύελλες"
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
+#, fuzzy
+msgid "Light drizzle"
+msgstr "Παγωμένο ψιλόβροχο"
 
-#: applet.js:985
-msgid "Snow"
-msgstr "Χιόνι"
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
+msgid "Heavy ice pellets"
+msgstr ""
 
-#: applet.js:987
-msgid "Hail"
-msgstr "Χαλάζι"
+#: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
+msgid "Ice pellets"
+msgstr ""
 
-#: applet.js:989
-msgid "Sleet"
-msgstr "Χιονόνερο"
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
+msgid "Light ice pellets"
+msgstr ""
 
-#: applet.js:991
-msgid "Dust"
-msgstr "Σκόνη"
-
-#: applet.js:993
-msgid "Foggy"
-msgstr "Ομιχλώδης"
-
-#: applet.js:995
-msgid "Haze"
-msgstr "Ομίχλη"
-
-#: applet.js:997
-msgid "Smoky"
-msgstr "Καπνώδης"
-
-#: applet.js:999
-msgid "Blustery"
-msgstr "Θορυβώδης"
-
-#: applet.js:1001
-msgid "Windy"
-msgstr "Ανεμώδης"
-
-#: applet.js:1003
-msgid "Cold"
-msgstr "Κρύο"
-
-#: applet.js:1005
-msgid "Cloudy"
-msgstr "Συννεφιασμένος"
-
-#: applet.js:1008
-msgid "Mostly cloudy"
-msgstr "Κυρίως νεφελώδης"
-
-#: applet.js:1011 applet.js:1037
-msgid "Partly cloudy"
-msgstr "Μερικώς νεφελώδης"
-
-#: applet.js:1013
-msgid "Clear"
-msgstr "Αίθριος"
-
-#: applet.js:1015
-msgid "Sunny"
-msgstr "Ηλιόλουστος"
-
-#: applet.js:1018
-msgid "Fair"
-msgstr "Αίθριος"
-
-#: applet.js:1020
-msgid "Mixed rain and hail"
-msgstr "Βροχή και χαλάζι"
-
-#: applet.js:1022
-msgid "Hot"
-msgstr "Καυτός"
-
-#: applet.js:1024
-msgid "Isolated thunderstorms"
-msgstr "Μεμονωμένες καταιγίδες"
-
-#: applet.js:1027
-msgid "Scattered thunderstorms"
-msgstr "Διάσπαρτες καταιγίδες"
-
-#: applet.js:1029
-msgid "Scattered showers"
-msgstr "Διάσπαρτες βροχοπτώσεις"
-
-#: applet.js:1031 applet.js:1035
+#: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
+#: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
+#: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Ισχυρή χιονόπτωση"
 
-#: applet.js:1033
-msgid "Scattered snow showers"
-msgstr "Διάσπαρτες χιονοπτώσεις"
+#: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
+#: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
+#: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
+msgid "Snow"
+msgstr "Χιόνι"
 
-#: applet.js:1039
-msgid "Thundershowers"
-msgstr "Βροχοπτώσεις με κεραυνούς"
+#: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
+#: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
+#: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
+#, fuzzy
+msgid "Light snow"
+msgstr "Ελαφριά χιονόπτωση"
 
-#: applet.js:1041
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
+#, fuzzy
+msgid "Flurries"
+msgstr "Νυφάδες χιονιού"
+
+#: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
+#, fuzzy
+msgid "Thunderstorm"
+msgstr "Καταιγίδες"
+
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
+msgid "Light fog"
+msgstr ""
+
+#: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
+#: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
+#: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
+#, fuzzy
+msgid "Fog"
+msgstr "Ομιχλώδης"
+
+#: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
+#: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
+msgid "Cloudy"
+msgstr "Συννεφιασμένος"
+
+#: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
+msgid "Mostly cloudy"
+msgstr "Κυρίως νεφελώδης"
+
+#: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
+#: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
+#: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
+msgid "Partly cloudy"
+msgstr "Μερικώς νεφελώδης"
+
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
+#, fuzzy
+msgid "Mostly clear"
+msgstr "Κυρίως νεφελώδης"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
+#: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
+#: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
+msgid "Clear"
+msgstr "Αίθριος"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
+msgid "Sunny"
+msgstr "Ηλιόλουστος"
+
+#: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
+#: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
+#: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
+msgid "Unknown"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "and"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "until"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "Possible"
+msgstr ""
+
+#: 3.0/darkSky.js:211
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://darksky.net/dev/register"
+msgstr ""
+
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from DarkSky"
+msgstr ""
+
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
+msgid "Could not obtain location"
+msgstr ""
+
+#: 3.0/ipApi.js:95
+msgid ""
+"Location Service responded with errors, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
+#, fuzzy
+msgid "Cloudiness"
+msgstr "Συννεφιασμένος"
+
+#: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
+#, fuzzy
+msgid "Clear sky"
+msgstr "Αίθριος"
+
+#: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
+msgid "Fair"
+msgstr "Αίθριος"
+
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
+msgid "Heavy rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
+#, fuzzy
+msgid "Heavy rain showers"
+msgstr "Ισχυρή χιονόπτωση"
+
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
+msgid "Heavy rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
+#, fuzzy
+msgid "Heavy sleet"
+msgstr "Ισχυρή χιονόπτωση"
+
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
+msgid "Heavy sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
+#, fuzzy
+msgid "Heavy sleet showers"
+msgstr "Ισχυρή χιονόπτωση"
+
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
+msgid "Heavy sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
+#, fuzzy
+msgid "Heavy snow and thunder"
+msgstr "Ισχυρή χιονόπτωση"
+
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
+#, fuzzy
+msgid "Heavy snow showers"
+msgstr "Χιονοπτώσεις"
+
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
+msgid "Heavy snow showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
+msgid "Light rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
+#, fuzzy
+msgid "Light rain showers"
+msgstr "Ελαφριά χιονόπτωση"
+
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
+#, fuzzy
+msgid "Light rain showers and thunder"
+msgstr "Ελαφριά χιονόπτωση"
+
+#: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
+msgid "Light sleet"
+msgstr ""
+
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
+msgid "Light sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
+#, fuzzy
+msgid "Light sleet showers"
+msgstr "Ελαφριά χιονόπτωση"
+
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
+#, fuzzy
+msgid "Light sleet showers and thunder"
+msgstr "Ελαφριά χιονόπτωση"
+
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
+#, fuzzy
+msgid "Light snow and thunder"
+msgstr "Ελαφριά χιονόπτωση"
+
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
+msgid "Light snow showers"
+msgstr "Ελαφριά χιονόπτωση"
+
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
+#, fuzzy
+msgid "Light snow showers and thunder"
+msgstr "Ελαφριά χιονόπτωση"
+
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
+msgid "Rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
+#, fuzzy
+msgid "Rain showers"
+msgstr "Χιονοπτώσεις"
+
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
+msgid "Rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:511 3.0/met_norway.js:512 3.0/met_norway.js:518
+#: 3.0/met_norway.js:525 3.0/met_norway.js:532 3.0/met_uk.js:638
+#: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
+#: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
+#: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
+msgid "Sleet"
+msgstr "Χιονόνερο"
+
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
+#, fuzzy
+msgid "Sleet and thunder"
+msgstr "Διάσπαρτες καταιγίδες"
+
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
+#, fuzzy
+msgid "Sleet showers"
+msgstr "Διάσπαρτες βροχοπτώσεις"
+
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
+msgid "Sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
+msgid "Snow and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Χιονοπτώσεις"
 
-#: applet.js:1043
-msgid "Isolated thundershowers"
-msgstr "Μεμονωμένες βροχοπτώσεις με κεραυνούς"
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
+#, fuzzy
+msgid "Snow showers and thunder"
+msgstr "Χιονοπτώσεις"
 
-#: applet.js:1046
-msgid "Not available"
-msgstr "Μη διαθέσιμο"
+#: 3.0/met_uk.js:162 3.0/met_uk.js:192 3.0/met_uk.js:239 3.0/us_weather.js:151
+#: 3.0/us_weather.js:179
+msgid "Unexpected response from API"
+msgstr ""
 
-#: applet.js:1051
-msgid "Monday"
-msgstr "Δευτέρα"
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
+msgid "Visibility"
+msgstr ""
 
-#: applet.js:1051
-msgid "Tuesday"
-msgstr "Τρίτη"
+#: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
+msgid "Failed to Process Current Weather Info"
+msgstr ""
 
-#: applet.js:1051
-msgid "Wednesday"
-msgstr "Τετάρτη"
+#: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
+msgid "Failed to Process Forecast Info"
+msgstr ""
 
-#: applet.js:1051
-msgid "Thursday"
-msgstr "Πέμπτη"
+#: 3.0/met_uk.js:408
+msgid "Very poor - Less than"
+msgstr ""
 
-#: applet.js:1051
-msgid "Friday"
-msgstr "Παρασκευή"
+#: 3.0/met_uk.js:410
+msgid "Poor - Between"
+msgstr ""
 
-#: applet.js:1051
-msgid "Saturday"
-msgstr "Σάββατο"
+#: 3.0/met_uk.js:412
+msgid "Moderate - Between"
+msgstr ""
 
-#: applet.js:1051
+#: 3.0/met_uk.js:414
+msgid "Good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:416
+msgid "Very good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:417
+msgid "Excellent - More than"
+msgstr ""
+
+#: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
+msgid "Mist"
+msgstr ""
+
+#: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
+msgid "Overcast"
+msgstr ""
+
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
+#, fuzzy
+msgid "Light rain shower"
+msgstr "Ελαφριά χιονόπτωση"
+
+#: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
+msgid "Drizzle"
+msgstr "Ψιλόβροχο"
+
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
+#, fuzzy
+msgid "Heavy rain shower"
+msgstr "Ισχυρή χιονόπτωση"
+
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
+#, fuzzy
+msgid "Sleet shower"
+msgstr "Διάσπαρτες βροχοπτώσεις"
+
+#: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
+msgid "Hail"
+msgstr "Χαλάζι"
+
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
+#, fuzzy
+msgid "Hail shower"
+msgstr "Χιονοπτώσεις"
+
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
+#, fuzzy
+msgid "Light snow shower"
+msgstr "Ελαφριά χιονόπτωση"
+
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
+#, fuzzy
+msgid "Heavy snow shower"
+msgstr "Ισχυρή χιονόπτωση"
+
+#: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
+#, fuzzy
+msgid "Thunder"
+msgstr "Καταιγίδες"
+
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
+#, fuzzy
+msgid "Thunder shower"
+msgstr "Βροχοπτώσεις με κεραυνούς"
+
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
+msgid "Please make sure Location is in the correct format in the Settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
+msgid "Make sure you entered the correct key in settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
+msgid ""
+"Location not found, make sure location is available or it is in the correct "
+"format"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
+msgid "If this problem persists, please contact the Author of this applet"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
+msgid "Unknown Error, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
+msgid "Thunderstorm with light rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
+#, fuzzy
+msgid "Thunderstorm with rain"
+msgstr "Καταιγίδες"
+
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
+msgid "Thunderstorm with heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
+#, fuzzy
+msgid "Light thunderstorm"
+msgstr "Καταιγίδες"
+
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
+#, fuzzy
+msgid "Heavy thunderstorm"
+msgstr "Ισχυρές καταιγίδες"
+
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
+#, fuzzy
+msgid "Ragged thunderstorm"
+msgstr "Μεμονωμένες καταιγίδες"
+
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
+msgid "Thunderstorm with light drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
+#, fuzzy
+msgid "Thunderstorm with drizzle"
+msgstr "Καταιγίδες"
+
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
+msgid "Thunderstorm with heavy drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
+msgid "Light intensity drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
+msgid "Heavy intensity drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
+msgid "Light intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Drizzle rain"
+msgstr "Ψιλόβροχο"
+
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
+msgid "Heavy intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
+#, fuzzy
+msgid "Shower rain and drizzle"
+msgstr "Βροχή και χαλάζι"
+
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
+msgid "Heavy shower rain and drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
+#, fuzzy
+msgid "Shower drizzle"
+msgstr "Παγωμένο ψιλόβροχο"
+
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
+msgid "Moderate rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
+msgid "Heavy intensity rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
+msgid "Very heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
+#, fuzzy
+msgid "Extreme rain"
+msgstr "Παγωμένη βροχή"
+
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
+#, fuzzy
+msgid "Light intensity shower rain"
+msgstr "Ελαφριά χιονόπτωση"
+
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
+#, fuzzy
+msgid "Shower rain"
+msgstr "Ισχυρές βροχοπτώσεις"
+
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
+msgid "Heavy intensity shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
+msgid "Ragged shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
+#, fuzzy
+msgid "Shower sleet"
+msgstr "Ισχυρές βροχοπτώσεις"
+
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
+#, fuzzy
+msgid "Light rain and snow"
+msgstr "Βροχή και χιόνι"
+
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
+#, fuzzy
+msgid "Rain and snow"
+msgstr "Βροχή και χιόνι"
+
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
+#, fuzzy
+msgid "Light shower snow"
+msgstr "Ελαφριά χιονόπτωση"
+
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
+#, fuzzy
+msgid "Shower snow"
+msgstr "Ισχυρές βροχοπτώσεις"
+
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
+#, fuzzy
+msgid "Heavy shower snow"
+msgstr "Ισχυρή χιονόπτωση"
+
+#: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
+#, fuzzy
+msgid "Smoke"
+msgstr "Καπνώδης"
+
+#: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
+msgid "Haze"
+msgstr "Ομίχλη"
+
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
+msgid "Sand, dust whirls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
+msgid "Sand"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
+msgid "Dust"
+msgstr "Σκόνη"
+
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
+msgid "Volcanic ash"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
+msgid "Squalls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
+msgid "Tornado"
+msgstr "Ανεμοστρόβιλος"
+
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
+msgid "Sky is clear"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
+#, fuzzy
+msgid "Clouds"
+msgstr "Συννεφιασμένος"
+
+#: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
+msgid "Few clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
+#, fuzzy
+msgid "Scattered clouds"
+msgstr "Διάσπαρτες βροχοπτώσεις"
+
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
+msgid "Broken clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
+msgid "Overcast clouds"
+msgstr ""
+
+#: 3.0/us_weather.js:120
+msgid "Could not get forecast for your area"
+msgstr ""
+
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
+msgid "Location is outside US, please use a different provider."
+msgstr ""
+
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
+msgid "Failed to Process Hourly Forecast Info"
+msgstr ""
+
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
+msgid "Clear and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
+msgid "Few clouds and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
+#, fuzzy
+msgid "Partly cloudy and windy"
+msgstr "Μερικώς νεφελώδης"
+
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
+#, fuzzy
+msgid "Mostly cloudy and windy"
+msgstr "Κυρίως νεφελώδης"
+
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
+msgid "Overcast and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
+#, fuzzy
+msgid "Snowy rain"
+msgstr "Νυφάδες χιονιού"
+
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
+#, fuzzy
+msgid "Freezing rain and snow"
+msgstr "Παγωμένη βροχή"
+
+#: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
+msgid "Hurricane"
+msgstr "Τυφώνας"
+
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
+msgid "Storm"
+msgstr ""
+
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
+msgid "Tropical storm"
+msgstr "Τροπική καταιγίδα"
+
+#: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
+msgid "Hot"
+msgstr "Καυτός"
+
+#: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
+msgid "Cold"
+msgstr "Κρύο"
+
+#: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
+msgid "Blizzard"
+msgstr ""
+
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
+msgid "Today"
+msgstr "Σήμερα"
+
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
+msgid "Tomorrow"
+msgstr "Αύριο"
+
+#: 3.0/utils.js:204
 msgid "Sunday"
 msgstr "Κυριακή"
 
-#: applet.js:1056
+#: 3.0/utils.js:204
+msgid "Monday"
+msgstr "Δευτέρα"
+
+#: 3.0/utils.js:204
+msgid "Tuesday"
+msgstr "Τρίτη"
+
+#: 3.0/utils.js:204
+msgid "Wednesday"
+msgstr "Τετάρτη"
+
+#: 3.0/utils.js:204
+msgid "Thursday"
+msgstr "Πέμπτη"
+
+#: 3.0/utils.js:204
+msgid "Friday"
+msgstr "Παρασκευή"
+
+#: 3.0/utils.js:204
+msgid "Saturday"
+msgstr "Σάββατο"
+
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
+msgid "Calm"
+msgstr ""
+
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
+msgid "Light air"
+msgstr ""
+
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
+msgid "Light breeze"
+msgstr ""
+
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
+msgid "Gentle breeze"
+msgstr ""
+
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
+msgid "Moderate breeze"
+msgstr ""
+
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
+msgid "Fresh breeze"
+msgstr ""
+
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
+msgid "Strong breeze"
+msgstr ""
+
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
+msgid "Near gale"
+msgstr ""
+
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
+msgid "Gale"
+msgstr ""
+
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
+msgid "Strong gale"
+msgstr ""
+
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
+msgid "Violent storm"
+msgstr ""
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "Β"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "ΒΑ"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "Α"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "ΝΑ"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "Ν"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "ΝΔ"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "Δ"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "ΒΔ"
 
-#. cinnamon-weather->settings-schema.json->woeidLookup->description
-msgid "Get WOEID"
-msgstr "Εύρεση WOEID"
+#: 3.0/weatherbit.js:312
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://www.weatherbit.io/account/create"
+msgstr ""
 
-#. cinnamon-weather->settings-schema.json->verticalOrientation->description
-msgid "Vertical orientation"
-msgstr "Κάθετος προσανατολισμός"
+#: 3.0/yahoo.js:78
+msgid ""
+"Unknown Error happened while calling Yahoo bridge,\n"
+" see Looking Glass log for errors"
+msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showTextInPanel->description
-msgid "Display current temperature in panel"
-msgstr "Εμφάνιση της τρέχουσας θερμοκρασίας στο πάνελ"
+#: 3.0/yahoo.js:91
+msgid ""
+"Yahoo bridge responded in bad format,\n"
+" see Looking Glass log for errors"
+msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeid->description
+#: 3.0/yahoo.js:177
+msgid "Missing package"
+msgstr ""
+
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
 #, fuzzy
-msgid "WOEID"
-msgstr "Εύρεση WOEID"
+msgid "Please install '"
+msgstr "Παρακαλώ περιμένετε"
 
-#. cinnamon-weather->settings-schema.json->woeid->tooltip
-msgid "Where On Earth ID"
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+msgid "', then refresh manually."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->description
-msgid "Temperature unit"
-msgstr "Μονάδα θερμοκρασίας:"
-
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "fahrenheit"
-msgstr "Φαρενάιτ"
-
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "celsius"
-msgstr "Κελσίου"
-
-#. cinnamon-weather->settings-schema.json->translateCondition->description
-msgid "Translate condition"
-msgstr "Μετάφραση καιρικών συνθηκών"
-
-#. cinnamon-weather->settings-schema.json->locationLabelOverride->description
-msgid "Override location label"
-msgstr "Παράκαμψη ετικέτας τοποθεσίας"
-
-#. cinnamon-weather->settings-schema.json->show24Hours->description
-msgid "Display time in 24 hour format"
-msgstr "Εμφάνιση ώρας σε 24ωρη μορφή"
-
-#. cinnamon-weather->settings-schema.json->forecastDays->description
-msgid "Forecast length"
-msgstr "Εύρος πρόβλεψης"
-
-#. cinnamon-weather->settings-schema.json->forecastDays->units
-msgid "days"
-msgstr "ημέρες"
-
-#. cinnamon-weather->settings-schema.json->showSunrise->description
-msgid "Show sunrise / sunset times"
-msgstr "Εμφάνιση ώρας ανατολής / δύσης"
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->description
-msgid "Wind speed unit"
-msgstr "Μονάδα ταχύτητας ανέμου"
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "kph"
-msgstr "χλμ/ώρα"
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "m/s"
-msgstr "μ./δεύτ"
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "knots"
-msgstr "κόμβοι"
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "mph"
-msgstr "μιλ./ώρα"
-
-#. cinnamon-weather->settings-schema.json->showCommentInPanel->description
-msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
-msgstr ""
-"Εμφάνιση των καιρικών συνθηκών (π.χ.  \"Ανεμώδης\", \"Αίθριος\") στο πάνελ"
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->description
-msgid "Atmospheric pressure unit"
-msgstr "Μονάδα ατμοσφαιρικής πίεσης"
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "psi"
+#: 3.0/yahoo.js:182
+msgid "Could not connect to Yahoo API."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "atm"
+#: 3.0/yahoo.js:186
+msgid ""
+"Unknown error happened while obtaining weather, see Looking Glass logs for "
+"more information"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "kPa"
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
+#, fuzzy
+msgid "Tropical Storm"
+msgstr "Τροπική καταιγίδα"
+
+#: 3.0/yahoo.js:439
+#, fuzzy
+msgid "Severe Thunderstorms"
+msgstr "Ισχυρές καταιγίδες"
+
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
+msgid "Thunderstorms"
+msgstr "Καταιγίδες"
+
+#: 3.0/yahoo.js:441
+#, fuzzy
+msgid "Mixed Rain and Snow"
+msgstr "Βροχή και χιόνι"
+
+#: 3.0/yahoo.js:442
+#, fuzzy
+msgid "Mixed Rain and Sleet"
+msgstr "Βροχή και χιονόνερο"
+
+#: 3.0/yahoo.js:443
+#, fuzzy
+msgid "Mixed Snow and Sleet"
+msgstr "Χιόνι και χιονόνερο"
+
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
+#, fuzzy
+msgid "Freezing Drizzle"
+msgstr "Παγωμένο ψιλόβροχο"
+
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
+#, fuzzy
+msgid "Freezing Rain"
+msgstr "Παγωμένη βροχή"
+
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
+msgid "Showers"
+msgstr "Ισχυρές βροχοπτώσεις"
+
+#: 3.0/yahoo.js:449
+#, fuzzy
+msgid "Snow Flurries"
+msgstr "Νυφάδες χιονιού"
+
+#: 3.0/yahoo.js:450
+#, fuzzy
+msgid "Light Snow Showers"
+msgstr "Ελαφριά χιονόπτωση"
+
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
+#, fuzzy
+msgid "Blowing Snow"
+msgstr "Χιονοθύελλες"
+
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
+msgid "Foggy"
+msgstr "Ομιχλώδης"
+
+#: 3.0/yahoo.js:458
+msgid "Smoky"
+msgstr "Καπνώδης"
+
+#: 3.0/yahoo.js:459
+msgid "Blustery"
+msgstr "Θορυβώδης"
+
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
+msgid "Windy"
+msgstr "Ανεμώδης"
+
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
+#, fuzzy
+msgid "Mostly Cloudy"
+msgstr "Κυρίως νεφελώδης"
+
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
+#, fuzzy
+msgid "Partly Cloudy"
+msgstr "Μερικώς νεφελώδης"
+
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
+#, fuzzy
+msgid "Mostly Sunny"
+msgstr "Κυρίως νεφελώδης"
+
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
+#, fuzzy
+msgid "Mixed Rain and Hail"
+msgstr "Βροχή και χαλάζι"
+
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
+#, fuzzy
+msgid "Isolated Thunderstorms"
+msgstr "Μεμονωμένες καταιγίδες"
+
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
+#, fuzzy
+msgid "Scattered Thunderstorms"
+msgstr "Διάσπαρτες καταιγίδες"
+
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
+#, fuzzy
+msgid "Scattered Showers"
+msgstr "Διάσπαρτες βροχοπτώσεις"
+
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
+#, fuzzy
+msgid "Heavy Rain"
+msgstr "Ισχυρή χιονόπτωση"
+
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
+#, fuzzy
+msgid "Scattered Snow Showers"
+msgstr "Διάσπαρτες χιονοπτώσεις"
+
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
+#, fuzzy
+msgid "Heavy Snow"
+msgstr "Ισχυρή χιονόπτωση"
+
+#: 3.0/yahoo.js:478
+#, fuzzy
+msgid "Not Available"
+msgstr "Μη διαθέσιμο"
+
+#: 3.0/yahoo.js:479
+#, fuzzy
+msgid "Scattered Thundershowers"
+msgstr "Διάσπαρτες καταιγίδες"
+
+#: 3.8/weather-applet.js:9638
+msgid ""
+"Could not retrieve logs, log file was not found under path\n"
+" {logFilePath}"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "Pa"
+#: 3.8/weather-applet.js:9642
+msgid ""
+"Could not get contents of log file under path\n"
+" {logFilePath}"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mm Hg"
+#. 3.0->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10283
+msgid "Met Office UK"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "at"
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mbar"
+#: 3.8/weather-applet.js:10476
+msgid "Data was not found for location"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "in Hg"
+#: 3.8/weather-applet.js:10557
+msgid "Very poor"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->description
+#: 3.8/weather-applet.js:10557
+msgid "Less than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "Excellent"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "More than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566
+msgid "Poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
+msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10571
+msgid "Moderate"
+msgstr ""
+
+#: 3.8/weather-applet.js:10576
+msgid "Good"
+msgstr ""
+
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
+msgid "Very good"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10942
+#, fuzzy
+msgid "OpenWeatherMap"
+msgstr "Καιρός"
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:11396
+msgid "MET Norway"
+msgstr ""
+
+#: 3.8/weather-applet.js:11955
+#, fuzzy
+msgid "WeatherBit"
+msgstr "Καιρός"
+
+#: 3.8/weather-applet.js:12386
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Αύριο"
+
+#: 3.8/weather-applet.js:12561
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12575
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12723
+#, fuzzy
+msgid "US Weather"
+msgstr "Καιρός"
+
+#: 3.8/weather-applet.js:13292
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13474
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "Χιονοθύελλες"
+
+#: 3.8/weather-applet.js:13478
+#, fuzzy
+msgid "Heavy drizzle"
+msgstr "Παγωμένο ψιλόβροχο"
+
+#: 3.8/weather-applet.js:13482
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13484
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13486
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:13490
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "Παγωμένο ψιλόβροχο"
+
+#: 3.8/weather-applet.js:13492
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13494
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13496
+#, fuzzy
+msgid "Freezing fog"
+msgstr "Παγωμένη βροχή"
+
+#: 3.8/weather-applet.js:13502
+msgid "Funnel cloud/tornado"
+msgstr ""
+
+#: 3.8/weather-applet.js:13504
+#, fuzzy
+msgid "Hail showers"
+msgstr "Χιονοπτώσεις"
+
+#: 3.8/weather-applet.js:13506
+msgid "Ice"
+msgstr ""
+
+#: 3.8/weather-applet.js:13508
+msgid "Lightning without thunder"
+msgstr ""
+
+#: 3.8/weather-applet.js:13512
+msgid "Precipitation in vicinity"
+msgstr ""
+
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
+#, fuzzy
+msgid "Heavy rain and snow"
+msgstr "Βροχή και χιόνι"
+
+#: 3.8/weather-applet.js:13518
+#, fuzzy
+msgid "Light rain And snow"
+msgstr "Βροχή και χιόνι"
+
+#: 3.8/weather-applet.js:13526
+msgid "Sky coverage decreasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13528
+msgid "Sky coverage increasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13530
+msgid "Sky unchanged"
+msgstr ""
+
+#: 3.8/weather-applet.js:13532
+msgid "Smoke or haze"
+msgstr ""
+
+#: 3.8/weather-applet.js:13536
+#, fuzzy
+msgid "Snow and rain showers"
+msgstr "Χιονοπτώσεις"
+
+#: 3.8/weather-applet.js:13548
+msgid "Thunderstorm without precipitation"
+msgstr ""
+
+#: 3.8/weather-applet.js:13550
+msgid "Diamond dust"
+msgstr ""
+
+#: 3.8/weather-applet.js:13556
+#, fuzzy
+msgid "Partially cloudy"
+msgstr "Μερικώς νεφελώδης"
+
+#: 3.8/weather-applet.js:13578
+msgid "Please make sure you entered the API key correctly"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:13595
+msgid "DMI Denmark"
+msgstr ""
+
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
+msgid "NOT FOUND"
+msgstr ""
+
+#: 3.8/weather-applet.js:13779
+msgid "Blowing snow"
+msgstr "Χιονοθύελλες"
+
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
+#, fuzzy
+msgid "Slight snow"
+msgstr "Χιονοθύελλες"
+
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
+#, fuzzy
+msgid "Moderate snow"
+msgstr "Ισχυρή χιονόπτωση"
+
+#: 3.8/weather-applet.js:13842
+#, fuzzy
+msgid "Moderate rain showers"
+msgstr "Διάσπαρτες βροχοπτώσεις"
+
+#: 3.8/weather-applet.js:13849
+msgid "Mixed rain and snow"
+msgstr "Βροχή και χιόνι"
+
+#: 3.8/weather-applet.js:13856
+#, fuzzy
+msgid "Heavy mixed rain and snow"
+msgstr "Βροχή και χιόνι"
+
+#: 3.8/weather-applet.js:14024
+#, fuzzy
+msgid "AccuWeather"
+msgstr "Καιρός"
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+msgid "Weather Underground"
+msgstr ""
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+msgid "The location you provided was not found."
+msgstr ""
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+msgid "Strong Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "Βροχή και χιόνι"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "Βροχή και χιονόνερο"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "Χιονοπτώσεις"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "Κυρίως νεφελώδης"
+
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "Καιρός"
+
+#: 3.8/weather-applet.js:15603
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+
+#: 3.8/weather-applet.js:15831
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+
+#: 3.8/weather-applet.js:15968
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:15975
+msgid ""
+"Could not get contents of config file under path\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr ""
+
+#: 3.8/weather-applet.js:16675
+msgid "Dew Point"
+msgstr ""
+
+#: 3.8/weather-applet.js:16747
+msgid "Precipitation will end in {precipEnd} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16749
+msgid "Precipitation won't end in within an hour"
+msgstr ""
+
+#: 3.8/weather-applet.js:16752
+msgid "Precipitation will start within {precipStart} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16964
+msgid "Forecast parsing failed, see logs for more details."
+msgstr ""
+
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
+msgid "As of {lastUpdatedTime}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17502
+msgid "{distance} {distanceUnit} from you"
+msgstr ""
+
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
+msgid "Error Saving Debug Information"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Debug Information saved successfully"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Saved to {filePath}"
+msgstr ""
+
+#: 3.8/LogSaver.py:16
+msgid "Save to File"
+msgstr ""
+
+#: 3.8/LogSaver.py:29
+msgid "Select a destination"
+msgstr ""
+
+#. metadata.json->name
+#. 3.8->settings-schema.json->providers->title
+msgid "Weather"
+msgstr "Καιρός"
+
+#. metadata.json->description
+msgid "View your local weather forecast"
+msgstr "Εμφάνιση της τοπικής πρόβλεψης"
+
+#. 3.0->settings-schema.json->head->description
+msgid "Settings for weather@mockturtl 3.0+"
+msgstr ""
+
+#. 3.0->settings-schema.json->keybinding->description
+#. 3.8->settings-schema.json->keybinding->description
+msgid "Set the keybinding to call the menu"
+msgstr ""
+
+#. 3.0->settings-schema.json->descriptions->description
+msgid "Weather service information"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->description
+msgid "Click here for detailed description"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->tooltip
+#. 3.0->settings-schema.json->getLocation->tooltip
+#. 3.8->settings-schema.json->getLocation->tooltip
+msgid "Opens webpage guide"
+msgstr ""
+
+#. 3.0->settings-schema.json->providerSettings->description
+#. 3.8->settings-schema.json->provider-options->title
+msgid "Weather Provider Options"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->description
+#. 3.8->settings-schema.json->dataService->description
+msgid "Data service"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "DarkSky (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weatherbit (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Yahoo"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Climacell (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->description
+#. 3.8->settings-schema.json->apiKey->description
+msgid "API Key"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->tooltip
+#. 3.8->settings-schema.json->apiKey->tooltip
+msgid "Copy this from your account of the used Data service and paste it here."
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->description
+#. 3.8->settings-schema.json->manualLocation->description
+msgid "Manual Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->tooltip
+#. 3.8->settings-schema.json->manualLocation->tooltip
+msgid "Enable this if your location is not accurate"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->description
+msgid "Location - Coordinates"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->tooltip
+msgid ""
+"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an "
+"address.\n"
+"Waits for 3 seconds after you stop typing before refreshes the weather."
+msgstr ""
+
+#. 3.0->settings-schema.json->getLocation->description
+msgid "Setup API Key and Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->units
+#. 3.8->settings-schema.json->refreshInterval->units
+msgid "minutes"
+msgstr "λεπτά"
+
+#. 3.0->settings-schema.json->refreshInterval->description
+#. 3.8->settings-schema.json->refreshInterval->description
 #, fuzzy
 msgid "Update interval"
 msgstr "Διάστημα ενημέρωσης (λεπτά)"
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->units
-msgid "minutes"
-msgstr "λεπτά"
+#. 3.0->settings-schema.json->forecastDays->units
+#. 3.8->settings-schema.json->forecastDays->units
+msgid "days"
+msgstr "ημέρες"
 
-#. cinnamon-weather->settings-schema.json->useSymbolicIcons->description
-msgid "Symbolic icons"
-msgstr "Συμβολικά εικονίδια"
+#. 3.0->settings-schema.json->forecastDays->description
+#. 3.8->settings-schema.json->forecastDays->description
+msgid "Forecast length"
+msgstr "Εύρος πρόβλεψης"
 
-#. cinnamon-weather->metadata.json->description
-msgid "View your local weather forecast"
-msgstr "Εμφάνιση της τοπικής πρόβλεψης"
+#. 3.0->settings-schema.json->forecastHours->units
+#. 3.8->settings-schema.json->forecastHours->units
+msgid "hours"
+msgstr ""
 
-#. cinnamon-weather->metadata.json->name
-msgid "Weather"
-msgstr "Καιρός"
+#. 3.0->settings-schema.json->forecastHours->description
+#. 3.8->settings-schema.json->forecastHours->description
+#, fuzzy
+msgid "Hourly Forecast length"
+msgstr "Εύρος πρόβλεψης"
 
-#~ msgid "Show 5-day forecast"
-#~ msgstr "Εμφάνιση 5-ήμερης πρόβλεψης"
+#. 3.0->settings-schema.json->unitSettings->description
+msgid "Units"
+msgstr ""
 
-#~ msgid "Please wait"
-#~ msgstr "Παρακαλώ περιμένετε"
+#. 3.0->settings-schema.json->temperatureUnit->description
+#. 3.8->settings-schema.json->temperatureUnit->description
+msgid "Temperature unit"
+msgstr "Μονάδα θερμοκρασίας:"
 
-#~ msgid "Today"
-#~ msgstr "Σήμερα"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Automatic"
+msgstr ""
 
-#~ msgid "Tomorrow"
-#~ msgstr "Αύριο"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#, fuzzy
+msgid "Celsius"
+msgstr "Κελσίου"
 
-#~ msgid "Schema \"%s\" not found."
-#~ msgstr "Δεν βρέθηκε το σχήμα \"%s\"."
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#, fuzzy
+msgid "Fahrenheit"
+msgstr "Φαρενάιτ"
+
+#. 3.0->settings-schema.json->temperatureUnit->tooltip
+#. 3.0->settings-schema.json->distanceUnit->tooltip
+#. 3.8->settings-schema.json->temperatureUnit->tooltip
+#. 3.8->settings-schema.json->distanceUnit->tooltip
+msgid ""
+"Automatic will try to guess your preference based your current display "
+"language."
+msgstr ""
+
+#. 3.0->settings-schema.json->windSpeedUnit->description
+#. 3.8->settings-schema.json->windSpeedUnit->description
+msgid "Wind speed unit"
+msgstr "Μονάδα ταχύτητας ανέμου"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "kph"
+msgstr "χλμ/ώρα"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "mph"
+msgstr "μιλ./ώρα"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "m/s"
+msgstr "μ./δεύτ"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "knots"
+msgstr "κόμβοι"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "Beaufort"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->description
+#. 3.8->settings-schema.json->pressureUnit->description
+msgid "Atmospheric pressure unit"
+msgstr "Μονάδα ατμοσφαιρικής πίεσης"
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "hPa"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "in Hg"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "mm Hg"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "psi"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "at"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "atm"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "Pa"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->description
+#. 3.8->settings-schema.json->distanceUnit->description
+msgid "Distance unit"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Metric"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Imperial"
+msgstr ""
+
+#. 3.0->settings-schema.json->panelSettings->description
+msgid "Panel options"
+msgstr ""
+
+#. 3.0->settings-schema.json->showTextInPanel->description
+#. 3.8->settings-schema.json->showTextInPanel->description
+msgid "Display current temperature in panel"
+msgstr "Εμφάνιση της τρέχουσας θερμοκρασίας στο πάνελ"
+
+#. 3.0->settings-schema.json->showCommentInPanel->description
+#. 3.8->settings-schema.json->showCommentInPanel->description
+msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
+msgstr ""
+"Εμφάνιση των καιρικών συνθηκών (π.χ.  \"Ανεμώδης\", \"Αίθριος\") στο πάνελ"
+
+#. 3.0->settings-schema.json->showCommentInPanel->tooltip
+#. 3.8->settings-schema.json->showCommentInPanel->tooltip
+msgid "Only works with horizontal panels"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempTextOverride->description
+#. 3.8->settings-schema.json->tempTextOverride->description
+#, fuzzy
+msgid "Override label on panel"
+msgstr "Παράκαμψη ετικέτας τοποθεσίας"
+
+#. 3.0->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.0->settings-schema.json->useCustomMenuIcons->tooltip
+#. 3.8->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.8->settings-schema.json->useCustomMenuIcons->tooltip
+msgid "Iconset is weather-icons by Erik Flowers"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->description
+#. 3.8->settings-schema.json->useCustomAppletIcons->description
+msgid "Use custom icons on the panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->displaySettings->description
+#. 3.8->settings-schema.json->presentation-section->title
+msgid "Presentation"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->description
+#. 3.8->settings-schema.json->verticalOrientation->description
+#, fuzzy
+msgid "Show forecast vertically"
+msgstr "Εμφάνιση 5-ήμερης πρόβλεψης"
+
+#. 3.0->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->units
+#. 3.8->settings-schema.json->forecastColumns->units
+msgid "columns"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->description
+#. 3.8->settings-schema.json->forecastColumns->description
+msgid "Maximum number of columns for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->units
+#. 3.8->settings-schema.json->forecastRows->units
+msgid "rows"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->description
+#. 3.8->settings-schema.json->forecastRows->description
+msgid "Maximum number of rows for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->showSunrise->description
+#. 3.8->settings-schema.json->showSunrise->description
+msgid "Show sunrise / sunset times"
+msgstr "Εμφάνιση ώρας ανατολής / δύσης"
+
+#. 3.0->settings-schema.json->show24Hours->description
+#. 3.8->settings-schema.json->show24Hours->description
+msgid "Display time in 24 hour format"
+msgstr "Εμφάνιση ώρας σε 24ωρη μορφή"
+
+#. 3.0->settings-schema.json->shortHourlyTime->description
+#. 3.8->settings-schema.json->shortHourlyTime->description
+msgid "Only display hours for hourly forecast time"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->tooltip
+#. 3.8->settings-schema.json->shortHourlyTime->tooltip
+msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->description
+#. 3.8->settings-schema.json->showForecastDates->description
+#, fuzzy
+msgid "Display date for daily forecasts"
+msgstr "Εμφάνιση ώρας σε 24ωρη μορφή"
+
+#. 3.0->settings-schema.json->showForecastDates->tooltip
+#. 3.8->settings-schema.json->showForecastDates->tooltip
+msgid "Like \"Friday 15\""
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureHighFirst->description
+#. 3.8->settings-schema.json->temperatureHighFirst->description
+msgid "Show high temperature first in forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempRussianStyle->description
+#. 3.8->settings-schema.json->tempRussianStyle->description
+#, fuzzy
+msgid "Show temperature Russian style"
+msgstr "Μονάδα θερμοκρασίας:"
+
+#. 3.0->settings-schema.json->locationLabelOverride->description
+#. 3.8->settings-schema.json->locationLabelOverride->description
+msgid "Override location label"
+msgstr "Παράκαμψη ετικέτας τοποθεσίας"
+
+#. 3.0->settings-schema.json->conditionSettings->description
+#. 3.8->settings-schema.json->weather-conditions->title
+#, fuzzy
+msgid "Weather conditions"
+msgstr "Μετάφραση καιρικών συνθηκών"
+
+#. 3.0->settings-schema.json->translateCondition->description
+#. 3.8->settings-schema.json->translateCondition->description
+#, fuzzy
+msgid "Translate conditions"
+msgstr "Μετάφραση καιρικών συνθηκών"
+
+#. 3.0->settings-schema.json->shortConditions->description
+#. 3.8->settings-schema.json->shortConditions->description
+#, fuzzy
+msgid "Less verbose conditions"
+msgstr "Μετάφραση καιρικών συνθηκών"
+
+#. 3.0->settings-schema.json->iconSettings->description
+#. 3.8->settings-schema.json->icons->title
+msgid "Icons"
+msgstr ""
+
+#. 3.0->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons in the applet"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomMenuIcons->description
+#. 3.8->settings-schema.json->useCustomMenuIcons->description
+msgid "Use custom icons in the popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->locations-page->title
+#. 3.8->settings-schema.json->location->description
+msgid "Location"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-page->title
+msgid "Other options"
+msgstr ""
+
+#. 3.8->settings-schema.json->info-section->title
+msgid "Help"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-section->title
+msgid "Location settings"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-store->title
+msgid "Saved Locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->panel-options->title
+msgid "Panel (Taskbar)"
+msgstr ""
+
+#. 3.8->settings-schema.json->presentation->title
+msgid "Popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-section->title
+msgid "Other Units"
+msgstr ""
+
+#. 3.8->settings-schema.json->temp-unit-section->title
+#, fuzzy
+msgid "Temperature Unit"
+msgstr "Μονάδα θερμοκρασίας:"
+
+#. 3.8->settings-schema.json->keybindings->title
+msgid "Keybindings"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info->title
+msgid "More about the Weather applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->submit-issue->title
+msgid "Report an issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->debug-options->title
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Debug"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->tooltip
+msgid ""
+"You can choose between several different weather forecast providers. Some "
+"providers require a API key to work, some have regional limits, differ in "
+"forecast length, and they all need a functional internet connection to work. "
+"The options are described in detail on the Cinnamon Spices Website which you "
+"can access with the button on the Help tab."
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Met Office UK (UK only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "US National Weather (US only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Pirate Weather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Visual Crossing (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Tomorrow.io (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "AccuWeather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weather Underground (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->location->tooltip
+msgid ""
+"You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use "
+"'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street} "
+"{City/Town} {Postcode} {Country}. The search algorithm is very flexible with "
+"the format. After 3 seconds without typing the address you entered is "
+"replaced automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->description
+#, fuzzy
+msgid "Save current location to storage"
+msgstr "Παράκαμψη ετικέτας τοποθεσίας"
+
+#. 3.8->settings-schema.json->saveLocation->tooltip
+msgid ""
+"Saves location information to file so you can switch between them with "
+"buttons in the applet, which will appear if you have more than one."
+msgstr ""
+
+#. 3.8->settings-schema.json->getLocation->description
+msgid "Weather Applet at Cinnamon Spices Website"
+msgstr ""
+
+#. 3.8->settings-schema.json->refreshInterval->tooltip
+msgid ""
+"If you are using a provider with API keys set it to an interval you won't "
+"run out of your quota with."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastDays->tooltip
+msgid ""
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->description
+msgid "Enable minutely precipitation forecast"
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->tooltip
+msgid ""
+"If you'd like to use this make sure you use your exact coordinates/address "
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
+msgstr ""
+
+#. 3.8->settings-schema.json->showBothTempUnits->description
+msgid "Show both temperature units at the same time"
+msgstr ""
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+#, fuzzy
+msgid "Override tooltip on panel"
+msgstr "Παράκαμψη ετικέτας τοποθεσίας"
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
+msgid "Always show Hourly Weather"
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->tooltip
+msgid ""
+"Hide/Show button will be hidden and Hourly weather will be permanently "
+"visible."
+msgstr ""
+
+#. 3.8->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->description
+msgid "Your saved locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->tooltip
+msgid ""
+"You have to make sure the Search entry field is unique and your Timezone is "
+"in the IANA time zone format (e.g. 'Europe/London')"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Latitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Longitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "City"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Country"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Timezone"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Search entry"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->description
+msgid "Display wind direction as text"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->tooltip
+msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->tooltip
+msgid "Does not apply to custom iconset, that is symbolic by default"
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons throughout the applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info-label->description
+msgid ""
+"For detailed information about the applet please go to the Spices Website to "
+"find info about known issues, troubleshooting, changelog and more by "
+"clicking the button below. Here you can ask questions etc in the comment "
+"section by logging in with your Github account."
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->description
+msgid "Submit an Issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->tooltip
+msgid ""
+"Opens webpage where you can fill out a new issue for the applet, needs a "
+"GitHub account.\n"
+" Please make sure that the issue is not already submitted."
+msgstr ""
+
+#. 3.8->settings-schema.json->maintainer->description
+msgid "Current maintainer: Gr3q"
+msgstr ""
+
+#. 3.8->settings-schema.json->issue-reporting-explanation->description
+msgid ""
+"If you find an issue with this applet please make a report by clicking on "
+"the button below and login in with your Github account.\n"
+"\n"
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
+msgstr ""
+
+#. 3.8->settings-schema.json->loc-info->description
+msgid ""
+"Your location in most cases work automatically but you can enter it manually "
+"by coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,"
+"Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/"
+"Town} {Postcode} {Country}. The search algorithm is very flexible with the "
+"format. After 3 seconds without typing the address you entered is replaced "
+"automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->description
+msgid "Log Level"
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->tooltip
+msgid ""
+"Info is the regular logging, Debug is debug, and Verbose also logs network "
+"request payloads. Changing this will only be effective on future logs. Only "
+"change it you are instructed or you know what you are doing."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Verbose"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->description
+msgid "Click Save to save debug information to a file"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->tooltip
+msgid ""
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
+msgstr ""
+
+#. 3.8->settings-schema.json->selectedLogPath->description
+msgid "Selected path to save Logs"
+msgstr ""

--- a/weather@mockturtl/files/weather@mockturtl/po/es.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/es.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-30 08:55+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2024-01-30 09:49-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,65 +20,65 @@ msgstr ""
 "X-Generator: Poedit 3.4.2\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17607
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Error"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17608 3.8/weather-applet.js:17610
-#: 3.8/weather-applet.js:17612 3.8/weather-applet.js:17615
-#: 3.8/weather-applet.js:17618 3.8/weather-applet.js:17619
-#: 3.8/weather-applet.js:17620 3.8/weather-applet.js:17621
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Error de servicio"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17609
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Clave de API incorrecta"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17611
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Formato de ubicación incorrecto"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17613
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Tecla bloqueada"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17614
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "No se pudo obtener la ubicación"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17616
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "No hay clave de API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17617
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Sin ubicación"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17622
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Paquetes perdidos"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17623
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Sin ubicación"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9711
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Applet del Clima"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17921
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17922
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Click para abrir"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16215
-#: 3.8/weather-applet.js:17925
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Recargar"
 
@@ -87,8 +88,8 @@ msgstr "La API devolvió el código de estado entre 400 y 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Ubicación"
 
@@ -100,14 +101,14 @@ msgstr "No puede guardar una ubicación obtenida automáticamente, lo lamento"
 msgid "Could not get weather information"
 msgstr "No se pudo obtener información del Clima"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17760
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Error inesperado al actualizar información del Clima, por favor mire el log "
 "en Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:18003
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -123,7 +124,7 @@ msgstr "Error de red, mire los logs en Looking Glass"
 msgid "As of"
 msgstr "A partir de las"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:17006
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Powered by"
 
@@ -131,52 +132,52 @@ msgstr "Powered by"
 msgid "from you"
 msgstr "de ti"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16919
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:16919
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10312
-#: 3.8/weather-applet.js:17084
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10313
-#: 3.8/weather-applet.js:17085
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17262
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Cargando el clima actual..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17265
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Cargando pronóstico del clima..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16168
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Cargando..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16189
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16190
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Humedad"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16191
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Presión"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12257 3.8/weather-applet.js:12263
-#: 3.8/weather-applet.js:14217 3.8/weather-applet.js:14218
-#: 3.8/weather-applet.js:16037
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Viento"
 
@@ -185,40 +186,39 @@ msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Asegúrese de que ha introducido una ubicación o use la ubicación automática"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9952
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "No se pudo encontrar la ubicación según la dirección, verifique si es "
 "correcta"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9973
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Fallo en la llamada a la API de geolocalización, ver errores en Looking "
 "Glass."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Advertencia"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9872
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Sólo se puede guardar las ubicaciones correctas cuando el applet no se está "
 "actualizando"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "No puede guardar una ubicación incorrecta"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9880
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Info"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "La ubicación ya está guardada"
 
@@ -257,15 +257,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10740 3.8/weather-applet.js:11711
-#: 3.8/weather-applet.js:12150 3.8/weather-applet.js:12659
-#: 3.8/weather-applet.js:13021 3.8/weather-applet.js:14388
-#: 3.8/weather-applet.js:14929
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Sensación térmica"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:14991
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "No se pudo procesar la información del Clima"
 
@@ -278,7 +278,7 @@ msgstr ""
 "u obtenga una primero en https://developer.tomorrow.io/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:14871
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -286,7 +286,7 @@ msgstr ""
 "Asegúrese de que\n"
 "introdujo la clave de API correctamente y su cuenta no haya sido bloqueada"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12113
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -297,60 +297,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10516 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10530 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:11379 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:11386 3.8/weather-applet.js:11393
-#: 3.8/weather-applet.js:11400 3.8/weather-applet.js:12292
-#: 3.8/weather-applet.js:13187
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Lluvia muy intensa"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11554 3.8/weather-applet.js:11555
-#: 3.8/weather-applet.js:11561 3.8/weather-applet.js:12277
-#: 3.8/weather-applet.js:12278 3.8/weather-applet.js:12284
-#: 3.8/weather-applet.js:12291 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12340 3.8/weather-applet.js:12347
-#: 3.8/weather-applet.js:12801 3.8/weather-applet.js:12850
-#: 3.8/weather-applet.js:12851 3.8/weather-applet.js:12858
-#: 3.8/weather-applet.js:13179 3.8/weather-applet.js:13448
-#: 3.8/weather-applet.js:13449 3.8/weather-applet.js:13490
-#: 3.8/weather-applet.js:14189 3.8/weather-applet.js:14190
-#: 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Lluvia"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10495 3.8/weather-applet.js:10509
-#: 3.8/weather-applet.js:10510 3.8/weather-applet.js:11009
-#: 3.8/weather-applet.js:11463 3.8/weather-applet.js:11464
-#: 3.8/weather-applet.js:11470 3.8/weather-applet.js:11477
-#: 3.8/weather-applet.js:11484 3.8/weather-applet.js:12285
-#: 3.8/weather-applet.js:13189
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Lluvia ligera"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12348 3.8/weather-applet.js:13163
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Lluvia helada"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11014
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12822
-#: 3.8/weather-applet.js:12823 3.8/weather-applet.js:12829
-#: 3.8/weather-applet.js:12830 3.8/weather-applet.js:12836
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Lluvia helada"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12341 3.8/weather-applet.js:13165
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Lluvia helada"
 
@@ -358,177 +358,177 @@ msgstr "Lluvia helada"
 msgid "Light freezing drizzle"
 msgstr "Llovizna helada"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12327
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Lluvia helada"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13145
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Llovizna ligera"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12362
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Granizo pesado"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12354 3.8/weather-applet.js:12355
-#: 3.8/weather-applet.js:12361 3.8/weather-applet.js:12368
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Granizo"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12369
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Granizo ligero"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10600
-#: 3.8/weather-applet.js:10607 3.8/weather-applet.js:10614
-#: 3.8/weather-applet.js:10615 3.8/weather-applet.js:11021
-#: 3.8/weather-applet.js:11435 3.8/weather-applet.js:11436
-#: 3.8/weather-applet.js:11442 3.8/weather-applet.js:11449
-#: 3.8/weather-applet.js:11456 3.8/weather-applet.js:12320
-#: 3.8/weather-applet.js:13205 3.8/weather-applet.js:13525
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Nevada fuerte"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:11610
-#: 3.8/weather-applet.js:11611 3.8/weather-applet.js:11617
-#: 3.8/weather-applet.js:12298 3.8/weather-applet.js:12299
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12795
-#: 3.8/weather-applet.js:13199 3.8/weather-applet.js:13434
-#: 3.8/weather-applet.js:13518 3.8/weather-applet.js:14203
-#: 3.8/weather-applet.js:14204 3.8/weather-applet.js:14581
-#: 3.8/weather-applet.js:14582
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Nieve"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11019
-#: 3.8/weather-applet.js:11519 3.8/weather-applet.js:11520
-#: 3.8/weather-applet.js:11526 3.8/weather-applet.js:11533
-#: 3.8/weather-applet.js:11540 3.8/weather-applet.js:12313
-#: 3.8/weather-applet.js:13207
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Nieve ligera"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12305
-#: 3.8/weather-applet.js:12306 3.8/weather-applet.js:14560
-#: 3.8/weather-applet.js:14561
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Ráfagas"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:12375 3.8/weather-applet.js:12376
-#: 3.8/weather-applet.js:12867 3.8/weather-applet.js:12868
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13532
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:14210
-#: 3.8/weather-applet.js:14211
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Tormenta eléctrica"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12243
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Niebla ligera"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11372
-#: 3.8/weather-applet.js:11373 3.8/weather-applet.js:12235
-#: 3.8/weather-applet.js:12236 3.8/weather-applet.js:12242
-#: 3.8/weather-applet.js:12937 3.8/weather-applet.js:12938
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:14161
-#: 3.8/weather-applet.js:14162 3.8/weather-applet.js:14609
-#: 3.8/weather-applet.js:14610
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Bruma"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10474 3.8/weather-applet.js:10475
-#: 3.8/weather-applet.js:11358 3.8/weather-applet.js:11359
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:12208
-#: 3.8/weather-applet.js:13427 3.8/weather-applet.js:13428
-#: 3.8/weather-applet.js:14154 3.8/weather-applet.js:14155
-#: 3.8/weather-applet.js:14651 3.8/weather-applet.js:14652
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Nublado"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12228
-#: 3.8/weather-applet.js:12229 3.8/weather-applet.js:12745
-#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:12780
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Mayormente nublado"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10439
-#: 3.8/weather-applet.js:10440 3.8/weather-applet.js:10446
-#: 3.8/weather-applet.js:10447 3.8/weather-applet.js:11547
-#: 3.8/weather-applet.js:11548 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12222 3.8/weather-applet.js:12738
-#: 3.8/weather-applet.js:12739 3.8/weather-applet.js:12773
-#: 3.8/weather-applet.js:13420 3.8/weather-applet.js:13421
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Mayormente soleado"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10425 3.8/weather-applet.js:10426
-#: 3.8/weather-applet.js:11039 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:12724
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12759
-#: 3.8/weather-applet.js:13223 3.8/weather-applet.js:13413
-#: 3.8/weather-applet.js:13414 3.8/weather-applet.js:14140
-#: 3.8/weather-applet.js:14141 3.8/weather-applet.js:14147
-#: 3.8/weather-applet.js:14148 3.8/weather-applet.js:14686
-#: 3.8/weather-applet.js:14687
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Despejado"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10432
-#: 3.8/weather-applet.js:10433 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:14693
-#: 3.8/weather-applet.js:14694
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Soleado"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10418
-#: 3.8/weather-applet.js:10419 3.8/weather-applet.js:10453
-#: 3.8/weather-applet.js:10454 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10643 3.8/weather-applet.js:11341
-#: 3.8/weather-applet.js:11342 3.8/weather-applet.js:11639
-#: 3.8/weather-applet.js:11640 3.8/weather-applet.js:12192
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12715
-#: 3.8/weather-applet.js:12716 3.8/weather-applet.js:12944
-#: 3.8/weather-applet.js:12945 3.8/weather-applet.js:14073
-#: 3.8/weather-applet.js:14074 3.8/weather-applet.js:14224
-#: 3.8/weather-applet.js:14225 3.8/weather-applet.js:14797
-#: 3.8/weather-applet.js:14799
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Desconocido"
 
@@ -552,7 +552,7 @@ msgstr ""
 "Introduzca una clave de API en la configuración,\n"
 "u obtenga una primero en https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:14881
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -560,7 +560,7 @@ msgstr ""
 "Asegúrese de que\n"
 "introdujo la clave de API que ha obtenido desde DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:15197
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "No se pudo obtener la ubicación"
 
@@ -571,121 +571,121 @@ msgstr ""
 "El servicio de ubicación respondió con errores, mire los logs en Looking "
 "Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11203
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Abundancia de nubes"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11351
-#: 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Cielo despejado"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11365 3.8/weather-applet.js:11366
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Buen tiempo"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11387
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Fuerte aguacero y llovizna"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11394
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Lluvia muy intensa"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11401
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Chubascos y truenos"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11407
-#: 3.8/weather-applet.js:11408 3.8/weather-applet.js:11414
-#: 3.8/weather-applet.js:11421 3.8/weather-applet.js:11428
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Aguanieve"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11415
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Aguanieve y truenos"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11422
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Fuertes chubascos de Aguanieve"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11429
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Fuertes chubascos de Aguanieve y truenos"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11443
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Fuertes nevadas y truenos"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11450
-#: 3.8/weather-applet.js:13526
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Fuertes nevadas"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11457
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Fuertes nevadas y truenos"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11471
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Lluvia ligera y truenos"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11478
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Lluvia ligera"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11485
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Lluvia ligera y truenos"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11491
-#: 3.8/weather-applet.js:11492 3.8/weather-applet.js:11498
-#: 3.8/weather-applet.js:11505 3.8/weather-applet.js:11512
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Lluvia ligera de Aguanieve"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11499
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Lluvia ligera de Aguanieve y truenos"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11506
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Lluvia ligera de Aguanieve"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11513
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Lluvia ligera de Aguanieve y truenos"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11527
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Ligera Nevada y truenos"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11534
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Ligeros chubascos de nieve"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11541
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Ligeros chubascos de nieve y truenos"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11562
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Lluvia y truenos"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11568
-#: 3.8/weather-applet.js:11569 3.8/weather-applet.js:11575
-#: 3.8/weather-applet.js:12859 3.8/weather-applet.js:13185
-#: 3.8/weather-applet.js:13491 3.8/weather-applet.js:13497
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Chubascos"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11576
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Chubascos y truenos"
 
@@ -694,44 +694,44 @@ msgstr "Chubascos y truenos"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10537
-#: 3.8/weather-applet.js:10544 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11582 3.8/weather-applet.js:11583
-#: 3.8/weather-applet.js:11589 3.8/weather-applet.js:11596
-#: 3.8/weather-applet.js:11603 3.8/weather-applet.js:12808
-#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12815
-#: 3.8/weather-applet.js:12816 3.8/weather-applet.js:12843
-#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14196
-#: 3.8/weather-applet.js:14197 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Aguanieve"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11590
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Aguanieve y truenos"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11597
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Lluvia de Aguanieve"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11604
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Ligeros chubascos de Aguanieve y truenos"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11618
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Nieve y trueno"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11624 3.8/weather-applet.js:11625
-#: 3.8/weather-applet.js:11631 3.8/weather-applet.js:13203
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Chubasco de nieve"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11632
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Chubasco de nieve y truenos"
 
@@ -740,21 +740,21 @@ msgstr "Chubasco de nieve y truenos"
 msgid "Unexpected response from API"
 msgstr "Respuesta inesperada de la API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10237
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Visibilidad"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10265
-#: 3.8/weather-applet.js:10817 3.8/weather-applet.js:11722
-#: 3.8/weather-applet.js:12672
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "No se pudo procesar la información del clima actual"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10055
-#: 3.8/weather-applet.js:10089 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11782 3.8/weather-applet.js:12474
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "No se pudo procesar la información del pronóstico"
 
@@ -783,89 +783,89 @@ msgid "Excellent - More than"
 msgstr "Excelente - Más de"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10460 3.8/weather-applet.js:10461
-#: 3.8/weather-applet.js:11029 3.8/weather-applet.js:13175
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Niebla"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:12752
-#: 3.8/weather-applet.js:12753 3.8/weather-applet.js:12787
-#: 3.8/weather-applet.js:13219
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Nubarrones"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10489
-#: 3.8/weather-applet.js:10496
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Llovizna de intensidad ligera"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:12326
-#: 3.8/weather-applet.js:13141 3.8/weather-applet.js:14532
-#: 3.8/weather-applet.js:14533
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Llovizna"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:10524
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Aguacero"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10538
-#: 3.8/weather-applet.js:10545
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Chubascos de Aguanieve"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:13217 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14169 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:14589
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Granizo"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Fuertes granizadas"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Nevada ligera"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Nevada fuerte"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10621 3.8/weather-applet.js:10628
-#: 3.8/weather-applet.js:10635 3.8/weather-applet.js:10636
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Truenos"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Tormenta de truenos"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10872
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Asegúrese de que la ubicación está en el formato correcto en la configuración"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10876
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Asegúrese de que introdujo la clave correcta en la configuración"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10681 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -873,211 +873,211 @@ msgstr ""
 "Ubicación no encontrada, asegúrese de que la ubicación está disponible o "
 "está en el formato correcto"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10884
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Si el problema persiste, contacte al autor de este applet"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10888
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Error desconocido, consulte los logs en Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10990
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Tormenta con lluvia ligera"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10991
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Tormenta con lluvia"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10992
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Tormenta con fuertes lluvias"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10993
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Tormenta ligera"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10995
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Tormenta fuerte"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10996
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Tormenta torrencial"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10997
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Tormenta con llovizna ligera"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10998
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Tormenta con llovizna"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10999
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Tormenta con fuerte llovizna"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11000
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Llovizna de intensidad ligera"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11002
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Llovizna de intensidad fuerte"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11003
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Llovizna de intensidad ligera"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11004
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Llovizna"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11005
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Llovizna de intensidad fuerte"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11006
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Aguacero y llovizna"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11007
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Fuerte aguacero y llovizna"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11008
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Aguacero"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11010
-#: 3.8/weather-applet.js:13455 3.8/weather-applet.js:13456
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Lluvia moderada"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11011
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Lluvia intensa"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11012
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Lluvia muy intensa"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11013
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Lluvia extrema"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11015
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Llovizna de intensidad ligera"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11016
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Aguacero"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11017
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Aguacero de intensidad fuerte"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11018
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Lluvia irregular"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11023
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Aguanieve"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11024
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Lluvia ligera y nieve"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11025
-#: 3.8/weather-applet.js:13462 3.8/weather-applet.js:13463
-#: 3.8/weather-applet.js:13469 3.8/weather-applet.js:13504
-#: 3.8/weather-applet.js:13511
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Lluvia y nieve"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11026
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Ligeros chubascos de nieve"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11027
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Chubasco de nieve"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11028
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Fuertes chubascos de nieve"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:12902
-#: 3.8/weather-applet.js:12903 3.8/weather-applet.js:14623
-#: 3.8/weather-applet.js:14624
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Humo"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11031 3.8/weather-applet.js:12909
-#: 3.8/weather-applet.js:12910 3.8/weather-applet.js:14616
-#: 3.8/weather-applet.js:14617
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Niebla"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11032
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Arena, remolinos de polvo"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11034
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Arena"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11035 3.8/weather-applet.js:12895
-#: 3.8/weather-applet.js:12896 3.8/weather-applet.js:14602
-#: 3.8/weather-applet.js:14603
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Polvo"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11036
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Ceniza volcánica"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:13209
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Borrascas"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11038 3.8/weather-applet.js:12874
-#: 3.8/weather-applet.js:12875 3.8/weather-applet.js:14475
-#: 3.8/weather-applet.js:14476
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Tornados"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11041
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Cielo despejado"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11042
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Nubarrones"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11043
-#: 3.8/weather-applet.js:12731 3.8/weather-applet.js:12732
-#: 3.8/weather-applet.js:12766
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Pocas nubes"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11044
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Nubes dispersas"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11045
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Nubes rotas"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11046
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Totalmente cubierto"
 
@@ -1085,80 +1085,80 @@ msgstr "Totalmente cubierto"
 msgid "Could not get forecast for your area"
 msgstr "No se pudo obtener el pronóstico para su área"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12431
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "La ubicación está fuera de EE. UU., Utilice un proveedor diferente."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12495
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "No se pudo procesar la información del pronóstico"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12760
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Despejado y con viento"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12767
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Pocas nubes y viento"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12774
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Parcialmente nublado y con viento"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Mayormente nublado y con viento"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12788
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Nublado y con viento"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12802
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Lluvia helada"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12837
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Lluvia helada y nieve"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9153 3.8/weather-applet.js:12881
-#: 3.8/weather-applet.js:12882 3.8/weather-applet.js:14489
-#: 3.8/weather-applet.js:14490
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Huracán"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9148
-#: 3.8/weather-applet.js:12888
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Tormenta"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12889
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Tormenta tropical"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12916 3.8/weather-applet.js:12917
-#: 3.8/weather-applet.js:14721 3.8/weather-applet.js:14722
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Caluroso"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12923 3.8/weather-applet.js:12924
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Muy frío"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12930 3.8/weather-applet.js:12931
-#: 3.8/weather-applet.js:14770 3.8/weather-applet.js:14771
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Ventisca"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9025
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Hoy"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9027
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Mañana"
 
@@ -1190,79 +1190,79 @@ msgstr "Viernes"
 msgid "Saturday"
 msgstr "Sábado"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9118
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Tranquilo"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9121
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Aire ligero"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9124
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Brisa ligera"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9127
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Brisa suave"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9130
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Brisa moderada"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9133
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Brisa fresca"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9136
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Brisa fuerte"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9139
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Vendaval moderado"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9142
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Vendaval"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9145
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Vendaval fuerte"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9151
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Tormenta violenta"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "NE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "E"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "SE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "SO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "O"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "NO"
 
@@ -1314,7 +1314,7 @@ msgstr ""
 "Se produjo un error desconocido al obtener el Clima, consulte los registros "
 "de Looking Glass para más información"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14482 3.8/weather-applet.js:14483
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Tormenta tropical"
 
@@ -1322,7 +1322,7 @@ msgstr "Tormenta tropical"
 msgid "Severe Thunderstorms"
 msgstr "Tormenta eléctrica fuerte"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14503 3.8/weather-applet.js:14504
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Tormenta eléctrica"
 
@@ -1338,15 +1338,15 @@ msgstr "Mezcla de Lluvia y Aguanieve"
 msgid "Mixed Snow and Sleet"
 msgstr "Mezcla de nieve y Aguanieve"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Llovizna helada"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Lluvia helada"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Chubasco de nieve"
 
@@ -1358,11 +1358,11 @@ msgstr "Copos de nieve"
 msgid "Light Snow Showers"
 msgstr "Ligeros chubascos de nieve"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14574 3.8/weather-applet.js:14575
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Ventisca"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13441 3.8/weather-applet.js:13442
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Neblinoso"
 
@@ -1374,54 +1374,54 @@ msgstr "Humo"
 msgid "Blustery"
 msgstr "Tempestuoso"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14637 3.8/weather-applet.js:14638
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Viento"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:14658 3.8/weather-applet.js:14659
-#: 3.8/weather-applet.js:14665 3.8/weather-applet.js:14666
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Mayormente nublado"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14175 3.8/weather-applet.js:14176
-#: 3.8/weather-applet.js:14182 3.8/weather-applet.js:14183
-#: 3.8/weather-applet.js:14672 3.8/weather-applet.js:14673
-#: 3.8/weather-applet.js:14679 3.8/weather-applet.js:14680
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Mayormente soleado"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:14714 3.8/weather-applet.js:14715
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Mezcla de lluvia y granizo"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:14728 3.8/weather-applet.js:14729
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Tormentas aisladas"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:14735 3.8/weather-applet.js:14736
-#: 3.8/weather-applet.js:14791 3.8/weather-applet.js:14792
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Tormentas eléctricas dispersas"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:14742 3.8/weather-applet.js:14743
-#: 3.8/weather-applet.js:14777 3.8/weather-applet.js:14778
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Chubascos dispersos"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:14749 3.8/weather-applet.js:14750
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Lluvia fuerte"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:14756 3.8/weather-applet.js:14757
-#: 3.8/weather-applet.js:14784 3.8/weather-applet.js:14785
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Chubascos de nieve dispersos"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:14763 3.8/weather-applet.js:14764
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Nevada fuerte"
 
@@ -1433,7 +1433,7 @@ msgstr "No disponible"
 msgid "Scattered Thundershowers"
 msgstr "Nubes dispersas"
 
-#: 3.8/weather-applet.js:9637
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1442,7 +1442,7 @@ msgstr ""
 "registro en la ruta\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9641
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1451,11 +1451,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10013
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10118
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1463,275 +1463,275 @@ msgstr ""
 "WindyMET Office UK solo cubre el Reino Unido, asegúrese de que su ubicación "
 "esté en el país"
 
-#: 3.8/weather-applet.js:10197
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "No se encontraron datos para la ubicación"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Muy pobre"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Menos que {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Excelente"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Mas de {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10287
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Pobre"
 
-#: 3.8/weather-applet.js:10287 3.8/weather-applet.js:10292
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:10302
-#: 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Entre {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10292
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Moderada"
 
-#: 3.8/weather-applet.js:10297
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Bueno"
 
-#: 3.8/weather-applet.js:10302 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Muy bueno"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10662
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:11659
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12080
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12250
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Viento ligero"
 
-#: 3.8/weather-applet.js:12264
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Viento fuerte"
 
-#: 3.8/weather-applet.js:12411
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:12962
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:13139
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Nieve soplada o a la deriva"
 
-#: 3.8/weather-applet.js:13143
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Llovizna"
 
-#: 3.8/weather-applet.js:13147
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Llovizna de intensidad fuerte"
 
-#: 3.8/weather-applet.js:13149
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Llovizna de intensidad ligera"
 
-#: 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Tormenta de polvo"
 
-#: 3.8/weather-applet.js:13155
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Llovizna helada fuerte/lluvia helada"
 
-#: 3.8/weather-applet.js:13157
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Llovizna helada fuerte/lluvia helada"
 
-#: 3.8/weather-applet.js:13159
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Llovizna helada ligera/lluvia helada"
 
-#: 3.8/weather-applet.js:13161
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Niebla helada"
 
-#: 3.8/weather-applet.js:13167
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Nube de embudo/tornado"
 
-#: 3.8/weather-applet.js:13169
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Lluvias de granizo"
 
-#: 3.8/weather-applet.js:13171
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Hielo"
 
-#: 3.8/weather-applet.js:13173
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Rayo sin trueno"
 
-#: 3.8/weather-applet.js:13177
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Precipitación en las cercanías"
 
-#: 3.8/weather-applet.js:13181 3.8/weather-applet.js:13470
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Lluvia fuerte y nieve"
 
-#: 3.8/weather-applet.js:13183
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Lluvia ligera y nieve"
 
-#: 3.8/weather-applet.js:13191
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Disminución de la cobertura del cielo"
 
-#: 3.8/weather-applet.js:13193
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Aumento de la cobertura del cielo"
 
-#: 3.8/weather-applet.js:13195
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Cielo sin cambios"
 
-#: 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Humo o neblina"
 
-#: 3.8/weather-applet.js:13201
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Chubascos y nieve"
 
-#: 3.8/weather-applet.js:13213
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Tormenta sin lluvia"
 
-#: 3.8/weather-applet.js:13215
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Prismas de hielo"
 
-#: 3.8/weather-applet.js:13221
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.8/weather-applet.js:13243
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Asegúrese de que introdujo la clave de API correcta"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13259
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:13402 3.8/weather-applet.js:13403
-#: 3.8/weather-applet.js:13539 3.8/weather-applet.js:13540
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "NO ENCONTRADO"
 
-#: 3.8/weather-applet.js:13435
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Nieve soplada"
 
-#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:13477
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Nieve ligera"
 
-#: 3.8/weather-applet.js:13483 3.8/weather-applet.js:13484
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Nieve moderada"
 
-#: 3.8/weather-applet.js:13498
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Lluvia moderada"
 
-#: 3.8/weather-applet.js:13505
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Lluvia y nieve"
 
-#: 3.8/weather-applet.js:13512
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Lluvia fuerte y nieve"
 
-#: 3.8/weather-applet.js:13657
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:13953
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:13966
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "Por favor, seleccione otro proveedor o ubicación"
 
-#: 3.8/weather-applet.js:14263
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14453
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "La clave de la API que ha proporcionado no es válida."
 
-#: 3.8/weather-applet.js:14460
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "No se encontró la ubicación que proporcionó."
 
-#: 3.8/weather-applet.js:14496 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Tormenta fuerte"
 
-#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:14512
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Lluvia y nieve"
 
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Lluvia y Aguanieve"
 
-#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Chubasco de nieve"
 
-#: 3.8/weather-applet.js:14630 3.8/weather-applet.js:14631
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "Ventoso"
 
-#: 3.8/weather-applet.js:14644 3.8/weather-applet.js:14645
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr "Gélido"
 
-#: 3.8/weather-applet.js:14700 3.8/weather-applet.js:14701
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Mayormente despejado"
 
-#: 3.8/weather-applet.js:14853
+#: 3.8/weather-applet.js:15247
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:15206
+#: 3.8/weather-applet.js:15603
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
@@ -1739,13 +1739,13 @@ msgstr ""
 "El Servicio de Localización no pudo encontrar su ubicación, por favor vea "
 "los registros en Looking Glass"
 
-#: 3.8/weather-applet.js:15428
+#: 3.8/weather-applet.js:15831
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Asegúrese de que ha introducido una ubicación o utilice Ubicación automática "
 "en su lugar."
 
-#: 3.8/weather-applet.js:15565
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1754,7 +1754,7 @@ msgstr ""
 "en la ruta\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15572
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1763,59 +1763,59 @@ msgstr ""
 "ruta\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Este proveedor requiere una clave API para operar"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Punto de rocío"
 
-#: 3.8/weather-applet.js:16264
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "La precipitación terminará en {precipEnd} minutos"
 
-#: 3.8/weather-applet.js:16266
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "La precipitación no terminará en una hora"
 
-#: 3.8/weather-applet.js:16269
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "La precipitación comenzará en {precipStart} minutos"
 
-#: 3.8/weather-applet.js:16481
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Error al analizar la pronósticos, consulte los registros para obtener más "
 "detalles."
 
-#: 3.8/weather-applet.js:17013 3.8/weather-applet.js:17802
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "A partir de las {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:17019
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} de usted"
 
-#: 3.8/weather-applet.js:17023
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "Nombre de la estación: {stationName}"
 
-#: 3.8/weather-applet.js:17026
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "Área: {stationArea}"
 
-#: 3.8/weather-applet.js:17573 3.8/weather-applet.js:17583
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Error al guardar la información de depuración"
 
-#: 3.8/weather-applet.js:17595
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "La información de depuración se guardó correctamente"
 
-#: 3.8/weather-applet.js:17595
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Guardado en {filePath}"
-
-#: 3.8/weather-applet.js:17726
-msgid "This provider requires an API key to operate"
-msgstr "Este proveedor requiere una clave API para operar"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -2622,9 +2622,3 @@ msgstr ""
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr "Ruta seleccionada para guardar los registros"
-
-#~ msgid "DarkSky"
-#~ msgstr "DarkSky"
-
-#~ msgid "This API has ceased to function, please use another one."
-#~ msgstr "Esta API ha dejado de funcionar, utilice otra."

--- a/weather@mockturtl/files/weather@mockturtl/po/eu.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/eu.po
@@ -5,8 +5,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-12 12:27-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2014-09-20 23:11+0200\n"
 "Last-Translator: Asier Iturralde Sarasola <asier.iturralde@gmail.com>\n"
 "Language-Team: Librezale <librezale@librezale.org\n"
@@ -17,438 +18,2580 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Virtaal 0.7.1\n"
 
-#: applet.js:249
+#: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
+#: 3.8/weather-applet.js:17877
+msgid "Error"
+msgstr ""
+
+#: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
+#: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
+msgid "Service Error"
+msgstr ""
+
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
+msgid "Incorrect API Key"
+msgstr ""
+
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
+msgid "Incorrect Location Format"
+msgstr ""
+
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
+msgid "Key Blocked"
+msgstr ""
+
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
+msgid "Can't find location"
+msgstr ""
+
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
+msgid "No Api Key"
+msgstr ""
+
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
+msgid "No Location"
+msgstr ""
+
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
+msgid "Missing Packages"
+msgstr ""
+
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
+msgid "Location not covered"
+msgstr ""
+
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
+msgid "Weather Applet"
+msgstr ""
+
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: applet.js:250
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Klikatu irekitzeko"
 
-#: applet.js:289
-msgid "Settings"
-msgstr "Ezarpenak"
-
-#: applet.js:555
-msgid "Sunrise"
-msgstr "Egunsentia"
-
-#: applet.js:556
-msgid "Sunset"
-msgstr "Ilunabarra"
-
-#: applet.js:648
-msgid "Loading current weather ..."
-msgstr "Uneko eguraldia kargatzen..."
-
-#: applet.js:649
-msgid "Loading future weather ..."
-msgstr "Etorkizuneko eguraldia kargatzen..."
-
-#: applet.js:671
-msgid "Loading ..."
-msgstr "Kargatzen..."
-
-#: applet.js:677
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr ""
 
-#: applet.js:740
-msgid "Temperature:"
+#: 3.0/applet.js:272
+msgid "API returned status code between 400 and 500"
+msgstr ""
+
+#: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
+#: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
+msgid "Location Store"
+msgstr ""
+
+#: 3.0/applet.js:426
+msgid "You can't save a location obtained automatically, sorry"
+msgstr ""
+
+#: 3.0/applet.js:601
+msgid "Could not get weather information"
+msgstr ""
+
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
+msgid ""
+"Unexpected Error While Refreshing Weather, please see log in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
+msgid ""
+"Could not update weather for a while...\n"
+"are you connected to the internet?"
+msgstr ""
+
+#: 3.0/applet.js:684
+msgid "Network Error, please check logs in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:969 3.0/applet.js:1110
+msgid "As of"
+msgstr ""
+
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
+msgid "Powered by"
+msgstr ""
+
+#: 3.0/applet.js:1113
+msgid "from you"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
+msgid "mm"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
+msgid "in"
+msgstr ""
+
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
+msgid "mi"
+msgstr ""
+
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
+msgid "km"
+msgstr ""
+
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
+msgid "Loading current weather ..."
+msgstr "Uneko eguraldia kargatzen..."
+
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
+msgid "Loading future weather ..."
+msgstr "Etorkizuneko eguraldia kargatzen..."
+
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
+msgid "Loading ..."
+msgstr "Kargatzen..."
+
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
+#, fuzzy
+msgid "Temperature"
 msgstr "Tenperatura:"
 
-#: applet.js:742
-msgid "Humidity:"
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
+#, fuzzy
+msgid "Humidity"
 msgstr "Hezetasuna:"
 
-#: applet.js:744
-msgid "Pressure:"
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
+#, fuzzy
+msgid "Pressure"
 msgstr "Presioa:"
 
-#: applet.js:746
-msgid "Wind:"
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
+#, fuzzy
+msgid "Wind"
 msgstr "Haizea:"
 
-#: applet.js:748
-msgid "Wind Chill:"
-msgstr "Haizearen sentsazioa:"
+#: 3.0/applet.js:1639
+msgid "Make sure you entered a location or use Automatic location instead"
+msgstr ""
 
-#: applet.js:953
-msgid "Tornado"
-msgstr "Tornadoa"
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
+msgid "Could not find location based on address, please check if it's right"
+msgstr ""
 
-#: applet.js:955
-msgid "Tropical storm"
-msgstr "Ekaitz tropikala"
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
+msgid "Failed to call Geolocation API, see Looking Glass for errors."
+msgstr ""
 
-#: applet.js:957
-msgid "Hurricane"
-msgstr "Urakana"
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "Warning"
+msgstr ""
 
-#: applet.js:959
-msgid "Severe thunderstorms"
-msgstr "Trumoi-ekaitz gogorra"
+#: 3.0/applet.js:2032
+msgid "You can only save correct locations when the applet is not refreshing"
+msgstr ""
 
-#: applet.js:961
-msgid "Thunderstorms"
-msgstr "Trumoi-ekaitzak"
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "You can't save an incorrect location"
+msgstr ""
 
-#: applet.js:963
-msgid "Mixed rain and snow"
-msgstr "Euria eta elurra"
+#. 3.8->settings-schema.json->logLevel->options
+#: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.8/weather-applet.js:9875
+msgid "Info"
+msgstr ""
 
-#: applet.js:965
-msgid "Mixed rain and sleet"
-msgstr "Euria eta elurbustia"
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
+msgid "Location is already saved"
+msgstr ""
 
-#: applet.js:967
-msgid "Mixed snow and sleet"
-msgstr "Elurra eta elurbustia"
+#: 3.0/applet.js:2049 3.0/applet.js:2083
+msgid "Success"
+msgstr ""
 
-#: applet.js:969
-msgid "Freezing drizzle"
-msgstr "Zirimiri izoztua"
+#: 3.0/applet.js:2049
+msgid "Location is saved to library"
+msgstr ""
 
-#: applet.js:971
-msgid "Drizzle"
-msgstr "Zirimiria"
+#: 3.0/applet.js:2062
+msgid "You can't remove a location while the applet is refreshing"
+msgstr ""
 
-#: applet.js:973
+#: 3.0/applet.js:2066
+msgid "You can't remove an incorrect location"
+msgstr ""
+
+#: 3.0/applet.js:2070
+msgid "Location is not in storage, can't delete"
+msgstr ""
+
+#: 3.0/applet.js:2083
+msgid "Location is deleted from library"
+msgstr ""
+
+#: 3.0/applet.js:2131
+msgid ""
+"Failed to load in data from location storage, please see the logs for more "
+"information"
+msgstr ""
+
+#: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
+#: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
+msgid "Feels Like"
+msgstr ""
+
+#: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
+#: 3.8/weather-applet.js:15387
+msgid "Failed to Process Weather Info"
+msgstr ""
+
+#: 3.0/climacell.js:224
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://developer.climacell.co/sign-up"
+msgstr ""
+
+#: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
+msgid ""
+"Please Make sure you\n"
+"entered the API key correctly and your account is not locked"
+msgstr ""
+
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Climacell"
+msgstr ""
+
+#: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
+#: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
+#: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
+#, fuzzy
+msgid "Heavy rain"
+msgstr "Elur-jasa"
+
+#: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
+#: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
+#: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
+msgid "Rain"
+msgstr ""
+
+#: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
+#: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
+#: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
+#, fuzzy
+msgid "Light rain"
+msgstr "Euri izoztua"
+
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
+#, fuzzy
+msgid "Heavy freezing rain"
+msgstr "Euri izoztua"
+
+#: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
+#: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
+#: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Euri izoztua"
 
-#: applet.js:975 applet.js:977
-msgid "Showers"
-msgstr "Zaparradak"
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
+#, fuzzy
+msgid "Light freezing rain"
+msgstr "Euri izoztua"
 
-#: applet.js:979
-msgid "Snow flurries"
-msgstr "Elur-jasak"
+#: 3.0/climacell.js:301
+#, fuzzy
+msgid "Light freezing drizzle"
+msgstr "Zirimiri izoztua"
 
-#: applet.js:981
-msgid "Light snow showers"
-msgstr "Elur-zaparrada arinak"
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
+msgid "Freezing drizzle"
+msgstr "Zirimiri izoztua"
 
-#: applet.js:983
-msgid "Blowing snow"
-msgstr "Elur-jasa haizetsua"
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
+#, fuzzy
+msgid "Light drizzle"
+msgstr "Zirimiri izoztua"
 
-#: applet.js:985
-msgid "Snow"
-msgstr "Elurra"
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
+msgid "Heavy ice pellets"
+msgstr ""
 
-#: applet.js:987
-msgid "Hail"
-msgstr "Kazkabarra"
+#: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
+msgid "Ice pellets"
+msgstr ""
 
-#: applet.js:989
-msgid "Sleet"
-msgstr "Elurbustia"
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
+msgid "Light ice pellets"
+msgstr ""
 
-#: applet.js:991
-msgid "Dust"
-msgstr "Hautsa"
-
-#: applet.js:993
-msgid "Foggy"
-msgstr "Lainotsua"
-
-#: applet.js:995
-msgid "Haze"
-msgstr "Gandua"
-
-#: applet.js:997
-msgid "Smoky"
-msgstr "Ketsua"
-
-#: applet.js:999
-msgid "Blustery"
-msgstr "Ekaitztsua"
-
-#: applet.js:1001
-msgid "Windy"
-msgstr "Haizetsua"
-
-#: applet.js:1003
-msgid "Cold"
-msgstr "Hotza"
-
-#: applet.js:1005
-msgid "Cloudy"
-msgstr "Hodeitsua"
-
-#: applet.js:1008
-msgid "Mostly cloudy"
-msgstr "Nagusiki hodeitsua"
-
-#: applet.js:1011 applet.js:1037
-msgid "Partly cloudy"
-msgstr "Nahiko hodeitsua"
-
-#: applet.js:1013
-msgid "Clear"
-msgstr "Garbia"
-
-#: applet.js:1015
-msgid "Sunny"
-msgstr "Eguzkitsua"
-
-#: applet.js:1018
-msgid "Fair"
-msgstr "Ona"
-
-#: applet.js:1020
-msgid "Mixed rain and hail"
-msgstr "Euria eta kazkabarra"
-
-#: applet.js:1022
-msgid "Hot"
-msgstr "Beroa"
-
-#: applet.js:1024
-msgid "Isolated thunderstorms"
-msgstr "Trumoi-ekaitz isolatuak"
-
-#: applet.js:1027
-msgid "Scattered thunderstorms"
-msgstr "Trumoi-ekaitz sakabanatuak"
-
-#: applet.js:1029
-msgid "Scattered showers"
-msgstr "Zaparrada sakabanatuak"
-
-#: applet.js:1031 applet.js:1035
+#: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
+#: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
+#: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Elur-jasa"
 
-#: applet.js:1033
-msgid "Scattered snow showers"
-msgstr "Elur-zaparrada sakabanatuak"
+#: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
+#: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
+#: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
+msgid "Snow"
+msgstr "Elurra"
 
-#: applet.js:1039
-msgid "Thundershowers"
-msgstr "Zaparrada ekaiztsuak"
+#: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
+#: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
+#: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
+#, fuzzy
+msgid "Light snow"
+msgstr "Elur-zaparrada arinak"
 
-#: applet.js:1041
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
+#, fuzzy
+msgid "Flurries"
+msgstr "Elur-jasak"
+
+#: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
+#, fuzzy
+msgid "Thunderstorm"
+msgstr "Trumoi-ekaitzak"
+
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
+msgid "Light fog"
+msgstr ""
+
+#: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
+#: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
+#: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
+#, fuzzy
+msgid "Fog"
+msgstr "Lainotsua"
+
+#: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
+#: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
+msgid "Cloudy"
+msgstr "Hodeitsua"
+
+#: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
+msgid "Mostly cloudy"
+msgstr "Nagusiki hodeitsua"
+
+#: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
+#: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
+#: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
+msgid "Partly cloudy"
+msgstr "Nahiko hodeitsua"
+
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
+#, fuzzy
+msgid "Mostly clear"
+msgstr "Nagusiki hodeitsua"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
+#: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
+#: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
+msgid "Clear"
+msgstr "Garbia"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
+msgid "Sunny"
+msgstr "Eguzkitsua"
+
+#: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
+#: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
+#: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
+msgid "Unknown"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "and"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "until"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "Possible"
+msgstr ""
+
+#: 3.0/darkSky.js:211
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://darksky.net/dev/register"
+msgstr ""
+
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from DarkSky"
+msgstr ""
+
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
+msgid "Could not obtain location"
+msgstr ""
+
+#: 3.0/ipApi.js:95
+msgid ""
+"Location Service responded with errors, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
+#, fuzzy
+msgid "Cloudiness"
+msgstr "Hodeitsua"
+
+#: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
+#, fuzzy
+msgid "Clear sky"
+msgstr "Garbia"
+
+#: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
+msgid "Fair"
+msgstr "Ona"
+
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
+msgid "Heavy rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
+#, fuzzy
+msgid "Heavy rain showers"
+msgstr "Elur-jasa"
+
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
+msgid "Heavy rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
+#, fuzzy
+msgid "Heavy sleet"
+msgstr "Elur-jasa"
+
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
+msgid "Heavy sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
+#, fuzzy
+msgid "Heavy sleet showers"
+msgstr "Elur-jasa"
+
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
+msgid "Heavy sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
+#, fuzzy
+msgid "Heavy snow and thunder"
+msgstr "Elur-jasa"
+
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
+#, fuzzy
+msgid "Heavy snow showers"
+msgstr "Elur-zaparradak"
+
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
+msgid "Heavy snow showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
+msgid "Light rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
+#, fuzzy
+msgid "Light rain showers"
+msgstr "Elur-zaparrada arinak"
+
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
+#, fuzzy
+msgid "Light rain showers and thunder"
+msgstr "Elur-zaparrada arinak"
+
+#: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
+msgid "Light sleet"
+msgstr ""
+
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
+msgid "Light sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
+#, fuzzy
+msgid "Light sleet showers"
+msgstr "Elur-zaparrada arinak"
+
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
+#, fuzzy
+msgid "Light sleet showers and thunder"
+msgstr "Elur-zaparrada arinak"
+
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
+#, fuzzy
+msgid "Light snow and thunder"
+msgstr "Elur-zaparrada arinak"
+
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
+msgid "Light snow showers"
+msgstr "Elur-zaparrada arinak"
+
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
+#, fuzzy
+msgid "Light snow showers and thunder"
+msgstr "Elur-zaparrada arinak"
+
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
+msgid "Rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
+#, fuzzy
+msgid "Rain showers"
+msgstr "Elur-zaparradak"
+
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
+msgid "Rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:511 3.0/met_norway.js:512 3.0/met_norway.js:518
+#: 3.0/met_norway.js:525 3.0/met_norway.js:532 3.0/met_uk.js:638
+#: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
+#: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
+#: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
+msgid "Sleet"
+msgstr "Elurbustia"
+
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
+#, fuzzy
+msgid "Sleet and thunder"
+msgstr "Trumoi-ekaitz sakabanatuak"
+
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
+#, fuzzy
+msgid "Sleet showers"
+msgstr "Zaparrada sakabanatuak"
+
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
+msgid "Sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
+msgid "Snow and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Elur-zaparradak"
 
-#: applet.js:1043
-msgid "Isolated thundershowers"
-msgstr "Zaparrada ekaitztsu isolatuak"
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
+#, fuzzy
+msgid "Snow showers and thunder"
+msgstr "Elur-zaparradak"
 
-#: applet.js:1046
-msgid "Not available"
-msgstr "Ez dago erabilgarri"
+#: 3.0/met_uk.js:162 3.0/met_uk.js:192 3.0/met_uk.js:239 3.0/us_weather.js:151
+#: 3.0/us_weather.js:179
+msgid "Unexpected response from API"
+msgstr ""
 
-#: applet.js:1051
-msgid "Monday"
-msgstr "Astelehena"
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
+msgid "Visibility"
+msgstr ""
 
-#: applet.js:1051
-msgid "Tuesday"
-msgstr "Asteartea"
+#: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
+msgid "Failed to Process Current Weather Info"
+msgstr ""
 
-#: applet.js:1051
-msgid "Wednesday"
-msgstr "Asteazkena"
+#: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
+msgid "Failed to Process Forecast Info"
+msgstr ""
 
-#: applet.js:1051
-msgid "Thursday"
-msgstr "Osteguna"
+#: 3.0/met_uk.js:408
+msgid "Very poor - Less than"
+msgstr ""
 
-#: applet.js:1051
-msgid "Friday"
-msgstr "Ostirala"
+#: 3.0/met_uk.js:410
+msgid "Poor - Between"
+msgstr ""
 
-#: applet.js:1051
-msgid "Saturday"
-msgstr "Larunbata"
+#: 3.0/met_uk.js:412
+msgid "Moderate - Between"
+msgstr ""
 
-#: applet.js:1051
+#: 3.0/met_uk.js:414
+msgid "Good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:416
+msgid "Very good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:417
+msgid "Excellent - More than"
+msgstr ""
+
+#: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
+msgid "Mist"
+msgstr ""
+
+#: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
+msgid "Overcast"
+msgstr ""
+
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
+#, fuzzy
+msgid "Light rain shower"
+msgstr "Elur-zaparrada arinak"
+
+#: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
+msgid "Drizzle"
+msgstr "Zirimiria"
+
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
+#, fuzzy
+msgid "Heavy rain shower"
+msgstr "Elur-jasa"
+
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
+#, fuzzy
+msgid "Sleet shower"
+msgstr "Zaparrada sakabanatuak"
+
+#: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
+msgid "Hail"
+msgstr "Kazkabarra"
+
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
+#, fuzzy
+msgid "Hail shower"
+msgstr "Elur-zaparradak"
+
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
+#, fuzzy
+msgid "Light snow shower"
+msgstr "Elur-zaparrada arinak"
+
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
+#, fuzzy
+msgid "Heavy snow shower"
+msgstr "Elur-jasa"
+
+#: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
+#, fuzzy
+msgid "Thunder"
+msgstr "Trumoi-ekaitzak"
+
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
+#, fuzzy
+msgid "Thunder shower"
+msgstr "Zaparrada ekaiztsuak"
+
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
+msgid "Please make sure Location is in the correct format in the Settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
+msgid "Make sure you entered the correct key in settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
+msgid ""
+"Location not found, make sure location is available or it is in the correct "
+"format"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
+msgid "If this problem persists, please contact the Author of this applet"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
+msgid "Unknown Error, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
+msgid "Thunderstorm with light rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
+#, fuzzy
+msgid "Thunderstorm with rain"
+msgstr "Trumoi-ekaitzak"
+
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
+msgid "Thunderstorm with heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
+#, fuzzy
+msgid "Light thunderstorm"
+msgstr "Trumoi-ekaitzak"
+
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
+#, fuzzy
+msgid "Heavy thunderstorm"
+msgstr "Trumoi-ekaitz gogorra"
+
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
+#, fuzzy
+msgid "Ragged thunderstorm"
+msgstr "Trumoi-ekaitz isolatuak"
+
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
+msgid "Thunderstorm with light drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
+#, fuzzy
+msgid "Thunderstorm with drizzle"
+msgstr "Trumoi-ekaitzak"
+
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
+msgid "Thunderstorm with heavy drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
+msgid "Light intensity drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
+msgid "Heavy intensity drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
+msgid "Light intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Drizzle rain"
+msgstr "Zirimiria"
+
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
+msgid "Heavy intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
+#, fuzzy
+msgid "Shower rain and drizzle"
+msgstr "Euria eta kazkabarra"
+
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
+msgid "Heavy shower rain and drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
+#, fuzzy
+msgid "Shower drizzle"
+msgstr "Zirimiri izoztua"
+
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
+msgid "Moderate rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
+msgid "Heavy intensity rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
+msgid "Very heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
+#, fuzzy
+msgid "Extreme rain"
+msgstr "Euri izoztua"
+
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
+#, fuzzy
+msgid "Light intensity shower rain"
+msgstr "Elur-zaparrada arinak"
+
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
+#, fuzzy
+msgid "Shower rain"
+msgstr "Zaparradak"
+
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
+msgid "Heavy intensity shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
+msgid "Ragged shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
+#, fuzzy
+msgid "Shower sleet"
+msgstr "Zaparradak"
+
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
+#, fuzzy
+msgid "Light rain and snow"
+msgstr "Euria eta elurra"
+
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
+#, fuzzy
+msgid "Rain and snow"
+msgstr "Euria eta elurra"
+
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
+#, fuzzy
+msgid "Light shower snow"
+msgstr "Elur-zaparrada arinak"
+
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
+#, fuzzy
+msgid "Shower snow"
+msgstr "Zaparradak"
+
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
+#, fuzzy
+msgid "Heavy shower snow"
+msgstr "Elur-jasa"
+
+#: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
+#, fuzzy
+msgid "Smoke"
+msgstr "Ketsua"
+
+#: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
+msgid "Haze"
+msgstr "Gandua"
+
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
+msgid "Sand, dust whirls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
+msgid "Sand"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
+msgid "Dust"
+msgstr "Hautsa"
+
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
+msgid "Volcanic ash"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
+msgid "Squalls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
+msgid "Tornado"
+msgstr "Tornadoa"
+
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
+msgid "Sky is clear"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
+#, fuzzy
+msgid "Clouds"
+msgstr "Hodeitsua"
+
+#: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
+msgid "Few clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
+#, fuzzy
+msgid "Scattered clouds"
+msgstr "Zaparrada sakabanatuak"
+
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
+msgid "Broken clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
+msgid "Overcast clouds"
+msgstr ""
+
+#: 3.0/us_weather.js:120
+msgid "Could not get forecast for your area"
+msgstr ""
+
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
+msgid "Location is outside US, please use a different provider."
+msgstr ""
+
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
+msgid "Failed to Process Hourly Forecast Info"
+msgstr ""
+
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
+msgid "Clear and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
+msgid "Few clouds and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
+#, fuzzy
+msgid "Partly cloudy and windy"
+msgstr "Nahiko hodeitsua"
+
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
+#, fuzzy
+msgid "Mostly cloudy and windy"
+msgstr "Nagusiki hodeitsua"
+
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
+msgid "Overcast and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
+#, fuzzy
+msgid "Snowy rain"
+msgstr "Elur-jasak"
+
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
+#, fuzzy
+msgid "Freezing rain and snow"
+msgstr "Euri izoztua"
+
+#: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
+msgid "Hurricane"
+msgstr "Urakana"
+
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
+msgid "Storm"
+msgstr ""
+
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
+msgid "Tropical storm"
+msgstr "Ekaitz tropikala"
+
+#: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
+msgid "Hot"
+msgstr "Beroa"
+
+#: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
+msgid "Cold"
+msgstr "Hotza"
+
+#: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
+msgid "Blizzard"
+msgstr ""
+
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
+msgid "Today"
+msgstr "Gaur"
+
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
+msgid "Tomorrow"
+msgstr "Bihar"
+
+#: 3.0/utils.js:204
 msgid "Sunday"
 msgstr "Igandea"
 
-#: applet.js:1056
+#: 3.0/utils.js:204
+msgid "Monday"
+msgstr "Astelehena"
+
+#: 3.0/utils.js:204
+msgid "Tuesday"
+msgstr "Asteartea"
+
+#: 3.0/utils.js:204
+msgid "Wednesday"
+msgstr "Asteazkena"
+
+#: 3.0/utils.js:204
+msgid "Thursday"
+msgstr "Osteguna"
+
+#: 3.0/utils.js:204
+msgid "Friday"
+msgstr "Ostirala"
+
+#: 3.0/utils.js:204
+msgid "Saturday"
+msgstr "Larunbata"
+
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
+msgid "Calm"
+msgstr ""
+
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
+msgid "Light air"
+msgstr ""
+
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
+msgid "Light breeze"
+msgstr ""
+
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
+msgid "Gentle breeze"
+msgstr ""
+
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
+msgid "Moderate breeze"
+msgstr ""
+
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
+msgid "Fresh breeze"
+msgstr ""
+
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
+msgid "Strong breeze"
+msgstr ""
+
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
+msgid "Near gale"
+msgstr ""
+
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
+msgid "Gale"
+msgstr ""
+
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
+msgid "Strong gale"
+msgstr ""
+
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
+msgid "Violent storm"
+msgstr ""
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "I"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "IE"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "E"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "HE"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "H"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "HM"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "M"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "IM"
 
-#. cinnamon-weather->settings-schema.json->woeidLookup->description
-msgid "Get WOEID"
-msgstr "Eskuratu WOEIDa"
-
-#. cinnamon-weather->settings-schema.json->verticalOrientation->description
-msgid "Vertical orientation"
+#: 3.0/weatherbit.js:312
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://www.weatherbit.io/account/create"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showTextInPanel->description
-msgid "Display current temperature in panel"
-msgstr "Bistaratu uneko tenperatura panelean"
-
-#. cinnamon-weather->settings-schema.json->woeid->description
-msgid "WOEID"
-msgstr "WOEID"
-
-#. cinnamon-weather->settings-schema.json->woeid->tooltip
-msgid "Where On Earth ID"
-msgstr "Where On Earth ID"
-
-#. cinnamon-weather->settings-schema.json->temperatureUnit->description
-msgid "Temperature unit"
-msgstr "Tenperatura unitatea"
-
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "fahrenheit"
-msgstr "fahrenheit"
-
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "celsius"
-msgstr "celsius"
-
-#. cinnamon-weather->settings-schema.json->translateCondition->description
-msgid "Translate condition"
-msgstr "Itzuli egoera"
-
-#. cinnamon-weather->settings-schema.json->locationLabelOverride->description
-msgid "Override location label"
-msgstr "Gainidatzi kokapenaren etiketa"
-
-#. cinnamon-weather->settings-schema.json->show24Hours->description
-msgid "Display time in 24 hour format"
+#: 3.0/yahoo.js:78
+msgid ""
+"Unknown Error happened while calling Yahoo bridge,\n"
+" see Looking Glass log for errors"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->forecastDays->description
-msgid "Forecast length"
+#: 3.0/yahoo.js:91
+msgid ""
+"Yahoo bridge responded in bad format,\n"
+" see Looking Glass log for errors"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->forecastDays->units
-msgid "days"
+#: 3.0/yahoo.js:177
+msgid "Missing package"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showSunrise->description
-msgid "Show sunrise / sunset times"
-msgstr "Erakutsi egunsenti / ilunabar orduak"
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+#, fuzzy
+msgid "Please install '"
+msgstr "Itxaron mesedez"
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->description
-msgid "Wind speed unit"
-msgstr "Haizearen abiaduraren unitatea"
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "kph"
-msgstr "km/h"
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "m/s"
-msgstr "m/s"
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "knots"
-msgstr "korapilo"
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "mph"
-msgstr "mph"
-
-#. cinnamon-weather->settings-schema.json->showCommentInPanel->description
-msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
-msgstr "Erakutsi eguraldiaren egoera (adb. \"Haizetsu\", \"Garbi\") panelean"
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->description
-msgid "Atmospheric pressure unit"
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+msgid "', then refresh manually."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "psi"
+#: 3.0/yahoo.js:182
+msgid "Could not connect to Yahoo API."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "atm"
+#: 3.0/yahoo.js:186
+msgid ""
+"Unknown error happened while obtaining weather, see Looking Glass logs for "
+"more information"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "kPa"
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
+#, fuzzy
+msgid "Tropical Storm"
+msgstr "Ekaitz tropikala"
+
+#: 3.0/yahoo.js:439
+#, fuzzy
+msgid "Severe Thunderstorms"
+msgstr "Trumoi-ekaitz gogorra"
+
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
+msgid "Thunderstorms"
+msgstr "Trumoi-ekaitzak"
+
+#: 3.0/yahoo.js:441
+#, fuzzy
+msgid "Mixed Rain and Snow"
+msgstr "Euria eta elurra"
+
+#: 3.0/yahoo.js:442
+#, fuzzy
+msgid "Mixed Rain and Sleet"
+msgstr "Euria eta elurbustia"
+
+#: 3.0/yahoo.js:443
+#, fuzzy
+msgid "Mixed Snow and Sleet"
+msgstr "Elurra eta elurbustia"
+
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
+#, fuzzy
+msgid "Freezing Drizzle"
+msgstr "Zirimiri izoztua"
+
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
+#, fuzzy
+msgid "Freezing Rain"
+msgstr "Euri izoztua"
+
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
+msgid "Showers"
+msgstr "Zaparradak"
+
+#: 3.0/yahoo.js:449
+#, fuzzy
+msgid "Snow Flurries"
+msgstr "Elur-jasak"
+
+#: 3.0/yahoo.js:450
+#, fuzzy
+msgid "Light Snow Showers"
+msgstr "Elur-zaparrada arinak"
+
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
+#, fuzzy
+msgid "Blowing Snow"
+msgstr "Elur-jasa haizetsua"
+
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
+msgid "Foggy"
+msgstr "Lainotsua"
+
+#: 3.0/yahoo.js:458
+msgid "Smoky"
+msgstr "Ketsua"
+
+#: 3.0/yahoo.js:459
+msgid "Blustery"
+msgstr "Ekaitztsua"
+
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
+msgid "Windy"
+msgstr "Haizetsua"
+
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
+#, fuzzy
+msgid "Mostly Cloudy"
+msgstr "Nagusiki hodeitsua"
+
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
+#, fuzzy
+msgid "Partly Cloudy"
+msgstr "Nahiko hodeitsua"
+
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
+#, fuzzy
+msgid "Mostly Sunny"
+msgstr "Nagusiki hodeitsua"
+
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
+#, fuzzy
+msgid "Mixed Rain and Hail"
+msgstr "Euria eta kazkabarra"
+
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
+#, fuzzy
+msgid "Isolated Thunderstorms"
+msgstr "Trumoi-ekaitz isolatuak"
+
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
+#, fuzzy
+msgid "Scattered Thunderstorms"
+msgstr "Trumoi-ekaitz sakabanatuak"
+
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
+#, fuzzy
+msgid "Scattered Showers"
+msgstr "Zaparrada sakabanatuak"
+
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
+#, fuzzy
+msgid "Heavy Rain"
+msgstr "Elur-jasa"
+
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
+#, fuzzy
+msgid "Scattered Snow Showers"
+msgstr "Elur-zaparrada sakabanatuak"
+
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
+#, fuzzy
+msgid "Heavy Snow"
+msgstr "Elur-jasa"
+
+#: 3.0/yahoo.js:478
+#, fuzzy
+msgid "Not Available"
+msgstr "Ez dago erabilgarri"
+
+#: 3.0/yahoo.js:479
+#, fuzzy
+msgid "Scattered Thundershowers"
+msgstr "Trumoi-ekaitz sakabanatuak"
+
+#: 3.8/weather-applet.js:9638
+msgid ""
+"Could not retrieve logs, log file was not found under path\n"
+" {logFilePath}"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "Pa"
+#: 3.8/weather-applet.js:9642
+msgid ""
+"Could not get contents of log file under path\n"
+" {logFilePath}"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mm Hg"
+#. 3.0->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10283
+msgid "Met Office UK"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "at"
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mbar"
+#: 3.8/weather-applet.js:10476
+msgid "Data was not found for location"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "in Hg"
+#: 3.8/weather-applet.js:10557
+msgid "Very poor"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->description
+#: 3.8/weather-applet.js:10557
+msgid "Less than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "Excellent"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "More than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566
+msgid "Poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
+msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10571
+msgid "Moderate"
+msgstr ""
+
+#: 3.8/weather-applet.js:10576
+msgid "Good"
+msgstr ""
+
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
+msgid "Very good"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10942
+msgid "OpenWeatherMap"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:11396
+msgid "MET Norway"
+msgstr ""
+
+#: 3.8/weather-applet.js:11955
+msgid "WeatherBit"
+msgstr ""
+
+#: 3.8/weather-applet.js:12386
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Bihar"
+
+#: 3.8/weather-applet.js:12561
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12575
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12723
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:13292
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13474
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "Elur-jasa haizetsua"
+
+#: 3.8/weather-applet.js:13478
+#, fuzzy
+msgid "Heavy drizzle"
+msgstr "Zirimiri izoztua"
+
+#: 3.8/weather-applet.js:13482
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13484
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13486
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:13490
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "Zirimiri izoztua"
+
+#: 3.8/weather-applet.js:13492
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13494
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13496
+#, fuzzy
+msgid "Freezing fog"
+msgstr "Euri izoztua"
+
+#: 3.8/weather-applet.js:13502
+msgid "Funnel cloud/tornado"
+msgstr ""
+
+#: 3.8/weather-applet.js:13504
+#, fuzzy
+msgid "Hail showers"
+msgstr "Elur-zaparradak"
+
+#: 3.8/weather-applet.js:13506
+msgid "Ice"
+msgstr ""
+
+#: 3.8/weather-applet.js:13508
+msgid "Lightning without thunder"
+msgstr ""
+
+#: 3.8/weather-applet.js:13512
+msgid "Precipitation in vicinity"
+msgstr ""
+
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
+#, fuzzy
+msgid "Heavy rain and snow"
+msgstr "Euria eta elurra"
+
+#: 3.8/weather-applet.js:13518
+#, fuzzy
+msgid "Light rain And snow"
+msgstr "Euria eta elurra"
+
+#: 3.8/weather-applet.js:13526
+msgid "Sky coverage decreasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13528
+msgid "Sky coverage increasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13530
+msgid "Sky unchanged"
+msgstr ""
+
+#: 3.8/weather-applet.js:13532
+msgid "Smoke or haze"
+msgstr ""
+
+#: 3.8/weather-applet.js:13536
+#, fuzzy
+msgid "Snow and rain showers"
+msgstr "Elur-zaparradak"
+
+#: 3.8/weather-applet.js:13548
+msgid "Thunderstorm without precipitation"
+msgstr ""
+
+#: 3.8/weather-applet.js:13550
+msgid "Diamond dust"
+msgstr ""
+
+#: 3.8/weather-applet.js:13556
+#, fuzzy
+msgid "Partially cloudy"
+msgstr "Nahiko hodeitsua"
+
+#: 3.8/weather-applet.js:13578
+msgid "Please make sure you entered the API key correctly"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:13595
+msgid "DMI Denmark"
+msgstr ""
+
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
+msgid "NOT FOUND"
+msgstr ""
+
+#: 3.8/weather-applet.js:13779
+msgid "Blowing snow"
+msgstr "Elur-jasa haizetsua"
+
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
+#, fuzzy
+msgid "Slight snow"
+msgstr "Elur-jasa haizetsua"
+
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
+#, fuzzy
+msgid "Moderate snow"
+msgstr "Elur-jasa"
+
+#: 3.8/weather-applet.js:13842
+#, fuzzy
+msgid "Moderate rain showers"
+msgstr "Zaparrada sakabanatuak"
+
+#: 3.8/weather-applet.js:13849
+msgid "Mixed rain and snow"
+msgstr "Euria eta elurra"
+
+#: 3.8/weather-applet.js:13856
+#, fuzzy
+msgid "Heavy mixed rain and snow"
+msgstr "Euria eta elurra"
+
+#: 3.8/weather-applet.js:14024
+msgid "AccuWeather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+msgid "Weather Underground"
+msgstr ""
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+msgid "The location you provided was not found."
+msgstr ""
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+msgid "Strong Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "Euria eta elurra"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "Euria eta elurbustia"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "Elur-zaparradak"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "Nagusiki hodeitsua"
+
+#: 3.8/weather-applet.js:15247
+msgid "Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:15603
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+
+#: 3.8/weather-applet.js:15831
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+
+#: 3.8/weather-applet.js:15968
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:15975
+msgid ""
+"Could not get contents of config file under path\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr ""
+
+#: 3.8/weather-applet.js:16675
+msgid "Dew Point"
+msgstr ""
+
+#: 3.8/weather-applet.js:16747
+msgid "Precipitation will end in {precipEnd} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16749
+msgid "Precipitation won't end in within an hour"
+msgstr ""
+
+#: 3.8/weather-applet.js:16752
+msgid "Precipitation will start within {precipStart} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16964
+msgid "Forecast parsing failed, see logs for more details."
+msgstr ""
+
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
+msgid "As of {lastUpdatedTime}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17502
+msgid "{distance} {distanceUnit} from you"
+msgstr ""
+
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
+msgid "Error Saving Debug Information"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Debug Information saved successfully"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Saved to {filePath}"
+msgstr ""
+
+#: 3.8/LogSaver.py:16
+msgid "Save to File"
+msgstr ""
+
+#: 3.8/LogSaver.py:29
+msgid "Select a destination"
+msgstr ""
+
+#. metadata.json->name
+#. 3.8->settings-schema.json->providers->title
+msgid "Weather"
+msgstr ""
+
+#. metadata.json->description
+msgid "View your local weather forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->head->description
+msgid "Settings for weather@mockturtl 3.0+"
+msgstr ""
+
+#. 3.0->settings-schema.json->keybinding->description
+#. 3.8->settings-schema.json->keybinding->description
+msgid "Set the keybinding to call the menu"
+msgstr ""
+
+#. 3.0->settings-schema.json->descriptions->description
+msgid "Weather service information"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->description
+msgid "Click here for detailed description"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->tooltip
+#. 3.0->settings-schema.json->getLocation->tooltip
+#. 3.8->settings-schema.json->getLocation->tooltip
+msgid "Opens webpage guide"
+msgstr ""
+
+#. 3.0->settings-schema.json->providerSettings->description
+#. 3.8->settings-schema.json->provider-options->title
+msgid "Weather Provider Options"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->description
+#. 3.8->settings-schema.json->dataService->description
+msgid "Data service"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "DarkSky (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weatherbit (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Yahoo"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Climacell (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->description
+#. 3.8->settings-schema.json->apiKey->description
+msgid "API Key"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->tooltip
+#. 3.8->settings-schema.json->apiKey->tooltip
+msgid "Copy this from your account of the used Data service and paste it here."
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->description
+#. 3.8->settings-schema.json->manualLocation->description
+msgid "Manual Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->tooltip
+#. 3.8->settings-schema.json->manualLocation->tooltip
+msgid "Enable this if your location is not accurate"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->description
+msgid "Location - Coordinates"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->tooltip
+msgid ""
+"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an "
+"address.\n"
+"Waits for 3 seconds after you stop typing before refreshes the weather."
+msgstr ""
+
+#. 3.0->settings-schema.json->getLocation->description
+msgid "Setup API Key and Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->units
+#. 3.8->settings-schema.json->refreshInterval->units
+msgid "minutes"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->description
+#. 3.8->settings-schema.json->refreshInterval->description
 #, fuzzy
 msgid "Update interval"
 msgstr "Eguneratze-tartea (minutuak)"
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->units
-msgid "minutes"
+#. 3.0->settings-schema.json->forecastDays->units
+#. 3.8->settings-schema.json->forecastDays->units
+msgid "days"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->useSymbolicIcons->description
-msgid "Symbolic icons"
-msgstr "Ikono sinbolikoak"
-
-#. cinnamon-weather->metadata.json->description
-msgid "View your local weather forecast"
+#. 3.0->settings-schema.json->forecastDays->description
+#. 3.8->settings-schema.json->forecastDays->description
+msgid "Forecast length"
 msgstr ""
 
-#. cinnamon-weather->metadata.json->name
-msgid "Weather"
+#. 3.0->settings-schema.json->forecastHours->units
+#. 3.8->settings-schema.json->forecastHours->units
+msgid "hours"
 msgstr ""
 
-#~ msgid "Show 5-day forecast"
-#~ msgstr "Erakutsi 5 eguneko iragarpena"
+#. 3.0->settings-schema.json->forecastHours->description
+#. 3.8->settings-schema.json->forecastHours->description
+msgid "Hourly Forecast length"
+msgstr ""
 
-#~ msgid "Please wait"
-#~ msgstr "Itxaron mesedez"
+#. 3.0->settings-schema.json->unitSettings->description
+msgid "Units"
+msgstr ""
 
-#~ msgid "Today"
-#~ msgstr "Gaur"
+#. 3.0->settings-schema.json->temperatureUnit->description
+#. 3.8->settings-schema.json->temperatureUnit->description
+msgid "Temperature unit"
+msgstr "Tenperatura unitatea"
 
-#~ msgid "Tomorrow"
-#~ msgstr "Bihar"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Automatic"
+msgstr ""
 
-#~ msgid "http://edg3.co.uk/snippets/weather-location-codes/"
-#~ msgstr "http://edg3.co.uk/snippets/weather-location-codes/"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#, fuzzy
+msgid "Celsius"
+msgstr "celsius"
+
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#, fuzzy
+msgid "Fahrenheit"
+msgstr "fahrenheit"
+
+#. 3.0->settings-schema.json->temperatureUnit->tooltip
+#. 3.0->settings-schema.json->distanceUnit->tooltip
+#. 3.8->settings-schema.json->temperatureUnit->tooltip
+#. 3.8->settings-schema.json->distanceUnit->tooltip
+msgid ""
+"Automatic will try to guess your preference based your current display "
+"language."
+msgstr ""
+
+#. 3.0->settings-schema.json->windSpeedUnit->description
+#. 3.8->settings-schema.json->windSpeedUnit->description
+msgid "Wind speed unit"
+msgstr "Haizearen abiaduraren unitatea"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "kph"
+msgstr "km/h"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "mph"
+msgstr "mph"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "m/s"
+msgstr "m/s"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "knots"
+msgstr "korapilo"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "Beaufort"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->description
+#. 3.8->settings-schema.json->pressureUnit->description
+msgid "Atmospheric pressure unit"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "hPa"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "in Hg"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "mm Hg"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "psi"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "at"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "atm"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "Pa"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->description
+#. 3.8->settings-schema.json->distanceUnit->description
+msgid "Distance unit"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Metric"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Imperial"
+msgstr ""
+
+#. 3.0->settings-schema.json->panelSettings->description
+msgid "Panel options"
+msgstr ""
+
+#. 3.0->settings-schema.json->showTextInPanel->description
+#. 3.8->settings-schema.json->showTextInPanel->description
+msgid "Display current temperature in panel"
+msgstr "Bistaratu uneko tenperatura panelean"
+
+#. 3.0->settings-schema.json->showCommentInPanel->description
+#. 3.8->settings-schema.json->showCommentInPanel->description
+msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
+msgstr "Erakutsi eguraldiaren egoera (adb. \"Haizetsu\", \"Garbi\") panelean"
+
+#. 3.0->settings-schema.json->showCommentInPanel->tooltip
+#. 3.8->settings-schema.json->showCommentInPanel->tooltip
+msgid "Only works with horizontal panels"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempTextOverride->description
+#. 3.8->settings-schema.json->tempTextOverride->description
+#, fuzzy
+msgid "Override label on panel"
+msgstr "Gainidatzi kokapenaren etiketa"
+
+#. 3.0->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.0->settings-schema.json->useCustomMenuIcons->tooltip
+#. 3.8->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.8->settings-schema.json->useCustomMenuIcons->tooltip
+msgid "Iconset is weather-icons by Erik Flowers"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->description
+#. 3.8->settings-schema.json->useCustomAppletIcons->description
+msgid "Use custom icons on the panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->displaySettings->description
+#. 3.8->settings-schema.json->presentation-section->title
+msgid "Presentation"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->description
+#. 3.8->settings-schema.json->verticalOrientation->description
+#, fuzzy
+msgid "Show forecast vertically"
+msgstr "Erakutsi 5 eguneko iragarpena"
+
+#. 3.0->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->units
+#. 3.8->settings-schema.json->forecastColumns->units
+msgid "columns"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->description
+#. 3.8->settings-schema.json->forecastColumns->description
+msgid "Maximum number of columns for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->units
+#. 3.8->settings-schema.json->forecastRows->units
+msgid "rows"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->description
+#. 3.8->settings-schema.json->forecastRows->description
+msgid "Maximum number of rows for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->showSunrise->description
+#. 3.8->settings-schema.json->showSunrise->description
+msgid "Show sunrise / sunset times"
+msgstr "Erakutsi egunsenti / ilunabar orduak"
+
+#. 3.0->settings-schema.json->show24Hours->description
+#. 3.8->settings-schema.json->show24Hours->description
+msgid "Display time in 24 hour format"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->description
+#. 3.8->settings-schema.json->shortHourlyTime->description
+msgid "Only display hours for hourly forecast time"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->tooltip
+#. 3.8->settings-schema.json->shortHourlyTime->tooltip
+msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->description
+#. 3.8->settings-schema.json->showForecastDates->description
+msgid "Display date for daily forecasts"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->tooltip
+#. 3.8->settings-schema.json->showForecastDates->tooltip
+msgid "Like \"Friday 15\""
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureHighFirst->description
+#. 3.8->settings-schema.json->temperatureHighFirst->description
+msgid "Show high temperature first in forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempRussianStyle->description
+#. 3.8->settings-schema.json->tempRussianStyle->description
+#, fuzzy
+msgid "Show temperature Russian style"
+msgstr "Tenperatura unitatea"
+
+#. 3.0->settings-schema.json->locationLabelOverride->description
+#. 3.8->settings-schema.json->locationLabelOverride->description
+msgid "Override location label"
+msgstr "Gainidatzi kokapenaren etiketa"
+
+#. 3.0->settings-schema.json->conditionSettings->description
+#. 3.8->settings-schema.json->weather-conditions->title
+#, fuzzy
+msgid "Weather conditions"
+msgstr "Itzuli egoera"
+
+#. 3.0->settings-schema.json->translateCondition->description
+#. 3.8->settings-schema.json->translateCondition->description
+#, fuzzy
+msgid "Translate conditions"
+msgstr "Itzuli egoera"
+
+#. 3.0->settings-schema.json->shortConditions->description
+#. 3.8->settings-schema.json->shortConditions->description
+#, fuzzy
+msgid "Less verbose conditions"
+msgstr "Itzuli egoera"
+
+#. 3.0->settings-schema.json->iconSettings->description
+#. 3.8->settings-schema.json->icons->title
+msgid "Icons"
+msgstr ""
+
+#. 3.0->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons in the applet"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomMenuIcons->description
+#. 3.8->settings-schema.json->useCustomMenuIcons->description
+msgid "Use custom icons in the popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->locations-page->title
+#. 3.8->settings-schema.json->location->description
+msgid "Location"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-page->title
+msgid "Other options"
+msgstr ""
+
+#. 3.8->settings-schema.json->info-section->title
+msgid "Help"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-section->title
+msgid "Location settings"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-store->title
+msgid "Saved Locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->panel-options->title
+msgid "Panel (Taskbar)"
+msgstr ""
+
+#. 3.8->settings-schema.json->presentation->title
+msgid "Popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-section->title
+msgid "Other Units"
+msgstr ""
+
+#. 3.8->settings-schema.json->temp-unit-section->title
+#, fuzzy
+msgid "Temperature Unit"
+msgstr "Tenperatura unitatea"
+
+#. 3.8->settings-schema.json->keybindings->title
+msgid "Keybindings"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info->title
+msgid "More about the Weather applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->submit-issue->title
+msgid "Report an issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->debug-options->title
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Debug"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->tooltip
+msgid ""
+"You can choose between several different weather forecast providers. Some "
+"providers require a API key to work, some have regional limits, differ in "
+"forecast length, and they all need a functional internet connection to work. "
+"The options are described in detail on the Cinnamon Spices Website which you "
+"can access with the button on the Help tab."
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Met Office UK (UK only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "US National Weather (US only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Pirate Weather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Visual Crossing (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Tomorrow.io (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "AccuWeather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weather Underground (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->location->tooltip
+msgid ""
+"You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use "
+"'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street} "
+"{City/Town} {Postcode} {Country}. The search algorithm is very flexible with "
+"the format. After 3 seconds without typing the address you entered is "
+"replaced automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->description
+#, fuzzy
+msgid "Save current location to storage"
+msgstr "Gainidatzi kokapenaren etiketa"
+
+#. 3.8->settings-schema.json->saveLocation->tooltip
+msgid ""
+"Saves location information to file so you can switch between them with "
+"buttons in the applet, which will appear if you have more than one."
+msgstr ""
+
+#. 3.8->settings-schema.json->getLocation->description
+msgid "Weather Applet at Cinnamon Spices Website"
+msgstr ""
+
+#. 3.8->settings-schema.json->refreshInterval->tooltip
+msgid ""
+"If you are using a provider with API keys set it to an interval you won't "
+"run out of your quota with."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastDays->tooltip
+msgid ""
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->description
+msgid "Enable minutely precipitation forecast"
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->tooltip
+msgid ""
+"If you'd like to use this make sure you use your exact coordinates/address "
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
+msgstr ""
+
+#. 3.8->settings-schema.json->showBothTempUnits->description
+msgid "Show both temperature units at the same time"
+msgstr ""
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+#, fuzzy
+msgid "Override tooltip on panel"
+msgstr "Gainidatzi kokapenaren etiketa"
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
+msgid "Always show Hourly Weather"
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->tooltip
+msgid ""
+"Hide/Show button will be hidden and Hourly weather will be permanently "
+"visible."
+msgstr ""
+
+#. 3.8->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->description
+msgid "Your saved locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->tooltip
+msgid ""
+"You have to make sure the Search entry field is unique and your Timezone is "
+"in the IANA time zone format (e.g. 'Europe/London')"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Latitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Longitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "City"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Country"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Timezone"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Search entry"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->description
+msgid "Display wind direction as text"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->tooltip
+msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->tooltip
+msgid "Does not apply to custom iconset, that is symbolic by default"
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons throughout the applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info-label->description
+msgid ""
+"For detailed information about the applet please go to the Spices Website to "
+"find info about known issues, troubleshooting, changelog and more by "
+"clicking the button below. Here you can ask questions etc in the comment "
+"section by logging in with your Github account."
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->description
+msgid "Submit an Issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->tooltip
+msgid ""
+"Opens webpage where you can fill out a new issue for the applet, needs a "
+"GitHub account.\n"
+" Please make sure that the issue is not already submitted."
+msgstr ""
+
+#. 3.8->settings-schema.json->maintainer->description
+msgid "Current maintainer: Gr3q"
+msgstr ""
+
+#. 3.8->settings-schema.json->issue-reporting-explanation->description
+msgid ""
+"If you find an issue with this applet please make a report by clicking on "
+"the button below and login in with your Github account.\n"
+"\n"
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
+msgstr ""
+
+#. 3.8->settings-schema.json->loc-info->description
+msgid ""
+"Your location in most cases work automatically but you can enter it manually "
+"by coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,"
+"Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/"
+"Town} {Postcode} {Country}. The search algorithm is very flexible with the "
+"format. After 3 seconds without typing the address you entered is replaced "
+"automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->description
+msgid "Log Level"
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->tooltip
+msgid ""
+"Info is the regular logging, Debug is debug, and Verbose also logs network "
+"request payloads. Changing this will only be effective on future logs. Only "
+"change it you are instructed or you know what you are doing."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Verbose"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->description
+msgid "Click Save to save debug information to a file"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->tooltip
+msgid ""
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
+msgstr ""
+
+#. 3.8->settings-schema.json->selectedLogPath->description
+msgid "Selected path to save Logs"
+msgstr ""

--- a/weather@mockturtl/files/weather@mockturtl/po/fi.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/fi.po
@@ -11,8 +11,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 3.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-01 22:49+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2024-04-07 18:55+0300\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: suomi <>\n"
@@ -24,65 +25,65 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17615
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Virhe"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17616 3.8/weather-applet.js:17618
-#: 3.8/weather-applet.js:17620 3.8/weather-applet.js:17623
-#: 3.8/weather-applet.js:17626 3.8/weather-applet.js:17627
-#: 3.8/weather-applet.js:17628 3.8/weather-applet.js:17629
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Palvelussa virhe"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17617
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Väärä API avain"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17619
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Väärä muoto sijainnissa"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17621
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Avain estetty"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17622
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Sijaintia ei löytynyt"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17624
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Ei API avainta"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17625
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Ei sijaintia"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17630
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Puuttuvat paketit"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17631
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Sijaintia ei löytynyt"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9711
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Sää"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17929
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17930
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Avaa napsauttamalla"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16220
-#: 3.8/weather-applet.js:17933
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Päivitä"
 
@@ -92,8 +93,8 @@ msgstr "API palautti tilakoodin väliltä 400–500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Sijainti"
 
@@ -105,12 +106,12 @@ msgstr "Et voi tallentaa automaattisesti hankittua sijaintia"
 msgid "Could not get weather information"
 msgstr "Säätietoja ei voitu saada"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17768
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr "Odottamaton virhe päivitettäessä säätietoja, katso Looking Glass loki"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:18011
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -126,7 +127,7 @@ msgstr "Verkko virhe, tarkista Looking Glass loki"
 msgid "As of"
 msgstr "Klo"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:17011
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Tiedot toimitti"
 
@@ -134,52 +135,52 @@ msgstr "Tiedot toimitti"
 msgid "from you"
 msgstr "sinulta"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16924
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:16924
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "asti"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10312
-#: 3.8/weather-applet.js:17089
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "ml"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10313
-#: 3.8/weather-applet.js:17090
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17267
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Ladataan säätietoja ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17270
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Ladataan tulevia säätietoja ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16173
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Ladataan ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16194
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Lämpötila"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16195
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Kosteus"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16196
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Ilmanpaine"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12257 3.8/weather-applet.js:12263
-#: 3.8/weather-applet.js:14217 3.8/weather-applet.js:14218
-#: 3.8/weather-applet.js:16042
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Tuuli"
 
@@ -187,35 +188,34 @@ msgstr "Tuuli"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr "Varmista, että annoit sijainnin tai käytä automaattista sijaintia"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9952
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Sijaintia ei löytynyt osoitteen perusteella, tarkista että se on oikein"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9973
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "Paikannuksen kutsuminen epäonnistui, katso Looking Glass virheet."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Varoitus"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9872
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "Voit tallentaa oikeat sijainnit vain, kun sovelma ei ole päivittymässä"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Et voi tallentaa virheellistä sijaintia"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9880
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Perustieto"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Sijainti on jo tallennettu"
 
@@ -253,15 +253,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10740 3.8/weather-applet.js:11711
-#: 3.8/weather-applet.js:12150 3.8/weather-applet.js:12659
-#: 3.8/weather-applet.js:13021 3.8/weather-applet.js:14388
-#: 3.8/weather-applet.js:14928
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Tuntuu kuin"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:14990
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Säätietojen käsittely epäonnistui"
 
@@ -274,7 +274,7 @@ msgstr ""
 "Hanki se ensin https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:14870
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -282,7 +282,7 @@ msgstr ""
 "Oletko varma että,\n"
 "annoit API-avaimen oikein tai onko tunnuksesi voimassa"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12113
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -293,60 +293,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10516 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10530 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:11379 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:11386 3.8/weather-applet.js:11393
-#: 3.8/weather-applet.js:11400 3.8/weather-applet.js:12292
-#: 3.8/weather-applet.js:13187
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Voimakasta vesisadetta"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11554 3.8/weather-applet.js:11555
-#: 3.8/weather-applet.js:11561 3.8/weather-applet.js:12277
-#: 3.8/weather-applet.js:12278 3.8/weather-applet.js:12284
-#: 3.8/weather-applet.js:12291 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12340 3.8/weather-applet.js:12347
-#: 3.8/weather-applet.js:12801 3.8/weather-applet.js:12850
-#: 3.8/weather-applet.js:12851 3.8/weather-applet.js:12858
-#: 3.8/weather-applet.js:13179 3.8/weather-applet.js:13448
-#: 3.8/weather-applet.js:13449 3.8/weather-applet.js:13490
-#: 3.8/weather-applet.js:14189 3.8/weather-applet.js:14190
-#: 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Sadetta"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10495 3.8/weather-applet.js:10509
-#: 3.8/weather-applet.js:10510 3.8/weather-applet.js:11009
-#: 3.8/weather-applet.js:11463 3.8/weather-applet.js:11464
-#: 3.8/weather-applet.js:11470 3.8/weather-applet.js:11477
-#: 3.8/weather-applet.js:11484 3.8/weather-applet.js:12285
-#: 3.8/weather-applet.js:13189
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Heikkoa vesisadetta"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12348 3.8/weather-applet.js:13163
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Voimakasta jäätävää sadetta"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11014
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12822
-#: 3.8/weather-applet.js:12823 3.8/weather-applet.js:12829
-#: 3.8/weather-applet.js:12830 3.8/weather-applet.js:12836
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Jäätävää sadetta"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12341 3.8/weather-applet.js:13165
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Kevyttä jäätävää sadetta"
 
@@ -354,177 +354,177 @@ msgstr "Kevyttä jäätävää sadetta"
 msgid "Light freezing drizzle"
 msgstr "Kevyttä jäätävää tihkua"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12327
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Jäätävää tihkua"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13145
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Kevyttä tihkua"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12362
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Rankat raekuurot"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12354 3.8/weather-applet.js:12355
-#: 3.8/weather-applet.js:12361 3.8/weather-applet.js:12368
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Rakeita"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12369
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Pieniä rakeita"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10600
-#: 3.8/weather-applet.js:10607 3.8/weather-applet.js:10614
-#: 3.8/weather-applet.js:10615 3.8/weather-applet.js:11021
-#: 3.8/weather-applet.js:11435 3.8/weather-applet.js:11436
-#: 3.8/weather-applet.js:11442 3.8/weather-applet.js:11449
-#: 3.8/weather-applet.js:11456 3.8/weather-applet.js:12320
-#: 3.8/weather-applet.js:13205 3.8/weather-applet.js:13525
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Sakeaa lumisadetta"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:11610
-#: 3.8/weather-applet.js:11611 3.8/weather-applet.js:11617
-#: 3.8/weather-applet.js:12298 3.8/weather-applet.js:12299
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12795
-#: 3.8/weather-applet.js:13199 3.8/weather-applet.js:13434
-#: 3.8/weather-applet.js:13518 3.8/weather-applet.js:14203
-#: 3.8/weather-applet.js:14204 3.8/weather-applet.js:14581
-#: 3.8/weather-applet.js:14582
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Lumisadetta"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11019
-#: 3.8/weather-applet.js:11519 3.8/weather-applet.js:11520
-#: 3.8/weather-applet.js:11526 3.8/weather-applet.js:11533
-#: 3.8/weather-applet.js:11540 3.8/weather-applet.js:12313
-#: 3.8/weather-applet.js:13207
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Kevyttä lumisadetta"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12305
-#: 3.8/weather-applet.js:12306 3.8/weather-applet.js:14560
-#: 3.8/weather-applet.js:14561
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Puuskatuulia"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:12375 3.8/weather-applet.js:12376
-#: 3.8/weather-applet.js:12867 3.8/weather-applet.js:12868
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13532
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:14210
-#: 3.8/weather-applet.js:14211
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Ukkosmyrskyä"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12243
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Heikkoa sumua"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11372
-#: 3.8/weather-applet.js:11373 3.8/weather-applet.js:12235
-#: 3.8/weather-applet.js:12236 3.8/weather-applet.js:12242
-#: 3.8/weather-applet.js:12937 3.8/weather-applet.js:12938
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:14161
-#: 3.8/weather-applet.js:14162 3.8/weather-applet.js:14609
-#: 3.8/weather-applet.js:14610
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Sumua"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10474 3.8/weather-applet.js:10475
-#: 3.8/weather-applet.js:11358 3.8/weather-applet.js:11359
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:12208
-#: 3.8/weather-applet.js:13427 3.8/weather-applet.js:13428
-#: 3.8/weather-applet.js:14154 3.8/weather-applet.js:14155
-#: 3.8/weather-applet.js:14651 3.8/weather-applet.js:14652
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Pilvistä"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12228
-#: 3.8/weather-applet.js:12229 3.8/weather-applet.js:12745
-#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:12780
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Enimmäkseen pilvistä"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10439
-#: 3.8/weather-applet.js:10440 3.8/weather-applet.js:10446
-#: 3.8/weather-applet.js:10447 3.8/weather-applet.js:11547
-#: 3.8/weather-applet.js:11548 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12222 3.8/weather-applet.js:12738
-#: 3.8/weather-applet.js:12739 3.8/weather-applet.js:12773
-#: 3.8/weather-applet.js:13420 3.8/weather-applet.js:13421
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Puolipilvistä"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Enimmäkseen selkeää"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10425 3.8/weather-applet.js:10426
-#: 3.8/weather-applet.js:11039 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:12724
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12759
-#: 3.8/weather-applet.js:13223 3.8/weather-applet.js:13413
-#: 3.8/weather-applet.js:13414 3.8/weather-applet.js:14140
-#: 3.8/weather-applet.js:14141 3.8/weather-applet.js:14147
-#: 3.8/weather-applet.js:14148 3.8/weather-applet.js:14686
-#: 3.8/weather-applet.js:14687
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Selkeää"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10432
-#: 3.8/weather-applet.js:10433 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:14693
-#: 3.8/weather-applet.js:14694
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Aurinkoista"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10418
-#: 3.8/weather-applet.js:10419 3.8/weather-applet.js:10453
-#: 3.8/weather-applet.js:10454 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10643 3.8/weather-applet.js:11341
-#: 3.8/weather-applet.js:11342 3.8/weather-applet.js:11639
-#: 3.8/weather-applet.js:11640 3.8/weather-applet.js:12192
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12715
-#: 3.8/weather-applet.js:12716 3.8/weather-applet.js:12944
-#: 3.8/weather-applet.js:12945 3.8/weather-applet.js:14073
-#: 3.8/weather-applet.js:14074 3.8/weather-applet.js:14224
-#: 3.8/weather-applet.js:14225 3.8/weather-applet.js:14797
-#: 3.8/weather-applet.js:14799
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Tuntematon virhe"
 
@@ -548,7 +548,7 @@ msgstr ""
 "Anna API-avain asetuksissa.\n"
 "Hanki se ensin https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:14880
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -556,7 +556,7 @@ msgstr ""
 "Varmista, että antamasi\n"
 "API-avain on peräisin yritykseltä DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:15196
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Sijaintia ei löytynyt"
 
@@ -565,121 +565,121 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr "Sijaintipalvelu vastasi virheillä. Katso Looking Glass loki"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11203
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Pilvistä"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11351
-#: 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Selkeää"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11365 3.8/weather-applet.js:11366
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Selkeää"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11387
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Rankkasadetta ja ukkostaa"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11394
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Voimakkaita sadekuuroja"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11401
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Voimakkaita sadekuuroja ja ukkosta"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11407
-#: 3.8/weather-applet.js:11408 3.8/weather-applet.js:11414
-#: 3.8/weather-applet.js:11421 3.8/weather-applet.js:11428
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Voimakasta räntäsadetta"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11415
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Voimakasta räntäsadetta"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11422
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Voimakkaita räntäsateita"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11429
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Voimakkaita räntäsateita"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11443
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Runsasta lumisadetta"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11450
-#: 3.8/weather-applet.js:13526
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Voimakasta lumisadetta"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11457
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Runsaita lumikuuroja"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11471
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Heikkoa vesisadetta ja ukkosta"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11478
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Heikkoja sadekuuroja"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11485
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Heikkoja sadekuuroja ja ukkosta"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11491
-#: 3.8/weather-applet.js:11492 3.8/weather-applet.js:11498
-#: 3.8/weather-applet.js:11505 3.8/weather-applet.js:11512
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Heikkoa räntäsadetta"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11499
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Heikkoa räntäsadetta"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11506
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Heikkoa räntäsadetta"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11513
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Heikkoa räntäsadetta"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11527
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Kevyttä lumisadetta"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11534
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Kevyttä lumisadetta"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11541
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Kevyttä lumisadetta"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11562
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Sadetta ja ukkosta"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11568
-#: 3.8/weather-applet.js:11569 3.8/weather-applet.js:11575
-#: 3.8/weather-applet.js:12859 3.8/weather-applet.js:13185
-#: 3.8/weather-applet.js:13491 3.8/weather-applet.js:13497
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Sadekuuroja"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11576
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Sadekuuroja ja ukkosta"
 
@@ -688,44 +688,44 @@ msgstr "Sadekuuroja ja ukkosta"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10537
-#: 3.8/weather-applet.js:10544 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11582 3.8/weather-applet.js:11583
-#: 3.8/weather-applet.js:11589 3.8/weather-applet.js:11596
-#: 3.8/weather-applet.js:11603 3.8/weather-applet.js:12808
-#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12815
-#: 3.8/weather-applet.js:12816 3.8/weather-applet.js:12843
-#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14196
-#: 3.8/weather-applet.js:14197 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Räntää"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11590
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Räntää"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11597
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Räntäkuuroja"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11604
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Räntäkuuroja"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11618
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Lumikuuroja"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11624 3.8/weather-applet.js:11625
-#: 3.8/weather-applet.js:11631 3.8/weather-applet.js:13203
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Lumikuuroja"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11632
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Lumikuuroja"
 
@@ -734,21 +734,21 @@ msgstr "Lumikuuroja"
 msgid "Unexpected response from API"
 msgstr "Odottamaton API:n vastaus"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10237
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Näkyvyys"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10265
-#: 3.8/weather-applet.js:10817 3.8/weather-applet.js:11722
-#: 3.8/weather-applet.js:12672
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Säätietojen käsittely epäonnistui"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10055
-#: 3.8/weather-applet.js:10089 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11782 3.8/weather-applet.js:12474
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Forecast tietojen käsittely epäonnistui"
 
@@ -777,298 +777,298 @@ msgid "Excellent - More than"
 msgstr "Erinomainen - enemmän kuin"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10460 3.8/weather-applet.js:10461
-#: 3.8/weather-applet.js:11029 3.8/weather-applet.js:13175
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Sumua"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:12752
-#: 3.8/weather-applet.js:12753 3.8/weather-applet.js:12787
-#: 3.8/weather-applet.js:13219
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Pilvistä"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10489
-#: 3.8/weather-applet.js:10496
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Heikkoja sadekuuroja"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:12326
-#: 3.8/weather-applet.js:13141 3.8/weather-applet.js:14532
-#: 3.8/weather-applet.js:14533
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Tihkusadetta"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:10524
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Voimakkaita sadekuuroja"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10538
-#: 3.8/weather-applet.js:10545
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Räntäkuuroja"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:13217 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14169 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:14589
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Rakeita"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Raekuurot"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Kevyitä lumikuuroja"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Voimakkaita lumikuuroja"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10621 3.8/weather-applet.js:10628
-#: 3.8/weather-applet.js:10635 3.8/weather-applet.js:10636
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Ukkosta"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Ukkoskuuroja"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10872
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Varmista, että asetuksissa sijainti on oikeassa muodossa"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10876
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Varmista, että annoit asetuksissa oikean avaimen"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10681 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr "Sijaintia ei löydy. Varmista, että paikkakunta on kirjoitettu oikein"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10884
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Jos ongelma jatkuu, ota yhteyttä tämän sovelman tekijään"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10888
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Tuntematon virhe, katso Looking Glass loki"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10990
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Ukkosta ja heikkoa vesisadetta"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10991
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Ukkosta ja sadekuuroja"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10992
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Ukkosta ja voimakasta vesisadetta"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10993
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Mahdollista ukkosta"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10995
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Voimakkaita ukkosmyrskyjä"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10996
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Yksittäisiä ukkosmyrskyjä"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10997
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Ukkoskuuroja ja tihkua"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10998
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Ukkoskuuroja ja tihkua"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10999
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Ukkoskuuroja ja voimakasta tihkusadetta"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11000
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Kevyttä tihkua"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11002
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Voimakasta tihkusadetta"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11003
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Kevyttä tihkusadetta"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11004
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Tihkusadetta"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11005
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Voimakkaasti tihkusadetta"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11006
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Sadekuuroja ja tihkusadetta"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11007
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Voimakkaita sadekuuroja ja tihkusadetta"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11008
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Tihkusadetta"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11010
-#: 3.8/weather-applet.js:13455 3.8/weather-applet.js:13456
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Kohtalaista vesisadetta"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11011
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Voimakasta sadetta"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11012
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Voimakasta vesisadetta"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11013
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Kovaa sadetta"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11015
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Kevyttä sadetta"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11016
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Sadekuuroja"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11017
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Voimakasta sadetta"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11018
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Hajanaisia sateita"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11023
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Sadekuuroja"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11024
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Heikkoa vesisadetta ja lunta"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11025
-#: 3.8/weather-applet.js:13462 3.8/weather-applet.js:13463
-#: 3.8/weather-applet.js:13469 3.8/weather-applet.js:13504
-#: 3.8/weather-applet.js:13511
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Sadetta ja lunta"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11026
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Kevyt lumisade"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11027
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Lumisadetta"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11028
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Voimakasta lumisadetta"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:12902
-#: 3.8/weather-applet.js:12903 3.8/weather-applet.js:14623
-#: 3.8/weather-applet.js:14624
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Savua"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11031 3.8/weather-applet.js:12909
-#: 3.8/weather-applet.js:12910 3.8/weather-applet.js:14616
-#: 3.8/weather-applet.js:14617
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Usvaa"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11032
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Hiekkaa ja pölypyörteet"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11034
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Hiekkaa"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11035 3.8/weather-applet.js:12895
-#: 3.8/weather-applet.js:12896 3.8/weather-applet.js:14602
-#: 3.8/weather-applet.js:14603
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Pölyä"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11036
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Vulkaanista tuhkaa"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:13209
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Tuulenpuuskia"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11038 3.8/weather-applet.js:12874
-#: 3.8/weather-applet.js:12875 3.8/weather-applet.js:14475
-#: 3.8/weather-applet.js:14476
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11041
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Taivas on selkeä"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11042
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Pilvistä"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11043
-#: 3.8/weather-applet.js:12731 3.8/weather-applet.js:12732
-#: 3.8/weather-applet.js:12766
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Muutamia pilviä"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11044
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Paikoin pilvistä"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11045
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Hajanaisia pilviä"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11046
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Pilvistä"
 
@@ -1076,80 +1076,80 @@ msgstr "Pilvistä"
 msgid "Could not get forecast for your area"
 msgstr "Alueellesi ei saatu ennustetta"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12431
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "Sijainti on USA:n ulkopuolella, käytä toista palvelua."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12495
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Forecast tuntiennuste epäonnistui"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12760
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Selkeää ja tuulista"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12767
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Vähän pilviä ja tuulista"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12774
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Puolipilvistä ja tuulista"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Enimmäkseen pilvistä ja tuulista"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12788
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Pilvistä ja tuulista"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12802
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Lumisadetta"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12837
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Jäätävää sadetta"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9153 3.8/weather-applet.js:12881
-#: 3.8/weather-applet.js:12882 3.8/weather-applet.js:14489
-#: 3.8/weather-applet.js:14490
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Hurrikaani"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9148
-#: 3.8/weather-applet.js:12888
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Myrsky"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12889
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Trooppinen myrsky"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12916 3.8/weather-applet.js:12917
-#: 3.8/weather-applet.js:14721 3.8/weather-applet.js:14722
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Kuumaa"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12923 3.8/weather-applet.js:12924
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Kylmää"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12930 3.8/weather-applet.js:12931
-#: 3.8/weather-applet.js:14770 3.8/weather-applet.js:14771
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Myrsky"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9025
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Tänään"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9027
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Huomenna"
 
@@ -1181,79 +1181,79 @@ msgstr "Perjantai"
 msgid "Saturday"
 msgstr "Launtai"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9118
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Tyyntä"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9121
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Kevyttä tuulta"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9124
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Heikkoa tuulta"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9127
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Hento tuulenvire"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9130
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Kohtalainen tuuli"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9133
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Raikasta tuulta"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9136
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Voimakasta tuulta"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9139
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Lähellä myrskyä"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9142
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Navakka tuuli"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9145
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Voimakas myrsky"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9151
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Raju myrsky"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "Pohjoinen"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "Koillinen"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "Itä"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "Kaakko"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "Etelä"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "Lounas"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "Länsi"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "Luode"
 
@@ -1305,7 +1305,7 @@ msgstr ""
 "Säätiedoissa tapahtui tuntematon virhe, katso lokista Looking Glass "
 "lisätietoja"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14482 3.8/weather-applet.js:14483
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Trooppinen myrsky"
 
@@ -1313,7 +1313,7 @@ msgstr "Trooppinen myrsky"
 msgid "Severe Thunderstorms"
 msgstr "Hajanaisia ukkosmyrskyjä"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14503 3.8/weather-applet.js:14504
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Ukkosmyrskyjä"
 
@@ -1329,15 +1329,15 @@ msgstr "Räntäsadetta ja loskaa"
 msgid "Mixed Snow and Sleet"
 msgstr "Lumisadetta ja loskaa"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Jäätävää tihkua"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Jäätävää sadetta"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Sadekuuroja"
 
@@ -1349,11 +1349,11 @@ msgstr "Lumikuuroja"
 msgid "Light Snow Showers"
 msgstr "Kevyitä lumisateita"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14574 3.8/weather-applet.js:14575
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Lumipyry"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13441 3.8/weather-applet.js:13442
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Sumua"
 
@@ -1365,54 +1365,54 @@ msgstr "Savua"
 msgid "Blustery"
 msgstr "Tuulista"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14637 3.8/weather-applet.js:14638
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Tuulinen"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:14658 3.8/weather-applet.js:14659
-#: 3.8/weather-applet.js:14665 3.8/weather-applet.js:14666
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Enimmäkseen pilvistä"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14175 3.8/weather-applet.js:14176
-#: 3.8/weather-applet.js:14182 3.8/weather-applet.js:14183
-#: 3.8/weather-applet.js:14672 3.8/weather-applet.js:14673
-#: 3.8/weather-applet.js:14679 3.8/weather-applet.js:14680
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Puolipilvistä"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Enimmäkseen aurinkoista"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:14714 3.8/weather-applet.js:14715
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Sadetta ja rakeita"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:14728 3.8/weather-applet.js:14729
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Mahdollista ukkosta"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:14735 3.8/weather-applet.js:14736
-#: 3.8/weather-applet.js:14791 3.8/weather-applet.js:14792
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Paikoin ukkosta"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:14742 3.8/weather-applet.js:14743
-#: 3.8/weather-applet.js:14777 3.8/weather-applet.js:14778
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Paikoin sadekuuroja"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:14749 3.8/weather-applet.js:14750
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Voimakasta vesisadetta"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:14756 3.8/weather-applet.js:14757
-#: 3.8/weather-applet.js:14784 3.8/weather-applet.js:14785
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Paikoin lumisadetta"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:14763 3.8/weather-applet.js:14764
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Sakeaa lumisadetta"
 
@@ -1424,7 +1424,7 @@ msgstr "Ei saatavilla"
 msgid "Scattered Thundershowers"
 msgstr "Paikoin ukkoskuuroja"
 
-#: 3.8/weather-applet.js:9637
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1432,7 +1432,7 @@ msgstr ""
 "Lokeja ei voitu noutaa, lokitiedostoa ei löytynyt polusta\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9641
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1441,11 +1441,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10013
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10118
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1453,285 +1453,285 @@ msgstr ""
 "MET Office UK kattaa vain Britanian. Varmista, että sijaintisi on tässä "
 "maassa"
 
-#: 3.8/weather-applet.js:10197
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Sijainnin tietoja ei löytynyt"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Hyvin huono"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Vähemmän kuin {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Erinomainen"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Enemmän kuin {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10287
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Huono"
 
-#: 3.8/weather-applet.js:10287 3.8/weather-applet.js:10292
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:10302
-#: 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Välillä {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10292
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Kohtalainen"
 
-#: 3.8/weather-applet.js:10297
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Hyvä"
 
-#: 3.8/weather-applet.js:10302 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Todella hyvä"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10662
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:11659
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12080
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12250
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Kevyt tuuli"
 
-#: 3.8/weather-applet.js:12264
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Kova tuuli"
 
-#: 3.8/weather-applet.js:12411
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:12962
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:13139
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Tuulista tai kinostuvaa lunta"
 
-#: 3.8/weather-applet.js:13143
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Voimakasta tihkusadetta"
 
-#: 3.8/weather-applet.js:13147
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Voimakasta tihkusadetta"
 
-#: 3.8/weather-applet.js:13149
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Kevyttä tihkusadetta"
 
-#: 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Pölypuuskia"
 
-#: 3.8/weather-applet.js:13155
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Jäätävää sadetta"
 
-#: 3.8/weather-applet.js:13157
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Voimakasta jäätävää sadetta"
 
-#: 3.8/weather-applet.js:13159
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Kevyttä jäätävää tihkua"
 
-#: 3.8/weather-applet.js:13161
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Jäätyvää sumua"
 
-#: 3.8/weather-applet.js:13167
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Pyörremyrsky"
 
-#: 3.8/weather-applet.js:13169
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Raekuuroja"
 
-#: 3.8/weather-applet.js:13171
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Jäätä"
 
-#: 3.8/weather-applet.js:13173
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Mahdollista ukkosta"
 
-#: 3.8/weather-applet.js:13177
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Sademäärä lähistöllä"
 
-#: 3.8/weather-applet.js:13181 3.8/weather-applet.js:13470
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Voimakasta vesi ja lumisadetta"
 
-#: 3.8/weather-applet.js:13183
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Heikkoa vesisadetta ja lunta"
 
-#: 3.8/weather-applet.js:13191
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Taivas selkenee"
 
-#: 3.8/weather-applet.js:13193
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Taivas pilvistyy"
 
-#: 3.8/weather-applet.js:13195
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Taivas ennallaan"
 
-#: 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Savua tai utua"
 
-#: 3.8/weather-applet.js:13201
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Lunta ja sadekuuroja"
 
-#: 3.8/weather-applet.js:13213
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Ukkosta ilman sadetta"
 
-#: 3.8/weather-applet.js:13215
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Timanttipölyä"
 
-#: 3.8/weather-applet.js:13221
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Puolipilvistä"
 
-#: 3.8/weather-applet.js:13243
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Oletko varma että, annoit API-avaimen oikein"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13259
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:13402 3.8/weather-applet.js:13403
-#: 3.8/weather-applet.js:13539 3.8/weather-applet.js:13540
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "Ei löydy"
 
-#: 3.8/weather-applet.js:13435
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Puuskittaista lumisadetta"
 
-#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:13477
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Heikosti lunta"
 
-#: 3.8/weather-applet.js:13483 3.8/weather-applet.js:13484
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Kohtalaista lunta"
 
-#: 3.8/weather-applet.js:13498
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Kohtalaisia sadekuuroja"
 
-#: 3.8/weather-applet.js:13505
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Sadetta ja lunta"
 
-#: 3.8/weather-applet.js:13512
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Voimakkaasti sadetta"
 
-#: 3.8/weather-applet.js:13657
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:13953
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:13966
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "Valitse toinen palveluntarjoaja tai sijainti"
 
-#: 3.8/weather-applet.js:14263
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14453
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "Antamasi API-avain on virheellinen."
 
-#: 3.8/weather-applet.js:14460
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "Antamaasi sijaintia ei löytynyt."
 
-#: 3.8/weather-applet.js:14496 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Voimakas myrsky"
 
-#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:14512
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Sadetta ja lunta"
 
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Sadetta ja räntää"
 
-#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Lumisadetta"
 
-#: 3.8/weather-applet.js:14630 3.8/weather-applet.js:14631
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "Tuulinen"
 
-#: 3.8/weather-applet.js:14644 3.8/weather-applet.js:14645
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr "Kylmä"
 
-#: 3.8/weather-applet.js:14700 3.8/weather-applet.js:14701
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Enimmäkseen selkeää"
 
-#: 3.8/weather-applet.js:14853
+#: 3.8/weather-applet.js:15247
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:15205
+#: 3.8/weather-applet.js:15603
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr "Sijaintipalvelu ei löytänyt sinun sijaintia, katso Looking Glass loki"
 
-#: 3.8/weather-applet.js:15433
+#: 3.8/weather-applet.js:15831
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr "Varmista, että annoit sijaintisi tai käytä automaattista hakua."
 
-#: 3.8/weather-applet.js:15570
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1739,7 +1739,7 @@ msgstr ""
 "Määrityksiä ei voitu noutaa, polusta ei löytynyt tiedostoa\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15577
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1747,57 +1747,57 @@ msgstr ""
 "Polun alaisen asetustiedoston sisältöä ei voitu hakea\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:16197
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Tämä palvelu vaatii API-avaimen"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Kastepiste"
 
-#: 3.8/weather-applet.js:16269
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Sade loppuu {precipEnd} minuutissa"
 
-#: 3.8/weather-applet.js:16271
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "Sade ei lopu tunnin sisällä"
 
-#: 3.8/weather-applet.js:16274
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Sade alkaa {precipStart} minuutissa"
 
-#: 3.8/weather-applet.js:16486
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Ennusteen tekeminen epäonnistui. Katso lisätietoja lokeista."
 
-#: 3.8/weather-applet.js:17018 3.8/weather-applet.js:17810
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "Klo {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:17024
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} sinusta"
 
-#: 3.8/weather-applet.js:17028
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "Aseman nimi:: {stationName}"
 
-#: 3.8/weather-applet.js:17031
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "Alue: {stationArea}"
 
-#: 3.8/weather-applet.js:17581 3.8/weather-applet.js:17591
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Virhe debug-tietojen tallentamisessa"
 
-#: 3.8/weather-applet.js:17603
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Debug-tiedot tallennettu"
 
-#: 3.8/weather-applet.js:17603
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Tallennettu {filePath}"
-
-#: 3.8/weather-applet.js:17734
-msgid "This provider requires an API key to operate"
-msgstr "Tämä palvelu vaatii API-avaimen"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -2581,30 +2581,3 @@ msgstr ""
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr "Polku lokin tallentamiseen"
-
-#~ msgid "DarkSky"
-#~ msgstr "DarkSky"
-
-#~ msgid "This API has ceased to function, please use another one."
-#~ msgstr "Tämä API on lakannut toimimasta, käytä toista."
-
-#~ msgid "API key doesn't provide access to Hourly Weather, skipping"
-#~ msgstr "API-avain ei tarjoa pääsyä tunti ennusteisiin, ohitetaan"
-
-#~ msgid "Please install '{missingPackage}', then refresh manually."
-#~ msgstr "Asenna '{missingPackage}', sitten päivitä manuaalisesti."
-
-#~ msgid "Light Snow"
-#~ msgstr "Kevyttä lunta"
-
-#~ msgid "Currently only used with DarkSky."
-#~ msgstr "Tällä hetkellä sitä käyttää vain DarkSky."
-
-#~ msgid "Units, Icons and Keys"
-#~ msgstr "Yksikkö, kuvake ja avain"
-
-#~ msgid "ClimacellV4 (key needed)"
-#~ msgstr "ClimacellV4 (avain tarvitaan)"
-
-#~ msgid "ClimacellV3 (key needed)"
-#~ msgstr "ClimacellV3 (avain tarvitaan)"

--- a/weather@mockturtl/files/weather@mockturtl/po/fr.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/fr.po
@@ -8,8 +8,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: weather@mockturtl 3.4.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-30 08:55+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2024-01-31 12:12+0100\n"
 "Last-Translator: FabRCT <fab.rct@gmail.com>\n"
 "Language-Team: Français <ecyrbe@gmail.com>\n"
@@ -21,65 +22,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17607
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Erreur"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17608 3.8/weather-applet.js:17610
-#: 3.8/weather-applet.js:17612 3.8/weather-applet.js:17615
-#: 3.8/weather-applet.js:17618 3.8/weather-applet.js:17619
-#: 3.8/weather-applet.js:17620 3.8/weather-applet.js:17621
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Erreur du service"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17609
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Clé API incorrecte"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17611
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Format d'emplacement incorrect"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17613
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Clé bloquée"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17614
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Impossible de trouver l'emplacement"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17616
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Aucune clé API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17617
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Aucun emplacement"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17622
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Paquets manquants"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17623
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Emplacement non couvert"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9711
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Applet Météo"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17921
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17922
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Cliquez pour ouvrir"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16215
-#: 3.8/weather-applet.js:17925
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Actualiser"
 
@@ -89,8 +90,8 @@ msgstr "L'API a renvoyé un code d'état compris entre 400 et 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Dépôt de localisation"
 
@@ -103,14 +104,14 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr "Impossible d'obtenir les informations"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17760
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Erreur inattendue en actualisant la météo, veuillez consulter les journaux "
 "dans Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:18003
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -126,7 +127,7 @@ msgstr "Erreur réseau, veuillez consulter les journaux dans Looking Glass"
 msgid "As of"
 msgstr "À"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:17006
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Données fournies par"
 
@@ -134,52 +135,52 @@ msgstr "Données fournies par"
 msgid "from you"
 msgstr "de vous"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16919
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:16919
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "à"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10312
-#: 3.8/weather-applet.js:17084
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10313
-#: 3.8/weather-applet.js:17085
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17262
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Chargement de la météo..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17265
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Chargement des prévisions..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16168
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Chargement..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16189
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Température"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16190
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Humidité"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16191
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Pression"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12257 3.8/weather-applet.js:12263
-#: 3.8/weather-applet.js:14217 3.8/weather-applet.js:14218
-#: 3.8/weather-applet.js:16037
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Vent"
 
@@ -189,39 +190,38 @@ msgstr ""
 "Assurez-vous d'avoir entré un emplacement ou utilisez la localisation "
 "automatique"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9952
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Impossible de trouver l'emplacement en fonction de l'adresse, veuillez "
 "vérifier si elle est correcte"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9973
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Échec de l'API de géolocalisation, consultez Looking Glass pour les erreurs."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Avertissement"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9872
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Vous ne pouvez enregistrer les emplacements corrects que lorsque l'applet ne "
 "s'actualise pas"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Vous ne pouvez pas enregistrer un emplacement incorrect"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9880
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Information"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "L'emplacement est déjà enregistré"
 
@@ -261,15 +261,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10740 3.8/weather-applet.js:11711
-#: 3.8/weather-applet.js:12150 3.8/weather-applet.js:12659
-#: 3.8/weather-applet.js:13021 3.8/weather-applet.js:14388
-#: 3.8/weather-applet.js:14929
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "T° ressentie"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:14991
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Échec du traitement de l'information météorologique"
 
@@ -282,7 +282,7 @@ msgstr ""
 "ou en obtenir une sur https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:14871
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -290,7 +290,7 @@ msgstr ""
 "Veuillez vous assurer que vous avez\n"
 "saisi correctement la clé API et que votre compte n'est pas verrouillé"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12113
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -301,60 +301,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10516 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10530 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:11379 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:11386 3.8/weather-applet.js:11393
-#: 3.8/weather-applet.js:11400 3.8/weather-applet.js:12292
-#: 3.8/weather-applet.js:13187
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Forte pluie"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11554 3.8/weather-applet.js:11555
-#: 3.8/weather-applet.js:11561 3.8/weather-applet.js:12277
-#: 3.8/weather-applet.js:12278 3.8/weather-applet.js:12284
-#: 3.8/weather-applet.js:12291 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12340 3.8/weather-applet.js:12347
-#: 3.8/weather-applet.js:12801 3.8/weather-applet.js:12850
-#: 3.8/weather-applet.js:12851 3.8/weather-applet.js:12858
-#: 3.8/weather-applet.js:13179 3.8/weather-applet.js:13448
-#: 3.8/weather-applet.js:13449 3.8/weather-applet.js:13490
-#: 3.8/weather-applet.js:14189 3.8/weather-applet.js:14190
-#: 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Pluie"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10495 3.8/weather-applet.js:10509
-#: 3.8/weather-applet.js:10510 3.8/weather-applet.js:11009
-#: 3.8/weather-applet.js:11463 3.8/weather-applet.js:11464
-#: 3.8/weather-applet.js:11470 3.8/weather-applet.js:11477
-#: 3.8/weather-applet.js:11484 3.8/weather-applet.js:12285
-#: 3.8/weather-applet.js:13189
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Pluie légère"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12348 3.8/weather-applet.js:13163
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Pluie verglaçante intense"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11014
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12822
-#: 3.8/weather-applet.js:12823 3.8/weather-applet.js:12829
-#: 3.8/weather-applet.js:12830 3.8/weather-applet.js:12836
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Pluie verglaçante"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12341 3.8/weather-applet.js:13165
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Pluie verglaçante légère"
 
@@ -362,177 +362,177 @@ msgstr "Pluie verglaçante légère"
 msgid "Light freezing drizzle"
 msgstr "Bruine verglaçante légère"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12327
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Bruine verglaçante"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13145
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Bruine légère"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12362
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Fort grésil"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12354 3.8/weather-applet.js:12355
-#: 3.8/weather-applet.js:12361 3.8/weather-applet.js:12368
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Grésil"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12369
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Léger grésil"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10600
-#: 3.8/weather-applet.js:10607 3.8/weather-applet.js:10614
-#: 3.8/weather-applet.js:10615 3.8/weather-applet.js:11021
-#: 3.8/weather-applet.js:11435 3.8/weather-applet.js:11436
-#: 3.8/weather-applet.js:11442 3.8/weather-applet.js:11449
-#: 3.8/weather-applet.js:11456 3.8/weather-applet.js:12320
-#: 3.8/weather-applet.js:13205 3.8/weather-applet.js:13525
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Neige abondante"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:11610
-#: 3.8/weather-applet.js:11611 3.8/weather-applet.js:11617
-#: 3.8/weather-applet.js:12298 3.8/weather-applet.js:12299
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12795
-#: 3.8/weather-applet.js:13199 3.8/weather-applet.js:13434
-#: 3.8/weather-applet.js:13518 3.8/weather-applet.js:14203
-#: 3.8/weather-applet.js:14204 3.8/weather-applet.js:14581
-#: 3.8/weather-applet.js:14582
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Neige"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11019
-#: 3.8/weather-applet.js:11519 3.8/weather-applet.js:11520
-#: 3.8/weather-applet.js:11526 3.8/weather-applet.js:11533
-#: 3.8/weather-applet.js:11540 3.8/weather-applet.js:12313
-#: 3.8/weather-applet.js:13207
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Neige légère"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12305
-#: 3.8/weather-applet.js:12306 3.8/weather-applet.js:14560
-#: 3.8/weather-applet.js:14561
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Rafales"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:12375 3.8/weather-applet.js:12376
-#: 3.8/weather-applet.js:12867 3.8/weather-applet.js:12868
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13532
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:14210
-#: 3.8/weather-applet.js:14211
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Orage"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12243
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Brouillard léger"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11372
-#: 3.8/weather-applet.js:11373 3.8/weather-applet.js:12235
-#: 3.8/weather-applet.js:12236 3.8/weather-applet.js:12242
-#: 3.8/weather-applet.js:12937 3.8/weather-applet.js:12938
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:14161
-#: 3.8/weather-applet.js:14162 3.8/weather-applet.js:14609
-#: 3.8/weather-applet.js:14610
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Brouillard"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10474 3.8/weather-applet.js:10475
-#: 3.8/weather-applet.js:11358 3.8/weather-applet.js:11359
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:12208
-#: 3.8/weather-applet.js:13427 3.8/weather-applet.js:13428
-#: 3.8/weather-applet.js:14154 3.8/weather-applet.js:14155
-#: 3.8/weather-applet.js:14651 3.8/weather-applet.js:14652
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Nuageux"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12228
-#: 3.8/weather-applet.js:12229 3.8/weather-applet.js:12745
-#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:12780
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Principalement nuageux"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10439
-#: 3.8/weather-applet.js:10440 3.8/weather-applet.js:10446
-#: 3.8/weather-applet.js:10447 3.8/weather-applet.js:11547
-#: 3.8/weather-applet.js:11548 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12222 3.8/weather-applet.js:12738
-#: 3.8/weather-applet.js:12739 3.8/weather-applet.js:12773
-#: 3.8/weather-applet.js:13420 3.8/weather-applet.js:13421
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Partiellement nuageux"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Principalement dégagé"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10425 3.8/weather-applet.js:10426
-#: 3.8/weather-applet.js:11039 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:12724
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12759
-#: 3.8/weather-applet.js:13223 3.8/weather-applet.js:13413
-#: 3.8/weather-applet.js:13414 3.8/weather-applet.js:14140
-#: 3.8/weather-applet.js:14141 3.8/weather-applet.js:14147
-#: 3.8/weather-applet.js:14148 3.8/weather-applet.js:14686
-#: 3.8/weather-applet.js:14687
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Clair"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10432
-#: 3.8/weather-applet.js:10433 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:14693
-#: 3.8/weather-applet.js:14694
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Ensoleillé"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10418
-#: 3.8/weather-applet.js:10419 3.8/weather-applet.js:10453
-#: 3.8/weather-applet.js:10454 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10643 3.8/weather-applet.js:11341
-#: 3.8/weather-applet.js:11342 3.8/weather-applet.js:11639
-#: 3.8/weather-applet.js:11640 3.8/weather-applet.js:12192
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12715
-#: 3.8/weather-applet.js:12716 3.8/weather-applet.js:12944
-#: 3.8/weather-applet.js:12945 3.8/weather-applet.js:14073
-#: 3.8/weather-applet.js:14074 3.8/weather-applet.js:14224
-#: 3.8/weather-applet.js:14225 3.8/weather-applet.js:14797
-#: 3.8/weather-applet.js:14799
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Inconnue"
 
@@ -556,7 +556,7 @@ msgstr ""
 "Veuillez saisir la clé API dans les paramètres,\n"
 "ou en obtenir une sur https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:14881
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -564,7 +564,7 @@ msgstr ""
 "Veuillez vous assurer que vous avez\n"
 "saisi correctement la clé API récupérée sur DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:15197
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Impossible d'obtenir l'emplacement"
 
@@ -575,121 +575,121 @@ msgstr ""
 "Le service de localisation a répondu avec des erreurs, veuillez consulter "
 "les journaux dans Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11203
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Nébulosité"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11351
-#: 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Ciel clair"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11365 3.8/weather-applet.js:11366
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Beau"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11387
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Forte pluie et orage"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11394
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Fortes averses"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11401
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Fortes averses et orage"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11407
-#: 3.8/weather-applet.js:11408 3.8/weather-applet.js:11414
-#: 3.8/weather-applet.js:11421 3.8/weather-applet.js:11428
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Grêle"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11415
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Grêle avec orage"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11422
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Fortes averses de grésil"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11429
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Fortes averses de grésil et orage"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11443
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Importantes chutes de neige avec orages"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11450
-#: 3.8/weather-applet.js:13526
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Fortes averses de neige"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11457
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Fortes averses de neige et orage"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11471
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Pluie légère et orage"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11478
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Averses de pluie légère"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11485
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Averses de pluie légère et orage"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11491
-#: 3.8/weather-applet.js:11492 3.8/weather-applet.js:11498
-#: 3.8/weather-applet.js:11505 3.8/weather-applet.js:11512
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Léger grésil"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11499
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Grésil avec orage"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11506
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Faibles averses de grésil"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11513
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Faibles averses de grésil et orage"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11527
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Neige légère avec orage"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11534
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Légères averses de neige"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11541
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Légères averses de neige et orage"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11562
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Pluie et orage"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11568
-#: 3.8/weather-applet.js:11569 3.8/weather-applet.js:11575
-#: 3.8/weather-applet.js:12859 3.8/weather-applet.js:13185
-#: 3.8/weather-applet.js:13491 3.8/weather-applet.js:13497
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Averses"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11576
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Averses et orage"
 
@@ -698,44 +698,44 @@ msgstr "Averses et orage"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10537
-#: 3.8/weather-applet.js:10544 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11582 3.8/weather-applet.js:11583
-#: 3.8/weather-applet.js:11589 3.8/weather-applet.js:11596
-#: 3.8/weather-applet.js:11603 3.8/weather-applet.js:12808
-#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12815
-#: 3.8/weather-applet.js:12816 3.8/weather-applet.js:12843
-#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14196
-#: 3.8/weather-applet.js:14197 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Grésil"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11590
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Grésil et orage"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11597
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Averses de grésil"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11604
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Averses de grésil et orage"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11618
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Neige et orage"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11624 3.8/weather-applet.js:11625
-#: 3.8/weather-applet.js:11631 3.8/weather-applet.js:13203
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Averses de neige"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11632
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Averses de neige et orage"
 
@@ -744,21 +744,21 @@ msgstr "Averses de neige et orage"
 msgid "Unexpected response from API"
 msgstr "Réponse inattendue de l'API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10237
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Visibilité"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10265
-#: 3.8/weather-applet.js:10817 3.8/weather-applet.js:11722
-#: 3.8/weather-applet.js:12672
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Échec du traitement de l'information météorologique actuelle"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10055
-#: 3.8/weather-applet.js:10089 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11782 3.8/weather-applet.js:12474
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Échec du traitement des données de prévision"
 
@@ -787,89 +787,89 @@ msgid "Excellent - More than"
 msgstr "Excellente - Plus de"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10460 3.8/weather-applet.js:10461
-#: 3.8/weather-applet.js:11029 3.8/weather-applet.js:13175
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Brouillard"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:12752
-#: 3.8/weather-applet.js:12753 3.8/weather-applet.js:12787
-#: 3.8/weather-applet.js:13219
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Ciel couvert"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10489
-#: 3.8/weather-applet.js:10496
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Averses de pluie légère"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:12326
-#: 3.8/weather-applet.js:13141 3.8/weather-applet.js:14532
-#: 3.8/weather-applet.js:14533
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Bruine"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:10524
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Fortes averses"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10538
-#: 3.8/weather-applet.js:10545
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Averses de grésil"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:13217 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14169 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:14589
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Grêle"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Averses de grêle"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Légères averses de neige"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Fortes averses de neige"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10621 3.8/weather-applet.js:10628
-#: 3.8/weather-applet.js:10635 3.8/weather-applet.js:10636
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Orage"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Averses et orage"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10872
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Veuillez vous assurer que l'emplacement est au bon format dans les paramètres"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10876
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Assurez-vous d'avoir saisi la bonne clé dans les paramètres"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10681 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -877,211 +877,211 @@ msgstr ""
 "Emplacement introuvable, assurez-vous que l'emplacement existe ou qu'il est "
 "dans le bon format"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10884
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Si ce problème persiste, veuillez contacter l'auteur de cette applet"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10888
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Erreur inconnue, veuillez consulter les journaux dans Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10990
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Orage avec pluie légère"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10991
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Orage avec pluie"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10992
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Orage avec forte pluie"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10993
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Orage léger"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10995
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Orage violent"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10996
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Orage isolé"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10997
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Orage avec bruine légère"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10998
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Orage avec bruine"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10999
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Orage avec forte bruine"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11000
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Bruine de faible intensité"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11002
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Bruine de forte intensité"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11003
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Bruine de faible intensité"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11004
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Pluie fine"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11005
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Bruine de forte intensité"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11006
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Pluie et bruine"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11007
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Pluie et bruine abondantes"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11008
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Bruine"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11010
-#: 3.8/weather-applet.js:13455 3.8/weather-applet.js:13456
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Pluie modérée"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11011
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Pluie de forte intensité"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11012
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Pluie très forte"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11013
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Pluie extrême"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11015
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Averses légères"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11016
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Averses"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11017
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Averses de forte intensité"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11018
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Averses irrégulières"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11023
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Averses de grésil"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11024
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Neige et pluie légère"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11025
-#: 3.8/weather-applet.js:13462 3.8/weather-applet.js:13463
-#: 3.8/weather-applet.js:13469 3.8/weather-applet.js:13504
-#: 3.8/weather-applet.js:13511
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Pluie et neige"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11026
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Faibles averses de neige"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11027
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Averses de neige"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11028
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Fortes averses de neige"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:12902
-#: 3.8/weather-applet.js:12903 3.8/weather-applet.js:14623
-#: 3.8/weather-applet.js:14624
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Brouillard épais"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11031 3.8/weather-applet.js:12909
-#: 3.8/weather-applet.js:12910 3.8/weather-applet.js:14616
-#: 3.8/weather-applet.js:14617
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Brume"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11032
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Tourbillons de poussière, sable"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11034
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Sable"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11035 3.8/weather-applet.js:12895
-#: 3.8/weather-applet.js:12896 3.8/weather-applet.js:14602
-#: 3.8/weather-applet.js:14603
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Poussière"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11036
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Cendres volcaniques"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:13209
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Bourrasques"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11038 3.8/weather-applet.js:12874
-#: 3.8/weather-applet.js:12875 3.8/weather-applet.js:14475
-#: 3.8/weather-applet.js:14476
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Tornade"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11041
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Le ciel est clair"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11042
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Nuageux"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11043
-#: 3.8/weather-applet.js:12731 3.8/weather-applet.js:12732
-#: 3.8/weather-applet.js:12766
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Quelques nuages"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11044
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Nuages épars"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11045
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Nuages fragmentés"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11046
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Ciel couvert"
 
@@ -1089,82 +1089,82 @@ msgstr "Ciel couvert"
 msgid "Could not get forecast for your area"
 msgstr "Impossible d'obtenir les prévisions pour votre région"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12431
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 "L'emplacement est en dehors des États-Unis, veuillez utiliser un autre "
 "fournisseur."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12495
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Échec du traitement des prévisions horaires"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12760
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Clair et venteux"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12767
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Quelques nuages et venteux"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12774
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Partiellement nuageux et venteux"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Principalement pluvieux et venteux"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12788
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Ciel couvert et venteux"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12802
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Neige mouillée"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12837
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Pluie verglaçante et neige"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9153 3.8/weather-applet.js:12881
-#: 3.8/weather-applet.js:12882 3.8/weather-applet.js:14489
-#: 3.8/weather-applet.js:14490
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Ouragan"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9148
-#: 3.8/weather-applet.js:12888
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Tempête"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12889
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Tempête tropicale"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12916 3.8/weather-applet.js:12917
-#: 3.8/weather-applet.js:14721 3.8/weather-applet.js:14722
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Chaud"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12923 3.8/weather-applet.js:12924
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Froid"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12930 3.8/weather-applet.js:12931
-#: 3.8/weather-applet.js:14770 3.8/weather-applet.js:14771
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Tempête de neige"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9025
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Aujourd'hui"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9027
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Demain"
 
@@ -1196,79 +1196,79 @@ msgstr "Vendredi"
 msgid "Saturday"
 msgstr "Samedi"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9118
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Calme"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9121
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Très légère brise"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9124
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Légère brise"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9127
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Petite brise"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9130
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Jolie brise"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9133
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Bonne brise"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9136
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Vent frais"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9139
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Grand frais"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9142
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Coup de vent"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9145
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Fort coup de vent"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9151
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Violente tempête"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "NE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "E"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "SE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "SO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "O"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "NO"
 
@@ -1321,7 +1321,7 @@ msgstr ""
 "Une erreur inconnue s'est produite lors de l'obtention de la météo, "
 "consultez les journaux Looking Glass pour plus d'informations"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14482 3.8/weather-applet.js:14483
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Tempête tropicale"
 
@@ -1329,7 +1329,7 @@ msgstr "Tempête tropicale"
 msgid "Severe Thunderstorms"
 msgstr "Orages violents"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14503 3.8/weather-applet.js:14504
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Orages"
 
@@ -1345,15 +1345,15 @@ msgstr "Pluie et grésil"
 msgid "Mixed Snow and Sleet"
 msgstr "Neige et grésil"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Bruine verglaçante"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Pluie verglaçante"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Averses"
 
@@ -1365,11 +1365,11 @@ msgstr "Averses de neige"
 msgid "Light Snow Showers"
 msgstr "Légères chutes de neige"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14574 3.8/weather-applet.js:14575
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Neige poudreuse"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13441 3.8/weather-applet.js:13442
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Brumeux"
 
@@ -1381,54 +1381,54 @@ msgstr "Brouillard épais"
 msgid "Blustery"
 msgstr "Tempête"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14637 3.8/weather-applet.js:14638
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Venteux"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:14658 3.8/weather-applet.js:14659
-#: 3.8/weather-applet.js:14665 3.8/weather-applet.js:14666
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Principalement nuageux"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14175 3.8/weather-applet.js:14176
-#: 3.8/weather-applet.js:14182 3.8/weather-applet.js:14183
-#: 3.8/weather-applet.js:14672 3.8/weather-applet.js:14673
-#: 3.8/weather-applet.js:14679 3.8/weather-applet.js:14680
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Partiellement nuageux"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Principalement ensoleillé"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:14714 3.8/weather-applet.js:14715
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Pluie et grêle"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:14728 3.8/weather-applet.js:14729
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Orages isolés"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:14735 3.8/weather-applet.js:14736
-#: 3.8/weather-applet.js:14791 3.8/weather-applet.js:14792
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Orages dispersés"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:14742 3.8/weather-applet.js:14743
-#: 3.8/weather-applet.js:14777 3.8/weather-applet.js:14778
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Averses dispersées"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:14749 3.8/weather-applet.js:14750
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Forte pluie"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:14756 3.8/weather-applet.js:14757
-#: 3.8/weather-applet.js:14784 3.8/weather-applet.js:14785
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Averses de neige dispersées"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:14763 3.8/weather-applet.js:14764
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Importantes chutes de neige"
 
@@ -1440,7 +1440,7 @@ msgstr "Indisponible"
 msgid "Scattered Thundershowers"
 msgstr "Orages épars"
 
-#: 3.8/weather-applet.js:9637
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1449,7 +1449,7 @@ msgstr ""
 "trouvé\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9641
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1458,11 +1458,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10013
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10118
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1470,275 +1470,275 @@ msgstr ""
 "MET Office UK ne couvre que le Royaume-Uni, veuillez vous assurer que votre "
 "emplacement est dans ce pays"
 
-#: 3.8/weather-applet.js:10197
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Les données n'ont pas été trouvées pour l'emplacement"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Très mauvaise"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Moins de {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Excellente"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Plus de {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10287
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Mauvais"
 
-#: 3.8/weather-applet.js:10287 3.8/weather-applet.js:10292
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:10302
-#: 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Entre {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10292
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Modérée"
 
-#: 3.8/weather-applet.js:10297
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Bon"
 
-#: 3.8/weather-applet.js:10302 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Très bonne"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10662
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:11659
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12080
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12250
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Vent léger"
 
-#: 3.8/weather-applet.js:12264
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Vent fort"
 
-#: 3.8/weather-applet.js:12411
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "Météo aux États-Unis"
 
-#: 3.8/weather-applet.js:12962
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:13139
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Neige poudreuse ou à la dérive"
 
-#: 3.8/weather-applet.js:13143
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Bruine abondante"
 
-#: 3.8/weather-applet.js:13147
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Bruine abondante/pluie"
 
-#: 3.8/weather-applet.js:13149
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Bruine légère/pluie"
 
-#: 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Tempête de poussière"
 
-#: 3.8/weather-applet.js:13155
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Bruine verglaçante/pluie verglaçante"
 
-#: 3.8/weather-applet.js:13157
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Bruine verglaçante abondante/pluie verglaçante"
 
-#: 3.8/weather-applet.js:13159
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Bruine verglaçante légère/pluie verglaçante"
 
-#: 3.8/weather-applet.js:13161
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Brouillard verglaçant"
 
-#: 3.8/weather-applet.js:13167
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Entonnoir nuageux/tornade"
 
-#: 3.8/weather-applet.js:13169
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Averses de grêle"
 
-#: 3.8/weather-applet.js:13171
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Glace"
 
-#: 3.8/weather-applet.js:13173
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Foudre sans tonnerre"
 
-#: 3.8/weather-applet.js:13177
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Précipitations à proximité"
 
-#: 3.8/weather-applet.js:13181 3.8/weather-applet.js:13470
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Pluie et neige abondantes"
 
-#: 3.8/weather-applet.js:13183
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Pluie légère et neige"
 
-#: 3.8/weather-applet.js:13191
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Couverture nuageuse en diminution"
 
-#: 3.8/weather-applet.js:13193
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Couverture nuageuse en augmentation"
 
-#: 3.8/weather-applet.js:13195
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Ciel inchangé"
 
-#: 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Fumée ou brume"
 
-#: 3.8/weather-applet.js:13201
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Averses de neige et de pluie"
 
-#: 3.8/weather-applet.js:13213
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Orage sans précipitations"
 
-#: 3.8/weather-applet.js:13215
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Poudrin de glace"
 
-#: 3.8/weather-applet.js:13221
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Partiellement nuageux"
 
-#: 3.8/weather-applet.js:13243
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Veuillez vous assurer que vous avez saisi correctement la clé API"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13259
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:13402 3.8/weather-applet.js:13403
-#: 3.8/weather-applet.js:13539 3.8/weather-applet.js:13540
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "NON TROUVÉ"
 
-#: 3.8/weather-applet.js:13435
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Neige poudreuse"
 
-#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:13477
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Neige légère"
 
-#: 3.8/weather-applet.js:13483 3.8/weather-applet.js:13484
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Neige modérée"
 
-#: 3.8/weather-applet.js:13498
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Averses de pluie modérées"
 
-#: 3.8/weather-applet.js:13505
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Mélange pluie et neige"
 
-#: 3.8/weather-applet.js:13512
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Mélange pluie et neige abondant"
 
-#: 3.8/weather-applet.js:13657
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:13953
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:13966
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "Veuillez sélectionner un fournisseur ou un emplacement différent"
 
-#: 3.8/weather-applet.js:14263
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14453
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "La clé API que vous avez fournie n'est pas valide."
 
-#: 3.8/weather-applet.js:14460
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "L'emplacement que vous avez fourni n'a pas été trouvé."
 
-#: 3.8/weather-applet.js:14496 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Forte tempête"
 
-#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:14512
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Pluie et neige"
 
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Pluie et grésil"
 
-#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Averses de neige"
 
-#: 3.8/weather-applet.js:14630 3.8/weather-applet.js:14631
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "Venteux"
 
-#: 3.8/weather-applet.js:14644 3.8/weather-applet.js:14645
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr "Glacial"
 
-#: 3.8/weather-applet.js:14700 3.8/weather-applet.js:14701
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Principalement dégagé"
 
-#: 3.8/weather-applet.js:14853
+#: 3.8/weather-applet.js:15247
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:15206
+#: 3.8/weather-applet.js:15603
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
@@ -1746,13 +1746,13 @@ msgstr ""
 "Le service de localisation a répondu avec des erreurs, veuillez consulter "
 "les journaux dans Looking Glass"
 
-#: 3.8/weather-applet.js:15428
+#: 3.8/weather-applet.js:15831
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Assurez-vous d'avoir entré un emplacement ou utilisez la localisation "
 "automatique."
 
-#: 3.8/weather-applet.js:15565
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1761,7 +1761,7 @@ msgstr ""
 "les chemins\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15572
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1769,59 +1769,59 @@ msgstr ""
 "Impossible de lire le contenu du fichier de configuration suivant\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Ce fournisseur nécessite une clé API pour fonctionner"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Point de rosée"
 
-#: 3.8/weather-applet.js:16264
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "La précipitation s'arrêtera dans {precipEnd} minutes"
 
-#: 3.8/weather-applet.js:16266
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "La précipitation ne s'arrêtera pas dans l'heure"
 
-#: 3.8/weather-applet.js:16269
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "La précipitation commencera dans les {precipStart} minutes"
 
-#: 3.8/weather-applet.js:16481
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Échec de l'analyse des prévisions, consultez les journaux pour plus de "
 "détails."
 
-#: 3.8/weather-applet.js:17013 3.8/weather-applet.js:17802
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "À {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:17019
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} de vous"
 
-#: 3.8/weather-applet.js:17023
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "Nom de la station: {stationName}"
 
-#: 3.8/weather-applet.js:17026
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "Région: {stationArea}"
 
-#: 3.8/weather-applet.js:17573 3.8/weather-applet.js:17583
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Erreur lors de l'enregistrement des informations de débogage"
 
-#: 3.8/weather-applet.js:17595
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Informations de débogage enregistrées avec succès"
 
-#: 3.8/weather-applet.js:17595
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Enregistré dans {filePath}"
-
-#: 3.8/weather-applet.js:17726
-msgid "This provider requires an API key to operate"
-msgstr "Ce fournisseur nécessite une clé API pour fonctionner"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -1923,8 +1923,8 @@ msgid ""
 "address.\n"
 "Waits for 3 seconds after you stop typing before refreshes the weather."
 msgstr ""
-"Les entrées acceptables sont « Latitude, Longitude ». Par exemple : « "
-"68.1932, 17.1426 » ou une adresse.\n"
+"Les entrées acceptables sont « Latitude, Longitude ». Par exemple : "
+"« 68.1932, 17.1426 » ou une adresse.\n"
 "Attendez 3 secondes après avoir arrêté de taper, puis actualisez la météo."
 
 #. 3.0->settings-schema.json->getLocation->description
@@ -2593,12 +2593,12 @@ msgid ""
 "automatically for validating your choice."
 msgstr ""
 "Dans la plupart des cas, votre emplacement fonctionne automatiquement, mais "
-"vous pouvez l'entrer manuellement par les coordonnées « Latitude, Longitude "
-"» (par exemple « 51, 5085, -0,1257 ») ou utiliser « Ville, Code du pays "
-"» (par exemple « Paris, FR ») ou essayer d'entrer « {Numéro de maison} {Rue} "
-"{Ville} {Code postal} {Pays} ». L'algorithme de recherche est très flexible "
-"avec le format. Au bout de 3 secondes sans saisie, l'adresse que vous avez "
-"entrée est automatiquement remplacée pour valider votre choix."
+"vous pouvez l'entrer manuellement par les coordonnées « Latitude, "
+"Longitude » (par exemple « 51, 5085, -0,1257 ») ou utiliser « Ville, Code du "
+"pays » (par exemple « Paris, FR ») ou essayer d'entrer « {Numéro de maison} "
+"{Rue} {Ville} {Code postal} {Pays} ». L'algorithme de recherche est très "
+"flexible avec le format. Au bout de 3 secondes sans saisie, l'adresse que "
+"vous avez entrée est automatiquement remplacée pour valider votre choix."
 
 #. 3.8->settings-schema.json->logLevel->description
 msgid "Log Level"
@@ -2637,388 +2637,3 @@ msgstr ""
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr "Chemin sélectionné pour enregistrer les journaux"
-
-#~ msgid "DarkSky"
-#~ msgstr "DarkSky"
-
-#~ msgid "This API has ceased to function, please use another one."
-#~ msgstr "Cette API a cessé de fonctionner, veuillez en utiliser une autre."
-
-#~ msgid "Climacell"
-#~ msgstr "Climacell"
-
-#~ msgid "Light Snow"
-#~ msgstr "Neige légère"
-
-#~ msgid "API key doesn't provide access to Hourly Weather, skipping"
-#~ msgstr "La clé API ne donne pas accès à la météo horaire, on l'ignore"
-
-#~ msgid "ClimacellV4 (key needed)"
-#~ msgstr "ClimacellV4 (clé requise)"
-
-#~ msgid "ClimacellV3 (key needed)"
-#~ msgstr "ClimacellV3 (clé requise)"
-
-#~ msgid "Please install '{missingPackage}', then refresh manually."
-#~ msgstr ""
-#~ "Veuillez installer '{missingPackage}', puis actualisez manuellement."
-
-#~ msgid "Currently only used with DarkSky."
-#~ msgstr "Actuellement uniquement disponible avec DarkSky."
-
-#~ msgid "Units, Icons and Keys"
-#~ msgstr "Unités, icônes et clés"
-
-#~ msgid "How to choose a weather provider"
-#~ msgstr "Comment choisir un fournisseur de prévisions météorologiques"
-
-#~ msgid "Allowed location formats"
-#~ msgstr "Formats de localisation autorisés"
-
-#~ msgid "View additional information"
-#~ msgstr "Afficher des informations supplémentaires"
-
-#~ msgid "Substantial Rain"
-#~ msgstr "Pluie importante"
-
-#~ msgid "Light Rain"
-#~ msgstr "Pluie légère"
-
-#~ msgid "Substantial Freezing Rain"
-#~ msgstr "Pluie verglaçante importante"
-
-#~ msgid "Light Freezing Rain"
-#~ msgstr "Pluie verglaçante légère"
-
-#~ msgid "Light Drizzle"
-#~ msgstr "Bruine légère"
-
-#~ msgid "Substantial Ice Pellets"
-#~ msgstr "Grésil important"
-
-#~ msgid "Substantial Snow"
-#~ msgstr "Neige importante"
-
-#~ msgid "Clear Sky"
-#~ msgstr "Ciel clair"
-
-#~ msgid "Rain Showers"
-#~ msgstr "Averses"
-
-#~ msgid "Few Clouds"
-#~ msgstr "Quelques nuages"
-
-#~ msgid "Delete current location from storage"
-#~ msgstr "Supprimer l'enregistrement de l'emplacement actuel"
-
-#~ msgid "Removes location information from storage file."
-#~ msgstr ""
-#~ "Supprime les informations de localisation du fichier d'enregistrement."
-
-#~ msgid "Settings"
-#~ msgstr "Paramètres"
-
-#~ msgid "Cloudiness:"
-#~ msgstr "Nébulosité :"
-
-#~ msgid "Sunrise"
-#~ msgstr "Lever du soleil"
-
-#~ msgid "Sunset"
-#~ msgstr "Coucher du soleil"
-
-#~ msgid "Service Unavailable"
-#~ msgstr "Service indisponible"
-
-#~ msgid "Wrong API Key"
-#~ msgstr "Clé d'API non reconnue"
-
-#~ msgid "City Not found"
-#~ msgstr "Ville non trouvée"
-
-#~ msgid "Key Temp. Blocked"
-#~ msgstr "Clé temporairement bloquée"
-
-#~ msgid "Settings for weather@mockturtl 1.8+"
-#~ msgstr "Paramètres pour weather@mockturtl 1.8+"
-
-#~ msgid "Weather Provider Settings"
-#~ msgstr "Paramètres du fournisseur de données météo"
-
-#~ msgid ""
-#~ "Acceptable inputs: City,CountryCode or Zipcode,CountryCode or Latitude,"
-#~ "Longitude"
-#~ msgstr ""
-#~ "Entrées acceptables : Ville, CodePays ou CodePostal, CodePays ou "
-#~ "Latitude, Longitude"
-
-#~ msgid "Personal Settings"
-#~ msgstr "Paramètres personnels"
-
-#~ msgid "Vertical orientation"
-#~ msgstr "Afficher verticalement les prévisions"
-
-#~ msgid "Translate condition"
-#~ msgstr "Traduire les conditions météorologiques"
-
-#~ msgid "Symbolic icons"
-#~ msgstr "Icônes symboliques"
-
-#~ msgid "Acceptable inputs is Latitude,Longitude"
-#~ msgstr "Entrées acceptables : Latitude, Longitude"
-
-#~ msgid "Contact"
-#~ msgstr "Contact"
-
-#~ msgid "Weather provider choices and details"
-#~ msgstr "Choix et détails sur les fournisseurs de données météo"
-
-#~ msgid "Entering location manually"
-#~ msgstr "Saisie manuelle de l'emplacement"
-
-#~ msgid ""
-#~ "OpenWeatherMap:\n"
-#~ "The default, works out of the box.\n"
-#~ "Big Thanks to them supporting free open source projects, like this! "
-#~ "Supports 7 forecast days and 48 forecast hours."
-#~ msgstr ""
-#~ "OpenWeatherMap:\n"
-#~ "La valeur par défaut, fonctionne immédiatement.\n"
-#~ "Un grand merci à eux pour leur soutien à des projets libres, comme celui-"
-#~ "ci ! Prend en charge 7 jours de prévision et 48 heures de prévision."
-
-#~ msgid ""
-#~ "DarkSky:\n"
-#~ "It doesn't accept new registrations and will be closed in 2021. Supports "
-#~ "8 forecast days and 168 forecast hours."
-#~ msgstr ""
-#~ "DarkSky :\n"
-#~ "Il n'accepte pas les nouvelles inscriptions et sera fermé en 2021. Prend "
-#~ "en charge 8 jours de prévision et 168 heures de prévision."
-
-#~ msgid ""
-#~ "MET Norway:\n"
-#~ "Current weather is shown for the next hour, and the daily forecasts are "
-#~ "generated from 6 hour forecasts, so it can look incorrect sometimes. "
-#~ "Supports 10 forecast days and 48 forecast hours."
-#~ msgstr ""
-#~ "MET Norway :\n"
-#~ "La météo actuelle est affichée pour l'heure suivante et les prévisions "
-#~ "quotidiennes sont générées à partir de prévisions sur 6 heures, de sorte "
-#~ "qu'elles peuvent parfois sembler incorrectes. Prend en charge les "
-#~ "prévisions journalières sur 10 jours et horaires sur 48 heures."
-
-#~ msgid ""
-#~ "WeatherBit:\n"
-#~ "At least 10 minutes as refresh rate is recommended, since otherwise you "
-#~ "might exceed you daily quota. Supports 16 forecast days and 48 forecast "
-#~ "hours."
-#~ msgstr ""
-#~ "WeatherBit :\n"
-#~ "Un taux de rafraîchissement d'au moins 10 minutes est recommandé, sinon "
-#~ "vous pourriez dépasser votre quota quotidien. Prend en charge 16 jours de "
-#~ "prévisions journalières et 48 heures de prévisions horaires."
-
-#~ msgid ""
-#~ "Yahoo:\n"
-#~ "Requires 'python3-requests-oauthlib' package installed (for Arch based "
-#~ "distros 'python-requests-oauthlib'), Updates every 2 hours. Only supports "
-#~ "10 forecast days and no hours."
-#~ msgstr ""
-#~ "Yahoo :\n"
-#~ "Nécessite l'installation du package 'python3-requests-oauthlib' (pour les "
-#~ "distributions basées sur Arch 'python-requests-oauthlib'), Mises à jour "
-#~ "toutes les 2 heures. Prend uniquement en charge 10 jours de prévisions "
-#~ "journalière et aucune prévision horaire."
-
-#~ msgid ""
-#~ "Climacell:\n"
-#~ "At least 10 minutes refresh rate is recommended with a free plan. "
-#~ "Supports 16 forecast days and 96 forecast hours."
-#~ msgstr ""
-#~ "Climacell:\n"
-#~ "Un taux de rafraîchissement d'au moins 10 minutes est recommandé avec "
-#~ "l'offre gratuite. Prend en charge 16 jours de prévision et 96 heures de "
-#~ "prévision."
-
-#~ msgid ""
-#~ "Met Office UK:\n"
-#~ "UK only option. If it does not find a site in 50km range around you it "
-#~ "will not show weather. Please let me know if this happens and you live in "
-#~ "the UK. Supports 5 days and 36 hours of forecasts. Sometimes it takes 5-8 "
-#~ "seconds to load the first time, please be patient."
-#~ msgstr ""
-#~ "Met Office UK:\n"
-#~ "Option Royaume-Uni uniquement. S'il ne trouve pas de site à 50 km autour "
-#~ "de vous, il ne montrera pas la météo. S'il vous plaît, avertissez-moi si "
-#~ "cela se produit et que vous vivez au Royaume-Uni. Prend en charge 5 jours "
-#~ "et 36 heures de prévisions. Parfois, cela prend 5-8 secondes pour charger "
-#~ "la première fois, soyez patient."
-
-#~ msgid ""
-#~ "US National Weather Service:\n"
-#~ "US only option. First load can take up to 15-20 seconds, please be "
-#~ "patient. Current weather is merged from a max 50km area, if some data is "
-#~ "missing from the closest one. Supports 7 days and 156 hours of forecasts."
-#~ msgstr ""
-#~ "US National Weather Service:\n"
-#~ "Option US uniquement. Le premier chargement peut prendre jusqu'à 15-20 "
-#~ "secondes, veuillez être patient. La météo actuelle est fusionnée à partir "
-#~ "d'une zone maximale de 50 km, si certaines données sont manquantes dans "
-#~ "la zone la plus proche. Prend en charge 7 jours et 156 heures de "
-#~ "prévisions."
-
-#~ msgid ""
-#~ "You can either use coordinates as {latitude},{longitude},\n"
-#~ " or an address, from smallest detail to biggest, like '{house num} "
-#~ "{street} {city/town} {postcode} {country}'. All of them are optional, "
-#~ "although at least city and country is recommended. You can use commas if "
-#~ "you like.\n"
-#~ "\n"
-#~ "After you stop typing the field will be replaced after 3 seconds with the "
-#~ "full address, for you to validate if it's correct."
-#~ msgstr ""
-#~ "Vous pouvez utiliser des coordonnées telles que {latitude}, {longitude},\n"
-#~ "  ou une adresse, du plus précis au plus global, comme \"{numéro} {rue} "
-#~ "{ville} {code postale} {pays}\". Tous sont facultatifs, mais la ville et "
-#~ "le pays sont recommandés. Vous pouvez utiliser des virgules si vous le "
-#~ "souhaitez.\n"
-#~ "\n"
-#~ "Une fois que vous arrêtez de taper, le champ sera remplacé après 3 "
-#~ "secondes par l'adresse complète, pour que vous puissiez valider si elle "
-#~ "est correcte."
-
-#~ msgid "Ligth Rain"
-#~ msgstr "Pluie légère"
-
-#~ msgid "Please enter location in the correct format (coordinates)"
-#~ msgstr ""
-#~ "Veuillez saisir l'emplacement sous forme de coordonnées géographiques"
-
-#~ msgid ""
-#~ "powered by: OpenWeatherMap, DarkSky, MET Norway, Weatherbit,\n"
-#~ "Yahoo and ip-api. Big Thanks to OpenWeatherMap for their FOSS support!"
-#~ msgstr ""
-#~ "Propulsé par : OpenWeatherMap, DarkSky, MET Norway, Weatherbit, Yahoo! et "
-#~ "ip-api.\n"
-#~ "Un grand merci à OpenWeatherMap pour leur support FOSS !"
-
-#~ msgid "Settings for weather@mockturtl 3.8+"
-#~ msgstr "Paramètres pour weather@mockturtl 3.8+"
-
-#~ msgid ""
-#~ "powered by: OpenWeatherMap, DarkSky, MET Norway, Weatherbit, Yahoo and ip-"
-#~ "api. Big Thanks to OpenWeatherMap for their FOSS support!"
-#~ msgstr ""
-#~ "Fonctionne avec : OpenWeatherMap, DarkSky, MET Norway, Weatherbit, Yahoo! "
-#~ "et ip-api.\n"
-#~ "Un grand merci à OpenWeatherMap pour leur support FOSS !"
-
-#~ msgid "Drizzle with Thunderstorms"
-#~ msgstr "Bruine avec orages"
-
-#~ msgid "Mostly Drizzle"
-#~ msgstr "Principalement bruine"
-
-#~ msgid "Mostly Drizzle with Thunderstorms"
-#~ msgstr "Principalement bruine avec orages"
-
-#~ msgid "Mostly Heavy Sleet"
-#~ msgstr "Principalement grêle"
-
-#~ msgid "Mostly Heavy Sleet with Thunderstorms"
-#~ msgstr "Principalement grêle avec orages"
-
-#~ msgid "Mostly Light Rain with Thunderstorms"
-#~ msgstr "Principalement pluie légère avec orages"
-
-#~ msgid "Mostly Light Sleet"
-#~ msgstr "Principalement grésil léger"
-
-#~ msgid "Mostly Light Sleet with Thunderstorms"
-#~ msgstr "Principalement grésil léger avec orages"
-
-#~ msgid "Mostly Light Snow"
-#~ msgstr "Principalement neige légère"
-
-#~ msgid "Mostly Light Snow with Thunderstorms"
-#~ msgstr "Principalement neige légère avec orages"
-
-#~ msgid "Rain with Thunderstorms"
-#~ msgstr "Pluie avec orages"
-
-#~ msgid "Mostly Rainy with Thunderstorms"
-#~ msgstr "Principalement pluvieux avec orages"
-
-#~ msgid "Mostly Sleet with Thunderstorms"
-#~ msgstr "Principalement grésil avec orages"
-
-#~ msgid "Snowy"
-#~ msgstr "Neigeux"
-
-#~ msgid "Mostly Snowy with Thunderstorms"
-#~ msgstr "Principalement neigeux avec orages"
-
-#~ msgid ""
-#~ "OpenWeatherMap - The default, works out of the box, only accepts "
-#~ "coordinates as a location now!"
-#~ msgstr ""
-#~ "OpenWeatherMap - Service par défaut, prêt à l'emploi, accepte uniquement "
-#~ "des coordonnées comme emplacement."
-
-#~ msgid ""
-#~ "DarkSky - Needs key, please click on 'Setup API Key and Location' for the "
-#~ "steps how to obtain one."
-#~ msgstr ""
-#~ "DarkSky - Nécessite une clé, veuillez cliquer sur 'Configurer la clé "
-#~ "d'API et l'emplacement' pour connaître les étapes à suivre pour l'obtenir."
-
-#~ msgid ""
-#~ "MET Norway - Current weather is shown for the next hour, and the daily "
-#~ "forecasts \n"
-#~ "are generated from 6 hour forecasts, so it can look incorrect sometimes."
-#~ msgstr ""
-#~ "MET Norway - La météo actuelle affichée est celle pour l'heure à venir et "
-#~ "les prévisions quotidiennes\n"
-#~ "sont générées à partir de prévisions sur 6 heures, ce qui peut parfois "
-#~ "sembler incorrect."
-
-#~ msgid ""
-#~ "WeatherBit - At least 10 minutes as refresh rate is recommended,\n"
-#~ "since otherwise you might exceed you daily quota."
-#~ msgstr ""
-#~ "WeatherBit - Un intervalle de mise à jour d'au moins 10 minutes est "
-#~ "recommandé\n"
-#~ "pour ne pas dépasser le quota de rafraîchissement quotidien autorisé."
-
-#~ msgid ""
-#~ "Yahoo - Requires 'python3-requests-oauthlib' package installed (for Arch\n"
-#~ "based distros 'python-requests-oauthlib'), Updates every 2 hours."
-#~ msgstr ""
-#~ "Yahoo! - Nécessite l'installation du paquet 'python3-requests-"
-#~ "oauthlib' (pour les distributions basées sur Arch\n"
-#~ " 'python-requests-oauthlib'). Actualisation toutes les 2 heures."
-
-#~ msgid "Updated"
-#~ msgstr "Mise à jour"
-
-#~ msgid ""
-#~ "WeatherBit - Minimum of 10min refresh rate is recommended or you might "
-#~ "exceed you daily quota.\n"
-#~ "Needs a key, please click on 'Setup API Key and Location' for the steps "
-#~ "how to obtain one."
-#~ msgstr ""
-#~ "WeatherBit - Un taux de rafraîchissement minimum de 10 minutes est "
-#~ "recommandé ou vous pourriez dépasser votre quota quotidien.\n"
-#~ "Si vous avez besoin d'une clé, veuillez cliquer sur 'Configurer la clé et "
-#~ "l'emplacement de l'API' pour les étapes pour en obtenir une."
-
-#~ msgid ""
-#~ "WeatherBit - Minimum of 10min refresh rate is recommended or you might "
-#~ "exceed you daily quota. Needs a key, please click on 'Setup API Key and "
-#~ "Location' for the steps how to obtain one."
-#~ msgstr ""
-#~ "WeatherBit - Un taux de rafraîchissement minimum de 10 minutes est "
-#~ "recommandé ou vous pourriez dépasser votre quota quotidien. Une clé est "
-#~ "requise, veuillez cliquer sur 'Configurer la clé API et l'emplacement' "
-#~ "pour les étapes pour en obtenir une."

--- a/weather@mockturtl/files/weather@mockturtl/po/he.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/he.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: weather@mockturtl 3.1.6\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-14 18:50+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2021-12-11 20:13+0200\n"
 "Last-Translator: Avi Markovitz <avi.markovitz@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -22,65 +23,65 @@ msgstr ""
 "X-Poedit-SearchPath-0: weather.pot\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:15249
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "שגיאה"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:15250 3.8/weather-applet.js:15252
-#: 3.8/weather-applet.js:15254 3.8/weather-applet.js:15257
-#: 3.8/weather-applet.js:15260 3.8/weather-applet.js:15261
-#: 3.8/weather-applet.js:15262 3.8/weather-applet.js:15263
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "שגיאת שירות"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:15251
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "מפתח API שגוי"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:15253
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "תבנית מקום שגויה"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:15255
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "מפתח נחסם"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:15256
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "לא ניתן למצוא מקום"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:15258
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "אין מפתח API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:15259
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "אין מיקום"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:15264
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "חבילות חסרות"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:15265
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "מיקום לא מכוסה"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9291
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "יישומון מזג־אוויר"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:15507
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:15508
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "נא להקיש לפתיחה"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:10897
-#: 3.8/weather-applet.js:15519
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "רענון"
 
@@ -90,8 +91,8 @@ msgstr "API החזיר קוד מצב בין 400 ו־500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9458
-#: 3.8/weather-applet.js:9462 3.8/weather-applet.js:9466
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "אחסון מיקום"
 
@@ -103,12 +104,12 @@ msgstr "לא ניתן לשמור מיקום שהושג באופן אוטומטי
 msgid "Could not get weather information"
 msgstr "לא ניתן לאחזר נתוני מזג־אויר"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:15356
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr "שגיאה בלתי צפויה בעת רענון מזג־אויר, נא לעיין ביומן בלוקינג־גלאס"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:15636
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -124,7 +125,7 @@ msgstr "שגיאת רשת, נא לבדוק יומנים בלוקינג־גלאס
 msgid "As of"
 msgstr "מאז"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:11583
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "מועצם על־ידי"
 
@@ -132,87 +133,86 @@ msgstr "מועצם על־ידי"
 msgid "from you"
 msgstr "ממך"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:11514
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "מילימטר"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:11514
-#: 3.8/weather-applet.js:11874
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "אינץ'"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10315
-#: 3.8/weather-applet.js:11644
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10316
-#: 3.8/weather-applet.js:11645
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "קמ״ש"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:11815
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "טעינת מזג־אויר נוכחי..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:11818
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "טעינת מזג־אויר עתידי..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:10836
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "טעינה..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:10862
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "מידות־חום"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:10863
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "לחות"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:10864
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "לחץ־אויר"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:10865 3.8/weather-applet.js:14684
-#: 3.8/weather-applet.js:14691 3.8/weather-applet.js:14692
-#: 3.8/weather-applet.js:14698
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "רוח"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:9784
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr "נא לוודא שהוזן מיקום או לעשות שימוש במיקום אוטומטי במקום זאת"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9538
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr "לא ניתן למצוא מיקום המבוסס על כתובת, נא לבדוק שהכתובת נכונה"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9559
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "קריאה ל־API Geolocation כשלה, לשגיאות נא לעיין בלוקינג־גלאס."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9458
-#: 3.8/weather-applet.js:9462
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "אזהרה"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9458
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "ניתן לשמור מיקומים באופן תקין רק כאשר היישומון אינו במצב רענון"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9462
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "לא ניתן לשמור מיקום שגוי"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9466
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "מידע"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9466
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "המיקום כבר נשמר"
 
@@ -248,14 +248,15 @@ msgstr "טעינת נתונים מאחסון המיקום כשלה, נא לעי�
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11934 3.8/weather-applet.js:12253
-#: 3.8/weather-applet.js:12816 3.8/weather-applet.js:13170
-#: 3.8/weather-applet.js:14278 3.8/weather-applet.js:14585
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "מרגיש כמו"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:11980
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "כשל בעיבוד נתוני מזג אויר"
 
@@ -268,7 +269,7 @@ msgstr ""
 "או לקבל אחד תחילה מ־https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:12010 3.8/weather-applet.js:13336
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -276,7 +277,7 @@ msgstr ""
 "נא לוודא שמפתח API\n"
 "הוזן באופן תקין ושהחשבון לא נעול"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:14551
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -287,58 +288,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10518 3.8/weather-applet.js:10525
-#: 3.8/weather-applet.js:10532 3.8/weather-applet.js:10533
-#: 3.8/weather-applet.js:13781 3.8/weather-applet.js:13782
-#: 3.8/weather-applet.js:13788 3.8/weather-applet.js:13795
-#: 3.8/weather-applet.js:13802 3.8/weather-applet.js:14448
-#: 3.8/weather-applet.js:14727
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "ממטרי גשם כבדים"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12959 3.8/weather-applet.js:13008
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13016
-#: 3.8/weather-applet.js:13956 3.8/weather-applet.js:13957
-#: 3.8/weather-applet.js:13963 3.8/weather-applet.js:14440
-#: 3.8/weather-applet.js:14712 3.8/weather-applet.js:14713
-#: 3.8/weather-applet.js:14719 3.8/weather-applet.js:14726
-#: 3.8/weather-applet.js:14768 3.8/weather-applet.js:14775
-#: 3.8/weather-applet.js:14782 3.8/weather-applet.js:15030
-#: 3.8/weather-applet.js:15031 3.8/weather-applet.js:15072
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "גשם"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10490
-#: 3.8/weather-applet.js:10497 3.8/weather-applet.js:10511
-#: 3.8/weather-applet.js:10512 3.8/weather-applet.js:12523
-#: 3.8/weather-applet.js:13865 3.8/weather-applet.js:13866
-#: 3.8/weather-applet.js:13872 3.8/weather-applet.js:13879
-#: 3.8/weather-applet.js:13886 3.8/weather-applet.js:14450
-#: 3.8/weather-applet.js:14720
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "גשם קל"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:14424 3.8/weather-applet.js:14783
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "גשם קופא כבד"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:12528
-#: 3.8/weather-applet.js:12980 3.8/weather-applet.js:12981
-#: 3.8/weather-applet.js:12987 3.8/weather-applet.js:12988
-#: 3.8/weather-applet.js:12994 3.8/weather-applet.js:14769
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "גשם קופא"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:14426 3.8/weather-applet.js:14776
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "גשם קופא קל"
 
@@ -346,174 +349,189 @@ msgstr "גשם קופא קל"
 msgid "Light freezing drizzle"
 msgstr "רסס קופא קל"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:14762
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "רסס קופא"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14406
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "רסס קל"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:14797
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "כדורי קרח כבדים"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:14789 3.8/weather-applet.js:14790
-#: 3.8/weather-applet.js:14796 3.8/weather-applet.js:14803
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "כדורי קרח"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:14804
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "כדורי קרח קלים"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10602
-#: 3.8/weather-applet.js:10609 3.8/weather-applet.js:10616
-#: 3.8/weather-applet.js:10617 3.8/weather-applet.js:12535
-#: 3.8/weather-applet.js:13837 3.8/weather-applet.js:13838
-#: 3.8/weather-applet.js:13844 3.8/weather-applet.js:13851
-#: 3.8/weather-applet.js:13858 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14755 3.8/weather-applet.js:15107
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "שלג כבד"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:12534 3.8/weather-applet.js:12952
-#: 3.8/weather-applet.js:12953 3.8/weather-applet.js:14012
-#: 3.8/weather-applet.js:14013 3.8/weather-applet.js:14019
-#: 3.8/weather-applet.js:14460 3.8/weather-applet.js:14733
-#: 3.8/weather-applet.js:14734 3.8/weather-applet.js:14747
-#: 3.8/weather-applet.js:14754 3.8/weather-applet.js:15016
-#: 3.8/weather-applet.js:15100
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "שלג"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10581
-#: 3.8/weather-applet.js:10588 3.8/weather-applet.js:10595
-#: 3.8/weather-applet.js:10596 3.8/weather-applet.js:12533
-#: 3.8/weather-applet.js:13921 3.8/weather-applet.js:13922
-#: 3.8/weather-applet.js:13928 3.8/weather-applet.js:13935
-#: 3.8/weather-applet.js:13942 3.8/weather-applet.js:14468
-#: 3.8/weather-applet.js:14748
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "שלג קל"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:14740
-#: 3.8/weather-applet.js:14741
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "פתיתי שלג"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:12508
-#: 3.8/weather-applet.js:13025 3.8/weather-applet.js:13026
-#: 3.8/weather-applet.js:14472 3.8/weather-applet.js:14810
-#: 3.8/weather-applet.js:14811 3.8/weather-applet.js:15114
-#: 3.8/weather-applet.js:15115
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "סופות רעמים"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:14678
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "ערפל קל"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10469 3.8/weather-applet.js:10470
-#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:13095
-#: 3.8/weather-applet.js:13096 3.8/weather-applet.js:13774
-#: 3.8/weather-applet.js:13775 3.8/weather-applet.js:14414
-#: 3.8/weather-applet.js:14670 3.8/weather-applet.js:14671
-#: 3.8/weather-applet.js:14677
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "ערפל"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10476 3.8/weather-applet.js:10477
-#: 3.8/weather-applet.js:13760 3.8/weather-applet.js:13761
-#: 3.8/weather-applet.js:14642 3.8/weather-applet.js:14643
-#: 3.8/weather-applet.js:15009 3.8/weather-applet.js:15010
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "מעונן"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12903
-#: 3.8/weather-applet.js:12904 3.8/weather-applet.js:12938
-#: 3.8/weather-applet.js:14663 3.8/weather-applet.js:14664
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "מעונן לרוב"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10441
-#: 3.8/weather-applet.js:10442 3.8/weather-applet.js:10448
-#: 3.8/weather-applet.js:10449 3.8/weather-applet.js:12896
-#: 3.8/weather-applet.js:12897 3.8/weather-applet.js:12931
-#: 3.8/weather-applet.js:13949 3.8/weather-applet.js:13950
-#: 3.8/weather-applet.js:14656 3.8/weather-applet.js:14657
-#: 3.8/weather-applet.js:15002 3.8/weather-applet.js:15003
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "מעונן חלקית"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:14649
-#: 3.8/weather-applet.js:14650
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "בהיר לרוב"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10427 3.8/weather-applet.js:10428
-#: 3.8/weather-applet.js:12553 3.8/weather-applet.js:12882
-#: 3.8/weather-applet.js:12883 3.8/weather-applet.js:12917
-#: 3.8/weather-applet.js:14484 3.8/weather-applet.js:14635
-#: 3.8/weather-applet.js:14636 3.8/weather-applet.js:14995
-#: 3.8/weather-applet.js:14996
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "ניקוי"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10434
-#: 3.8/weather-applet.js:10435 3.8/weather-applet.js:14635
-#: 3.8/weather-applet.js:14636
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "שמשי"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10420
-#: 3.8/weather-applet.js:10421 3.8/weather-applet.js:10455
-#: 3.8/weather-applet.js:10456 3.8/weather-applet.js:10644
-#: 3.8/weather-applet.js:10645 3.8/weather-applet.js:12873
-#: 3.8/weather-applet.js:12874 3.8/weather-applet.js:13102
-#: 3.8/weather-applet.js:13103 3.8/weather-applet.js:13743
-#: 3.8/weather-applet.js:13744 3.8/weather-applet.js:14041
-#: 3.8/weather-applet.js:14042 3.8/weather-applet.js:14627
-#: 3.8/weather-applet.js:14628
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "לא ידוע"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:11874
+#: 3.0/darkSky.js:71
 msgid "and"
 msgstr "ו־"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:11874
+#: 3.0/darkSky.js:71
 msgid "until"
 msgstr "עד"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:11874
+#: 3.0/darkSky.js:71
 msgid "Possible"
 msgstr "אפשרי"
 
@@ -525,7 +543,7 @@ msgstr ""
 "נא להזין מפתח API בהגדרות,\n"
 "או לקבל אחד תחילה מ־https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:12020
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -533,130 +551,130 @@ msgstr ""
 "א לוודא שמפתח API\n"
 "שנתקבל מדרקסקיי הוזן"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:9242
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "לא ניתן להשיג מיקום"
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:9248
+#: 3.0/ipApi.js:95
 msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr "שירות המיקום הגיב עם שגיאות, נא לעיין ביומנים בלוקניג־גלאס"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:13597
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "עננות"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:12554 3.8/weather-applet.js:13753
-#: 3.8/weather-applet.js:13754
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "שמיים בהירים"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:13767 3.8/weather-applet.js:13768
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "נאה"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:13789
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "גשם כבד ורעמים"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:13796
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "ממטרי גשם כבדים"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:13803
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "ממטרי גשם כבדים ורעמים"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:13809
-#: 3.8/weather-applet.js:13810 3.8/weather-applet.js:13816
-#: 3.8/weather-applet.js:13823 3.8/weather-applet.js:13830
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג כבדים"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:13817
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג ורעמים כבדים"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:13824
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג כבדים"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:13831
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג ורעמים כבדים"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:13845
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "ממטרי שלג כבדים ורעמים"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:13852
-#: 3.8/weather-applet.js:15108
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "ממטרי שלג כבדים"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:13859
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "ממטרי שלג כבדים ורעמים"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:13873
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "גשם קל ורעמים"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:13880
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "ממטרי גשם קלים"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:13887
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "ממטרי גשם קלים ורעמים"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:13893
-#: 3.8/weather-applet.js:13894 3.8/weather-applet.js:13900
-#: 3.8/weather-applet.js:13907 3.8/weather-applet.js:13914
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "גֶּשֶׁם־שֶׁלֶג קל"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:13901
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג ורעמים קלים"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:13908
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג קלים"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:13915
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג ורעמים קלים"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:13929
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "ממטרי שלג קלים ורעמים"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:13936
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "ממטרי שלג קלים"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:13943
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "ממטרי שלג קלים ורעמים"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:13964
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "גשם ורעמים"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:13017
-#: 3.8/weather-applet.js:13970 3.8/weather-applet.js:13971
-#: 3.8/weather-applet.js:13977 3.8/weather-applet.js:14446
-#: 3.8/weather-applet.js:15073 3.8/weather-applet.js:15079
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "ממטרי גשם"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:13978
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "ממטרי גשם ורעמים"
 
@@ -665,42 +683,44 @@ msgstr "ממטרי גשם ורעמים"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10539
-#: 3.8/weather-applet.js:10546 3.8/weather-applet.js:10553
-#: 3.8/weather-applet.js:10554 3.8/weather-applet.js:12536
-#: 3.8/weather-applet.js:12966 3.8/weather-applet.js:12967
-#: 3.8/weather-applet.js:12973 3.8/weather-applet.js:12974
-#: 3.8/weather-applet.js:13001 3.8/weather-applet.js:13002
-#: 3.8/weather-applet.js:13984 3.8/weather-applet.js:13985
-#: 3.8/weather-applet.js:13991 3.8/weather-applet.js:13998
-#: 3.8/weather-applet.js:14005
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "גֶּשֶׁם־שֶׁלֶג"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:13992
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "גֶּשֶׁם־שֶׁלֶג ורעמים"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:13999
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:14006
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג ורעמים"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:14020
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "שלג ורעמים"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:14026 3.8/weather-applet.js:14027
-#: 3.8/weather-applet.js:14033 3.8/weather-applet.js:14464
-#: 3.8/weather-applet.js:15101
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "ממטרי שלג"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:14034
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "ממטרי שלג ורעמים"
 
@@ -709,21 +729,21 @@ msgstr "ממטרי שלג ורעמים"
 msgid "Unexpected response from API"
 msgstr "תגובת API לא צפויה"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10241
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "ראות"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10268
-#: 3.8/weather-applet.js:12333 3.8/weather-applet.js:12828
-#: 3.8/weather-applet.js:13180
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "כשל בעיבוד נתוני מזג אויר נוכחי"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10060
-#: 3.8/weather-applet.js:10095 3.8/weather-applet.js:12631
-#: 3.8/weather-applet.js:13206 3.8/weather-applet.js:13240
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "כשל בעיבוד נתוני תחזית"
 
@@ -752,293 +772,300 @@ msgid "Excellent - More than"
 msgstr "מעולב - יותר מ־"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10462 3.8/weather-applet.js:10463
-#: 3.8/weather-applet.js:12543 3.8/weather-applet.js:14436
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "ערפילים"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10483
-#: 3.8/weather-applet.js:10484 3.8/weather-applet.js:12910
-#: 3.8/weather-applet.js:12911 3.8/weather-applet.js:12945
-#: 3.8/weather-applet.js:14480
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "מוּעָב"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10491
-#: 3.8/weather-applet.js:10498
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "ממטרי גשם קלים"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10504 3.8/weather-applet.js:10505
-#: 3.8/weather-applet.js:12515 3.8/weather-applet.js:14402
-#: 3.8/weather-applet.js:14705 3.8/weather-applet.js:14706
-#: 3.8/weather-applet.js:14761
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "רסס"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10519
-#: 3.8/weather-applet.js:10526
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "ממטרי גשם כבדים"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10540
-#: 3.8/weather-applet.js:10547
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "ממטרי גֶּשֶׁם־שֶׁלֶג"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10560 3.8/weather-applet.js:10567
-#: 3.8/weather-applet.js:10574 3.8/weather-applet.js:10575
-#: 3.8/weather-applet.js:14478
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "ברד"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10561
-#: 3.8/weather-applet.js:10568
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "מטר ברד"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10582
-#: 3.8/weather-applet.js:10589
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "ממטרי שלג קל"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10603
-#: 3.8/weather-applet.js:10610
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "מטר שלג כבד"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10623 3.8/weather-applet.js:10630
-#: 3.8/weather-applet.js:10637 3.8/weather-applet.js:10638
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "רעמים"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10624
-#: 3.8/weather-applet.js:10631
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "ממטר רעמים"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:12386
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "נא לוודא שהמיקום\n"
 "הוזן בהגדרות בתבנית תקינה"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:12390
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "נא לוודא שהוזן מפתח נכון בהגדרות"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:12394
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr "המיקום לא נמצא, נא לוודא שהמיקום זמין או שהוא בתבנית הנכונה"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:12398
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "אם הבעיה נמשכת, נא ליצור קשר עם כותב יישומון זה"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:12402
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "שגיאה לא ידועה, נא לעיין ביומנים בלוקניג־גלאס"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:12504
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "סופות רעמים עם גשם קל"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:12505
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "סופות רעמים עם גשם"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:12506
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "סופות רעמים עם גשם כבד"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:12507
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "סופות רעמים קלה"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:12509
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "סופות רעמים כבדה"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:12510
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "סופות רעמים סוערת"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:12511
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "סופות רעמים עם רסס קל"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:12512
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "סופות רעמים עם רסס"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:12513
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "סופות רעמים עם רסס כבד"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:12514
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "רסס בעצימות נמוכה"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:12516
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "רסס בעצימות גבוהה"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:12517
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "רסס גשם בעצימות נמוכה"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:12518
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "גשם רסס"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:12519
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "רסס גשם בעצימות גבוהה"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:12520
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "מטר גשם ורסס"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:12521
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "מטר גשם ורסס כבד"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:12522
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "מטר רסס"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:12524
-#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "גשם מתון"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:12525
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "גשם עצמתי מאוד"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:12526
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "גשם כבד מאוד"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:12527
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "גשם קיצוני"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:12529
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "ממטרי גשם בעצימות נמוכה"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:12530
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "מטר גשם"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:12531
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "ממטרי גשם בעצימות גבוהה"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:12532
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "מטר גשם סוער"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:12537
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "מטר ברד"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:12538
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "גשם קל ושלג"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:12539
-#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
-#: 3.8/weather-applet.js:15051 3.8/weather-applet.js:15086
-#: 3.8/weather-applet.js:15093
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "גשם ושלג"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:12540
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "ממטרי שלג קל"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:12541
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "מטר שלג"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:12542
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "ממטרי שלג כבדים"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:12544 3.8/weather-applet.js:13060
-#: 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "עשן"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:12545 3.8/weather-applet.js:13067
-#: 3.8/weather-applet.js:13068
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "אובך"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:12546
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "חול, מערבולת אבק"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:12548
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "חול"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:12549 3.8/weather-applet.js:13053
-#: 3.8/weather-applet.js:13054
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "אבק"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:12550
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "עפר וולקני"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:12551
-#: 3.8/weather-applet.js:14470
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "תזזי"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:12552 3.8/weather-applet.js:13032
-#: 3.8/weather-applet.js:13033
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "טורנדו"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:12555
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "שמיים בהירים"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:12556
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "עננים"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:12557
-#: 3.8/weather-applet.js:12889 3.8/weather-applet.js:12890
-#: 3.8/weather-applet.js:12924
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "עננים מעטים"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:12558
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "עננים פזורים"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:12559
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "עננים שבורים"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:12560
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "מוּעָב"
 
@@ -1046,77 +1073,80 @@ msgstr "מוּעָב"
 msgid "Could not get forecast for your area"
 msgstr "לא ניתן לאחזר תחזית למיקום שלכם"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12589
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "המיקום הוא מחוץ לארה\"ב, נא להשתמש בספק אחר."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12653
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "כשל בעיבוד נתוני תחזית שעתית"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12918
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "בהיר ומשבי־רוח"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12925
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "עננים מעטים ומשבי־רוח"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12932
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "מעונן חלקית ומשבי־רוח"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12939
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "מעונן לרוב ומשבי־רוח"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12946
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "מוּעָב ומשבי־רוח"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12960
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "גשם מושלג"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12995
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "גשם קופא ושלג"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:8706 3.8/weather-applet.js:13039
-#: 3.8/weather-applet.js:13040
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "הוריקן"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:8701
-#: 3.8/weather-applet.js:13046
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "סערה"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13047
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "סופה טרופית"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13074 3.8/weather-applet.js:13075
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "חם"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13081 3.8/weather-applet.js:13082
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "קר"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13088 3.8/weather-applet.js:13089
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "סוּפַת שֶׁלֶג"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:8590
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "היום"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:8592
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "מחר"
 
@@ -1148,79 +1178,79 @@ msgstr "שישי"
 msgid "Saturday"
 msgstr "שבת"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:8671
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "רגוע"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:8674
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "אויר קל"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:8677
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "משב קל"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:8680
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "משב עדין"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:8683
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "משב מתון"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:8686
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "משב מרענן"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:8689
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "משב חזק"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:8692
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "קרוב לסוער"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:8695
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "סוער"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:8698
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "סערה חזקה"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:8704
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "סערה אלימה"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8856
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "צפ'"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8856
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "צמז'"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8856
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "מז׳"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8856
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "דמז'"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8856
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "ד'"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8856
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "דמע'"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8856
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "מע'"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8856
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "צמע'"
 
@@ -1272,7 +1302,7 @@ msgstr ""
 "אירעה שגיאה לא ידועה בעת אחזור מזג־אויר,\n"
 "למידע נוסף, נא לעיין ביומנים בלוקניג־גלאס"
 
-#: 3.0/yahoo.js:437
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "סופה טרופית"
 
@@ -1280,7 +1310,7 @@ msgstr "סופה טרופית"
 msgid "Severe Thunderstorms"
 msgstr "סופות רעמים חמורות"
 
-#: 3.0/yahoo.js:440
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "סופות רעמים"
 
@@ -1296,15 +1326,15 @@ msgstr "גשם מעורב בשלג מימי"
 msgid "Mixed Snow and Sleet"
 msgstr "שלג מעורב בברד"
 
-#: 3.0/yahoo.js:444
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "רסס קופא"
 
-#: 3.0/yahoo.js:446
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "גשם קופא"
 
-#: 3.0/yahoo.js:447
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "ממטרים"
 
@@ -1316,11 +1346,11 @@ msgstr "פתיתי שלג"
 msgid "Light Snow Showers"
 msgstr "ממטרי שלג קלים"
 
-#: 3.0/yahoo.js:451
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "שלג נושב"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "מעורפל"
 
@@ -1332,47 +1362,54 @@ msgstr "אפוף עשן"
 msgid "Blustery"
 msgstr "רוחות עזות"
 
-#: 3.0/yahoo.js:460
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "משבי־רוח"
 
-#: 3.0/yahoo.js:463
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "מעונן לרוב"
 
-#: 3.0/yahoo.js:464
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "מעונן חלקית"
 
-#: 3.0/yahoo.js:467
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "שמשי לרוב"
 
-#: 3.0/yahoo.js:469
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "גשם מעורב בברד"
 
-#: 3.0/yahoo.js:471
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "סופות רעמים מקומיות"
 
-#: 3.0/yahoo.js:472
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "סופות רעמים פזורות"
 
-#: 3.0/yahoo.js:473
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "ממטרים פזורים"
 
-#: 3.0/yahoo.js:474
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "ממטרי גשם כבדים"
 
-#: 3.0/yahoo.js:475
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "ממטרי שלג פזורים"
 
-#: 3.0/yahoo.js:476
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "ממטרי שלג כבדים"
 
@@ -1384,7 +1421,7 @@ msgstr "לא זמין"
 msgid "Scattered Thundershowers"
 msgstr "סופות רעמים פזורות"
 
-#: 3.8/weather-applet.js:9181
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1392,7 +1429,7 @@ msgstr ""
 "לא ניתן לאחזר יומנים, לא נמצא קובץ יומן בנתיב\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9185
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1400,15 +1437,315 @@ msgstr ""
 "לא ניתן לאחזר תכולת קובץ יומן מנתיב\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:9897
+#. 3.0->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10283
+msgid "Met Office UK"
+msgstr "Met Office UK"
+
+#: 3.8/weather-applet.js:10388
 msgid ""
-"Could not retrieve config, file was not found under path\n"
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
+msgstr ""
+
+#: 3.8/weather-applet.js:10476
+msgid "Data was not found for location"
+msgstr "לא נמצא מידע למיקום"
+
+#: 3.8/weather-applet.js:10557
+msgid "Very poor"
+msgstr "חלש מאוד"
+
+#: 3.8/weather-applet.js:10557
+msgid "Less than {distance} {distanceUnit}"
+msgstr "פחות מ־{distance} {distanceUnit}"
+
+#: 3.8/weather-applet.js:10561
+msgid "Excellent"
+msgstr "מצוין"
+
+#: 3.8/weather-applet.js:10561
+msgid "More than {distance} {distanceUnit}"
+msgstr "יותר מ־{distance} {distanceUnit}"
+
+#: 3.8/weather-applet.js:10566
+msgid "Poor"
+msgstr "חלש"
+
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
+msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
+msgstr "בין {smallerDistance}-{biggerDistance} {distanceUnit}"
+
+#: 3.8/weather-applet.js:10571
+msgid "Moderate"
+msgstr "מתון"
+
+#: 3.8/weather-applet.js:10576
+msgid "Good"
+msgstr "טוב"
+
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
+msgid "Very good"
+msgstr "טוב מאוד"
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10942
+msgid "OpenWeatherMap"
+msgstr "OpenWeatherMap"
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:11396
+msgid "MET Norway"
+msgstr "MET Norway"
+
+#: 3.8/weather-applet.js:11955
+msgid "WeatherBit"
+msgstr "WeatherBit"
+
+#: 3.8/weather-applet.js:12386
+msgid "Tomorrow.io"
+msgstr "Tomorrow.io"
+
+#: 3.8/weather-applet.js:12561
+msgid "Light wind"
+msgstr "רוח קלה"
+
+#: 3.8/weather-applet.js:12575
+msgid "Strong wind"
+msgstr "רוח חזקה"
+
+#: 3.8/weather-applet.js:12723
+msgid "US Weather"
+msgstr "מזג־אוויר ארה\"ב"
+
+#: 3.8/weather-applet.js:13292
+msgid "Visual Crossing"
+msgstr "ויזואל קרוסינג"
+
+#: 3.8/weather-applet.js:13474
+msgid "Blowing or drifting snow"
+msgstr "שלג נושב או נסחף"
+
+#: 3.8/weather-applet.js:13478
+msgid "Heavy drizzle"
+msgstr "רסס קבד"
+
+#: 3.8/weather-applet.js:13482
+msgid "Heavy drizzle/rain"
+msgstr "גשם/גשם־רסס כבד"
+
+#: 3.8/weather-applet.js:13484
+msgid "Light drizzle/rain"
+msgstr "גשם/גשם־רסס קל"
+
+#: 3.8/weather-applet.js:13486
+msgid "Dust Storm"
+msgstr "סופת אבק"
+
+#: 3.8/weather-applet.js:13490
+msgid "Freezing drizzle/freezing rain"
+msgstr "רסס קופא/גשם קופא"
+
+#: 3.8/weather-applet.js:13492
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "רסס קופא/גשם קופא כבד"
+
+#: 3.8/weather-applet.js:13494
+msgid "Light freezing drizzle/freezing rain"
+msgstr "רסס קופא/גשם קופא קל"
+
+#: 3.8/weather-applet.js:13496
+msgid "Freezing fog"
+msgstr "ערפל קופא"
+
+#: 3.8/weather-applet.js:13502
+msgid "Funnel cloud/tornado"
+msgstr "ענן משפך/טורנדו"
+
+#: 3.8/weather-applet.js:13504
+msgid "Hail showers"
+msgstr "ממטרי ברד"
+
+#: 3.8/weather-applet.js:13506
+msgid "Ice"
+msgstr "קרח"
+
+#: 3.8/weather-applet.js:13508
+msgid "Lightning without thunder"
+msgstr "ברקים ללא רעמים"
+
+#: 3.8/weather-applet.js:13512
+msgid "Precipitation in vicinity"
+msgstr "משקעים בקרבה"
+
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
+msgid "Heavy rain and snow"
+msgstr "ממטרי גשם ושלג כבדים"
+
+#: 3.8/weather-applet.js:13518
+msgid "Light rain And snow"
+msgstr "גשם קל ושלג"
+
+#: 3.8/weather-applet.js:13526
+msgid "Sky coverage decreasing"
+msgstr "הצטמצמות כיסוי שמים"
+
+#: 3.8/weather-applet.js:13528
+msgid "Sky coverage increasing"
+msgstr "התרחבות כיסוי שמים"
+
+#: 3.8/weather-applet.js:13530
+msgid "Sky unchanged"
+msgstr "שמיים ללא שינוי"
+
+#: 3.8/weather-applet.js:13532
+msgid "Smoke or haze"
+msgstr "עשן או אובך"
+
+#: 3.8/weather-applet.js:13536
+msgid "Snow and rain showers"
+msgstr "ממטרי שלג וגשם"
+
+#: 3.8/weather-applet.js:13548
+msgid "Thunderstorm without precipitation"
+msgstr "סופת רעמים ללא משקעים"
+
+#: 3.8/weather-applet.js:13550
+msgid "Diamond dust"
+msgstr "אבק יהלומים"
+
+#: 3.8/weather-applet.js:13556
+msgid "Partially cloudy"
+msgstr "מעונן חלקית"
+
+#: 3.8/weather-applet.js:13578
+msgid "Please make sure you entered the API key correctly"
+msgstr "נא לוודא שמפתח API הוזן נכון"
+
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:13595
+msgid "DMI Denmark"
+msgstr "DMI Denmark"
+
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
+msgid "NOT FOUND"
+msgstr "לא נמצא"
+
+#: 3.8/weather-applet.js:13779
+msgid "Blowing snow"
+msgstr "שלג נושב"
+
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
+msgid "Slight snow"
+msgstr "שלג קליל"
+
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
+msgid "Moderate snow"
+msgstr "שלג מתון"
+
+#: 3.8/weather-applet.js:13842
+msgid "Moderate rain showers"
+msgstr "ממטרי גשם מתונים"
+
+#: 3.8/weather-applet.js:13849
+msgid "Mixed rain and snow"
+msgstr "גשם מעורב בשלג"
+
+#: 3.8/weather-applet.js:13856
+msgid "Heavy mixed rain and snow"
+msgstr "ממטרי גשם מעורב בשלג כבדים"
+
+#: 3.8/weather-applet.js:14024
+#, fuzzy
+msgid "AccuWeather"
+msgstr "מזג־אוויר"
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+#, fuzzy
+msgid "Weather Underground"
+msgstr "תנאי מזג־אוויר"
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+msgid "The location you provided was not found."
+msgstr ""
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+#, fuzzy
+msgid "Strong Storm"
+msgstr "משב חזק"
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "גשם ושלג"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "גשם מעורב בשלג מימי"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "ממטרי שלג"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "בהיר לרוב"
+
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "מזג־אוויר ארה\"ב"
+
+#: 3.8/weather-applet.js:15603
+#, fuzzy
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr "שירות המיקום הגיב עם שגיאות, נא לעיין ביומנים בלוקניג־גלאס"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr "נא לוודא שהוזן מיקום או לעשות שימוש במיקום אוטומטי במקום זאת"
+
+#: 3.8/weather-applet.js:15968
+#, fuzzy
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 "לא ניתן לאחזר תצורה, לא נמצא קובץ בנתיב\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:9901
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1416,277 +1753,69 @@ msgstr ""
 "לא ניתן לאחזר תכולת קובץ תצורה מנתיב\n"
 " {configFilePath}"
 
-#. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10022
-msgid "Met Office UK"
-msgstr "Met Office UK"
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "נדרש מפתח API לשרות זה על מנת שיפעל"
 
-#: 3.8/weather-applet.js:10206
-msgid "Data was not found for location"
-msgstr "לא נמצא מידע למיקום"
-
-#: 3.8/weather-applet.js:10281
-msgid "Very poor"
-msgstr "חלש מאוד"
-
-#: 3.8/weather-applet.js:10281
-msgid "Less than {distance} {distanceUnit}"
-msgstr "פחות מ־{distance} {distanceUnit}"
-
-#: 3.8/weather-applet.js:10285
-msgid "Excellent"
-msgstr "מצוין"
-
-#: 3.8/weather-applet.js:10285
-msgid "More than {distance} {distanceUnit}"
-msgstr "יותר מ־{distance} {distanceUnit}"
-
-#: 3.8/weather-applet.js:10290
-msgid "Poor"
-msgstr "חלש"
-
-#: 3.8/weather-applet.js:10290 3.8/weather-applet.js:10295
-#: 3.8/weather-applet.js:10300 3.8/weather-applet.js:10305
-#: 3.8/weather-applet.js:10310
-msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
-msgstr "בין {smallerDistance}-{biggerDistance} {distanceUnit}"
-
-#: 3.8/weather-applet.js:10295
-msgid "Moderate"
-msgstr "מתון"
-
-#: 3.8/weather-applet.js:10300
-msgid "Good"
-msgstr "טוב"
-
-#: 3.8/weather-applet.js:10305 3.8/weather-applet.js:10310
-msgid "Very good"
-msgstr "טוב מאוד"
-
-#: 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "נקודת הטל"
 
-#: 3.8/weather-applet.js:10985
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "משקעים יפסקו תוך {precipEnd} דקות"
 
-#: 3.8/weather-applet.js:10987
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "משקעים לא יפסקו תוך שעה"
 
-#: 3.8/weather-applet.js:10990
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "משקעים יחלו בעוד {precipStart} דקות"
 
-#: 3.8/weather-applet.js:11586 3.8/weather-applet.js:15364
+#: 3.8/weather-applet.js:16964
+msgid "Forecast parsing failed, see logs for more details."
+msgstr ""
+
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "מאז {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:11592
-msgid "{distance}{distanceUnit} from you"
+#: 3.8/weather-applet.js:17502
+#, fuzzy
+msgid "{distance} {distanceUnit} from you"
 msgstr "{distance}{distanceUnit} ממך"
 
-#: 3.8/weather-applet.js:11860
-msgid "DarkSky"
-msgstr "DarkSky"
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
 
-#: 3.8/weather-applet.js:11884
-msgid "This API has ceased to function, please use another one."
-msgstr "ה־API חדל לתפקד, נא להשתמש באחד אחר."
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
 
-#. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:12186
-msgid "OpenWeatherMap"
-msgstr "OpenWeatherMap"
-
-#: 3.8/weather-applet.js:12570
-msgid "US Weather"
-msgstr "מזג־אוויר ארה\"ב"
-
-#: 3.8/weather-applet.js:13119
-msgid "WeatherBit"
-msgstr "WeatherBit"
-
-#. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13537
-msgid "MET Norway"
-msgstr "MET Norway"
-
-#: 3.8/weather-applet.js:14221
-msgid "Visual Crossing"
-msgstr "ויזואל קרוסינג"
-
-#: 3.8/weather-applet.js:14400
-msgid "Blowing or drifting snow"
-msgstr "שלג נושב או נסחף"
-
-#: 3.8/weather-applet.js:14404
-msgid "Heavy drizzle"
-msgstr "רסס קבד"
-
-#: 3.8/weather-applet.js:14408
-msgid "Heavy drizzle/rain"
-msgstr "גשם/גשם־רסס כבד"
-
-#: 3.8/weather-applet.js:14410
-msgid "Light drizzle/rain"
-msgstr "גשם/גשם־רסס קל"
-
-#: 3.8/weather-applet.js:14412
-msgid "Dust Storm"
-msgstr "סופת אבק"
-
-#: 3.8/weather-applet.js:14416
-msgid "Freezing drizzle/freezing rain"
-msgstr "רסס קופא/גשם קופא"
-
-#: 3.8/weather-applet.js:14418
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "רסס קופא/גשם קופא כבד"
-
-#: 3.8/weather-applet.js:14420
-msgid "Light freezing drizzle/freezing rain"
-msgstr "רסס קופא/גשם קופא קל"
-
-#: 3.8/weather-applet.js:14422
-msgid "Freezing fog"
-msgstr "ערפל קופא"
-
-#: 3.8/weather-applet.js:14428
-msgid "Funnel cloud/tornado"
-msgstr "ענן משפך/טורנדו"
-
-#: 3.8/weather-applet.js:14430
-msgid "Hail showers"
-msgstr "ממטרי ברד"
-
-#: 3.8/weather-applet.js:14432
-msgid "Ice"
-msgstr "קרח"
-
-#: 3.8/weather-applet.js:14434
-msgid "Lightning without thunder"
-msgstr "ברקים ללא רעמים"
-
-#: 3.8/weather-applet.js:14438
-msgid "Precipitation in vicinity"
-msgstr "משקעים בקרבה"
-
-#: 3.8/weather-applet.js:14442 3.8/weather-applet.js:15052
-msgid "Heavy rain and snow"
-msgstr "ממטרי גשם ושלג כבדים"
-
-#: 3.8/weather-applet.js:14444
-msgid "Light rain And snow"
-msgstr "גשם קל ושלג"
-
-#: 3.8/weather-applet.js:14452
-msgid "Sky coverage decreasing"
-msgstr "הצטמצמות כיסוי שמים"
-
-#: 3.8/weather-applet.js:14454
-msgid "Sky coverage increasing"
-msgstr "התרחבות כיסוי שמים"
-
-#: 3.8/weather-applet.js:14456
-msgid "Sky unchanged"
-msgstr "שמיים ללא שינוי"
-
-#: 3.8/weather-applet.js:14458
-msgid "Smoke or haze"
-msgstr "עשן או אובך"
-
-#: 3.8/weather-applet.js:14462
-msgid "Snow and rain showers"
-msgstr "ממטרי שלג וגשם"
-
-#: 3.8/weather-applet.js:14474
-msgid "Thunderstorm without precipitation"
-msgstr "סופת רעמים ללא משקעים"
-
-#: 3.8/weather-applet.js:14476
-msgid "Diamond dust"
-msgstr "אבק יהלומים"
-
-#: 3.8/weather-applet.js:14482
-msgid "Partially cloudy"
-msgstr "מעונן חלקית"
-
-#: 3.8/weather-applet.js:14505
-msgid "Please make sure you entered the API key correctly"
-msgstr "נא לוודא שמפתח API הוזן נכון"
-
-#: 3.8/weather-applet.js:14519
-msgid "Tomorrow.io"
-msgstr "Tomorrow.io"
-
-#: 3.8/weather-applet.js:14685
-msgid "Light wind"
-msgstr "רוח קלה"
-
-#: 3.8/weather-applet.js:14699
-msgid "Strong wind"
-msgstr "רוח חזקה"
-
-#. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14843
-msgid "DMI Denmark"
-msgstr "DMI Denmark"
-
-#: 3.8/weather-applet.js:14984 3.8/weather-applet.js:14985
-#: 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
-msgid "NOT FOUND"
-msgstr "לא נמצא"
-
-#: 3.8/weather-applet.js:15017
-msgid "Blowing snow"
-msgstr "שלג נושב"
-
-#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
-msgid "Slight snow"
-msgstr "שלג קליל"
-
-#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
-msgid "Moderate snow"
-msgstr "שלג מתון"
-
-#: 3.8/weather-applet.js:15080
-msgid "Moderate rain showers"
-msgstr "ממטרי גשם מתונים"
-
-#: 3.8/weather-applet.js:15087
-msgid "Mixed rain and snow"
-msgstr "גשם מעורב בשלג"
-
-#: 3.8/weather-applet.js:15094
-msgid "Heavy mixed rain and snow"
-msgstr "ממטרי גשם מעורב בשלג כבדים"
-
-#: 3.8/weather-applet.js:15225 3.8/weather-applet.js:15235
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr ""
 "שגיאה בשמירת מידע ניפוי־תקלים\n"
 "\n"
 "%s"
 
-#: 3.8/weather-applet.js:15246
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "מידע ניפוי־תקלים נשמר בהצלחה"
 
-#: 3.8/weather-applet.js:15246
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "נשמר ל־{filePath}"
 
-#: 3.8/weather-applet.js:15325
-msgid "This provider requires an API key to operate"
-msgstr "נדרש מפתח API לשרות זה על מנת שיפעל"
-
-#: 3.8/LogSaver.py:13
+#: 3.8/LogSaver.py:16
 msgid "Save to File"
 msgstr "שמירה לקובץ"
+
+#: 3.8/LogSaver.py:29
+msgid "Select a destination"
+msgstr ""
 
 #. metadata.json->name
 #. 3.8->settings-schema.json->providers->title
@@ -1731,7 +1860,6 @@ msgid "Data service"
 msgstr "שרות נתונים"
 
 #. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
 msgid "DarkSky (key needed)"
 msgstr "DarkSky (נדרש מפתח)"
 
@@ -1962,7 +2090,6 @@ msgid "Override label on panel"
 msgstr "עקיפת תווית בלוחית"
 
 #. 3.0->settings-schema.json->tempTextOverride->tooltip
-#. 3.8->settings-schema.json->tempTextOverride->tooltip
 msgid ""
 "Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
 "Can be used if label does not fit on vertical panel, among other smart "
@@ -2033,8 +2160,9 @@ msgid "Only display hours for hourly forecast time"
 msgstr "הצגת שעות בתחזית שעתית בלבד"
 
 #. 3.0->settings-schema.json->shortHourlyTime->tooltip
-msgid "Instead of 15:00 or 3 pm it will show up as 15 or 3 pm"
-msgstr "במקום 15:00 או 3 pm, יוצג כ־15 או 3 pm"
+#. 3.8->settings-schema.json->shortHourlyTime->tooltip
+msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
+msgstr "במקום 15:00 או 3 pm, זמן יוצג כ־15 או 3 pm"
 
 #. 3.0->settings-schema.json->showForecastDates->description
 #. 3.8->settings-schema.json->showForecastDates->description
@@ -2158,6 +2286,10 @@ msgstr ""
 "בפירוט באתר תבליני סינמון, אליו ניתן לגשת באמצעות הלחצן שבלשונית עזרה."
 
 #. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Met Office UK (UK only)"
 msgstr "Met Office UK (הממלכה הבריטית בלבד)"
 
@@ -2166,12 +2298,27 @@ msgid "US National Weather (US only)"
 msgstr "US National Weather (ארה\"ב בלבד)"
 
 #. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Pirate Weather (key needed)"
+msgstr "Weatherbit (נדרש מפתח)"
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Visual Crossing (key needed)"
 msgstr "Visual Crossing (נדרש מפתח)"
 
 #. 3.8->settings-schema.json->dataService->options
 msgid "Tomorrow.io (key needed)"
 msgstr "Tomorrow.io (נדרש מפתח)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "AccuWeather (key needed)"
+msgstr "Weatherbit (נדרש מפתח)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Weather Underground (key needed)"
+msgstr "Weatherbit (נדרש מפתח)"
 
 #. 3.8->settings-schema.json->location->tooltip
 msgid ""
@@ -2185,6 +2332,12 @@ msgstr ""
 "להשתמש בקוד 'עיר, מדינה' (למשל לונדון, בריטניה) או לנסות להזין {House "
 "number} {Street} {City/Town} {Postcode} {Country}. אלגוריתם החיפוש גמיש מאוד "
 "במבנה. לאחר 3 שניות ללא הקלדה, הכתובת שהזנה מוחלפת אוטומטית לשם אימות הבחירה."
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
 
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"
@@ -2211,9 +2364,20 @@ msgstr ""
 "שכמות הגישות לשרות לא תחרוג מהמכסה שהוקצתה."
 
 #. 3.8->settings-schema.json->forecastDays->tooltip
+#, fuzzy
 msgid ""
-"Maximum number of days that can be displayed, maximum rows and columns "
-"setting in the Presentation tab will affect the final number."
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+"מספר ימים מרבי הניתנים להצגה, הגדרות השורות והעמודות המרביות בלשונית המצג "
+"ישפיעו על המספר הסופי."
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+#, fuzzy
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
 msgstr ""
 "מספר ימים מרבי הניתנים להצגה, הגדרות השורות והעמודות המרביות בלשונית המצג "
 "ישפיעו על המספר הסופי."
@@ -2223,10 +2387,11 @@ msgid "Enable minutely precipitation forecast"
 msgstr "אפשור תחזית משקעים דקתית"
 
 #. 3.8->settings-schema.json->immediatePrecip->tooltip
+#, fuzzy
 msgid ""
 "If you'd like to use this make sure you use your exact coordinates/address "
-"as location to help its accuracy. Currently implemented with OpenWeatherMap "
-"only."
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
 msgstr ""
 "במידה ונעשה בזה שימוש, נא לוודא שימוש בכתובת/נקודת־ציון מפורשים לאחזור "
 "נתונים מדויקים. כרגע מיושם עם OpenWeatherMap בלבד."
@@ -2234,6 +2399,27 @@ msgstr ""
 #. 3.8->settings-schema.json->showBothTempUnits->description
 msgid "Show both temperature units at the same time"
 msgstr "הצגת שני סוגי יחידות מידת־חום בו זמנית"
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+#, fuzzy
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+"ערכים זמינים: {c} תנאים, {t} מידת־חום ו־{u} יחידה.\n"
+"ניתן לשימוש אם התווית אינה מתאימה ללוח אנכי, בין יתר הדברים החכמים."
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+#, fuzzy
+msgid "Override tooltip on panel"
+msgstr "עקיפת תווית בלוחית"
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
 
 #. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
 msgid "Always show Hourly Weather"
@@ -2292,10 +2478,6 @@ msgstr "הצג כיוון רוח כמלל"
 #. 3.8->settings-schema.json->displayWindAsText->tooltip
 msgid "Like SE, N instead of direction icons."
 msgstr "כמו צמ', צ' במקום סמלי כיוון."
-
-#. 3.8->settings-schema.json->shortHourlyTime->tooltip
-msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
-msgstr "במקום 15:00 או 3 pm, זמן יוצג כ־15 או 3 pm"
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"
@@ -2363,11 +2545,11 @@ msgid ""
 "format. After 3 seconds without typing the address you entered is replaced "
 "automatically for validating your choice."
 msgstr ""
-"המיקום ברוב המקרים יפעל אוטומטית, אך ניתן להזין אותו באופן ידני לפי נקודת־"
-"ציון 'קו רוחב, קו אורך' (כדוגמת 51.5085, – 0.1257) או להשתמש בקוד 'עיר, "
-"מדינה' (למשל לונדון, בריטניה) או לנסות להזין {House number} {Street} {City/"
-"Town} {Postcode} {Country}. אלגוריתם החיפוש גמיש מאוד במבנה. לאחר 3 שניות "
-"ללא הקלדה, הכתובת שהזנה מוחלפת אוטומטית לשם אימות הבחירה."
+"המיקום ברוב המקרים יפעל אוטומטית, אך ניתן להזין אותו באופן ידני לפי "
+"נקודת־ציון 'קו רוחב, קו אורך' (כדוגמת 51.5085, – 0.1257) או להשתמש בקוד "
+"'עיר, מדינה' (למשל לונדון, בריטניה) או לנסות להזין {House number} {Street} "
+"{City/Town} {Postcode} {Country}. אלגוריתם החיפוש גמיש מאוד במבנה. לאחר 3 "
+"שניות ללא הקלדה, הכתובת שהזנה מוחלפת אוטומטית לשם אימות הבחירה."
 
 #. 3.8->settings-schema.json->logLevel->description
 msgid "Log Level"

--- a/weather@mockturtl/files/weather@mockturtl/po/hr.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/hr.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-18 08:53+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2022-03-04 19:11+0100\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian <hr@li.org>\n"
@@ -16,69 +17,69 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:15684
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Greška"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:15685 3.8/weather-applet.js:15687
-#: 3.8/weather-applet.js:15689 3.8/weather-applet.js:15692
-#: 3.8/weather-applet.js:15695 3.8/weather-applet.js:15696
-#: 3.8/weather-applet.js:15697 3.8/weather-applet.js:15698
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Greška usluge"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:15686
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Neispravan API ključ"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:15688
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Neispravan format lokacije"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:15690
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Ključ je blokiran"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:15691
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Nemoguć pronalazak lokacije"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:15693
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Nema API ključa"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:15694
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Nema lokacije"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:15699
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Nedostaje paket"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:15700
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Lokacija nije pokrivena"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9299
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Aplet vremena"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:15963
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:15964
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Klikni za otvaranje"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:14508
-#: 3.8/weather-applet.js:15975
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Osvježi"
 
@@ -88,8 +89,8 @@ msgstr "API je vratio kôd stanja između 400 i 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9465
-#: 3.8/weather-applet.js:9469 3.8/weather-applet.js:9473
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Pohrana lokacije"
 
@@ -101,14 +102,14 @@ msgstr "Ne možete spremiti automatski dobivenu lokaciju, nažalost"
 msgid "Could not get weather information"
 msgstr "Nemoguće dobivanje informacija vremena"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:15795
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Dogodila se neočekivana greška pri osvježavanju vremena, pogledajte Cinnamon "
 "napredne kontrole i upravljanje"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:16053
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -126,7 +127,7 @@ msgstr ""
 msgid "As of"
 msgstr "Nadopunjeno u"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:15197
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Pogonjeno od strane"
 
@@ -134,92 +135,91 @@ msgstr "Pogonjeno od strane"
 msgid "from you"
 msgstr "od vas"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:15128
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:10257
-#: 3.8/weather-applet.js:15128
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "u"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:9895
-#: 3.8/weather-applet.js:15262
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:9896
-#: 3.8/weather-applet.js:15263
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:15433
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Učitavanje trenutne prognoze..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:15436
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Učitavanje buduće prognoze..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:14447
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Učitavanje..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:14473
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:14474
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Vlažnost"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:14475
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Tlak"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12105 3.8/weather-applet.js:12112
-#: 3.8/weather-applet.js:12113 3.8/weather-applet.js:12119
-#: 3.8/weather-applet.js:14476
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Vjetar"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:14017
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Pobrinite se da ste upisali lokaciju ili umjesto koristite Automatsku "
 "lokaciju"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9545
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Nemoguć pronalazak lokacije temeljene na adresi, provjerite je li ispravna"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9566
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Neuspjeli poziv Geolocation API-ja, pogledajte Napredne kontrole i "
 "upravljanja za više grešaka."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9465
-#: 3.8/weather-applet.js:9469
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Upozorenje"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9465
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "Možete spremiti samo ispravne lokacije kada se aplet ne osvježava"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9469
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Ne možete spremiti neispravnu lokaciju"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9473
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Informacije"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9473
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Lokacija je već spremljena"
 
@@ -257,14 +257,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10338 3.8/weather-applet.js:10645
-#: 3.8/weather-applet.js:11570 3.8/weather-applet.js:12008
-#: 3.8/weather-applet.js:12510 3.8/weather-applet.js:12872
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Kao da je"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:10383
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Neuspjela obrada informacija vremena"
 
@@ -277,7 +278,7 @@ msgstr ""
 "ili ga nabavite na https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:10266 3.8/weather-applet.js:11740
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -285,7 +286,7 @@ msgstr ""
 "Pobrinite se da ste upisali API ključ\n"
 "ispravno i vaš račun nije zaključan"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:11974
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -296,58 +297,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10096 3.8/weather-applet.js:10103
-#: 3.8/weather-applet.js:10110 3.8/weather-applet.js:10111
-#: 3.8/weather-applet.js:11201 3.8/weather-applet.js:11202
-#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11215
-#: 3.8/weather-applet.js:11222 3.8/weather-applet.js:12148
-#: 3.8/weather-applet.js:13038
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Jaka kiša"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11376 3.8/weather-applet.js:11377
-#: 3.8/weather-applet.js:11383 3.8/weather-applet.js:12133
-#: 3.8/weather-applet.js:12134 3.8/weather-applet.js:12140
-#: 3.8/weather-applet.js:12147 3.8/weather-applet.js:12189
-#: 3.8/weather-applet.js:12196 3.8/weather-applet.js:12203
-#: 3.8/weather-applet.js:12654 3.8/weather-applet.js:12703
-#: 3.8/weather-applet.js:12704 3.8/weather-applet.js:12711
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13297
-#: 3.8/weather-applet.js:13298 3.8/weather-applet.js:13339
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Kiša"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10068
-#: 3.8/weather-applet.js:10075 3.8/weather-applet.js:10089
-#: 3.8/weather-applet.js:10090 3.8/weather-applet.js:10914
-#: 3.8/weather-applet.js:11285 3.8/weather-applet.js:11286
-#: 3.8/weather-applet.js:11292 3.8/weather-applet.js:11299
-#: 3.8/weather-applet.js:11306 3.8/weather-applet.js:12141
-#: 3.8/weather-applet.js:13040
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Slaba kiša"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12204 3.8/weather-applet.js:13014
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Jaka ledena kiša"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:10919
-#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12675
-#: 3.8/weather-applet.js:12676 3.8/weather-applet.js:12682
-#: 3.8/weather-applet.js:12683 3.8/weather-applet.js:12689
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Ledena kiša"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12197 3.8/weather-applet.js:13016
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Slaba ledena kiša"
 
@@ -355,173 +358,189 @@ msgstr "Slaba ledena kiša"
 msgid "Light freezing drizzle"
 msgstr "Slabo ledeno rominjanje"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12183
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Ledeno rominjanje"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12996
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Slabo rominjanje"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12218
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Jaka tuča"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12210 3.8/weather-applet.js:12211
-#: 3.8/weather-applet.js:12217 3.8/weather-applet.js:12224
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Tuča"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12225
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Slaba tuča"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10180
-#: 3.8/weather-applet.js:10187 3.8/weather-applet.js:10194
-#: 3.8/weather-applet.js:10195 3.8/weather-applet.js:10926
-#: 3.8/weather-applet.js:11257 3.8/weather-applet.js:11258
-#: 3.8/weather-applet.js:11264 3.8/weather-applet.js:11271
-#: 3.8/weather-applet.js:11278 3.8/weather-applet.js:12176
-#: 3.8/weather-applet.js:13056 3.8/weather-applet.js:13374
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Jak snijeg"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:10925 3.8/weather-applet.js:11432
-#: 3.8/weather-applet.js:11433 3.8/weather-applet.js:11439
-#: 3.8/weather-applet.js:12154 3.8/weather-applet.js:12155
-#: 3.8/weather-applet.js:12168 3.8/weather-applet.js:12175
-#: 3.8/weather-applet.js:12647 3.8/weather-applet.js:12648
-#: 3.8/weather-applet.js:13050 3.8/weather-applet.js:13283
-#: 3.8/weather-applet.js:13367
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Snijeg"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10159
-#: 3.8/weather-applet.js:10166 3.8/weather-applet.js:10173
-#: 3.8/weather-applet.js:10174 3.8/weather-applet.js:10924
-#: 3.8/weather-applet.js:11341 3.8/weather-applet.js:11342
-#: 3.8/weather-applet.js:11348 3.8/weather-applet.js:11355
-#: 3.8/weather-applet.js:11362 3.8/weather-applet.js:12169
-#: 3.8/weather-applet.js:13058
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Slab snijeg"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12161
-#: 3.8/weather-applet.js:12162
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Snježni pljusak"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10899
-#: 3.8/weather-applet.js:12231 3.8/weather-applet.js:12232
-#: 3.8/weather-applet.js:12720 3.8/weather-applet.js:12721
-#: 3.8/weather-applet.js:13062 3.8/weather-applet.js:13381
-#: 3.8/weather-applet.js:13382
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Grmljavinski pljusak"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12099
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Slaba magla"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10047 3.8/weather-applet.js:10048
-#: 3.8/weather-applet.js:10938 3.8/weather-applet.js:11194
-#: 3.8/weather-applet.js:11195 3.8/weather-applet.js:12091
-#: 3.8/weather-applet.js:12092 3.8/weather-applet.js:12098
-#: 3.8/weather-applet.js:12790 3.8/weather-applet.js:12791
-#: 3.8/weather-applet.js:13004
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Magla"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10054 3.8/weather-applet.js:10055
-#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11181
-#: 3.8/weather-applet.js:12063 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:13276 3.8/weather-applet.js:13277
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Oblačno"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12084
-#: 3.8/weather-applet.js:12085 3.8/weather-applet.js:12598
-#: 3.8/weather-applet.js:12599 3.8/weather-applet.js:12633
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Pretežno oblačno"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10019
-#: 3.8/weather-applet.js:10020 3.8/weather-applet.js:10026
-#: 3.8/weather-applet.js:10027 3.8/weather-applet.js:11369
-#: 3.8/weather-applet.js:11370 3.8/weather-applet.js:12077
-#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12591
-#: 3.8/weather-applet.js:12592 3.8/weather-applet.js:12626
-#: 3.8/weather-applet.js:13269 3.8/weather-applet.js:13270
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Djelomično oblačno"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12070
-#: 3.8/weather-applet.js:12071
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Pretežno vedro"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10005 3.8/weather-applet.js:10006
-#: 3.8/weather-applet.js:10944 3.8/weather-applet.js:12056
-#: 3.8/weather-applet.js:12057 3.8/weather-applet.js:12577
-#: 3.8/weather-applet.js:12578 3.8/weather-applet.js:12612
-#: 3.8/weather-applet.js:13074 3.8/weather-applet.js:13262
-#: 3.8/weather-applet.js:13263
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Vedro"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10012
-#: 3.8/weather-applet.js:10013 3.8/weather-applet.js:12056
-#: 3.8/weather-applet.js:12057
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Sunčano"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:9998 3.8/weather-applet.js:9999
-#: 3.8/weather-applet.js:10033 3.8/weather-applet.js:10034
-#: 3.8/weather-applet.js:10222 3.8/weather-applet.js:10223
-#: 3.8/weather-applet.js:11163 3.8/weather-applet.js:11164
-#: 3.8/weather-applet.js:11461 3.8/weather-applet.js:11462
-#: 3.8/weather-applet.js:12048 3.8/weather-applet.js:12049
-#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12569
-#: 3.8/weather-applet.js:12797 3.8/weather-applet.js:12798
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Nepoznato"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10257
+#: 3.0/darkSky.js:71
 msgid "and"
 msgstr "i"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10257
+#: 3.0/darkSky.js:71
 msgid "until"
 msgstr "do"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10257
+#: 3.0/darkSky.js:71
 msgid "Possible"
 msgstr "Moguće"
 
@@ -533,7 +552,7 @@ msgstr ""
 "Upišite API ključ u postavkama,\n"
 "ili ga nabavite na https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:10276
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -541,132 +560,132 @@ msgstr ""
 "Pobrinite se da ste upisali\n"
 "API ključ dobiven od DarkSkya"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:9251
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Nemoguće dobivanje lokacije"
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:9257
+#: 3.0/ipApi.js:95
 msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 "Usluga lokacije je odgovorila greškom, pogledajte zapise u Cinnamon "
 "naprednim kontrolama i upravljanju"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11022
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Naoblaka"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:10945 3.8/weather-applet.js:11173
-#: 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Vedro"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11187 3.8/weather-applet.js:11188
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Vedro"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11209
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Jaka olujna kiša"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11216
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Snažni snježni pljuskvi"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11223
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Snažni olujni snježni pljuskovi"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11229
-#: 3.8/weather-applet.js:11230 3.8/weather-applet.js:11236
-#: 3.8/weather-applet.js:11243 3.8/weather-applet.js:11250
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Jaka susnježica"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11237
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Jaka olujna susnježica"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11244
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Snažan snježni pljusak"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11251
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Snažan olujni snježni pljusak"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11265
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Jak snijeg s grmljavinom"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11272
-#: 3.8/weather-applet.js:13375
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Snažan snježni pljusak"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11279
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Snažan snježni pljusak s grmljavinom"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11293
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Slaba kiša s grmljavinom"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11300
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Slabi pljuskovi"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11307
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Slabi pljuskovi s grmljavinom"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:11320
-#: 3.8/weather-applet.js:11327 3.8/weather-applet.js:11334
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Slaba susnježica"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11321
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Slaba susnježica s grmljavinom"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11328
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Slab snježni pljusak"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11335
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Slab snježni pljusak s grmljavinom"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11349
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Slabi snjeg s grmljavinom"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11356
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Slab snježni pljusak"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11363
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Slab snježni pljusak s grmljavinom"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11384
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Kiša s grmljavinom"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11390
-#: 3.8/weather-applet.js:11391 3.8/weather-applet.js:11397
-#: 3.8/weather-applet.js:12712 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13340 3.8/weather-applet.js:13346
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Kišni pljuskovi"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11398
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Kišni pljuskovi s grmljavinom"
 
@@ -675,42 +694,44 @@ msgstr "Kišni pljuskovi s grmljavinom"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10117
-#: 3.8/weather-applet.js:10124 3.8/weather-applet.js:10131
-#: 3.8/weather-applet.js:10132 3.8/weather-applet.js:10927
-#: 3.8/weather-applet.js:11404 3.8/weather-applet.js:11405
-#: 3.8/weather-applet.js:11411 3.8/weather-applet.js:11418
-#: 3.8/weather-applet.js:11425 3.8/weather-applet.js:12661
-#: 3.8/weather-applet.js:12662 3.8/weather-applet.js:12668
-#: 3.8/weather-applet.js:12669 3.8/weather-applet.js:12696
-#: 3.8/weather-applet.js:12697
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Susnježica"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11412
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Susnježica s grmljavinom"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11419
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Snježni pljusak"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11426
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Snježni pljusak s grmljavinom"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11440
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Snjeg s grmljavinom"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11446 3.8/weather-applet.js:11447
-#: 3.8/weather-applet.js:11453 3.8/weather-applet.js:13054
-#: 3.8/weather-applet.js:13368
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Snježni pljusak"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11454
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Snježni pljusak s grmljavinom"
 
@@ -719,20 +740,21 @@ msgstr "Snježni pljusak s grmljavinom"
 msgid "Unexpected response from API"
 msgstr "Neočekivan API odgovor"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:9820
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Vidljivost"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:9848 3.8/weather-applet.js:10722
-#: 3.8/weather-applet.js:11581 3.8/weather-applet.js:12523
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Neuspjela obrada trenutnih informacija vremena"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:9645
-#: 3.8/weather-applet.js:9679 3.8/weather-applet.js:11607
-#: 3.8/weather-applet.js:11641 3.8/weather-applet.js:12328
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Neuspjela obrada informacije prognoze"
 
@@ -761,85 +783,88 @@ msgid "Excellent - More than"
 msgstr "Izvrsno - Manje od"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10040 3.8/weather-applet.js:10041
-#: 3.8/weather-applet.js:10934 3.8/weather-applet.js:13026
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Sumaglica"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10061
-#: 3.8/weather-applet.js:10062 3.8/weather-applet.js:12605
-#: 3.8/weather-applet.js:12606 3.8/weather-applet.js:12640
-#: 3.8/weather-applet.js:13070
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Oblačno"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10069
-#: 3.8/weather-applet.js:10076
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Slabi pljuskovi"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10082 3.8/weather-applet.js:10083
-#: 3.8/weather-applet.js:10906 3.8/weather-applet.js:12126
-#: 3.8/weather-applet.js:12127 3.8/weather-applet.js:12182
-#: 3.8/weather-applet.js:12992
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Rominjanje"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10097
-#: 3.8/weather-applet.js:10104
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Jači pljuskovi"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10118
-#: 3.8/weather-applet.js:10125
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Snježni pljusak"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10138 3.8/weather-applet.js:10145
-#: 3.8/weather-applet.js:10152 3.8/weather-applet.js:10153
-#: 3.8/weather-applet.js:13068
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Tuča"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10139
-#: 3.8/weather-applet.js:10146
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Jaka tuča"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10160
-#: 3.8/weather-applet.js:10167
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Slab snježni pljusak"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10181
-#: 3.8/weather-applet.js:10188
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Snažan snježni pljusak"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10201 3.8/weather-applet.js:10208
-#: 3.8/weather-applet.js:10215 3.8/weather-applet.js:10216
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Grmljavina"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10202
-#: 3.8/weather-applet.js:10209
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Grmljavinski pljuskovi"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10777
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Pobrinite se da je lokacija u postavkama upisana ispravnim formatom"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10781
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Pobrinite se da ste upisali ispravan ključ u postavkama"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10785
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -847,209 +872,213 @@ msgstr ""
 "Lokacija nije pronađena, pobrinite se da je lokacija dostupna ili da je "
 "upisana u ispravnom formatu"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10789
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Ako se problem nastavi, kontaktirajte autora ovog apleta"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10793
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 "Nepoznata greška, pogledajte zapise Cinnamon naprednim kontrolama i "
 "upravljanju"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10895
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Grmljavinski pljusak sa slabom kišom"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10896
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Grmljavinski pljusak s kišom"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10897
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Grmljavinski pljusak s jakom kišom"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10898
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Slabi grmljavinski pljusak"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10900
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Snažni grmljavinski pljusak"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10901
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Oštri grmljavinski pljusak"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10902
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Grmljavinski pljusak sa slabim rominjanjem"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10903
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Grmljavinski pljusak s rominjanjem"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10904
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Grmljavinski pljusak s jačim rominjanjem"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:10905
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Slabo rominjanje"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:10907
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Jače rominjanje"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:10908
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Kiša sa slabim rominjanjem"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:10909
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Kiša s rominjanjem"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:10910
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Kiša s jačim rominjanjem"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:10911
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Pljusak s rominjanjem"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:10912
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Jak pljusak s rominjanjem"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:10913
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Pljusak s rominjanjem"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:10915
-#: 3.8/weather-applet.js:13304 3.8/weather-applet.js:13305
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Umjerena kiša"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:10916
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Jaka kiša"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:10917
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Vrlo jaka kiša"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:10918
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Olujna kiša"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:10920
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Slabi pljuskovi"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:10921
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Pljuskovi"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:10922
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Jači pljuskovi"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:10923
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Oštri pljuskovi"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:10928
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Susnježica ili pljuskovi"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:10929
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Slaba kiša sa snijegom"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:10930
-#: 3.8/weather-applet.js:13311 3.8/weather-applet.js:13312
-#: 3.8/weather-applet.js:13318 3.8/weather-applet.js:13353
-#: 3.8/weather-applet.js:13360
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Kiša sa snijegom"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:10931
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Slab sniježni pljusak"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:10932
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Sniježni pljusak"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:10933
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Snažan sniježni pljusak"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:10935 3.8/weather-applet.js:12755
-#: 3.8/weather-applet.js:12756
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Dim"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:10936 3.8/weather-applet.js:12762
-#: 3.8/weather-applet.js:12763
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Izmaglica"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:10937
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Pijesak, vrtlozi prašine"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:10939
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Pijesak"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:10940 3.8/weather-applet.js:12748
-#: 3.8/weather-applet.js:12749
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Prašina"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:10941
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Vulkanski pepeo"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:10942
-#: 3.8/weather-applet.js:13060
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Udari vjetra"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:10943 3.8/weather-applet.js:12727
-#: 3.8/weather-applet.js:12728
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:10946
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Vedro"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:10947
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Oblačno"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:10948
-#: 3.8/weather-applet.js:12584 3.8/weather-applet.js:12585
-#: 3.8/weather-applet.js:12619
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Mjestimično oblačno"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:10949
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Raspršeni oblaci"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:10950
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Razbijeni oblaci"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:10951
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Naoblaka"
 
@@ -1057,77 +1086,80 @@ msgstr "Naoblaka"
 msgid "Could not get forecast for your area"
 msgstr "Nemoguće dobivanje prognoze za vaše područje"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12285
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "Lokacija je van SAD-a, koristite drugog pružatelja usluge."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12349
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Neuspjela obrada informacije prognoze po satu"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12613
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Vedro i vjetrovito"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12620
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Mjestimično oblačno i vjetrovito"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12627
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Djelomično oblačno i vjetrovito"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12634
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Pretežno oblačno i vjetrovito"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12641
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Oblačno i vjetrovito"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12655
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Susnježica"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12690
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Ledena kiša sa snijegom"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:8714 3.8/weather-applet.js:12734
-#: 3.8/weather-applet.js:12735
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Uragan"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:8709
-#: 3.8/weather-applet.js:12741
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Oluja"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12742
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Tropska oluja"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12769 3.8/weather-applet.js:12770
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Vruće"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12776 3.8/weather-applet.js:12777
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Hladno"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12783 3.8/weather-applet.js:12784
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Mećava"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:8587
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Danas"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:8589
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Sutra"
 
@@ -1159,79 +1191,79 @@ msgstr "Petak"
 msgid "Saturday"
 msgstr "Subota"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:8679
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Mirno"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:8682
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Slabašan povjetarac"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:8685
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Slabi povjetarac"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:8688
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Lagani povjetarac"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:8691
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Umjereni povjetarac"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:8694
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Osvježavajući povjetarac"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:8697
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Snažan povjetarac"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:8700
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Umjeren vjetar"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:8703
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Vjetar"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:8706
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Snažan vjetar"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:8712
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Snažna oluja"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8862
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8862
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "SI"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8862
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "I"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8862
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "JI"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8862
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "J"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8862
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "JZ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8862
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "Z"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8862
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "SZ"
 
@@ -1283,7 +1315,7 @@ msgstr ""
 "Dogodila se nepoznata greška pri nabavljanju informacija vremena, pogledajte "
 "Napredne kontrole i upravljanja za više grešaka"
 
-#: 3.0/yahoo.js:437
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Tropska oluja"
 
@@ -1291,7 +1323,7 @@ msgstr "Tropska oluja"
 msgid "Severe Thunderstorms"
 msgstr "Grmljavinske oluje"
 
-#: 3.0/yahoo.js:440
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Oluje"
 
@@ -1307,15 +1339,15 @@ msgstr "Kiša sa susnježicom"
 msgid "Mixed Snow and Sleet"
 msgstr "Snijeg sa susnježicom"
 
-#: 3.0/yahoo.js:444
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Ledeno rominjanje"
 
-#: 3.0/yahoo.js:446
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Ledena kiša"
 
-#: 3.0/yahoo.js:447
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Pljuskovi"
 
@@ -1327,11 +1359,11 @@ msgstr "Snježni naleti"
 msgid "Light Snow Showers"
 msgstr "Slab sniježni pljusak"
 
-#: 3.0/yahoo.js:451
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Snježni zapusi"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13290 3.8/weather-applet.js:13291
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Maglovito"
 
@@ -1343,47 +1375,54 @@ msgstr "Dim"
 msgid "Blustery"
 msgstr "Vijavica"
 
-#: 3.0/yahoo.js:460
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Vjetrovito"
 
-#: 3.0/yahoo.js:463
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Pretežno oblačno"
 
-#: 3.0/yahoo.js:464
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Djelomično oblačno"
 
-#: 3.0/yahoo.js:467
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Pretežno sunčano"
 
-#: 3.0/yahoo.js:469
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Kiša sa susnježicom"
 
-#: 3.0/yahoo.js:471
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Lokalne grmljavinske oluje"
 
-#: 3.0/yahoo.js:472
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Mjestimične grmljavinske oluje"
 
-#: 3.0/yahoo.js:473
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Mjestimični pljuskovi"
 
-#: 3.0/yahoo.js:474
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Jaka kiša"
 
-#: 3.0/yahoo.js:475
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Mjestimični snježni pljuskovi"
 
-#: 3.0/yahoo.js:476
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Jak snijeg"
 
@@ -1395,7 +1434,7 @@ msgstr "Nedostupno"
 msgid "Scattered Thundershowers"
 msgstr "Mjestimične grmljavinske oluje"
 
-#: 3.8/weather-applet.js:9190
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1403,7 +1442,7 @@ msgstr ""
 "Nemoguće dobivanje zapisa, datoteka zapisa nije pronađena u putanji\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9194
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1412,243 +1451,317 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:9606
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:9786
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
+msgstr ""
+
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Nema pronađenih podataka za lokaciju"
 
-#: 3.8/weather-applet.js:9861
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Vrlo slabo"
 
-#: 3.8/weather-applet.js:9861
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Manje od {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:9865
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Izvrsno"
 
-#: 3.8/weather-applet.js:9865
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Više od {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:9870
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Slabo"
 
-#: 3.8/weather-applet.js:9870 3.8/weather-applet.js:9875
-#: 3.8/weather-applet.js:9880 3.8/weather-applet.js:9885
-#: 3.8/weather-applet.js:9890
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Između {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:9875
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Umjereno"
 
-#: 3.8/weather-applet.js:9880
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Dobro"
 
-#: 3.8/weather-applet.js:9885 3.8/weather-applet.js:9890
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Vrlo dobro"
 
-#: 3.8/weather-applet.js:10242
-msgid "DarkSky"
-msgstr "DarkSky"
-
-#: 3.8/weather-applet.js:10293
-msgid "This API has ceased to function, please use another one."
-msgstr "Ovaj API je prestao funkcionirati, upotrijebite drugi."
-
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10569
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10963
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norveška"
 
-#: 3.8/weather-applet.js:11520
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:11943
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12106
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Slab vjetar"
 
-#: 3.8/weather-applet.js:12120
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Snažan vjetar"
 
-#: 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:12815
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:12990
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Snježni zapusi"
 
-#: 3.8/weather-applet.js:12994
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Jače rominjanje"
 
-#: 3.8/weather-applet.js:12998
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Kiša s jačim rominjanjem"
 
-#: 3.8/weather-applet.js:13000
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Kiša sa slabim rominjanjem"
 
-#: 3.8/weather-applet.js:13002
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Pješčana oluja"
 
-#: 3.8/weather-applet.js:13006
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Ledeno rominjanje s kišom"
 
-#: 3.8/weather-applet.js:13008
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Jako ledeno rominjanje s kišom"
 
-#: 3.8/weather-applet.js:13010
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Slabo ledeno rominjanje s kišom"
 
-#: 3.8/weather-applet.js:13012
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Ledena magla"
 
-#: 3.8/weather-applet.js:13018
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Tornado/Pijavica"
 
-#: 3.8/weather-applet.js:13020
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Pljusak s tučom"
 
-#: 3.8/weather-applet.js:13022
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Led"
 
-#: 3.8/weather-applet.js:13024
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Munje bez grmljavine"
 
-#: 3.8/weather-applet.js:13028
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Oborine u blizini"
 
-#: 3.8/weather-applet.js:13032 3.8/weather-applet.js:13319
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Jaka olujna kiša sa snjegom"
 
-#: 3.8/weather-applet.js:13034
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Slaba kiša sa snijegom"
 
-#: 3.8/weather-applet.js:13042
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Smanjenje naoblake"
 
-#: 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Povećanje naoblake"
 
-#: 3.8/weather-applet.js:13046
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Naoblaka nepromjenjena"
 
-#: 3.8/weather-applet.js:13048
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Dim ili sumaglica"
 
-#: 3.8/weather-applet.js:13052
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Pljuskovi sa snjegom"
 
-#: 3.8/weather-applet.js:13064
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Grmljavinsko nevrijeme bez oborina"
 
-#: 3.8/weather-applet.js:13066
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Ledene iglice"
 
-#: 3.8/weather-applet.js:13072
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Djelomično oblačno"
 
-#: 3.8/weather-applet.js:13094
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Pobrinite se da ste upisali  API ključ ispravno"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13110
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:13252
-#: 3.8/weather-applet.js:13388 3.8/weather-applet.js:13389
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "NIJE PRONAĐENO"
 
-#: 3.8/weather-applet.js:13284
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Snježni zapusi"
 
-#: 3.8/weather-applet.js:13325 3.8/weather-applet.js:13326
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Slab snijeg"
 
-#: 3.8/weather-applet.js:13332 3.8/weather-applet.js:13333
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Umjereni snijeg"
 
-#: 3.8/weather-applet.js:13347
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Umjereni snježni pljuskvi"
 
-#: 3.8/weather-applet.js:13354
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Kiša sa snijegom"
 
-#: 3.8/weather-applet.js:13361
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Jaka kiša sa snijegom"
 
-#: 3.8/weather-applet.js:13458
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:14130
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+#, fuzzy
+msgid "Weather Underground"
+msgstr "Vremenska stanja"
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+#, fuzzy
+msgid "The location you provided was not found."
+msgstr "Nema postavljene lokacije"
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+#, fuzzy
+msgid "Strong Storm"
+msgstr "Snažan povjetarac"
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "Kiša sa snijegom"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "Kiša sa susnježicom"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+msgid "Snow Showers"
+msgstr "Snježni pljusak"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "Pretežno vedro"
+
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:15603
+#, fuzzy
 msgid ""
-"Could not retrieve config, file was not found under path\n"
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+"Usluga lokacije je odgovorila greškom, pogledajte zapise u Cinnamon "
+"naprednim kontrolama i upravljanju"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+"Pobrinite se da ste upisali lokaciju ili umjesto koristite Automatsku "
+"lokaciju"
+
+#: 3.8/weather-applet.js:15968
+#, fuzzy
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 "Nemoguće dobivanje podešavanja, datoteka nije pronađena u putanji\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1656,49 +1769,57 @@ msgstr ""
 "Nemoguće dobivanje sadržaja podešavanja u putanji\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:14470
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Ovaj pružatelj usluge zahtijeva API ključ kako bi radio"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Točka rošenja"
 
-#: 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Oborine će završiti za {precipEnd} minuta"
 
-#: 3.8/weather-applet.js:14598
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "Oborine neće završiti u sljedećih sat vremena"
 
-#: 3.8/weather-applet.js:14601
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Oborine će početi za {precipStart} minuta"
 
-#: 3.8/weather-applet.js:14804
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Obrada prognoze neuspjela, pogledajte zapise za više pojedinosti."
 
-#: 3.8/weather-applet.js:15204 3.8/weather-applet.js:15803
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "Kao da je {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:15210
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} od vas"
 
-#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:15670
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Greška spremanja informacija otklanjanja grešaka"
 
-#: 3.8/weather-applet.js:15681
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Informacije otklanjanja grešaka uspješno spremljene"
 
-#: 3.8/weather-applet.js:15681
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Spremljeno u {filePath}"
-
-#: 3.8/weather-applet.js:15762
-msgid "This provider requires an API key to operate"
-msgstr "Ovaj pružatelj usluge zahtijeva API ključ kako bi radio"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -1751,7 +1872,6 @@ msgid "Data service"
 msgstr "Usluga prognoze"
 
 #. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
 msgid "DarkSky (key needed)"
 msgstr "DarkSky (ključ nije potreban)"
 
@@ -2185,12 +2305,21 @@ msgstr ""
 "Cinnamon dodataka kojoj možete pristupiti putem tipke na kartici Pomoći."
 
 #. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Met Office UK (UK only)"
 msgstr "Met Office UK (samo UK)"
 
 #. 3.8->settings-schema.json->dataService->options
 msgid "US National Weather (US only)"
 msgstr "US National Weather (Samo SAD)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Pirate Weather (key needed)"
+msgstr "Weatherbit (ključ nije potreban)"
 
 #. 3.8->settings-schema.json->dataService->options
 msgid "Visual Crossing (key needed)"
@@ -2203,6 +2332,11 @@ msgstr "Tomorrow.io (ključ je potreban)"
 #. 3.8->settings-schema.json->dataService->options
 msgid "AccuWeather (key needed)"
 msgstr "AccuWeather (ključ je potreban)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Weather Underground (key needed)"
+msgstr "Weatherbit (ključ nije potreban)"
 
 #. 3.8->settings-schema.json->location->tooltip
 msgid ""
@@ -2218,6 +2352,12 @@ msgstr ""
 "Algoritam pretrage je vrlo prilagodljiv s formatom. Nakon 3 sekunde bez "
 "tipkanja adresa koju ste upisali je zamijenjena automatski prema vešem "
 "odabiru."
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
 
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"
@@ -2265,10 +2405,11 @@ msgid "Enable minutely precipitation forecast"
 msgstr "Omogući precizniju prognozu"
 
 #. 3.8->settings-schema.json->immediatePrecip->tooltip
+#, fuzzy
 msgid ""
 "If you'd like to use this make sure you use your exact coordinates/address "
-"as location to help its accuracy. Currently implemented with OpenWeatherMap "
-"only."
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
 msgstr ""
 "Ako želite koristiti ovu mogućnost pobrinite se da koristite točne "
 "koordinate/adresu kao i lokaciju za precizniju točnost. Trenutno je "
@@ -2289,6 +2430,16 @@ msgstr ""
 "jedinica.\n"
 "Može biti korisno ako stanje ne pristaje na okomit panel, uz ostale manje "
 "stvari."
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+#, fuzzy
+msgid "Override tooltip on panel"
+msgstr "Zaobiđi stanje na panelu"
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
 
 #. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
 msgid "Always show Hourly Weather"
@@ -2460,166 +2611,3 @@ msgstr ""
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr "Odabrana putanja za spremanje zapisa"
-
-#~ msgid "Light Snow"
-#~ msgstr "Slab snijeg"
-
-#~ msgid "API key doesn't provide access to Hourly Weather, skipping"
-#~ msgstr "API ključ ne pruža pristup prognozi po satu, preskakanje"
-
-#~ msgid "Please install '{missingPackage}', then refresh manually."
-#~ msgstr "Instalirajte '{missingPackage}', zatim ručno osvježite."
-
-#~ msgid "Instead of 15:00 or 3 pm it will show up as 15 or 3 pm"
-#~ msgstr "Umjesto 15:00 ili 3 pm biti će prikazano 15 ili 3 pm"
-
-#~ msgid "Currently only used with DarkSky."
-#~ msgstr "Trenutno se samo koristi s DarkSky."
-
-#~ msgid "ClimacellV4 (key needed)"
-#~ msgstr "ClimacellV4 (ključ je potreban)"
-
-#~ msgid "ClimacellV3 (key needed)"
-#~ msgstr "ClimacellV3 (ključ je potreban)"
-
-#~ msgid "Settings"
-#~ msgstr "Postavke"
-
-#~ msgid "No location provided"
-#~ msgstr "Nema postavljene lokacije"
-
-#~ msgid "Cloudiness:"
-#~ msgstr "Naoblaka:"
-
-#~ msgid "Sunrise"
-#~ msgstr "Izlazak sunca"
-
-#~ msgid "Sunset"
-#~ msgstr "Zalazak sunca"
-
-#~ msgid "Service Unavailable"
-#~ msgstr "Usluga nedostupna"
-
-#~ msgid "Wrong API Key"
-#~ msgstr "Neispravan API ključ"
-
-#~ msgid "City Not found"
-#~ msgstr "Grad nije pronađen"
-
-#~ msgid "Key Temp. Blocked"
-#~ msgstr "Ključ temp. blokiran"
-
-#~ msgid "Clear Sky"
-#~ msgstr "Vedro"
-
-#~ msgid "Ligth Rain"
-#~ msgstr "Slaba kiša"
-
-#~ msgid "Rain Showers"
-#~ msgstr "Kišni pljuskovi"
-
-#~ msgid "Snow Showers"
-#~ msgstr "Snježni pljusak"
-
-#~ msgid "Substantial Rain"
-#~ msgstr "Obilna kiša"
-
-#~ msgid "Substantial Freezing Rain"
-#~ msgstr "Obilna ledena kiša"
-
-#~ msgid "Substantial Ice Pellets"
-#~ msgstr "Obilna tuča"
-
-#~ msgid "Substantial Snow"
-#~ msgstr "Obilan snjeg"
-
-#~ msgid "Please enter location in the correct format (coordinates)"
-#~ msgstr "Upišite lokaciju u ispravnom formatu (koordinate)"
-
-#~ msgid "Settings for weather@mockturtl 1.8+"
-#~ msgstr "Postavke za weather@mockturtl 1.8+"
-
-#~ msgid "Weather Provider Settings"
-#~ msgstr "Postavke pružatelja usluge"
-
-#~ msgid ""
-#~ "Acceptable inputs: City,CountryCode or Zipcode,CountryCode or Latitude,"
-#~ "Longtitude"
-#~ msgstr ""
-#~ "Prihvatljivi upisi, Grad,Kôd zemlje ili poštanski broj,Kôd zemlje ili "
-#~ "Zemljopisna širina/dužina"
-
-#~ msgid "Personal Settings"
-#~ msgstr "Osobne postavke"
-
-#~ msgid "Vertical orientation"
-#~ msgstr "Okomita orijentacija"
-
-#~ msgid "Translate condition"
-#~ msgstr "Prikaži prevedeno trentno stanje vremena"
-
-#~ msgid "Symbolic icons"
-#~ msgstr "Prikaži simboličke ikone"
-
-#~ msgid "Acceptable inputs is Latitude,Longtitude"
-#~ msgstr "Prihvatljivi upisi su zemljopisna širina i dužina"
-
-#~ msgid ""
-#~ "powered by: OpenWeatherMap, DarkSky, MET Norway, Weatherbit,\n"
-#~ "Yahoo and ip-api. Big Thanks to OpenWeatherMap for their FOSS support!"
-#~ msgstr ""
-#~ "pogonjeno od strane: OpenWeatherMap, DarkSky, MET Norway, Weatherbit,\n"
-#~ "Yahoo i ip-api. Veliko hvala OpenWeatherMap za njihovu FOSS podršku!"
-
-#~ msgid "Settings for weather@mockturtl 3.8+"
-#~ msgstr "Postavke za weather@mockturtl 3.8+"
-
-#~ msgid "Weather provider information"
-#~ msgstr "Informacije pružatelja prognoze"
-
-#~ msgid ""
-#~ "powered by: OpenWeatherMap, DarkSky, MET Norway, Weatherbit, Yahoo and ip-"
-#~ "api. Big Thanks to OpenWeatherMap for their FOSS support!"
-#~ msgstr ""
-#~ "pogonjeno od strane: OpenWeatherMap, DarkSky, MET Norway, Weatherbit, "
-#~ "Yahoo i ip-api. Veliko hvala OpenWeatherMap za njihovu FOSS podršku!"
-
-#~ msgid "Updated"
-#~ msgstr "Nadopunjeno"
-
-#~ msgid "Wrong Location"
-#~ msgstr "Pogrešna lokacija"
-
-#~ msgid "Parsing weather information failed :("
-#~ msgstr "Neuspjela obrada informacije prognoze :("
-
-#~ msgid "No Api Key provided"
-#~ msgstr "Nema Api ključa lokacije"
-
-#~ msgid "Copy this from your account on OpenWeatherMap and paste it here."
-#~ msgstr ""
-#~ "Kopirajte ključ s vašeg OpenWeatherMap računa i zalijepite ga ovdje."
-
-#~ msgid "Wind Chill:"
-#~ msgstr "Kao da je:"
-
-#~ msgid "Get WOEID"
-#~ msgstr "Nabavite WOEID kôd"
-
-#~ msgid "http://woeid.rosselliot.co.nz/"
-#~ msgstr "http://woeid.rosselliot.co.nz/"
-
-#~ msgid "WOEID"
-#~ msgstr "WOEID"
-
-#~ msgid "Where On Earth ID"
-#~ msgstr "ID vaše lokacije"
-
-#~ msgid "kPa"
-#~ msgstr "kPa"
-
-#~ msgid "mbar"
-#~ msgstr "mbar"
-
-#~ msgid "http://edg3.co.uk/snippets/weather-location-codes/"
-#~ msgstr "http://edg3.co.uk/snippets/weather-location-codes/"

--- a/weather@mockturtl/files/weather@mockturtl/po/hu.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/hu.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: oversteer\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-01 22:49+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2024-02-09 19:05+0100\n"
 "Last-Translator: Vajda Örs <ors0092@gmail.com>\n"
 "Language-Team: \n"
@@ -19,65 +20,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17615
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Hiba"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17616 3.8/weather-applet.js:17618
-#: 3.8/weather-applet.js:17620 3.8/weather-applet.js:17623
-#: 3.8/weather-applet.js:17626 3.8/weather-applet.js:17627
-#: 3.8/weather-applet.js:17628 3.8/weather-applet.js:17629
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Szolgáltató hiba"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17617
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Rossz API-kulcs"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17619
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Hibás földrajzi helyzetformátum"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17621
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Kulcs ideiglenesen letilva"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17622
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Földrajzi helyzet nem található"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17624
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Nincs API-kulcs megadva"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17625
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "A földrajzi helyzet nincs megadva"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17630
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Hiányzó csomag"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17631
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "A földrajzi helyzetről nincs információ"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9711
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Időjárás kisalkalmazás"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17929
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "…"
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17930
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Megnyitás"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16220
-#: 3.8/weather-applet.js:17933
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Frissítés"
 
@@ -87,8 +88,8 @@ msgstr "Az API 400 és 500 közötti állapotkóddal hibát jelzett"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Földrajzi helyzet tároló"
 
@@ -100,14 +101,14 @@ msgstr "Az automatikusan megállapított földrajzi helyzet nem menthető el"
 msgid "Could not get weather information"
 msgstr "Az időjárás információk nem kérhetők le"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17768
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Ismeretlen hiba lépett fel frissítés közben, a hibaüzenet megtekinthető a "
 "Looking Glass naplóban"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:18011
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -125,7 +126,7 @@ msgstr ""
 msgid "As of"
 msgstr "Ekkorra:"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:17011
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Időjárási-adatszolgáltató:"
 
@@ -133,52 +134,52 @@ msgstr "Időjárási-adatszolgáltató:"
 msgid "from you"
 msgstr "öntől"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16924
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:16924
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "múlva"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10312
-#: 3.8/weather-applet.js:17089
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10313
-#: 3.8/weather-applet.js:17090
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17267
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Időjárás betöltése…"
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17270
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Időjárás-előrejelzés betöltése…"
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16173
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "(betöltés…)"
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16194
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Hőmérséklet"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16195
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Páratartalom"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16196
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Légnyomás"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12257 3.8/weather-applet.js:12263
-#: 3.8/weather-applet.js:14217 3.8/weather-applet.js:14218
-#: 3.8/weather-applet.js:16042
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Szél"
 
@@ -188,40 +189,39 @@ msgstr ""
 "Ellenőrizze hogy van-e földrajzi helyzet megadva vagy használja az "
 "automatikus helyzet-meghatározást"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9952
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Cím alapján nem található a földrajzi helyzet. Ellenőrizze a megadott "
 "adatokat"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9973
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Nem sikerült a helymeghatározási API meghívása a hibaüzenetek megtekinthetők "
 "a Looking Glass naplóban."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Figyelmeztetés"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9872
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Csak akkor távolítható el a földrajzi helyzet, ha a kisalkalmazás éppen nem "
 "áll frissítés alatt"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Nem menthető el a nem megfelelő földrajzi helyzet"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9880
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Információ"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "A földrajzi helyzet már el lett mentve"
 
@@ -260,15 +260,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10740 3.8/weather-applet.js:11711
-#: 3.8/weather-applet.js:12150 3.8/weather-applet.js:12659
-#: 3.8/weather-applet.js:13021 3.8/weather-applet.js:14388
-#: 3.8/weather-applet.js:14928
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Hőérzet"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:14990
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Nem sikerült feldolgozni az időjárás-jelentést"
 
@@ -281,14 +281,14 @@ msgstr ""
 "vagy szerezzen egyet a https://developer.climacell.co/sign-up oldalról"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:14870
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
 msgstr ""
 "Ellenőrizze hogy az API kulcs helyes és a felhasználói fiók nincs blokkolva"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12113
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -299,60 +299,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10516 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10530 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:11379 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:11386 3.8/weather-applet.js:11393
-#: 3.8/weather-applet.js:11400 3.8/weather-applet.js:12292
-#: 3.8/weather-applet.js:13187
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Erős eső"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11554 3.8/weather-applet.js:11555
-#: 3.8/weather-applet.js:11561 3.8/weather-applet.js:12277
-#: 3.8/weather-applet.js:12278 3.8/weather-applet.js:12284
-#: 3.8/weather-applet.js:12291 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12340 3.8/weather-applet.js:12347
-#: 3.8/weather-applet.js:12801 3.8/weather-applet.js:12850
-#: 3.8/weather-applet.js:12851 3.8/weather-applet.js:12858
-#: 3.8/weather-applet.js:13179 3.8/weather-applet.js:13448
-#: 3.8/weather-applet.js:13449 3.8/weather-applet.js:13490
-#: 3.8/weather-applet.js:14189 3.8/weather-applet.js:14190
-#: 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Eső"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10495 3.8/weather-applet.js:10509
-#: 3.8/weather-applet.js:10510 3.8/weather-applet.js:11009
-#: 3.8/weather-applet.js:11463 3.8/weather-applet.js:11464
-#: 3.8/weather-applet.js:11470 3.8/weather-applet.js:11477
-#: 3.8/weather-applet.js:11484 3.8/weather-applet.js:12285
-#: 3.8/weather-applet.js:13189
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Enyhe eső"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12348 3.8/weather-applet.js:13163
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Erős ónos eső"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11014
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12822
-#: 3.8/weather-applet.js:12823 3.8/weather-applet.js:12829
-#: 3.8/weather-applet.js:12830 3.8/weather-applet.js:12836
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Ónos eső"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12341 3.8/weather-applet.js:13165
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Szórványos ónos eső"
 
@@ -360,177 +360,177 @@ msgstr "Szórványos ónos eső"
 msgid "Light freezing drizzle"
 msgstr "Enyhe ónos eső"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12327
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Jeges szitálás"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13145
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Enyhe szitáló eső"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12362
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Erős jég eső"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12354 3.8/weather-applet.js:12355
-#: 3.8/weather-applet.js:12361 3.8/weather-applet.js:12368
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Jégeső"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12369
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Enyhe jégeső"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10600
-#: 3.8/weather-applet.js:10607 3.8/weather-applet.js:10614
-#: 3.8/weather-applet.js:10615 3.8/weather-applet.js:11021
-#: 3.8/weather-applet.js:11435 3.8/weather-applet.js:11436
-#: 3.8/weather-applet.js:11442 3.8/weather-applet.js:11449
-#: 3.8/weather-applet.js:11456 3.8/weather-applet.js:12320
-#: 3.8/weather-applet.js:13205 3.8/weather-applet.js:13525
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Erős havazás"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:11610
-#: 3.8/weather-applet.js:11611 3.8/weather-applet.js:11617
-#: 3.8/weather-applet.js:12298 3.8/weather-applet.js:12299
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12795
-#: 3.8/weather-applet.js:13199 3.8/weather-applet.js:13434
-#: 3.8/weather-applet.js:13518 3.8/weather-applet.js:14203
-#: 3.8/weather-applet.js:14204 3.8/weather-applet.js:14581
-#: 3.8/weather-applet.js:14582
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Havazás"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11019
-#: 3.8/weather-applet.js:11519 3.8/weather-applet.js:11520
-#: 3.8/weather-applet.js:11526 3.8/weather-applet.js:11533
-#: 3.8/weather-applet.js:11540 3.8/weather-applet.js:12313
-#: 3.8/weather-applet.js:13207
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Enyhe havazás"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12305
-#: 3.8/weather-applet.js:12306 3.8/weather-applet.js:14560
-#: 3.8/weather-applet.js:14561
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Széllökések"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:12375 3.8/weather-applet.js:12376
-#: 3.8/weather-applet.js:12867 3.8/weather-applet.js:12868
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13532
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:14210
-#: 3.8/weather-applet.js:14211
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Vihar"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12243
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Enyhe köd"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11372
-#: 3.8/weather-applet.js:11373 3.8/weather-applet.js:12235
-#: 3.8/weather-applet.js:12236 3.8/weather-applet.js:12242
-#: 3.8/weather-applet.js:12937 3.8/weather-applet.js:12938
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:14161
-#: 3.8/weather-applet.js:14162 3.8/weather-applet.js:14609
-#: 3.8/weather-applet.js:14610
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Köd"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10474 3.8/weather-applet.js:10475
-#: 3.8/weather-applet.js:11358 3.8/weather-applet.js:11359
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:12208
-#: 3.8/weather-applet.js:13427 3.8/weather-applet.js:13428
-#: 3.8/weather-applet.js:14154 3.8/weather-applet.js:14155
-#: 3.8/weather-applet.js:14651 3.8/weather-applet.js:14652
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Felhős"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12228
-#: 3.8/weather-applet.js:12229 3.8/weather-applet.js:12745
-#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:12780
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Nagyrészt felhős"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10439
-#: 3.8/weather-applet.js:10440 3.8/weather-applet.js:10446
-#: 3.8/weather-applet.js:10447 3.8/weather-applet.js:11547
-#: 3.8/weather-applet.js:11548 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12222 3.8/weather-applet.js:12738
-#: 3.8/weather-applet.js:12739 3.8/weather-applet.js:12773
-#: 3.8/weather-applet.js:13420 3.8/weather-applet.js:13421
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Közepesen felhős"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Nagyrészt tiszta"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10425 3.8/weather-applet.js:10426
-#: 3.8/weather-applet.js:11039 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:12724
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12759
-#: 3.8/weather-applet.js:13223 3.8/weather-applet.js:13413
-#: 3.8/weather-applet.js:13414 3.8/weather-applet.js:14140
-#: 3.8/weather-applet.js:14141 3.8/weather-applet.js:14147
-#: 3.8/weather-applet.js:14148 3.8/weather-applet.js:14686
-#: 3.8/weather-applet.js:14687
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Tiszta"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10432
-#: 3.8/weather-applet.js:10433 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:14693
-#: 3.8/weather-applet.js:14694
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Napos"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10418
-#: 3.8/weather-applet.js:10419 3.8/weather-applet.js:10453
-#: 3.8/weather-applet.js:10454 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10643 3.8/weather-applet.js:11341
-#: 3.8/weather-applet.js:11342 3.8/weather-applet.js:11639
-#: 3.8/weather-applet.js:11640 3.8/weather-applet.js:12192
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12715
-#: 3.8/weather-applet.js:12716 3.8/weather-applet.js:12944
-#: 3.8/weather-applet.js:12945 3.8/weather-applet.js:14073
-#: 3.8/weather-applet.js:14074 3.8/weather-applet.js:14224
-#: 3.8/weather-applet.js:14225 3.8/weather-applet.js:14797
-#: 3.8/weather-applet.js:14799
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Ismeretlen hiba"
 
@@ -554,7 +554,7 @@ msgstr ""
 "API-kulcs megadása szükséges a beállításokban,\n"
 "vagy szerezzen egyet a https://darksky.net/dev/register oldalról"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:14880
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -562,7 +562,7 @@ msgstr ""
 "Ellenőrizze, hogy a DarkSky szolgáltatótól származó\n"
 "API kulcsot helyesen adta meg"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:15196
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Helyzetmeghatározás sikertelen"
 
@@ -573,121 +573,121 @@ msgstr ""
 "Földrajzi helymeghatározás nem sikerült, a naplóbejegyzések megtekinthetők a "
 "Looking Glass naplóban"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11203
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Felhőzet"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11351
-#: 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Tiszta égbolt"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11365 3.8/weather-applet.js:11366
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Elfogadható"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11387
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Erős eső és mennydörgés"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11394
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Erős zivatarok"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11401
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Erős viharos záporeső és mennydörgés"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11407
-#: 3.8/weather-applet.js:11408 3.8/weather-applet.js:11414
-#: 3.8/weather-applet.js:11421 3.8/weather-applet.js:11428
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Erős havas eső"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11415
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Erős havas eső és mennydörgés"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11422
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Erős havas záporeső"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11429
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Erős havas záporeső és mennydörgés"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11443
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Erős havazás és mennydörgés"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11450
-#: 3.8/weather-applet.js:13526
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Erős hózápor"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11457
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Erős zápor és szitáló eső"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11471
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Enyhe esőzés és mennydörgés"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11478
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Enyhe záporeső"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11485
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Enyhe záporeső és mennydörgés"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11491
-#: 3.8/weather-applet.js:11492 3.8/weather-applet.js:11498
-#: 3.8/weather-applet.js:11505 3.8/weather-applet.js:11512
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Gyenge havas eső"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11499
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Gyenge havas eső és mennydörgés"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11506
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Gyenge havas záporeső"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11513
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Gyenge havas esőzápor és mennydörgés"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11527
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Könnyű havazás és mennydörgés"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11534
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Enyhe hózáporok"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11541
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Könnyű hózáporok és mennydörgés"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11562
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Esőzés és mennydörgés"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11568
-#: 3.8/weather-applet.js:11569 3.8/weather-applet.js:11575
-#: 3.8/weather-applet.js:12859 3.8/weather-applet.js:13185
-#: 3.8/weather-applet.js:13491 3.8/weather-applet.js:13497
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Záporok"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11576
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Záporok és mennydörgés"
 
@@ -696,44 +696,44 @@ msgstr "Záporok és mennydörgés"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10537
-#: 3.8/weather-applet.js:10544 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11582 3.8/weather-applet.js:11583
-#: 3.8/weather-applet.js:11589 3.8/weather-applet.js:11596
-#: 3.8/weather-applet.js:11603 3.8/weather-applet.js:12808
-#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12815
-#: 3.8/weather-applet.js:12816 3.8/weather-applet.js:12843
-#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14196
-#: 3.8/weather-applet.js:14197 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Havas eső"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11590
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Havas eső és mennydörgés"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11597
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Ónos záporeső"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11604
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Havas eső és mennydörgés"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11618
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Havazás és mennydörgés"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11624 3.8/weather-applet.js:11625
-#: 3.8/weather-applet.js:11631 3.8/weather-applet.js:13203
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Hózápor"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11632
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Viharos havazás és mennydörgés"
 
@@ -742,21 +742,21 @@ msgstr "Viharos havazás és mennydörgés"
 msgid "Unexpected response from API"
 msgstr "Váratlan válasz az API részéről"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10237
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Láthatóság"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10265
-#: 3.8/weather-applet.js:10817 3.8/weather-applet.js:11722
-#: 3.8/weather-applet.js:12672
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Nem sikerült feldolgozni a jelenlegi időjárás-jelentést"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10055
-#: 3.8/weather-applet.js:10089 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11782 3.8/weather-applet.js:12474
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Nem sikerült feldolgozni az időjárás-előrejelzést"
 
@@ -785,89 +785,89 @@ msgid "Excellent - More than"
 msgstr "Kiváló - Több mint"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10460 3.8/weather-applet.js:10461
-#: 3.8/weather-applet.js:11029 3.8/weather-applet.js:13175
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Köd"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:12752
-#: 3.8/weather-applet.js:12753 3.8/weather-applet.js:12787
-#: 3.8/weather-applet.js:13219
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Borús"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10489
-#: 3.8/weather-applet.js:10496
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Enyhe záporeső"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:12326
-#: 3.8/weather-applet.js:13141 3.8/weather-applet.js:14532
-#: 3.8/weather-applet.js:14533
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Szitáló eső"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:10524
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Erős zápor"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10538
-#: 3.8/weather-applet.js:10545
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Ónos záporeső"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:13217 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14169 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:14589
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Jégeső"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Jégzápor"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Enyhe elszórt hózápor"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Erős hózápor"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10621 3.8/weather-applet.js:10628
-#: 3.8/weather-applet.js:10635 3.8/weather-applet.js:10636
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Mennydörgés"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Viharzápor"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10872
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Kérem ellenőrizze hogy a földrajzi helyzet megfelelő formátumban van megadva"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10876
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Ellenőrizze hogy az API kulcs korrekt a beállításokban"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10681 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -875,213 +875,213 @@ msgstr ""
 "Földrajzi helyzet nem található, ellenőrizze hogy a földrajzi helyzet "
 "elérhető és megfelelő formátumban van megadva"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10884
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 "Ha a hiba továbbra is fennáll, vegye fel a kapcsolatot a kisalkalmazás "
 "fejlesztőjével"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10888
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Ismeretlen hiba, a hibaüzenet megtekinthető a Looking Glass naplóban"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10990
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Vihar enyhe esővel"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10991
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Vihar"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10992
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Vihar erős esőzéssel"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10993
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Enyhe vihar"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10995
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Erős vihar"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10996
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Viharok"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10997
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Vihar enyhén szitáló esővel"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10998
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Vihar szitáló esővel"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10999
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Vihar erősen szitáló esővel"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11000
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Enyhe szitáló eső"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11002
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Erősen szitáló eső"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11003
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Enyhén szitáló eső"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11004
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Szitáló eső"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11005
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Erősen szitáló eső"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11006
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Zápor és szitáló eső"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11007
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Erős zápor és szitáló eső"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11008
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Szitáló záporeső"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11010
-#: 3.8/weather-applet.js:13455 3.8/weather-applet.js:13456
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Esőzés"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11011
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Erős eső"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11012
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Nagyon erős esőzés"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11013
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Hatalmas Esőzés"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11015
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Enyhe záporeső"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11016
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Záporeső"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11017
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Erős záporeső"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11018
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Szakadozott záporeső"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11023
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Havas záporeső"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11024
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Enyhe esőzés és havazás"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11025
-#: 3.8/weather-applet.js:13462 3.8/weather-applet.js:13463
-#: 3.8/weather-applet.js:13469 3.8/weather-applet.js:13504
-#: 3.8/weather-applet.js:13511
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Esőzés és havazás"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11026
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Enyhe hózápor"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11027
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Elszórt havazás"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11028
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Erős hózápor"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:12902
-#: 3.8/weather-applet.js:12903 3.8/weather-applet.js:14623
-#: 3.8/weather-applet.js:14624
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Füst"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11031 3.8/weather-applet.js:12909
-#: 3.8/weather-applet.js:12910 3.8/weather-applet.js:14616
-#: 3.8/weather-applet.js:14617
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Pára"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11032
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Homok, porfelhők"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11034
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Homok"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11035 3.8/weather-applet.js:12895
-#: 3.8/weather-applet.js:12896 3.8/weather-applet.js:14602
-#: 3.8/weather-applet.js:14603
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Por"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11036
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Vulkáni hamu"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:13209
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Széllökések"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11038 3.8/weather-applet.js:12874
-#: 3.8/weather-applet.js:12875 3.8/weather-applet.js:14475
-#: 3.8/weather-applet.js:14476
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Tornádó"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11041
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Tiszta égbolt"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11042
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Felhős"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11043
-#: 3.8/weather-applet.js:12731 3.8/weather-applet.js:12732
-#: 3.8/weather-applet.js:12766
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Enyhén felhős"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11044
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Elszórtan felhős"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11045
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Szakadozott felhőzet"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11046
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Borult idő"
 
@@ -1089,82 +1089,82 @@ msgstr "Borult idő"
 msgid "Could not get forecast for your area"
 msgstr "Nem szerezhető be időjárás-előrejelzés a megadott földrajzi helyzethez"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12431
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 "Az Egyesült Államokon kívüli földrajzi helyzet esetén válasszon másik "
 "időjárás-előrejelzés szolgáltatót."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12495
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Nem sikerült feldolgozni az óránkénti időjárás-előrejelzést"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12760
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Tiszta és szeles"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12767
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Enyhén felhős és szeles"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12774
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Közepesen felhős és szeles"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Nagyrészt felhős és szeles"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12788
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Borult és szeles idő"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12802
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Havaseső"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12837
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Ónos eső és havazás"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9153 3.8/weather-applet.js:12881
-#: 3.8/weather-applet.js:12882 3.8/weather-applet.js:14489
-#: 3.8/weather-applet.js:14490
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Orkán"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9148
-#: 3.8/weather-applet.js:12888
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Szélvész"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12889
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Trópusi vihar"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12916 3.8/weather-applet.js:12917
-#: 3.8/weather-applet.js:14721 3.8/weather-applet.js:14722
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Forró"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12923 3.8/weather-applet.js:12924
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Hideg"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12930 3.8/weather-applet.js:12931
-#: 3.8/weather-applet.js:14770 3.8/weather-applet.js:14771
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Hóvihar"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9025
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Ma"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9027
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Holnap"
 
@@ -1196,79 +1196,79 @@ msgstr "Péntek"
 msgid "Saturday"
 msgstr "Szombat"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9118
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Szélcsend"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9121
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Gyenge szellő"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9124
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Enyhe szellő"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9127
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Gyenge szél"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9130
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Mérsékelt szél"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9133
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Élénk szél"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9136
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Erős szél"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9139
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Viharos szél"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9142
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Élénk viharos szél"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9145
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Heves vihar"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9151
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Heves szélvész"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "É"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "ÉK"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "K"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "DK"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "„%s” nem található"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "DNY"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "NY"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "ÉNY"
 
@@ -1321,7 +1321,7 @@ msgstr ""
 "közben. További információkért tekintse meg a naplóbejegyzéseket a Looking "
 "Glass naplóban"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14482 3.8/weather-applet.js:14483
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Trópusi vihar"
 
@@ -1329,7 +1329,7 @@ msgstr "Trópusi vihar"
 msgid "Severe Thunderstorms"
 msgstr "Veszélyes viharok"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14503 3.8/weather-applet.js:14504
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Viharok"
 
@@ -1345,15 +1345,15 @@ msgstr "Eső és ónos eső vegyesen"
 msgid "Mixed Snow and Sleet"
 msgstr "Hó és ónos eső vegyesen"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Jeges szitálás"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Ónos eső"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Záporok"
 
@@ -1365,11 +1365,11 @@ msgstr "Hófúvás"
 msgid "Light Snow Showers"
 msgstr "Enyhe hózápor"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14574 3.8/weather-applet.js:14575
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Hófúvás"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13441 3.8/weather-applet.js:13442
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Ködös"
 
@@ -1381,54 +1381,54 @@ msgstr "Füstös"
 msgid "Blustery"
 msgstr "Heves"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14637 3.8/weather-applet.js:14638
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Szeles"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:14658 3.8/weather-applet.js:14659
-#: 3.8/weather-applet.js:14665 3.8/weather-applet.js:14666
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Erősen felhős"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14175 3.8/weather-applet.js:14176
-#: 3.8/weather-applet.js:14182 3.8/weather-applet.js:14183
-#: 3.8/weather-applet.js:14672 3.8/weather-applet.js:14673
-#: 3.8/weather-applet.js:14679 3.8/weather-applet.js:14680
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Közepesen felhős"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Nagyrészt napos"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:14714 3.8/weather-applet.js:14715
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Eső és jégeső"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:14728 3.8/weather-applet.js:14729
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Helyi viharok"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:14735 3.8/weather-applet.js:14736
-#: 3.8/weather-applet.js:14791 3.8/weather-applet.js:14792
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Hirtelen viharokkal"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:14742 3.8/weather-applet.js:14743
-#: 3.8/weather-applet.js:14777 3.8/weather-applet.js:14778
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Elszórt záporok"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:14749 3.8/weather-applet.js:14750
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Erős eső"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:14756 3.8/weather-applet.js:14757
-#: 3.8/weather-applet.js:14784 3.8/weather-applet.js:14785
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Elszórt hózáporok"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:14763 3.8/weather-applet.js:14764
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Erős havazás"
 
@@ -1440,7 +1440,7 @@ msgstr "Nem érhető el"
 msgid "Scattered Thundershowers"
 msgstr "Elszórt zivatarok"
 
-#: 3.8/weather-applet.js:9637
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1448,7 +1448,7 @@ msgstr ""
 "Nem tölthető be a naplófájl a megadott elérési útvonalról:\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9641
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1457,11 +1457,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10013
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10118
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1469,276 +1469,276 @@ msgstr ""
 "A MET Office UK kizárólag Angliában érhető el. Bizonyosodjon meg róla, hogy "
 "a kiválasztott földrajzi hely Anglia területén van"
 
-#: 3.8/weather-applet.js:10197
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Nem található adat a földrajzi helyzethez"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Nagyon rossz"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Kevesebb mint {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Kiváló"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Több mint {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10287
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Rossz"
 
-#: 3.8/weather-applet.js:10287 3.8/weather-applet.js:10292
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:10302
-#: 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "{smallerDistance}-{biggerDistance} {distanceUnit} között"
 
-#: 3.8/weather-applet.js:10292
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Mérsékelt"
 
-#: 3.8/weather-applet.js:10297
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Jó"
 
-#: 3.8/weather-applet.js:10302 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Nagyon jó"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10662
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norvégia"
 
-#: 3.8/weather-applet.js:11659
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12080
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12250
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Enyhe szellő"
 
-#: 3.8/weather-applet.js:12264
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Erős szél"
 
-#: 3.8/weather-applet.js:12411
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:12962
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:13139
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Hófúvás vagy hócsuszamlás"
 
-#: 3.8/weather-applet.js:13143
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Erősen szitáló eső"
 
-#: 3.8/weather-applet.js:13147
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Erősen szitáló eső és eső"
 
-#: 3.8/weather-applet.js:13149
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Enyhe szitáló eső"
 
-#: 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Porvihar"
 
-#: 3.8/weather-applet.js:13155
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Jeges szitálás és ónos eső"
 
-#: 3.8/weather-applet.js:13157
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Erősen szitáló ónos eső és ónos eső"
 
-#: 3.8/weather-applet.js:13159
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Enyhe jégszitálás és ónos eső"
 
-#: 3.8/weather-applet.js:13161
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Zúzmarás köd"
 
-#: 3.8/weather-applet.js:13167
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Tölcsérfelhő és tornádó"
 
-#: 3.8/weather-applet.js:13169
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Jégzápor"
 
-#: 3.8/weather-applet.js:13171
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Jég"
 
-#: 3.8/weather-applet.js:13173
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Villámlás mennydörgés nélkül"
 
-#: 3.8/weather-applet.js:13177
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Csapadék a közelben"
 
-#: 3.8/weather-applet.js:13181 3.8/weather-applet.js:13470
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Erős eső és havazás"
 
-#: 3.8/weather-applet.js:13183
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Enyhe esőzés és havazás"
 
-#: 3.8/weather-applet.js:13191
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Csökkenő felhőzet"
 
-#: 3.8/weather-applet.js:13193
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Növekvő felhőzet"
 
-#: 3.8/weather-applet.js:13195
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Változatlan fedettség"
 
-#: 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Füst vagy köd"
 
-#: 3.8/weather-applet.js:13201
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Hózápor és záporeső"
 
-#: 3.8/weather-applet.js:13213
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Vihar lecsapás nélkül"
 
-#: 3.8/weather-applet.js:13215
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Jégtű"
 
-#: 3.8/weather-applet.js:13221
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Közepesen felhős"
 
-#: 3.8/weather-applet.js:13243
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Ellenőrizze hogy az API kulcsot helyesen adta meg"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13259
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Dánia"
 
-#: 3.8/weather-applet.js:13402 3.8/weather-applet.js:13403
-#: 3.8/weather-applet.js:13539 3.8/weather-applet.js:13540
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "NEM TALÁLHATÓ"
 
-#: 3.8/weather-applet.js:13435
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Hófúvás"
 
-#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:13477
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Enyhe havazás"
 
-#: 3.8/weather-applet.js:13483 3.8/weather-applet.js:13484
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Hóesés"
 
-#: 3.8/weather-applet.js:13498
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Záporok"
 
-#: 3.8/weather-applet.js:13505
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Esőzés és havazás"
 
-#: 3.8/weather-applet.js:13512
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Erős eső és havazás"
 
-#: 3.8/weather-applet.js:13657
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:13953
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:13966
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr ""
 "Válasszon másik időjárás-előrejelzés szolgáltatót vagy földrajzi helyet"
 
-#: 3.8/weather-applet.js:14263
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14453
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "A megadott API-kulcs nem érvényes."
 
-#: 3.8/weather-applet.js:14460
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "A megadott földrajzi helyzethez nem található."
 
-#: 3.8/weather-applet.js:14496 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Heves szélvész"
 
-#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:14512
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Esőzés és havazás"
 
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Eső és ónos eső vegyesen"
 
-#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Hózápor"
 
-#: 3.8/weather-applet.js:14630 3.8/weather-applet.js:14631
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "Szeles"
 
-#: 3.8/weather-applet.js:14644 3.8/weather-applet.js:14645
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr "Fagyos"
 
-#: 3.8/weather-applet.js:14700 3.8/weather-applet.js:14701
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Nagyrészt tiszta"
 
-#: 3.8/weather-applet.js:14853
+#: 3.8/weather-applet.js:15247
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:15205
+#: 3.8/weather-applet.js:15603
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
@@ -1746,13 +1746,13 @@ msgstr ""
 "Földrajzi helymeghatározás nem sikerült, a naplóbejegyzések megtekinthetők a "
 "Looking Glass naplóban"
 
-#: 3.8/weather-applet.js:15433
+#: 3.8/weather-applet.js:15831
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Ellenőrizze hogy van-e földrajzi helyzet megadva vagy használja az "
 "automatikus helyzet-meghatározást."
 
-#: 3.8/weather-applet.js:15570
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1760,7 +1760,7 @@ msgstr ""
 "Nem tölthető be a beállítófájl a megadott elérési útvonalról:\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15577
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1768,61 +1768,61 @@ msgstr ""
 "Nem tölthető be a beállítófájl tartalma a megadott elérési útvonalról:\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:16197
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr ""
+"Ez az időjárás-előrejelzés szolgáltató API-kulcs használatát írj elő a "
+"szolgáltatása használatához"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Harmatpont"
 
-#: 3.8/weather-applet.js:16269
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "A csapadék {precipEnd} percen belül megszűnik"
 
-#: 3.8/weather-applet.js:16271
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "A csapadék nem szűnik meg egy órán belül"
 
-#: 3.8/weather-applet.js:16274
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "A csapadék {precipStart} percen belül esni kezd"
 
-#: 3.8/weather-applet.js:16486
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Az előrejelzés értelmezése nem sikerült. További részletekért tekintse meg a "
 "naplófájlokat."
 
-#: 3.8/weather-applet.js:17018 3.8/weather-applet.js:17810
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "Frissítve: {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:17024
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance}{distanceUnit} távolságra Öntől"
 
-#: 3.8/weather-applet.js:17028
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "Állomásnév: {stationName}"
 
-#: 3.8/weather-applet.js:17031
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "Térség: {stationArea}"
 
-#: 3.8/weather-applet.js:17581 3.8/weather-applet.js:17591
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Hiba lépett fel a hibakeresési információk elmentése közben"
 
-#: 3.8/weather-applet.js:17603
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "A hibakeresési információk sikeresen mentve"
 
-#: 3.8/weather-applet.js:17603
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Elmentve ide: {filePath}"
-
-#: 3.8/weather-applet.js:17734
-msgid "This provider requires an API key to operate"
-msgstr ""
-"Ez az időjárás-előrejelzés szolgáltató API-kulcs használatát írj elő a "
-"szolgáltatása használatához"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -2637,138 +2637,3 @@ msgstr ""
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr "Naplófájlok mentése a következő útvonalra"
-
-#~ msgid "DarkSky"
-#~ msgstr "DarkSky"
-
-#~ msgid "This API has ceased to function, please use another one."
-#~ msgstr "Ez az API megszűnt. Válasszon egy másik szolgáltatást."
-
-#~ msgid "Oversteer - Steering Wheel Manager"
-#~ msgstr "Oversteer - Kormánykerék-kezelő"
-
-#~ msgid "Device path"
-#~ msgstr "Eszközútvonal"
-
-#~ msgid "show version"
-#~ msgstr "verzió megjelenítése"
-
-#~ msgid "System default"
-#~ msgstr "Rendszer alapértelmezés"
-
-#~ msgid "English"
-#~ msgstr "Angol"
-
-#~ msgid "Russian"
-#~ msgstr "Orosz"
-
-#~ msgid "Spanish"
-#~ msgstr "Spanyol"
-
-#~ msgid "Finnish"
-#~ msgstr "Finn"
-
-#~ msgid "Turkish"
-#~ msgstr "Török"
-
-#~ msgid "German"
-#~ msgstr "Német"
-
-#~ msgid "Invalid extension."
-#~ msgstr "Érvénytelen kiegészítő."
-
-#~ msgid "Preferences"
-#~ msgstr "Beállítások"
-
-#~ msgid "Save"
-#~ msgstr "Mentés"
-
-#~ msgid "Profile"
-#~ msgstr "Profil"
-
-#~ msgid "Compatibility mode"
-#~ msgstr "Kompatibilitási üzemmód"
-
-#~ msgid "Apply"
-#~ msgstr "Alkalmaz"
-
-#~ msgid "None"
-#~ msgstr "Nincs"
-
-#~ msgid "Buttons"
-#~ msgstr "Gombok listája"
-
-#~ msgid "Controls"
-#~ msgstr "Vezérlőelemek"
-
-#~ msgid "Always"
-#~ msgstr "Mindig"
-
-#~ msgid "Never"
-#~ msgstr "Soha"
-
-#~ msgid "Tools"
-#~ msgstr "Eszközök"
-
-#~ msgid "page1"
-#~ msgstr "oldal1"
-
-#~ msgid "page0"
-#~ msgstr "oldal0"
-
-#~ msgid "page6"
-#~ msgstr "oldal6"
-
-#~ msgid "Back"
-#~ msgstr "Vissza"
-
-#~ msgid "Run"
-#~ msgstr "Futtatás"
-
-#~ msgid "New"
-#~ msgstr "Új"
-
-#~ msgid "Rename"
-#~ msgstr "Átnevezés"
-
-#~ msgid "Delete"
-#~ msgstr "Törlés"
-
-#~ msgid "Import"
-#~ msgstr "Importálás"
-
-#~ msgid "Export"
-#~ msgstr "Exportálás"
-
-#~ msgid "Profiles"
-#~ msgstr "Profilok"
-
-#~ msgid "Language"
-#~ msgstr "Nyelv"
-
-#~ msgid "Start"
-#~ msgstr "Indulás"
-
-#~ msgid "Input force"
-#~ msgstr "Bemeneti erő"
-
-#~ msgid "Output force"
-#~ msgstr "Kimeneti erő"
-
-#~ msgid "RPM"
-#~ msgstr "RPM"
-
-#~ msgid "Input Force"
-#~ msgstr "Bemeneti erő"
-
-#~ msgid "RPM/s"
-#~ msgstr "RPM/s"
-
-#~ msgid "Steering Wheel Manager"
-#~ msgstr "Kormánykerék-kezelő"
-
-#~ msgid "org.berarma.Oversteer"
-#~ msgstr "org.berarma.Oversteer"
-
-#~ msgid "game;racing;cars;wheels"
-#~ msgstr "game;racing;cars;wheels;játék;verseny;autók;kormánykerék"

--- a/weather@mockturtl/files/weather@mockturtl/po/id.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/id.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: weather@mockturtl 3.2.1\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-18 08:53+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2022-03-22 13:51+0700\n"
 "Last-Translator: Ruddy Pranata <ruddy.pranata@gmail.com>\n"
 "Language-Team: Ruddy Pranata <ruddy.pranata@gmail.com>\n"
@@ -19,65 +20,65 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:15684
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Kesalahan"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:15685 3.8/weather-applet.js:15687
-#: 3.8/weather-applet.js:15689 3.8/weather-applet.js:15692
-#: 3.8/weather-applet.js:15695 3.8/weather-applet.js:15696
-#: 3.8/weather-applet.js:15697 3.8/weather-applet.js:15698
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Kesalahan Layanan"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:15686
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Kunci API salah"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:15688
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Format Lokasi Salah"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:15690
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Kunci Diblokir"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:15691
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Tidak dapat menemukan lokasi"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:15693
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "No Api Key"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:15694
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Tidak ada Lokasi"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:15699
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Paket Hilang"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:15700
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Lokasi tidak tercakup"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9299
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Applet Cuaca"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:15963
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:15964
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Klik untuk membuka"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:14508
-#: 3.8/weather-applet.js:15975
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Menyegarkan"
 
@@ -87,8 +88,8 @@ msgstr "API mengembalikan kode status antara 400 dan 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9465
-#: 3.8/weather-applet.js:9469 3.8/weather-applet.js:9473
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Lokasi Toko"
 
@@ -100,14 +101,14 @@ msgstr "Anda tidak dapat menyimpan lokasi yang diperoleh secara otomatis, maaf"
 msgid "Could not get weather information"
 msgstr "Tidak bisa mendapatkan informasi cuaca"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:15795
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Kesalahan Tak Terduga Saat Menyegarkan Cuaca, silakan lihat log in Looking "
 "Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:16053
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -123,7 +124,7 @@ msgstr "Kesalahan Jaringan, silakan periksa log di Looking Glass"
 msgid "As of"
 msgstr "Pada"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:15197
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Dipersembahkan oleh"
 
@@ -131,91 +132,90 @@ msgstr "Dipersembahkan oleh"
 msgid "from you"
 msgstr "darimu"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:15128
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:10257
-#: 3.8/weather-applet.js:15128
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:9895
-#: 3.8/weather-applet.js:15262
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:9896
-#: 3.8/weather-applet.js:15263
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:15433
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Memuat cuaca saat ini..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:15436
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Memuat cuaca masa depan..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:14447
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Memuat ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:14473
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Suhu"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:14474
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Kelembaban"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:14475
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Tekanan"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12105 3.8/weather-applet.js:12112
-#: 3.8/weather-applet.js:12113 3.8/weather-applet.js:12119
-#: 3.8/weather-applet.js:14476
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Angin"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:14017
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Pastikan Anda memasukkan lokasi atau gunakan Lokasi otomatis sebagai gantinya"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9545
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Tidak dapat menemukan lokasi berdasarkan alamat, harap periksa apakah itu "
 "benar"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9566
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "Gagal memanggil Geolocation API, lihat Looking Glass untuk kesalahan."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9465
-#: 3.8/weather-applet.js:9469
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Peringatan"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9465
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Anda hanya dapat menyimpan lokasi yang benar ketika applet tidak menyegarkan"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9469
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Anda tidak dapat menyimpan lokasi yang salah"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9473
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Info"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9473
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Lokasi sudah disimpan"
 
@@ -253,14 +253,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10338 3.8/weather-applet.js:10645
-#: 3.8/weather-applet.js:11570 3.8/weather-applet.js:12008
-#: 3.8/weather-applet.js:12510 3.8/weather-applet.js:12872
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Terasa seperti"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:10383
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Gagal Memproses Info Cuaca"
 
@@ -273,7 +274,7 @@ msgstr ""
 "atau dapatkan yang pertama di https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:10266 3.8/weather-applet.js:11740
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -281,7 +282,7 @@ msgstr ""
 "Harap Pastikan Anda\n"
 "memasukkan kunci API dengan benar dan akun Anda tidak terkunci"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:11974
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -292,58 +293,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10096 3.8/weather-applet.js:10103
-#: 3.8/weather-applet.js:10110 3.8/weather-applet.js:10111
-#: 3.8/weather-applet.js:11201 3.8/weather-applet.js:11202
-#: 3.8/weather-applet.js:11208 3.8/weather-applet.js:11215
-#: 3.8/weather-applet.js:11222 3.8/weather-applet.js:12148
-#: 3.8/weather-applet.js:13038
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Hujan deras"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11376 3.8/weather-applet.js:11377
-#: 3.8/weather-applet.js:11383 3.8/weather-applet.js:12133
-#: 3.8/weather-applet.js:12134 3.8/weather-applet.js:12140
-#: 3.8/weather-applet.js:12147 3.8/weather-applet.js:12189
-#: 3.8/weather-applet.js:12196 3.8/weather-applet.js:12203
-#: 3.8/weather-applet.js:12654 3.8/weather-applet.js:12703
-#: 3.8/weather-applet.js:12704 3.8/weather-applet.js:12711
-#: 3.8/weather-applet.js:13030 3.8/weather-applet.js:13297
-#: 3.8/weather-applet.js:13298 3.8/weather-applet.js:13339
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Hujan"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10068
-#: 3.8/weather-applet.js:10075 3.8/weather-applet.js:10089
-#: 3.8/weather-applet.js:10090 3.8/weather-applet.js:10914
-#: 3.8/weather-applet.js:11285 3.8/weather-applet.js:11286
-#: 3.8/weather-applet.js:11292 3.8/weather-applet.js:11299
-#: 3.8/weather-applet.js:11306 3.8/weather-applet.js:12141
-#: 3.8/weather-applet.js:13040
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Hujan ringan"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12204 3.8/weather-applet.js:13014
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Hujan es yang lebat"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:10919
-#: 3.8/weather-applet.js:12190 3.8/weather-applet.js:12675
-#: 3.8/weather-applet.js:12676 3.8/weather-applet.js:12682
-#: 3.8/weather-applet.js:12683 3.8/weather-applet.js:12689
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Hujan beku"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12197 3.8/weather-applet.js:13016
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Hujan es ringan"
 
@@ -351,173 +354,189 @@ msgstr "Hujan es ringan"
 msgid "Light freezing drizzle"
 msgstr "Gerimis beku ringan"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12183
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Gerimis Beku"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12996
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Gerimis ringan"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12218
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Pelet es berat"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12210 3.8/weather-applet.js:12211
-#: 3.8/weather-applet.js:12217 3.8/weather-applet.js:12224
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Pelet Es"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12225
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Pelet es ringan"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10180
-#: 3.8/weather-applet.js:10187 3.8/weather-applet.js:10194
-#: 3.8/weather-applet.js:10195 3.8/weather-applet.js:10926
-#: 3.8/weather-applet.js:11257 3.8/weather-applet.js:11258
-#: 3.8/weather-applet.js:11264 3.8/weather-applet.js:11271
-#: 3.8/weather-applet.js:11278 3.8/weather-applet.js:12176
-#: 3.8/weather-applet.js:13056 3.8/weather-applet.js:13374
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Salju tebal"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:10925 3.8/weather-applet.js:11432
-#: 3.8/weather-applet.js:11433 3.8/weather-applet.js:11439
-#: 3.8/weather-applet.js:12154 3.8/weather-applet.js:12155
-#: 3.8/weather-applet.js:12168 3.8/weather-applet.js:12175
-#: 3.8/weather-applet.js:12647 3.8/weather-applet.js:12648
-#: 3.8/weather-applet.js:13050 3.8/weather-applet.js:13283
-#: 3.8/weather-applet.js:13367
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Salju"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10159
-#: 3.8/weather-applet.js:10166 3.8/weather-applet.js:10173
-#: 3.8/weather-applet.js:10174 3.8/weather-applet.js:10924
-#: 3.8/weather-applet.js:11341 3.8/weather-applet.js:11342
-#: 3.8/weather-applet.js:11348 3.8/weather-applet.js:11355
-#: 3.8/weather-applet.js:11362 3.8/weather-applet.js:12169
-#: 3.8/weather-applet.js:13058
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Salju Ringan"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12161
-#: 3.8/weather-applet.js:12162
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Kebingungan"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10899
-#: 3.8/weather-applet.js:12231 3.8/weather-applet.js:12232
-#: 3.8/weather-applet.js:12720 3.8/weather-applet.js:12721
-#: 3.8/weather-applet.js:13062 3.8/weather-applet.js:13381
-#: 3.8/weather-applet.js:13382
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Hujan badai"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12099
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Kabut Tipis"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10047 3.8/weather-applet.js:10048
-#: 3.8/weather-applet.js:10938 3.8/weather-applet.js:11194
-#: 3.8/weather-applet.js:11195 3.8/weather-applet.js:12091
-#: 3.8/weather-applet.js:12092 3.8/weather-applet.js:12098
-#: 3.8/weather-applet.js:12790 3.8/weather-applet.js:12791
-#: 3.8/weather-applet.js:13004
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Kabut"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10054 3.8/weather-applet.js:10055
-#: 3.8/weather-applet.js:11180 3.8/weather-applet.js:11181
-#: 3.8/weather-applet.js:12063 3.8/weather-applet.js:12064
-#: 3.8/weather-applet.js:13276 3.8/weather-applet.js:13277
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Berawan"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12084
-#: 3.8/weather-applet.js:12085 3.8/weather-applet.js:12598
-#: 3.8/weather-applet.js:12599 3.8/weather-applet.js:12633
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Sebagian besar berawan"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10019
-#: 3.8/weather-applet.js:10020 3.8/weather-applet.js:10026
-#: 3.8/weather-applet.js:10027 3.8/weather-applet.js:11369
-#: 3.8/weather-applet.js:11370 3.8/weather-applet.js:12077
-#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12591
-#: 3.8/weather-applet.js:12592 3.8/weather-applet.js:12626
-#: 3.8/weather-applet.js:13269 3.8/weather-applet.js:13270
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Berawan"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12070
-#: 3.8/weather-applet.js:12071
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Sebagian besar jelas"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10005 3.8/weather-applet.js:10006
-#: 3.8/weather-applet.js:10944 3.8/weather-applet.js:12056
-#: 3.8/weather-applet.js:12057 3.8/weather-applet.js:12577
-#: 3.8/weather-applet.js:12578 3.8/weather-applet.js:12612
-#: 3.8/weather-applet.js:13074 3.8/weather-applet.js:13262
-#: 3.8/weather-applet.js:13263
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Jernih"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10012
-#: 3.8/weather-applet.js:10013 3.8/weather-applet.js:12056
-#: 3.8/weather-applet.js:12057
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Cerah"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:9998 3.8/weather-applet.js:9999
-#: 3.8/weather-applet.js:10033 3.8/weather-applet.js:10034
-#: 3.8/weather-applet.js:10222 3.8/weather-applet.js:10223
-#: 3.8/weather-applet.js:11163 3.8/weather-applet.js:11164
-#: 3.8/weather-applet.js:11461 3.8/weather-applet.js:11462
-#: 3.8/weather-applet.js:12048 3.8/weather-applet.js:12049
-#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12569
-#: 3.8/weather-applet.js:12797 3.8/weather-applet.js:12798
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Tidak dikenal"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10257
+#: 3.0/darkSky.js:71
 msgid "and"
 msgstr "dan"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10257
+#: 3.0/darkSky.js:71
 msgid "until"
 msgstr "sampai"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10257
+#: 3.0/darkSky.js:71
 msgid "Possible"
 msgstr "Mungkin"
 
@@ -529,7 +548,7 @@ msgstr ""
 "Silakan masukkan kunci API di pengaturan,\n"
 "atau dapatkan yang pertama di https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:10276
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -537,131 +556,131 @@ msgstr ""
 "Harap Pastikan Anda\n"
 "memasukkan kunci API yang Anda miliki dari DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:9251
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Tidak dapat memperoleh lokasi"
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:9257
+#: 3.0/ipApi.js:95
 msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 "Layanan Lokasi merespons dengan kesalahan, silakan lihat log di Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11022
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Keadaan mendung"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:10945 3.8/weather-applet.js:11173
-#: 3.8/weather-applet.js:11174
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Langit cerah"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11187 3.8/weather-applet.js:11188
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Terang"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11209
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Hujan lebat dan guntur"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11216
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Hujan deras"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11223
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Hujan deras disertai petir"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11229
-#: 3.8/weather-applet.js:11230 3.8/weather-applet.js:11236
-#: 3.8/weather-applet.js:11243 3.8/weather-applet.js:11250
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Hujan es lebat"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11237
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Hujan es lebat dan guntur"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11244
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Hujan es lebat"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11251
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Hujan es lebat dan guntur"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11265
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Salju lebat dan guntur"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11272
-#: 3.8/weather-applet.js:13375
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Hujan salju lebat"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11279
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Hujan salju lebat dan guntur"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11293
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Hujan ringan dan guntur"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11300
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Hujan rintik-rintik"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11307
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Hujan ringan dan guntur"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11313
-#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:11320
-#: 3.8/weather-applet.js:11327 3.8/weather-applet.js:11334
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Hujan es ringan"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11321
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Hujan es ringan dan guntur"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11328
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Hujan es ringan"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11335
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Hujan es ringan dan guntur"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11349
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Salju ringan dan guntur"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11356
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Hujan salju ringan"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11363
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Hujan salju ringan dan guntur"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11384
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Hujan dan guntur"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11390
-#: 3.8/weather-applet.js:11391 3.8/weather-applet.js:11397
-#: 3.8/weather-applet.js:12712 3.8/weather-applet.js:13036
-#: 3.8/weather-applet.js:13340 3.8/weather-applet.js:13346
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Gerimis"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11398
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Hujan deras dan guntur"
 
@@ -670,42 +689,44 @@ msgstr "Hujan deras dan guntur"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10117
-#: 3.8/weather-applet.js:10124 3.8/weather-applet.js:10131
-#: 3.8/weather-applet.js:10132 3.8/weather-applet.js:10927
-#: 3.8/weather-applet.js:11404 3.8/weather-applet.js:11405
-#: 3.8/weather-applet.js:11411 3.8/weather-applet.js:11418
-#: 3.8/weather-applet.js:11425 3.8/weather-applet.js:12661
-#: 3.8/weather-applet.js:12662 3.8/weather-applet.js:12668
-#: 3.8/weather-applet.js:12669 3.8/weather-applet.js:12696
-#: 3.8/weather-applet.js:12697
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Hujan Es"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11412
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Hujan es dan guntur"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11419
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Hujan es"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11426
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Hujan es dan guntur"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11440
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Salju dan guntur"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11446 3.8/weather-applet.js:11447
-#: 3.8/weather-applet.js:11453 3.8/weather-applet.js:13054
-#: 3.8/weather-applet.js:13368
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Hujan salju"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11454
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Hujan salju dan guntur"
 
@@ -714,20 +735,21 @@ msgstr "Hujan salju dan guntur"
 msgid "Unexpected response from API"
 msgstr "Respons tak terduga dari API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:9820
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Visibilitas"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:9848 3.8/weather-applet.js:10722
-#: 3.8/weather-applet.js:11581 3.8/weather-applet.js:12523
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Gagal Memproses Info Cuaca Saat Ini"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:9645
-#: 3.8/weather-applet.js:9679 3.8/weather-applet.js:11607
-#: 3.8/weather-applet.js:11641 3.8/weather-applet.js:12328
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Gagal Memproses Info Prakiraan"
 
@@ -756,292 +778,299 @@ msgid "Excellent - More than"
 msgstr "Luar biasa - Lebih dari"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10040 3.8/weather-applet.js:10041
-#: 3.8/weather-applet.js:10934 3.8/weather-applet.js:13026
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Kabut"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10061
-#: 3.8/weather-applet.js:10062 3.8/weather-applet.js:12605
-#: 3.8/weather-applet.js:12606 3.8/weather-applet.js:12640
-#: 3.8/weather-applet.js:13070
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Mendung"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10069
-#: 3.8/weather-applet.js:10076
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Light rain shower"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10082 3.8/weather-applet.js:10083
-#: 3.8/weather-applet.js:10906 3.8/weather-applet.js:12126
-#: 3.8/weather-applet.js:12127 3.8/weather-applet.js:12182
-#: 3.8/weather-applet.js:12992
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Gerimis"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10097
-#: 3.8/weather-applet.js:10104
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Hujan deras"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10118
-#: 3.8/weather-applet.js:10125
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Mandi hujan es"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10138 3.8/weather-applet.js:10145
-#: 3.8/weather-applet.js:10152 3.8/weather-applet.js:10153
-#: 3.8/weather-applet.js:13068
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Hujan Es"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10139
-#: 3.8/weather-applet.js:10146
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Hujan es"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10160
-#: 3.8/weather-applet.js:10167
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Hujan salju ringan"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10181
-#: 3.8/weather-applet.js:10188
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Hujan salju lebat"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10201 3.8/weather-applet.js:10208
-#: 3.8/weather-applet.js:10215 3.8/weather-applet.js:10216
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Guruh"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10202
-#: 3.8/weather-applet.js:10209
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Hujan petir"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10777
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Pastikan Lokasi dalam format yang benar di Pengaturan"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10781
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Pastikan Anda memasukkan kunci yang benar di pengaturan"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10785
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 "Lokasi tidak ditemukan, pastikan lokasi tersedia atau dalam format yang benar"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10789
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Jika masalah ini berlanjut, silakan hubungi Penulis applet ini"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10793
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Kesalahan Tidak Diketahui, silakan lihat log di Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10895
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Badai petir disertai hujan ringan"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10896
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Badai petir dengan hujan"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10897
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Badai petir disertai hujan lebat"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10898
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Badai petir ringan"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10900
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Badai petir yang hebat"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10901
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Badai petir"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10902
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Badai petir dengan gerimis ringan"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10903
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Badai petir dengan gerimis"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10904
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Badai petir dengan gerimis lebat"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:10905
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Gerimis dengan intensitas ringan"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:10907
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Gerimis dengan intensitas tinggi"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:10908
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Hujan gerimis intensitas ringan"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:10909
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Hujan gerimis"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:10910
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Hujan gerimis dengan intensitas tinggi"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:10911
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Mandi hujan dan gerimis"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:10912
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Hujan deras dan gerimis"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:10913
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Hujan gerimis"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:10915
-#: 3.8/weather-applet.js:13304 3.8/weather-applet.js:13305
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Hujan Sedang"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:10916
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Hujan dengan intensitas tinggi"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:10917
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Hujan sangat deras"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:10918
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Hujan ekstrim"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:10920
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Hujan pancuran intensitas ringan"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:10921
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Mandi Hujan"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:10922
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Hujan deras dengan intensitas tinggi"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:10923
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Hujan deras"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:10928
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Hujan Es"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:10929
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Hujan ringan dan salju"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:10930
-#: 3.8/weather-applet.js:13311 3.8/weather-applet.js:13312
-#: 3.8/weather-applet.js:13318 3.8/weather-applet.js:13353
-#: 3.8/weather-applet.js:13360
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Hujan dan salju"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:10931
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Hujan salju ringan"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:10932
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Mandi salju"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:10933
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Hujan salju lebat"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:10935 3.8/weather-applet.js:12755
-#: 3.8/weather-applet.js:12756
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Berasap"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:10936 3.8/weather-applet.js:12762
-#: 3.8/weather-applet.js:12763
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Kabut"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:10937
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Pasir, pusaran debu"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:10939
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Pasir"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:10940 3.8/weather-applet.js:12748
-#: 3.8/weather-applet.js:12749
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Debu"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:10941
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Abu vulkanik"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:10942
-#: 3.8/weather-applet.js:13060
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Badai"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:10943 3.8/weather-applet.js:12727
-#: 3.8/weather-applet.js:12728
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Angin Topan"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:10946
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Langit cerah"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:10947
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Awan"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:10948
-#: 3.8/weather-applet.js:12584 3.8/weather-applet.js:12585
-#: 3.8/weather-applet.js:12619
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Sedikit awan"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:10949
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Awan Tersebar"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:10950
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Berawan Sebagian"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:10951
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Awan Mendung"
 
@@ -1049,77 +1078,80 @@ msgstr "Awan Mendung"
 msgid "Could not get forecast for your area"
 msgstr "Tidak bisa mendapatkan perkiraan untuk wilayah Anda"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12285
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "Lokasi di luar AS, harap gunakan penyedia lain."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12349
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Gagal Memproses Info Prakiraan Per Jam"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12613
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Cerah dan berangin"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12620
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Sedikit awan dan berangin"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12627
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Sebagian berawan dan berangin"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12634
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Sebagian besar berawan dan berangin"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12641
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Mendung dan berangin"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12655
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Hujan Bersalju"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12690
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Hujan dan salju yang membekukan"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:8714 3.8/weather-applet.js:12734
-#: 3.8/weather-applet.js:12735
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Angin Ribut"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:8709
-#: 3.8/weather-applet.js:12741
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Badai"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12742
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Badai Tropis"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12769 3.8/weather-applet.js:12770
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Panas"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12776 3.8/weather-applet.js:12777
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Dingin"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12783 3.8/weather-applet.js:12784
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Badai Salju"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:8587
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Hari Ini"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:8589
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Besok"
 
@@ -1151,79 +1183,79 @@ msgstr "Jum'at"
 msgid "Saturday"
 msgstr "Sabtu"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:8679
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Tenang"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:8682
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Udara Ringan"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:8685
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Angin Sepoi-sepoi"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:8688
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Hembusan Angin Pelan"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:8691
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Angin Sedang"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:8694
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Angin Segar"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:8697
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Angin Kencang"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:8700
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Dekat Angin Kencang"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:8703
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Angin Ribut"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:8706
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Angin Ribut Kuat"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:8712
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Badai Dahsyat"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8862
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "U"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8862
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "TL"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8862
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "T"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8862
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "TS"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8862
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8862
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "BD"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8862
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "B"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8862
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "BL"
 
@@ -1275,7 +1307,7 @@ msgstr ""
 "Terjadi kesalahan yang tidak diketahui saat memperoleh cuaca, lihat log "
 "Looking Glass untuk informasi lebih lanjut"
 
-#: 3.0/yahoo.js:437
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Badai Tropis"
 
@@ -1283,7 +1315,7 @@ msgstr "Badai Tropis"
 msgid "Severe Thunderstorms"
 msgstr "Badai Petir yang Parah"
 
-#: 3.0/yahoo.js:440
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Badai Petir"
 
@@ -1299,15 +1331,15 @@ msgstr "Campuran Hujan dan Hujan es"
 msgid "Mixed Snow and Sleet"
 msgstr "Campuran Salju dan Hujan es"
 
-#: 3.0/yahoo.js:444
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Gerimis Beku"
 
-#: 3.0/yahoo.js:446
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Hujan Beku"
 
-#: 3.0/yahoo.js:447
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Gerimis"
 
@@ -1319,11 +1351,11 @@ msgstr "Hujan Salju"
 msgid "Light Snow Showers"
 msgstr "Hujan Salju Ringan"
 
-#: 3.0/yahoo.js:451
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Salju Berangin"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13290 3.8/weather-applet.js:13291
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Berkabut"
 
@@ -1335,47 +1367,54 @@ msgstr "Berasap"
 msgid "Blustery"
 msgstr "Kencang"
 
-#: 3.0/yahoo.js:460
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Berangin"
 
-#: 3.0/yahoo.js:463
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Sebagian Besar Berawan"
 
-#: 3.0/yahoo.js:464
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Berawan"
 
-#: 3.0/yahoo.js:467
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Umumnya cerah"
 
-#: 3.0/yahoo.js:469
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Campuran Hujan dan Hujan es"
 
-#: 3.0/yahoo.js:471
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Badai Petir Terisolasi"
 
-#: 3.0/yahoo.js:472
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Badai Petir Terisolasi"
 
-#: 3.0/yahoo.js:473
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Hujan Tersebar"
 
-#: 3.0/yahoo.js:474
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Hujan Deras"
 
-#: 3.0/yahoo.js:475
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Hujan Salju Tersebar"
 
-#: 3.0/yahoo.js:476
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Salju Berat"
 
@@ -1387,7 +1426,7 @@ msgstr "Tidak Tersedia"
 msgid "Scattered Thundershowers"
 msgstr "Hujan Petir Tersebar"
 
-#: 3.8/weather-applet.js:9190
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1395,7 +1434,7 @@ msgstr ""
 "Tidak dapat mengambil log, file log tidak ditemukan di bawah jalur\n"
 "  {logFilePath}"
 
-#: 3.8/weather-applet.js:9194
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1404,243 +1443,315 @@ msgstr ""
 "  {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:9606
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Bertemu Office UK"
 
-#: 3.8/weather-applet.js:9786
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
+msgstr ""
+
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Data tidak ditemukan untuk lokasi"
 
-#: 3.8/weather-applet.js:9861
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Sangat Buruk"
 
-#: 3.8/weather-applet.js:9861
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Kurang dari {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:9865
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Sangat Baik"
 
-#: 3.8/weather-applet.js:9865
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Lebih dari {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:9870
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Buruk"
 
-#: 3.8/weather-applet.js:9870 3.8/weather-applet.js:9875
-#: 3.8/weather-applet.js:9880 3.8/weather-applet.js:9885
-#: 3.8/weather-applet.js:9890
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Antara {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:9875
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Sedang"
 
-#: 3.8/weather-applet.js:9880
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Bagus"
 
-#: 3.8/weather-applet.js:9885 3.8/weather-applet.js:9890
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Sangat Baik"
 
-#: 3.8/weather-applet.js:10242
-msgid "DarkSky"
-msgstr "Langit yang gelap"
-
-#: 3.8/weather-applet.js:10293
-msgid "This API has ceased to function, please use another one."
-msgstr "API ini telah berhenti berfungsi, silakan gunakan yang lain."
-
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10569
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10963
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:11520
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:11943
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12106
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Angin sepoi-sepoi"
 
-#: 3.8/weather-applet.js:12120
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Angin Kencang"
 
-#: 3.8/weather-applet.js:12267
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:12815
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Penyeberangan Visual"
 
-#: 3.8/weather-applet.js:12990
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Meniup atau melayang salju"
 
-#: 3.8/weather-applet.js:12994
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Gerimis Lebat"
 
-#: 3.8/weather-applet.js:12998
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Gerimis/hujan lebat"
 
-#: 3.8/weather-applet.js:13000
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Gerimis/hujan ringan"
 
-#: 3.8/weather-applet.js:13002
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Badai Debu"
 
-#: 3.8/weather-applet.js:13006
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Gerimis beku/hujan beku"
 
-#: 3.8/weather-applet.js:13008
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Hujan gerimis/hujan yang membekukan"
 
-#: 3.8/weather-applet.js:13010
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Gerimis beku ringan/hujan beku"
 
-#: 3.8/weather-applet.js:13012
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Kabut Beku"
 
-#: 3.8/weather-applet.js:13018
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Awan corong/tornado"
 
-#: 3.8/weather-applet.js:13020
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Hujan es"
 
-#: 3.8/weather-applet.js:13022
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Es"
 
-#: 3.8/weather-applet.js:13024
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Petir tanpa guntur"
 
-#: 3.8/weather-applet.js:13028
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Curah hujan di sekitarnya"
 
-#: 3.8/weather-applet.js:13032 3.8/weather-applet.js:13319
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Hujan lebat dan salju"
 
-#: 3.8/weather-applet.js:13034
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Hujan ringan dan salju"
 
-#: 3.8/weather-applet.js:13042
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Cakupan langit berkurang"
 
-#: 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Cakupan langit meningkat"
 
-#: 3.8/weather-applet.js:13046
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Langit tidak berubah"
 
-#: 3.8/weather-applet.js:13048
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Asap atau kabut"
 
-#: 3.8/weather-applet.js:13052
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Hujan salju dan hujan"
 
-#: 3.8/weather-applet.js:13064
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Badai petir tanpa presipitasi"
 
-#: 3.8/weather-applet.js:13066
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Debu Berlian"
 
-#: 3.8/weather-applet.js:13072
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Sebagian berawan"
 
-#: 3.8/weather-applet.js:13094
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Pastikan Anda memasukkan kunci API dengan benar"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13110
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:13251 3.8/weather-applet.js:13252
-#: 3.8/weather-applet.js:13388 3.8/weather-applet.js:13389
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "Tidak Ditemukan"
 
-#: 3.8/weather-applet.js:13284
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Meniup Salju"
 
-#: 3.8/weather-applet.js:13325 3.8/weather-applet.js:13326
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Sedikit salju"
 
-#: 3.8/weather-applet.js:13332 3.8/weather-applet.js:13333
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Salju sedang"
 
-#: 3.8/weather-applet.js:13347
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Curah hujan sedang"
 
-#: 3.8/weather-applet.js:13354
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Campuran hujan dan salju"
 
-#: 3.8/weather-applet.js:13361
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Hujan lebat bercampur salju"
 
-#: 3.8/weather-applet.js:13458
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:14130
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+#, fuzzy
+msgid "Weather Underground"
+msgstr "Kondisi Cuaca"
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+msgid "The location you provided was not found."
+msgstr ""
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+#, fuzzy
+msgid "Strong Storm"
+msgstr "Angin Kencang"
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "Hujan dan salju"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "Campuran Hujan dan Hujan es"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "Hujan salju"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "Sebagian besar jelas"
+
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:15603
+#, fuzzy
 msgid ""
-"Could not retrieve config, file was not found under path\n"
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+"Layanan Lokasi merespons dengan kesalahan, silakan lihat log di Looking Glass"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+"Pastikan Anda memasukkan lokasi atau gunakan Lokasi otomatis sebagai gantinya"
+
+#: 3.8/weather-applet.js:15968
+#, fuzzy
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 "Tidak dapat mengambil konfigurasi, file tidak ditemukan di bawah jalur\n"
 "  {configFilePath}"
 
-#: 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1648,49 +1759,57 @@ msgstr ""
 "Tidak bisa mendapatkan konten file konfigurasi di bawah jalur\n"
 "  {configFilePath}"
 
-#: 3.8/weather-applet.js:14470
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Penyedia ini memerlukan kunci API untuk beroperasi"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Titik Embun"
 
-#: 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Curah hujan akan berakhir dalam {precipEnd} menit"
 
-#: 3.8/weather-applet.js:14598
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "Curah hujan tidak akan berakhir dalam waktu satu jam"
 
-#: 3.8/weather-applet.js:14601
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Curah hujan akan mulai dalam {precipStart} menit"
 
-#: 3.8/weather-applet.js:14804
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Penguraian perkiraan gagal, lihat log untuk detail selengkapnya."
 
-#: 3.8/weather-applet.js:15204 3.8/weather-applet.js:15803
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "Pada {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:15210
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} dari Anda"
 
-#: 3.8/weather-applet.js:15660 3.8/weather-applet.js:15670
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Kesalahan Menyimpan Informasi Debug"
 
-#: 3.8/weather-applet.js:15681
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Informasi Debug berhasil disimpan"
 
-#: 3.8/weather-applet.js:15681
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Disimpan ke {filePath}"
-
-#: 3.8/weather-applet.js:15762
-msgid "This provider requires an API key to operate"
-msgstr "Penyedia ini memerlukan kunci API untuk beroperasi"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -1743,7 +1862,6 @@ msgid "Data service"
 msgstr "Layanan Data"
 
 #. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
 msgid "DarkSky (key needed)"
 msgstr "DarkSky (kunci diperlukan)"
 
@@ -2179,12 +2297,21 @@ msgstr ""
 "Bantuan."
 
 #. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Met Office UK (UK only)"
 msgstr "Met Office UK (khusus Inggris)"
 
 #. 3.8->settings-schema.json->dataService->options
 msgid "US National Weather (US only)"
 msgstr "US National Weather (US only)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Pirate Weather (key needed)"
+msgstr "Weatherbit (kunci diperlukan)"
 
 #. 3.8->settings-schema.json->dataService->options
 msgid "Visual Crossing (key needed)"
@@ -2197,6 +2324,11 @@ msgstr "Tomorrow.io (diperlukan kunci)"
 #. 3.8->settings-schema.json->dataService->options
 msgid "AccuWeather (key needed)"
 msgstr "AccuWeather (kunci diperlukan)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Weather Underground (key needed)"
+msgstr "Weatherbit (kunci diperlukan)"
 
 #. 3.8->settings-schema.json->location->tooltip
 msgid ""
@@ -2212,6 +2344,12 @@ msgstr ""
 "pencarian sangat fleksibel dengan format. Setelah 3 detik tanpa mengetik "
 "alamat yang Anda masukkan diganti secara otomatis untuk memvalidasi pilihan "
 "Anda."
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
 
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"
@@ -2261,10 +2399,11 @@ msgid "Enable minutely precipitation forecast"
 msgstr "Aktifkan prakiraan curah hujan yang cermat"
 
 #. 3.8->settings-schema.json->immediatePrecip->tooltip
+#, fuzzy
 msgid ""
 "If you'd like to use this make sure you use your exact coordinates/address "
-"as location to help its accuracy. Currently implemented with OpenWeatherMap "
-"only."
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
 msgstr ""
 "Jika Anda ingin menggunakan ini, pastikan Anda menggunakan koordinat/alamat "
 "yang tepat sebagai lokasi untuk membantu keakuratannya. Saat ini "
@@ -2285,6 +2424,16 @@ msgstr ""
 "{u} adalah satuan.\n"
 "Dapat digunakan jika label tidak pas pada panel vertikal, di antara hal-hal "
 "cerdas lainnya."
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+#, fuzzy
+msgid "Override tooltip on panel"
+msgstr "Ganti label pada panel"
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
 
 #. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
 msgid "Always show Hourly Weather"

--- a/weather@mockturtl/files/weather@mockturtl/po/is.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/is.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: weather@mockturtl\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-21 09:37+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2023-07-21 16:50+0000\n"
 "Last-Translator: Sveinn í Felli <sv1@fellsnet.is>\n"
 "Language-Team: Icelandic\n"
@@ -19,65 +20,65 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17519
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Villa"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17520 3.8/weather-applet.js:17522
-#: 3.8/weather-applet.js:17524 3.8/weather-applet.js:17527
-#: 3.8/weather-applet.js:17530 3.8/weather-applet.js:17531
-#: 3.8/weather-applet.js:17532 3.8/weather-applet.js:17533
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Villa í þjónustu"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17521
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Rangur API-lykill"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17523
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Rangt snið á staðsetningu"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17525
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "API-lykill útilokaður"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17526
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Gat ekki fundið staðsetningu"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17528
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Enginn API-lykill"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17529
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Engin staðsetning"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17534
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Pakkar sem vantar"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17535
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Staðsetning ekki með"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9711
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Veðursmáforrit"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17833
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17834
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Smelltu til að opna"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16129
-#: 3.8/weather-applet.js:17837
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Endurlesa"
 
@@ -87,8 +88,8 @@ msgstr "API-forritsviðmótið skilaði stöðukóða á milli 400 og 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Vistun staðsetninga"
 
@@ -100,14 +101,14 @@ msgstr "Því miður, ekki er hægt að vista staðsetningu sem fundin er sjálf
 msgid "Could not get weather information"
 msgstr "Gat ekki náð í veðurupplýsingar"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17672
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Óvænt villa kom upp við að uppfæra veðurupplýsingar, skoðaðu atvikaskrár í "
 "Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:17915
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -123,7 +124,7 @@ msgstr "Villa í netkerfi, skoðaðu atvikaskrár í Looking Glass"
 msgid "As of"
 msgstr "Miðað við"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:16920
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Keyrt með"
 
@@ -131,94 +132,93 @@ msgstr "Keyrt með"
 msgid "from you"
 msgstr "frá þér"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16833
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:16833
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "í"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10312
-#: 3.8/weather-applet.js:16998
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "míl"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10313
-#: 3.8/weather-applet.js:16999
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17176
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Hleð inn veðurlýsingu ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17179
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Hleð inn veðurspá ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16082
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Hleð inn ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16103
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Hitastig"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16104
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Rakastig"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16105
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Loftþrýstingur"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12257 3.8/weather-applet.js:12263
-#: 3.8/weather-applet.js:14217 3.8/weather-applet.js:14218
-#: 3.8/weather-applet.js:15951
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Vindur"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:15343
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Gakktu úr skugga um að þú hafir sett inn staðsetningu eða sért að nota "
 "sjálfvirka staðsetningu"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9952
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Gat ekki fundið staðsetningu út frá heimilisfangi, athugaðu hvort það sé rétt"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9973
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Mistókst að fletta upp í API-viðmóti hnattstaðsetningar, skoðaðu atvikaskrár "
 "í Looking Glass til að sjá villur."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Aðvörun"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9872
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Þú getur aðeins vistað réttar staðsetningar þegar smáforritið er ekki að "
 "endulesa upplýsingar"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Þú getur ekki vistað ranga staðsetningu"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9880
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Upplýsingar"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Staðsetning er þegar vistuð"
 
@@ -258,15 +258,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10740 3.8/weather-applet.js:11711
-#: 3.8/weather-applet.js:12150 3.8/weather-applet.js:12659
-#: 3.8/weather-applet.js:13021 3.8/weather-applet.js:14388
-#: 3.8/weather-applet.js:14978
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Með vindkælingu"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:15040
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Tókst ekki að meðhöndla veðurupplýsingar"
 
@@ -279,7 +279,7 @@ msgstr ""
 "en náðu fyrst í einn slíkan á https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:14920
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -287,7 +287,7 @@ msgstr ""
 "Gakktu úr skugga um að þú hafir\n"
 "sett API-lykilinn rétt inn og að notandaaðgangurinn þinn sé ekki læstur"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12113
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -298,60 +298,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10516 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10530 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:11379 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:11386 3.8/weather-applet.js:11393
-#: 3.8/weather-applet.js:11400 3.8/weather-applet.js:12292
-#: 3.8/weather-applet.js:13187
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Úrfelli"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11554 3.8/weather-applet.js:11555
-#: 3.8/weather-applet.js:11561 3.8/weather-applet.js:12277
-#: 3.8/weather-applet.js:12278 3.8/weather-applet.js:12284
-#: 3.8/weather-applet.js:12291 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12340 3.8/weather-applet.js:12347
-#: 3.8/weather-applet.js:12801 3.8/weather-applet.js:12850
-#: 3.8/weather-applet.js:12851 3.8/weather-applet.js:12858
-#: 3.8/weather-applet.js:13179 3.8/weather-applet.js:13448
-#: 3.8/weather-applet.js:13449 3.8/weather-applet.js:13490
-#: 3.8/weather-applet.js:14189 3.8/weather-applet.js:14190
-#: 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Rigning"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10495 3.8/weather-applet.js:10509
-#: 3.8/weather-applet.js:10510 3.8/weather-applet.js:11009
-#: 3.8/weather-applet.js:11463 3.8/weather-applet.js:11464
-#: 3.8/weather-applet.js:11470 3.8/weather-applet.js:11477
-#: 3.8/weather-applet.js:11484 3.8/weather-applet.js:12285
-#: 3.8/weather-applet.js:13189
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Dálítil rigning"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12348 3.8/weather-applet.js:13163
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Talsverð frostrigning"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11014
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12822
-#: 3.8/weather-applet.js:12823 3.8/weather-applet.js:12829
-#: 3.8/weather-applet.js:12830 3.8/weather-applet.js:12836
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Frostrigning"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12341 3.8/weather-applet.js:13165
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Dálítil frostrigning"
 
@@ -359,177 +359,177 @@ msgstr "Dálítil frostrigning"
 msgid "Light freezing drizzle"
 msgstr "Dálítil frostsúld"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12327
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Frostsúld"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13145
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Dálítil súld"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12362
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Mikil ískorn"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12354 3.8/weather-applet.js:12355
-#: 3.8/weather-applet.js:12361 3.8/weather-applet.js:12368
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Ískorn"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12369
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Dálítil ískorn"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10600
-#: 3.8/weather-applet.js:10607 3.8/weather-applet.js:10614
-#: 3.8/weather-applet.js:10615 3.8/weather-applet.js:11021
-#: 3.8/weather-applet.js:11435 3.8/weather-applet.js:11436
-#: 3.8/weather-applet.js:11442 3.8/weather-applet.js:11449
-#: 3.8/weather-applet.js:11456 3.8/weather-applet.js:12320
-#: 3.8/weather-applet.js:13205 3.8/weather-applet.js:13525
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Mikil snjókoma"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:11610
-#: 3.8/weather-applet.js:11611 3.8/weather-applet.js:11617
-#: 3.8/weather-applet.js:12298 3.8/weather-applet.js:12299
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12795
-#: 3.8/weather-applet.js:13199 3.8/weather-applet.js:13434
-#: 3.8/weather-applet.js:13518 3.8/weather-applet.js:14203
-#: 3.8/weather-applet.js:14204 3.8/weather-applet.js:14581
-#: 3.8/weather-applet.js:14582
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Snjókoma"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11019
-#: 3.8/weather-applet.js:11519 3.8/weather-applet.js:11520
-#: 3.8/weather-applet.js:11526 3.8/weather-applet.js:11533
-#: 3.8/weather-applet.js:11540 3.8/weather-applet.js:12313
-#: 3.8/weather-applet.js:13207
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Dálítil snjókoma"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12305
-#: 3.8/weather-applet.js:12306 3.8/weather-applet.js:14560
-#: 3.8/weather-applet.js:14561
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Snjófjúk"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:12375 3.8/weather-applet.js:12376
-#: 3.8/weather-applet.js:12867 3.8/weather-applet.js:12868
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13532
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:14210
-#: 3.8/weather-applet.js:14211
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Þrumuveður"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12243
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Létt þoka"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11372
-#: 3.8/weather-applet.js:11373 3.8/weather-applet.js:12235
-#: 3.8/weather-applet.js:12236 3.8/weather-applet.js:12242
-#: 3.8/weather-applet.js:12937 3.8/weather-applet.js:12938
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:14161
-#: 3.8/weather-applet.js:14162 3.8/weather-applet.js:14609
-#: 3.8/weather-applet.js:14610
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Þoka"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10474 3.8/weather-applet.js:10475
-#: 3.8/weather-applet.js:11358 3.8/weather-applet.js:11359
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:12208
-#: 3.8/weather-applet.js:13427 3.8/weather-applet.js:13428
-#: 3.8/weather-applet.js:14154 3.8/weather-applet.js:14155
-#: 3.8/weather-applet.js:14651 3.8/weather-applet.js:14652
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Skýjað"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12228
-#: 3.8/weather-applet.js:12229 3.8/weather-applet.js:12745
-#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:12780
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Alskýjað"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10439
-#: 3.8/weather-applet.js:10440 3.8/weather-applet.js:10446
-#: 3.8/weather-applet.js:10447 3.8/weather-applet.js:11547
-#: 3.8/weather-applet.js:11548 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12222 3.8/weather-applet.js:12738
-#: 3.8/weather-applet.js:12739 3.8/weather-applet.js:12773
-#: 3.8/weather-applet.js:13420 3.8/weather-applet.js:13421
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Hálfskýjað"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Mestmegnis bjart"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10425 3.8/weather-applet.js:10426
-#: 3.8/weather-applet.js:11039 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:12724
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12759
-#: 3.8/weather-applet.js:13223 3.8/weather-applet.js:13413
-#: 3.8/weather-applet.js:13414 3.8/weather-applet.js:14140
-#: 3.8/weather-applet.js:14141 3.8/weather-applet.js:14147
-#: 3.8/weather-applet.js:14148 3.8/weather-applet.js:14686
-#: 3.8/weather-applet.js:14687
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Heiðskírt"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10432
-#: 3.8/weather-applet.js:10433 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:14693
-#: 3.8/weather-applet.js:14694
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Sólskin"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10418
-#: 3.8/weather-applet.js:10419 3.8/weather-applet.js:10453
-#: 3.8/weather-applet.js:10454 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10643 3.8/weather-applet.js:11341
-#: 3.8/weather-applet.js:11342 3.8/weather-applet.js:11639
-#: 3.8/weather-applet.js:11640 3.8/weather-applet.js:12192
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12715
-#: 3.8/weather-applet.js:12716 3.8/weather-applet.js:12944
-#: 3.8/weather-applet.js:12945 3.8/weather-applet.js:14073
-#: 3.8/weather-applet.js:14074 3.8/weather-applet.js:14224
-#: 3.8/weather-applet.js:14225 3.8/weather-applet.js:14797
-#: 3.8/weather-applet.js:14799
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Óþekkt"
 
@@ -553,7 +553,7 @@ msgstr ""
 "Settu inn API-lykil í stillingunum,\n"
 "en náðu fyrst í einn slíkan á https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:14930
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -561,131 +561,131 @@ msgstr ""
 "Gakktu úr skugga um að þú hafir\n"
 "sett API-lykilinn frá DarkSky rétt inn"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:14878
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Gat ekki fengið staðsetninguna"
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:14884
+#: 3.0/ipApi.js:95
 msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 "Staðsetningarþjónusta svaraði með villum, skoðaðu atvikaskrár í Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11203
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Skýjahula"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11351
-#: 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Heiðskírt"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11365 3.8/weather-applet.js:11366
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Bjartviðri"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11387
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Úrfelli og þrumur"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11394
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Talsverðir skúrir"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11401
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Talsverðir skúrir og þrumur"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11407
-#: 3.8/weather-applet.js:11408 3.8/weather-applet.js:11414
-#: 3.8/weather-applet.js:11421 3.8/weather-applet.js:11428
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Talsverð slydda"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11415
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Talsverð slydda og þrumur"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11422
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Talsverð slydduél"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11429
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Talsverð slydduél og þrumur"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11443
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Talsverð snjókoma og þrumur"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11450
-#: 3.8/weather-applet.js:13526
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Talsverð snjóél"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11457
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Talsverð snjóél og þrumur"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11471
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Dálítið regn og þrumur"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11478
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Dálitlir skúrir"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11485
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Dálitlir skúrir og þrumur"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11491
-#: 3.8/weather-applet.js:11492 3.8/weather-applet.js:11498
-#: 3.8/weather-applet.js:11505 3.8/weather-applet.js:11512
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Dálítil slydda"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11499
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Dálítil slydda og þrumur"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11506
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Dálítil slydduél"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11513
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Dálítil slydduél og þrumur"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11527
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Dálítil snjókoma og þrumur"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11534
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Dálítil snjóél"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11541
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Dálítil snjóél og þrumur"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11562
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Regn og þrumur"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11568
-#: 3.8/weather-applet.js:11569 3.8/weather-applet.js:11575
-#: 3.8/weather-applet.js:12859 3.8/weather-applet.js:13185
-#: 3.8/weather-applet.js:13491 3.8/weather-applet.js:13497
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Skúrir"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11576
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Skúrir og þrumur"
 
@@ -694,44 +694,44 @@ msgstr "Skúrir og þrumur"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10537
-#: 3.8/weather-applet.js:10544 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11582 3.8/weather-applet.js:11583
-#: 3.8/weather-applet.js:11589 3.8/weather-applet.js:11596
-#: 3.8/weather-applet.js:11603 3.8/weather-applet.js:12808
-#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12815
-#: 3.8/weather-applet.js:12816 3.8/weather-applet.js:12843
-#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14196
-#: 3.8/weather-applet.js:14197 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Slydda"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11590
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Slydda og þrumur"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11597
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Slydduél"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11604
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Slydduél og þrumur"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11618
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Snjókoma og þrumur"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11624 3.8/weather-applet.js:11625
-#: 3.8/weather-applet.js:11631 3.8/weather-applet.js:13203
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Snjóél"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11632
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Snjór og þrumur"
 
@@ -740,21 +740,21 @@ msgstr "Snjór og þrumur"
 msgid "Unexpected response from API"
 msgstr "Óskiljanlegt svar frá API-viðmótinu"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10237
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Skyggni"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10265
-#: 3.8/weather-applet.js:10817 3.8/weather-applet.js:11722
-#: 3.8/weather-applet.js:12672
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Tókst ekki að meðhöndla fyrirliggjandi veðurupplýsingar"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10055
-#: 3.8/weather-applet.js:10089 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11782 3.8/weather-applet.js:12474
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Tókst ekki að meðhöndla veðurspárupplýsingar"
 
@@ -783,88 +783,88 @@ msgid "Excellent - More than"
 msgstr "Frábært - meira en"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10460 3.8/weather-applet.js:10461
-#: 3.8/weather-applet.js:11029 3.8/weather-applet.js:13175
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Mistur"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:12752
-#: 3.8/weather-applet.js:12753 3.8/weather-applet.js:12787
-#: 3.8/weather-applet.js:13219
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Alskýjað"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10489
-#: 3.8/weather-applet.js:10496
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Dálitlar regnskúrir"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:12326
-#: 3.8/weather-applet.js:13141 3.8/weather-applet.js:14532
-#: 3.8/weather-applet.js:14533
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Súld"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:10524
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Talsverðir regnskúrir"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10538
-#: 3.8/weather-applet.js:10545
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Slydduél"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:13217 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14169 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:14589
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Haglél"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Haglél"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Dálítil snjóél"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Talsverð snjóél"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10621 3.8/weather-applet.js:10628
-#: 3.8/weather-applet.js:10635 3.8/weather-applet.js:10636
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Þrumur"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Þrumuskúrir"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10872
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Gakktu úr skugga um að staðsetning sé á réttu sniði í stillingunum"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10876
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Gakktu úr skugga um að þú hafir sett inn réttan lykil í stillingunum"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10681 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -872,212 +872,212 @@ msgstr ""
 "Staðsetning fannst ekki, gakktu úr skugga um að staðsetning sé tiltæk og á "
 "réttu sniði"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10884
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 "Ef vandamálið er viðvarandi skaltu hafa samband við höfund smáforritsins"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10888
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Óþekkt villa, skoðaðu atvikaskrár í Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10990
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Þrumuveður með dálítilli rigningu"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10991
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Þrumuveður með rigningu"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10992
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Þrumuveður með talsverðri rigningu"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10993
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Dálítið þrumuveður"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10995
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Talsvert þrumuveður"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10996
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Þrumuveður á köflum"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10997
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Þrumuveður með dálítilli súld"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10998
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Þrumuveður með súld"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10999
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Þrumuveður með talsverðri súld"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11000
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Súldarslæðingur"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11002
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Talsverð súldarrigning"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11003
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Dálítil súldarrigning"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11004
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Súldarrigning"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11005
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Talsverð súldarrigning"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11006
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Skúraleiðingar og súld"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11007
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Talsverðar skúraleiðingar og súld"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11008
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Súldarskúrir"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11010
-#: 3.8/weather-applet.js:13455 3.8/weather-applet.js:13456
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Nokkur rigning"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11011
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Talsverð rigning"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11012
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Úrfelli"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11013
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Mikið úrfelli"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11015
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Dálitlar skúraleiðingar"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11016
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Skúrir"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11017
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Talsverðar skúraleiðingar"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11018
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Skúraleiðingar á köflum"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11023
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Slydduél"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11024
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Dálitlir regn/snjóskúrir"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11025
-#: 3.8/weather-applet.js:13462 3.8/weather-applet.js:13463
-#: 3.8/weather-applet.js:13469 3.8/weather-applet.js:13504
-#: 3.8/weather-applet.js:13511
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Regn og snjókoma"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11026
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Dálítil snjóél"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11027
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Snjóél"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11028
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Talsverð snjóél"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:12902
-#: 3.8/weather-applet.js:12903 3.8/weather-applet.js:14623
-#: 3.8/weather-applet.js:14624
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Reykur"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11031 3.8/weather-applet.js:12909
-#: 3.8/weather-applet.js:12910 3.8/weather-applet.js:14616
-#: 3.8/weather-applet.js:14617
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Mistur"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11032
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Sand eða rykhvirflar"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11034
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Sandur"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11035 3.8/weather-applet.js:12895
-#: 3.8/weather-applet.js:12896 3.8/weather-applet.js:14602
-#: 3.8/weather-applet.js:14603
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Ryk"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11036
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Gosaska"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:13209
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Vindhviður"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11038 3.8/weather-applet.js:12874
-#: 3.8/weather-applet.js:12875 3.8/weather-applet.js:14475
-#: 3.8/weather-applet.js:14476
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Hvirfilbylur"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11041
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Heiðskírt"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11042
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Skýjað"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11043
-#: 3.8/weather-applet.js:12731 3.8/weather-applet.js:12732
-#: 3.8/weather-applet.js:12766
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Hálfskýjað"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11044
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Léttskýjað"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11045
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Skýjað með köflum"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11046
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Alskýjað"
 
@@ -1085,80 +1085,80 @@ msgstr "Alskýjað"
 msgid "Could not get forecast for your area"
 msgstr "Tókst ekki að fá spá fyrir svæðið þitt"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12431
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "Staðsetning er utan BNA, notaðu aðra þjónustuveitu."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12495
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Tókst ekki að meðhöndla upplýsingar fyrir klukkustundaspá"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12760
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Bjartviðri og vindur"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12767
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Léttskýjað og vindur"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12774
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Hálfskýjað og vindasamt"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Alskýjað og vindasamt"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12788
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Alskýjað og vindur"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12802
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Snjókennd rigning"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12837
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Frostrigning og snjór"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9153 3.8/weather-applet.js:12881
-#: 3.8/weather-applet.js:12882 3.8/weather-applet.js:14489
-#: 3.8/weather-applet.js:14490
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Fellibylur"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9148
-#: 3.8/weather-applet.js:12888
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Rok"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12889
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Hitabeltisstormur"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12916 3.8/weather-applet.js:12917
-#: 3.8/weather-applet.js:14721 3.8/weather-applet.js:14722
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Heitt"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12923 3.8/weather-applet.js:12924
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Kalt"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12930 3.8/weather-applet.js:12931
-#: 3.8/weather-applet.js:14770 3.8/weather-applet.js:14771
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Snjóbylur"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9025
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Í dag"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9027
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Á morgun"
 
@@ -1190,79 +1190,79 @@ msgstr "Föstudagur"
 msgid "Saturday"
 msgstr "Laugardagur"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9118
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Logn"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9121
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Andvari"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9124
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Kul"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9127
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Gola"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9130
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Stinningsgola"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9133
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Kaldi"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9136
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Stinningskaldi"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9139
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Allhvasst"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9142
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Hvassviðri"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9145
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Stormur"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9151
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Ofsaveður"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "NA"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "A"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "SA"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "SV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "V"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "NV"
 
@@ -1314,7 +1314,7 @@ msgstr ""
 "Óþekkt villa við að fletta upp veðurupplýsingum,\n"
 " skoðaðu atvikaskrár í Looking Glass til að sjá villur"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14482 3.8/weather-applet.js:14483
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Hitabeltisstormur"
 
@@ -1322,7 +1322,7 @@ msgstr "Hitabeltisstormur"
 msgid "Severe Thunderstorms"
 msgstr "Hvasst þrumuveður"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14503 3.8/weather-applet.js:14504
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Þrumuveður"
 
@@ -1338,15 +1338,15 @@ msgstr "Ýmist rigning eða slydda"
 msgid "Mixed Snow and Sleet"
 msgstr "Ýmist snjókoma eða slydda"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Frostsúld"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Frostrigning"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Skúrir"
 
@@ -1358,11 +1358,11 @@ msgstr "Snjóhryðjur"
 msgid "Light Snow Showers"
 msgstr "Dálítil snjóél"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14574 3.8/weather-applet.js:14575
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Snjóbylur"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13441 3.8/weather-applet.js:13442
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Þokuveður"
 
@@ -1374,54 +1374,54 @@ msgstr "Reykjarkóf"
 msgid "Blustery"
 msgstr "Vindhviður"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14637 3.8/weather-applet.js:14638
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Vindasamt"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:14658 3.8/weather-applet.js:14659
-#: 3.8/weather-applet.js:14665 3.8/weather-applet.js:14666
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Alskýjað"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14175 3.8/weather-applet.js:14176
-#: 3.8/weather-applet.js:14182 3.8/weather-applet.js:14183
-#: 3.8/weather-applet.js:14672 3.8/weather-applet.js:14673
-#: 3.8/weather-applet.js:14679 3.8/weather-applet.js:14680
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Hálfskýjað"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Sólskin að mestu"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:14714 3.8/weather-applet.js:14715
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Ýmist rigning eða haglél"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:14728 3.8/weather-applet.js:14729
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Þrumuveður á köflum"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:14735 3.8/weather-applet.js:14736
-#: 3.8/weather-applet.js:14791 3.8/weather-applet.js:14792
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Þrumuveður á dreif"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:14742 3.8/weather-applet.js:14743
-#: 3.8/weather-applet.js:14777 3.8/weather-applet.js:14778
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Skúrir á dreif"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:14749 3.8/weather-applet.js:14750
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Úrfelli"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:14756 3.8/weather-applet.js:14757
-#: 3.8/weather-applet.js:14784 3.8/weather-applet.js:14785
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Snjóél á dreif"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:14763 3.8/weather-applet.js:14764
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Talsverð snjókoma"
 
@@ -1433,7 +1433,7 @@ msgstr "Ekki tiltækt"
 msgid "Scattered Thundershowers"
 msgstr "Þrumuskúrir á dreif"
 
-#: 3.8/weather-applet.js:9637
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1441,7 +1441,7 @@ msgstr ""
 "Gat ekki náð í atvikaskrár, atvikaskrá fannst ekki á uppgefinni slóð\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9641
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1450,287 +1450,302 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10013
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "UK MET stofnunin"
 
-#: 3.8/weather-applet.js:10118
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
-"MET Office UK þjónustar einungis Bretland, gakktu úr skugga um að"
-" staðsetningin þín sé þar"
+"MET Office UK þjónustar einungis Bretland, gakktu úr skugga um að "
+"staðsetningin þín sé þar"
 
-#: 3.8/weather-applet.js:10197
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Engin gögn fundust fyrir staðsetningu"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Mjög lélegt"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "minna en {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Frábært"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "meira en {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10287
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Lélegt"
 
-#: 3.8/weather-applet.js:10287 3.8/weather-applet.js:10292
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:10302
-#: 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "milli {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10292
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Miðlungs"
 
-#: 3.8/weather-applet.js:10297
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Gott"
 
-#: 3.8/weather-applet.js:10302 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Mjög gott"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10662
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET - Noregur"
 
-#: 3.8/weather-applet.js:11659
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12080
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12250
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Dálítill vindur"
 
-#: 3.8/weather-applet.js:12264
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Talsverður vindur"
 
-#: 3.8/weather-applet.js:12411
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:12962
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:13139
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Skafrenningur"
 
-#: 3.8/weather-applet.js:13143
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Mikil súld"
 
-#: 3.8/weather-applet.js:13147
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Talsverð súld/rigning"
 
-#: 3.8/weather-applet.js:13149
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Dálítil súld/rigning"
 
-#: 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Rykstormur"
 
-#: 3.8/weather-applet.js:13155
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Frostsúld/frostrigning"
 
-#: 3.8/weather-applet.js:13157
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Talsverð frostsúld/frostrigning"
 
-#: 3.8/weather-applet.js:13159
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Dálítil frostsúld/frostrigning"
 
-#: 3.8/weather-applet.js:13161
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Frostþoka"
 
-#: 3.8/weather-applet.js:13167
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Skýstrokkur"
 
-#: 3.8/weather-applet.js:13169
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Haglél"
 
-#: 3.8/weather-applet.js:13171
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Ís"
 
-#: 3.8/weather-applet.js:13173
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Eldingar án þruma"
 
-#: 3.8/weather-applet.js:13177
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Úrkoma í grennd"
 
-#: 3.8/weather-applet.js:13181 3.8/weather-applet.js:13470
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Talsverð rigning eða snjókoma"
 
-#: 3.8/weather-applet.js:13183
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Dálítil rigning eða snjókoma"
 
-#: 3.8/weather-applet.js:13191
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Minnkandi skýjahula"
 
-#: 3.8/weather-applet.js:13193
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Vaxandi skýjahula"
 
-#: 3.8/weather-applet.js:13195
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Óbreytt skýjahula"
 
-#: 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Reykur eða mistur"
 
-#: 3.8/weather-applet.js:13201
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Regn- eða snjóél"
 
-#: 3.8/weather-applet.js:13213
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Þrumuveður án úrkomu"
 
-#: 3.8/weather-applet.js:13215
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Ískristallar"
 
-#: 3.8/weather-applet.js:13221
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Hálfskýjað"
 
-#: 3.8/weather-applet.js:13243
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Gakktu úr skugga um að þú hafir sett API-lykilinn rétt inn "
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13259
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:13402 3.8/weather-applet.js:13403
-#: 3.8/weather-applet.js:13539 3.8/weather-applet.js:13540
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "FINNST EKKI"
 
-#: 3.8/weather-applet.js:13435
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Snjóbylur"
 
-#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:13477
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Örlítil snjókoma"
 
-#: 3.8/weather-applet.js:13483 3.8/weather-applet.js:13484
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Nokkur rigning"
 
-#: 3.8/weather-applet.js:13498
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Nokkir skúrir"
 
-#: 3.8/weather-applet.js:13505
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Ýmist rigning eða snjókoma"
 
-#: 3.8/weather-applet.js:13512
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Talsverð rigning eða snjókoma"
 
-#: 3.8/weather-applet.js:13657
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:13953
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:13966
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "Veldu aðra þjónustu eða staðsetningu"
 
-#: 3.8/weather-applet.js:14263
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14453
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "API-lykillinn sem þú gafst upp er ógildur."
 
-#: 3.8/weather-applet.js:14460
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "Staðsetningin sem þú gafst upp fannst ekki."
 
-#: 3.8/weather-applet.js:14496 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Ofsarok"
 
-#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:14512
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Regn og snjókoma"
 
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Rigning og slydda"
 
-#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Snjóél"
 
-#: 3.8/weather-applet.js:14630 3.8/weather-applet.js:14631
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "Gjóla"
 
-#: 3.8/weather-applet.js:14644 3.8/weather-applet.js:14645
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr "Svalt"
 
-#: 3.8/weather-applet.js:14700 3.8/weather-applet.js:14701
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Að mestu leyti bjart"
 
-#: 3.8/weather-applet.js:14902
+#: 3.8/weather-applet.js:15247
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:15481
+#: 3.8/weather-applet.js:15603
+#, fuzzy
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+"Staðsetningarþjónusta svaraði með villum, skoðaðu atvikaskrár í Looking Glass"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+"Gakktu úr skugga um að þú hafir sett inn staðsetningu eða sért að nota "
+"sjálfvirka staðsetningu"
+
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1738,7 +1753,7 @@ msgstr ""
 "Gat ekki náð í stillingaskrá, stillingaskrá fannst ekki á uppgefinni slóð\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15486
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1746,60 +1761,60 @@ msgstr ""
 "Gat ekki náð í efni stillingaskrár á uppgefinni slóð\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:16106
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr ""
+"Þessi þjónustuveita krefst lykils að API-viðmóti til að hægt sé að nota hana"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Daggarmark"
 
-#: 3.8/weather-applet.js:16178
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Úrkoma mun hætta eftir {precipStart} mínútur"
 
-#: 3.8/weather-applet.js:16180
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "Úrkoma mun ekki hætta á næstu klukkustund"
 
-#: 3.8/weather-applet.js:16183
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Úrkoma mun hefjast eftir {precipStart} mínútur"
 
-#: 3.8/weather-applet.js:16395
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Túlkun veðurspár mistókst, skoðaðu atvikaskrár til að sjá frekari "
 "upplýsingar."
 
-#: 3.8/weather-applet.js:16927 3.8/weather-applet.js:17714
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "Miðað við {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:16933
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} frá þér"
 
-#: 3.8/weather-applet.js:16937
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "Heiti stöðvar: {stationName}"
 
-#: 3.8/weather-applet.js:16940
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "Svæði: {stationArea}"
 
-#: 3.8/weather-applet.js:17485 3.8/weather-applet.js:17495
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Villa við að vista villuleitarupplýsingar"
 
-#: 3.8/weather-applet.js:17507
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Tókst að vista villuleitarupplýsingar"
 
-#: 3.8/weather-applet.js:17507
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Vistað í {filePath}"
-
-#: 3.8/weather-applet.js:17638
-msgid "This provider requires an API key to operate"
-msgstr ""
-"Þessi þjónustuveita krefst lykils að API-viðmóti til að hægt sé að nota hana"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -2331,6 +2346,12 @@ msgstr ""
 "án þess að skrifa neitt verður fyllt sjálfkrafa inn með viðkomandi "
 "heimilisfangi á réttu sniði."
 
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
+
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"
 msgstr "Vista núverandi staðsetningu í gagnageymslu"
@@ -2384,9 +2405,9 @@ msgid ""
 "as location to help its accuracy. See Feature map on website on support for "
 "your provider"
 msgstr ""
-"Ef þú ætlar að nota þetta skaltu setja inn nákvæm hnit/heimilisfang sem"
-" staðsetningu. Skoðaðu upplýsingar á vefsvæðinu okkar varðand stuðning við"
-" þjónustuna þína"
+"Ef þú ætlar að nota þetta skaltu setja inn nákvæm hnit/heimilisfang sem "
+"staðsetningu. Skoðaðu upplýsingar á vefsvæðinu okkar varðand stuðning við "
+"þjónustuna þína"
 
 #. 3.8->settings-schema.json->showBothTempUnits->description
 msgid "Show both temperature units at the same time"
@@ -2411,7 +2432,8 @@ msgstr "Skrifa yfir ábendingu á skjástiku"
 msgid ""
 "Has the same behavior and available values as 'Override label on panel'."
 msgstr ""
-"Er með sömu hegðun og tiltæk gildi eins og 'Skrifa yfir merkingu á skjástiku'."
+"Er með sömu hegðun og tiltæk gildi eins og 'Skrifa yfir merkingu á "
+"skjástiku'."
 
 #. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
 msgid "Always show Hourly Weather"
@@ -2588,81 +2610,3 @@ msgstr ""
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr "Valin slóð þar sem á að vista atvikaskrár"
-
-#~ msgid "DarkSky"
-#~ msgstr "DarkSky"
-
-#~ msgid "This API has ceased to function, please use another one."
-#~ msgstr "Þetta API-kerfisviðmót er hætt að virka, veldu eitthvað annað."
-
-#~ msgid "Instead of 15:00 or 3 pm it will show up as 15 or 3 pm"
-#~ msgstr "Í stað 15:00 eða 3 eh mun birtast 15 eða 3 eh"
-
-#~ msgid "API key doesn't provide access to Hourly Weather, skipping"
-#~ msgstr "API-lykill gefur ekki aðgang að klukkutímaspám, sleppi þessu"
-
-#~ msgid "Please install '{missingPackage}', then refresh manually."
-#~ msgstr "Settu upp '{missingPackage}', síðan skaltu endurlesa handvirkt."
-
-#~ msgid "Light Snow"
-#~ msgstr "Dálítil snjókoma"
-
-#~ msgid "Currently only used with DarkSky."
-#~ msgstr "Í augnablikinu bara notað með DarkSky."
-
-#~ msgid "ClimacellV4 (key needed)"
-#~ msgstr "ClimacellV4 (lykill nauðsynlegur)"
-
-#~ msgid "ClimacellV3 (key needed)"
-#~ msgstr "ClimacellV3 (lykill nauðsynlegur)"
-
-#~ msgid "Units, Icons and Keys"
-#~ msgstr "Einingar, táknmyndir og skýringar"
-
-#~ msgid "How to choose a weather provider"
-#~ msgstr "Hvernig á að velja veðurþjónustu"
-
-#~ msgid "Allowed location formats"
-#~ msgstr "Leyfð snið staðsetninga"
-
-#~ msgid "View additional information"
-#~ msgstr "Skoða viðbótarupplýsingar"
-
-#~ msgid "Settings"
-#~ msgstr "Stillingar"
-
-#~ msgid "Sunrise"
-#~ msgstr "Sólarupprás"
-
-#~ msgid "Sunset"
-#~ msgstr "Sólsetur"
-
-#~ msgid "Wind Chill:"
-#~ msgstr "Vindkæling:"
-
-#~ msgid "Isolated thundershowers"
-#~ msgstr "Skúrir/él á stöku stað"
-
-#~ msgid "Get WOEID"
-#~ msgstr "Sækja WOEID"
-
-#~ msgid "Vertical orientation"
-#~ msgstr "Lóðrétt stefna"
-
-#~ msgid "WOEID"
-#~ msgstr "WOEID"
-
-#~ msgid "Where On Earth ID"
-#~ msgstr "Staðstetningarauðkenni"
-
-#~ msgid "kPa"
-#~ msgstr "kPa"
-
-#~ msgid "mbar"
-#~ msgstr "mbar"
-
-#~ msgid "Symbolic icons"
-#~ msgstr "Táknrænar táknmyndir"
-
-#~ msgid "Schema \"%s\" not found."
-#~ msgstr "Skemað \"%s\" fannst ekki."

--- a/weather@mockturtl/files/weather@mockturtl/po/it.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/it.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-21 09:37+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2023-10-29 17:21+0100\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -19,65 +20,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17519
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Errore"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17520 3.8/weather-applet.js:17522
-#: 3.8/weather-applet.js:17524 3.8/weather-applet.js:17527
-#: 3.8/weather-applet.js:17530 3.8/weather-applet.js:17531
-#: 3.8/weather-applet.js:17532 3.8/weather-applet.js:17533
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Errore di Servizio"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17521
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Chiave API errata"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17523
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Formato posizione errato"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17525
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Chiave bloccata"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17526
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Impossibile trovare la posizione"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17528
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Nessuna chiave API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17529
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Nessuna posizione"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17534
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Pacchetti Mancanti"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17535
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Località non coperta"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9711
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Applet Meteo"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17833
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17834
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Clicca per aprire"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16129
-#: 3.8/weather-applet.js:17837
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Ricarica"
 
@@ -87,8 +88,8 @@ msgstr "Le API hanno restituito un codice di status tra 400 e 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Archivio Posizioni"
 
@@ -101,14 +102,14 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr "Impossibile ottenere informazioni meteo"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17672
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Errore imprevisto durante l'aggiornamento del tempo, consultare il log in "
 "Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:17915
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -124,7 +125,7 @@ msgstr "Errore di rete, controlla i log in Looking Glass"
 msgid "As of"
 msgstr "Da"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:16920
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Offerto da"
 
@@ -132,95 +133,94 @@ msgstr "Offerto da"
 msgid "from you"
 msgstr "da te"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16833
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:16833
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10312
-#: 3.8/weather-applet.js:16998
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10313
-#: 3.8/weather-applet.js:16999
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17176
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Caricamento meteo in corso ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17179
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Caricamento meteo futuro ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16082
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Caricamento ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16103
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16104
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Umidità"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16105
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Pressione"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12257 3.8/weather-applet.js:12263
-#: 3.8/weather-applet.js:14217 3.8/weather-applet.js:14218
-#: 3.8/weather-applet.js:15951
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Vento"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:15343
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Assicurati di aver inserito una posizione o utilizza invece la Posizione "
 "automatica"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9952
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Impossibile trovare la posizione in base all'indirizzo, controlla se è "
 "corretto"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9973
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Impossibile chiamare l'API di geolocalizzazione, vedere Looking Glass per "
 "gli errori."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Attenzione"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9872
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "È possibile salvare le posizioni corrette solo quando l'applet non si sta "
 "aggiornando"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Non è possibile salvare una posizione errata"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9880
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Info"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Posizione già salvata"
 
@@ -259,15 +259,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10740 3.8/weather-applet.js:11711
-#: 3.8/weather-applet.js:12150 3.8/weather-applet.js:12659
-#: 3.8/weather-applet.js:13021 3.8/weather-applet.js:14388
-#: 3.8/weather-applet.js:14978
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Percepita"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:15040
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Elaborazione delle informazioni meteo non riuscita"
 
@@ -280,7 +280,7 @@ msgstr ""
 "o prendine una prima su https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:14920
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -289,7 +289,7 @@ msgstr ""
 "di aver immesso correttamente la chiave API e che il tuo account non è "
 "bloccato"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12113
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -300,60 +300,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10516 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10530 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:11379 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:11386 3.8/weather-applet.js:11393
-#: 3.8/weather-applet.js:11400 3.8/weather-applet.js:12292
-#: 3.8/weather-applet.js:13187
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Pioggia molto forte"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11554 3.8/weather-applet.js:11555
-#: 3.8/weather-applet.js:11561 3.8/weather-applet.js:12277
-#: 3.8/weather-applet.js:12278 3.8/weather-applet.js:12284
-#: 3.8/weather-applet.js:12291 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12340 3.8/weather-applet.js:12347
-#: 3.8/weather-applet.js:12801 3.8/weather-applet.js:12850
-#: 3.8/weather-applet.js:12851 3.8/weather-applet.js:12858
-#: 3.8/weather-applet.js:13179 3.8/weather-applet.js:13448
-#: 3.8/weather-applet.js:13449 3.8/weather-applet.js:13490
-#: 3.8/weather-applet.js:14189 3.8/weather-applet.js:14190
-#: 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Pioggia"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10495 3.8/weather-applet.js:10509
-#: 3.8/weather-applet.js:10510 3.8/weather-applet.js:11009
-#: 3.8/weather-applet.js:11463 3.8/weather-applet.js:11464
-#: 3.8/weather-applet.js:11470 3.8/weather-applet.js:11477
-#: 3.8/weather-applet.js:11484 3.8/weather-applet.js:12285
-#: 3.8/weather-applet.js:13189
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Lievi rovesci"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12348 3.8/weather-applet.js:13163
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Forti rovesci con grandine"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11014
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12822
-#: 3.8/weather-applet.js:12823 3.8/weather-applet.js:12829
-#: 3.8/weather-applet.js:12830 3.8/weather-applet.js:12836
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Grandine"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12341 3.8/weather-applet.js:13165
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Leggera pioggia gelata"
 
@@ -361,177 +361,177 @@ msgstr "Leggera pioggia gelata"
 msgid "Light freezing drizzle"
 msgstr "Lievi rovesci con grandine"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12327
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Pioggia fine ghiacciata"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13145
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Lievi rovesci"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12362
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Granuli di ghiaccio pesanti"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12354 3.8/weather-applet.js:12355
-#: 3.8/weather-applet.js:12361 3.8/weather-applet.js:12368
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Granuli di ghiaccio"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12369
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Granuli di ghiaccio leggeri"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10600
-#: 3.8/weather-applet.js:10607 3.8/weather-applet.js:10614
-#: 3.8/weather-applet.js:10615 3.8/weather-applet.js:11021
-#: 3.8/weather-applet.js:11435 3.8/weather-applet.js:11436
-#: 3.8/weather-applet.js:11442 3.8/weather-applet.js:11449
-#: 3.8/weather-applet.js:11456 3.8/weather-applet.js:12320
-#: 3.8/weather-applet.js:13205 3.8/weather-applet.js:13525
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Forte nevicata"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:11610
-#: 3.8/weather-applet.js:11611 3.8/weather-applet.js:11617
-#: 3.8/weather-applet.js:12298 3.8/weather-applet.js:12299
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12795
-#: 3.8/weather-applet.js:13199 3.8/weather-applet.js:13434
-#: 3.8/weather-applet.js:13518 3.8/weather-applet.js:14203
-#: 3.8/weather-applet.js:14204 3.8/weather-applet.js:14581
-#: 3.8/weather-applet.js:14582
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Neve"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11019
-#: 3.8/weather-applet.js:11519 3.8/weather-applet.js:11520
-#: 3.8/weather-applet.js:11526 3.8/weather-applet.js:11533
-#: 3.8/weather-applet.js:11540 3.8/weather-applet.js:12313
-#: 3.8/weather-applet.js:13207
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Neve leggera"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12305
-#: 3.8/weather-applet.js:12306 3.8/weather-applet.js:14560
-#: 3.8/weather-applet.js:14561
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Raffiche"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:12375 3.8/weather-applet.js:12376
-#: 3.8/weather-applet.js:12867 3.8/weather-applet.js:12868
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13532
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:14210
-#: 3.8/weather-applet.js:14211
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Temporale"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12243
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Nebbia leggera"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11372
-#: 3.8/weather-applet.js:11373 3.8/weather-applet.js:12235
-#: 3.8/weather-applet.js:12236 3.8/weather-applet.js:12242
-#: 3.8/weather-applet.js:12937 3.8/weather-applet.js:12938
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:14161
-#: 3.8/weather-applet.js:14162 3.8/weather-applet.js:14609
-#: 3.8/weather-applet.js:14610
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Nebbia"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10474 3.8/weather-applet.js:10475
-#: 3.8/weather-applet.js:11358 3.8/weather-applet.js:11359
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:12208
-#: 3.8/weather-applet.js:13427 3.8/weather-applet.js:13428
-#: 3.8/weather-applet.js:14154 3.8/weather-applet.js:14155
-#: 3.8/weather-applet.js:14651 3.8/weather-applet.js:14652
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Nuvoloso"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12228
-#: 3.8/weather-applet.js:12229 3.8/weather-applet.js:12745
-#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:12780
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Prevalentemente nuvoloso"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10439
-#: 3.8/weather-applet.js:10440 3.8/weather-applet.js:10446
-#: 3.8/weather-applet.js:10447 3.8/weather-applet.js:11547
-#: 3.8/weather-applet.js:11548 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12222 3.8/weather-applet.js:12738
-#: 3.8/weather-applet.js:12739 3.8/weather-applet.js:12773
-#: 3.8/weather-applet.js:13420 3.8/weather-applet.js:13421
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Parzialmente nuvoloso"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Prevalentemente soleggiato"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10425 3.8/weather-applet.js:10426
-#: 3.8/weather-applet.js:11039 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:12724
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12759
-#: 3.8/weather-applet.js:13223 3.8/weather-applet.js:13413
-#: 3.8/weather-applet.js:13414 3.8/weather-applet.js:14140
-#: 3.8/weather-applet.js:14141 3.8/weather-applet.js:14147
-#: 3.8/weather-applet.js:14148 3.8/weather-applet.js:14686
-#: 3.8/weather-applet.js:14687
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Sereno"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10432
-#: 3.8/weather-applet.js:10433 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:14693
-#: 3.8/weather-applet.js:14694
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Soleggiato"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10418
-#: 3.8/weather-applet.js:10419 3.8/weather-applet.js:10453
-#: 3.8/weather-applet.js:10454 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10643 3.8/weather-applet.js:11341
-#: 3.8/weather-applet.js:11342 3.8/weather-applet.js:11639
-#: 3.8/weather-applet.js:11640 3.8/weather-applet.js:12192
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12715
-#: 3.8/weather-applet.js:12716 3.8/weather-applet.js:12944
-#: 3.8/weather-applet.js:12945 3.8/weather-applet.js:14073
-#: 3.8/weather-applet.js:14074 3.8/weather-applet.js:14224
-#: 3.8/weather-applet.js:14225 3.8/weather-applet.js:14797
-#: 3.8/weather-applet.js:14799
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Sconosciuto"
 
@@ -555,7 +555,7 @@ msgstr ""
 "Inserisci la chiave API nelle impostazioni,\n"
 "o prendine una prima su https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:14930
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -563,132 +563,132 @@ msgstr ""
 "Per favore assicurati\n"
 "di aver immesso correttamente la chiave API forntia da DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:14878
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Impossibile ottenere la posizione"
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:14884
+#: 3.0/ipApi.js:95
 msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 "Il servizio di localizzazione ha risposto con errori, consultare i registri "
 "in Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11203
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Nuvolosità"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11351
-#: 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Cielo sereno"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11365 3.8/weather-applet.js:11366
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Sereno"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11387
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Forti rovesci e tuoni"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11394
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Forti rovesci di pioggia"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11401
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Forti rovesci e tuoni"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11407
-#: 3.8/weather-applet.js:11408 3.8/weather-applet.js:11414
-#: 3.8/weather-applet.js:11421 3.8/weather-applet.js:11428
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Forte nevicata"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11415
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Forte nevicata e tuoni"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11422
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Nevischio intenso"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11429
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Rovesci di nevischio e tuoni"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11443
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Nevicate abbondanti e tuoni"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11450
-#: 3.8/weather-applet.js:13526
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Forte nevicata"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11457
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Forte nevicata e tuoni"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11471
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Lievi rovesci e tuoni"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11478
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Lievi rovesci"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11485
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Lievi rovesci e tuoni"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11491
-#: 3.8/weather-applet.js:11492 3.8/weather-applet.js:11498
-#: 3.8/weather-applet.js:11505 3.8/weather-applet.js:11512
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Nevischio leggero"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11499
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Nevischio leggero e tuoni"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11506
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Lieve nevicata"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11513
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Leggeri rovesci di nevischio e tuoni"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11527
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Neve leggera e tuoni"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11534
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Rovesci nevosi leggeri"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11541
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Leggeri rovesci di neve e tuoni"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11562
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Pioggia e tuoni"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11568
-#: 3.8/weather-applet.js:11569 3.8/weather-applet.js:11575
-#: 3.8/weather-applet.js:12859 3.8/weather-applet.js:13185
-#: 3.8/weather-applet.js:13491 3.8/weather-applet.js:13497
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Rovesci"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11576
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Rovesci e tuoni"
 
@@ -697,44 +697,44 @@ msgstr "Rovesci e tuoni"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10537
-#: 3.8/weather-applet.js:10544 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11582 3.8/weather-applet.js:11583
-#: 3.8/weather-applet.js:11589 3.8/weather-applet.js:11596
-#: 3.8/weather-applet.js:11603 3.8/weather-applet.js:12808
-#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12815
-#: 3.8/weather-applet.js:12816 3.8/weather-applet.js:12843
-#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14196
-#: 3.8/weather-applet.js:14197 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Nevischio"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11590
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Nevischio e tuoni"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11597
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Lieve nevicata"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11604
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Rovesci di nevischio e tuoni"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11618
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Neve e tuoni"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11624 3.8/weather-applet.js:11625
-#: 3.8/weather-applet.js:11631 3.8/weather-applet.js:13203
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Rovesci nevosi"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11632
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Rovesci di neve e tuoni"
 
@@ -743,21 +743,21 @@ msgstr "Rovesci di neve e tuoni"
 msgid "Unexpected response from API"
 msgstr "Risposta inattesa dalle API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10237
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Visibilità"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10265
-#: 3.8/weather-applet.js:10817 3.8/weather-applet.js:11722
-#: 3.8/weather-applet.js:12672
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Elaborazione delle informazioni meteo correnti non riuscita"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10055
-#: 3.8/weather-applet.js:10089 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11782 3.8/weather-applet.js:12474
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Elaborazione delle informazioni di previsione non riuscita"
 
@@ -786,89 +786,89 @@ msgid "Excellent - More than"
 msgstr "Eccellente - Più di"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10460 3.8/weather-applet.js:10461
-#: 3.8/weather-applet.js:11029 3.8/weather-applet.js:13175
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Nebbia"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:12752
-#: 3.8/weather-applet.js:12753 3.8/weather-applet.js:12787
-#: 3.8/weather-applet.js:13219
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Nuvoloso"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10489
-#: 3.8/weather-applet.js:10496
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Lievi rovesci"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:12326
-#: 3.8/weather-applet.js:13141 3.8/weather-applet.js:14532
-#: 3.8/weather-applet.js:14533
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Lievi rovesci"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:10524
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Pioggia pesante"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10538
-#: 3.8/weather-applet.js:10545
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Nevischio"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:13217 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14169 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:14589
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Grandine"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Grandine"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Lieve nevicata"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Forte nevicata"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10621 3.8/weather-applet.js:10628
-#: 3.8/weather-applet.js:10635 3.8/weather-applet.js:10636
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Tuoni"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Tuoni"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10872
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Assicurati che la Posizione sia nel formato corretto nelle Impostazioni"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10876
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Assicurati di aver inserito la chiave corretta nelle impostazioni"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10681 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -876,211 +876,211 @@ msgstr ""
 "Posizione non trovata, assicurarsi che la posizione sia disponibile o che "
 "sia nel formato corretto"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10884
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Se il problema persiste, contattare l'autore di questa applet"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10888
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Errore sconosciuto, consultare i registri in Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10990
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Temporale con pioggia leggera"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10991
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Temporale con pioggia"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10992
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Temporale con forti piogge"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10993
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Lieve temporale"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10995
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Forte temporale"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10996
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Temporale irregolare"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10997
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Temporale con leggera pioviggine"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10998
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Temporale con pioviggine"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10999
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Temporale con forti rovesci"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11000
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Lievi rovesci"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11002
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Forti rovesci"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11003
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Lievi rovesci"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11004
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Rovesci"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11005
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Forti rovesci"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11006
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Rovesci"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11007
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Forti rovesci"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11008
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Rovesci"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11010
-#: 3.8/weather-applet.js:13455 3.8/weather-applet.js:13456
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Rovesci moderati"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11011
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Forti rovesci"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11012
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Pioggia molto forte"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11013
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Rovesci estremi"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11015
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Pioggia a bassa intensità"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11016
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Pioggia"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11017
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Pioggia intensa"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11018
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Pioggia"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11023
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Nevischio"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11024
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Lievi rovesci e neve"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11025
-#: 3.8/weather-applet.js:13462 3.8/weather-applet.js:13463
-#: 3.8/weather-applet.js:13469 3.8/weather-applet.js:13504
-#: 3.8/weather-applet.js:13511
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Pioggia e neve"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11026
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Lieve nevicata"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11027
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Neve"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11028
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Forte nevicata"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:12902
-#: 3.8/weather-applet.js:12903 3.8/weather-applet.js:14623
-#: 3.8/weather-applet.js:14624
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Fumo"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11031 3.8/weather-applet.js:12909
-#: 3.8/weather-applet.js:12910 3.8/weather-applet.js:14616
-#: 3.8/weather-applet.js:14617
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Foschia"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11032
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Sabbia, vortici di polvere"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11034
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Sabbia"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11035 3.8/weather-applet.js:12895
-#: 3.8/weather-applet.js:12896 3.8/weather-applet.js:14602
-#: 3.8/weather-applet.js:14603
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Polvere"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11036
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Cenere vulcanica"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:13209
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Burrasche"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11038 3.8/weather-applet.js:12874
-#: 3.8/weather-applet.js:12875 3.8/weather-applet.js:14475
-#: 3.8/weather-applet.js:14476
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11041
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Cielo sereno"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11042
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Nuvoloso"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11043
-#: 3.8/weather-applet.js:12731 3.8/weather-applet.js:12732
-#: 3.8/weather-applet.js:12766
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Poco nuvoloso"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11044
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Nubi sparse"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11045
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Nubi sparse"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11046
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Nuvoloso"
 
@@ -1088,81 +1088,81 @@ msgstr "Nuvoloso"
 msgid "Could not get forecast for your area"
 msgstr "Impossibile ottenere le previsioni per la tua zona"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12431
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 "La posizione è al di fuori degli Stati Uniti, utilizzare un provider diverso."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12495
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Impossibile elaborare le informazioni sulla Previsione Oraria"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12760
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Sereno e ventoso"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12767
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Poco nuvoloso con vento"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12774
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Parzialmente nuvoloso con vento"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Prevalentemente nuvoloso e ventoso"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12788
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Nuvoloso e ventoso"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12802
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Pioggia nevosa"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12837
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Pioggia gelata e neve"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9153 3.8/weather-applet.js:12881
-#: 3.8/weather-applet.js:12882 3.8/weather-applet.js:14489
-#: 3.8/weather-applet.js:14490
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Uragano"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9148
-#: 3.8/weather-applet.js:12888
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Tempesta"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12889
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Tempesta tropicale"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12916 3.8/weather-applet.js:12917
-#: 3.8/weather-applet.js:14721 3.8/weather-applet.js:14722
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Caldo"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12923 3.8/weather-applet.js:12924
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Freddo"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12930 3.8/weather-applet.js:12931
-#: 3.8/weather-applet.js:14770 3.8/weather-applet.js:14771
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Bufera di neve"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9025
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Oggi"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9027
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Domani"
 
@@ -1194,79 +1194,79 @@ msgstr "Venerdì"
 msgid "Saturday"
 msgstr "Sabato"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9118
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Sereno"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9121
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Aria leggera"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9124
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Brezza leggera"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9127
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Brezza leggera"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9130
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Brezza moderata"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9133
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Brezza fresca"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9136
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Vento forte"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9139
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Quasi burrasca"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9142
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Burrasca"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9145
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Forte burrasca"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9151
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Tempesta violenta"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "NE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "E"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "SE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "SO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "O"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "NO"
 
@@ -1318,7 +1318,7 @@ msgstr ""
 "Si è verificato un errore sconosciuto durante l'ottenimento del meteo, "
 "vedere i log di Looking Glass per ulteriori informazioni"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14482 3.8/weather-applet.js:14483
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Tempesta tropicale"
 
@@ -1326,7 +1326,7 @@ msgstr "Tempesta tropicale"
 msgid "Severe Thunderstorms"
 msgstr "Temporali di grande intensità"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14503 3.8/weather-applet.js:14504
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Temporali"
 
@@ -1342,15 +1342,15 @@ msgstr "Pioggia e nevischio"
 msgid "Mixed Snow and Sleet"
 msgstr "Neve e nevischio"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Pioggia gelata"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Grandine"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Rovesci"
 
@@ -1362,11 +1362,11 @@ msgstr "Raffiche di neve"
 msgid "Light Snow Showers"
 msgstr "Lieve nevicata"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14574 3.8/weather-applet.js:14575
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Bufera di neve"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13441 3.8/weather-applet.js:13442
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Nebbia"
 
@@ -1378,54 +1378,54 @@ msgstr "Fumoso"
 msgid "Blustery"
 msgstr "Tempesta"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14637 3.8/weather-applet.js:14638
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Ventoso"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:14658 3.8/weather-applet.js:14659
-#: 3.8/weather-applet.js:14665 3.8/weather-applet.js:14666
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Prevalentemente nuvoloso"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14175 3.8/weather-applet.js:14176
-#: 3.8/weather-applet.js:14182 3.8/weather-applet.js:14183
-#: 3.8/weather-applet.js:14672 3.8/weather-applet.js:14673
-#: 3.8/weather-applet.js:14679 3.8/weather-applet.js:14680
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Parzialmente nuvoloso"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Prevalentemente soleggiato"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:14714 3.8/weather-applet.js:14715
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Pioggia mista a grandine"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:14728 3.8/weather-applet.js:14729
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Temporali isolati"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:14735 3.8/weather-applet.js:14736
-#: 3.8/weather-applet.js:14791 3.8/weather-applet.js:14792
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Temporali sparsi"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:14742 3.8/weather-applet.js:14743
-#: 3.8/weather-applet.js:14777 3.8/weather-applet.js:14778
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Temporali sparsi"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:14749 3.8/weather-applet.js:14750
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Pioggia Intensa"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:14756 3.8/weather-applet.js:14757
-#: 3.8/weather-applet.js:14784 3.8/weather-applet.js:14785
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Nevicate sparse"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:14763 3.8/weather-applet.js:14764
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Neve Intensa"
 
@@ -1437,7 +1437,7 @@ msgstr "Non Disponibile"
 msgid "Scattered Thundershowers"
 msgstr "Temporali sparsi"
 
-#: 3.8/weather-applet.js:9637
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1446,7 +1446,7 @@ msgstr ""
 "percorso\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9641
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1455,11 +1455,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10013
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10118
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1467,277 +1467,293 @@ msgstr ""
 "MET Office UK copre solo il Regno Unito, assicurati che la tua posizione sia "
 "nel paese"
 
-#: 3.8/weather-applet.js:10197
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Non sono stati trovati dati per la posizione"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Molto povera"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Meno di {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Eccellente"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Più di {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10287
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Povera"
 
-#: 3.8/weather-applet.js:10287 3.8/weather-applet.js:10292
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:10302
-#: 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Tra {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10292
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Moderata"
 
-#: 3.8/weather-applet.js:10297
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Buona"
 
-#: 3.8/weather-applet.js:10302 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Molto buona"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10662
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:11659
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12080
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12250
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Vento lieve"
 
-#: 3.8/weather-applet.js:12264
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Vento forte"
 
-#: 3.8/weather-applet.js:12411
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:12962
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:13139
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Neve che soffia o cade"
 
-#: 3.8/weather-applet.js:13143
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Forti rovesci"
 
-#: 3.8/weather-applet.js:13147
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Forti rovesci"
 
-#: 3.8/weather-applet.js:13149
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Lievi rovesci"
 
-#: 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Tempesta di sabbia"
 
-#: 3.8/weather-applet.js:13155
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Grandine"
 
-#: 3.8/weather-applet.js:13157
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Forte Grandinata"
 
-#: 3.8/weather-applet.js:13159
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Lieve Grandinata"
 
-#: 3.8/weather-applet.js:13161
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Nebbia gelata"
 
-#: 3.8/weather-applet.js:13167
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Nube a imbuto/Tornado"
 
-#: 3.8/weather-applet.js:13169
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Rovesci di grandine"
 
-#: 3.8/weather-applet.js:13171
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Ghiaccio"
 
-#: 3.8/weather-applet.js:13173
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Fulmini senza tuoni"
 
-#: 3.8/weather-applet.js:13177
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Precipitazioni nelle vicinanze"
 
-#: 3.8/weather-applet.js:13181 3.8/weather-applet.js:13470
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Forti piogge e neve"
 
-#: 3.8/weather-applet.js:13183
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Lievi rovesci e neve"
 
-#: 3.8/weather-applet.js:13191
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Copertura del cielo in diminuzione"
 
-#: 3.8/weather-applet.js:13193
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Copertura del cielo in aumento"
 
-#: 3.8/weather-applet.js:13195
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Cielo invariato"
 
-#: 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Fumo o foschia"
 
-#: 3.8/weather-applet.js:13201
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Rovesci di neve e pioggia"
 
-#: 3.8/weather-applet.js:13213
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Temporale senza precipitazioni"
 
-#: 3.8/weather-applet.js:13215
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Polvere di diamante"
 
-#: 3.8/weather-applet.js:13221
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Parzialmente nuvoloso"
 
-#: 3.8/weather-applet.js:13243
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 "Per favore assicurati\n"
 "di aver immesso correttamente la chiave API"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13259
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:13402 3.8/weather-applet.js:13403
-#: 3.8/weather-applet.js:13539 3.8/weather-applet.js:13540
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "NON TROVATO"
 
-#: 3.8/weather-applet.js:13435
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Bufera di neve"
 
-#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:13477
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Lieve nevicata"
 
-#: 3.8/weather-applet.js:13483 3.8/weather-applet.js:13484
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Nevicata moderata"
 
-#: 3.8/weather-applet.js:13498
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Rovesci moderati"
 
-#: 3.8/weather-applet.js:13505
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Pioggia mista a neve"
 
-#: 3.8/weather-applet.js:13512
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Forti piogge miste e neve"
 
-#: 3.8/weather-applet.js:13657
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:13953
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:13966
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "Seleziona un provider o una località diversi"
 
-#: 3.8/weather-applet.js:14263
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14453
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "Chiave API inserita non valida."
 
-#: 3.8/weather-applet.js:14460
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "Località inserita non trovata."
 
-#: 3.8/weather-applet.js:14496 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Forte Tempesta"
 
-#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:14512
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Pioggia e Neve"
 
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Pioggia e Nevischio"
 
-#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Rovesci Nevosi"
 
-#: 3.8/weather-applet.js:14630 3.8/weather-applet.js:14631
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "Arioso"
 
-#: 3.8/weather-applet.js:14644 3.8/weather-applet.js:14645
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr "Frigido"
 
-#: 3.8/weather-applet.js:14700 3.8/weather-applet.js:14701
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Prevalentemente Sereno"
 
-#: 3.8/weather-applet.js:14902
+#: 3.8/weather-applet.js:15247
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:15481
+#: 3.8/weather-applet.js:15603
+#, fuzzy
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+"Il servizio di localizzazione ha risposto con errori, consultare i registri "
+"in Looking Glass"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+"Assicurati di aver inserito una posizione o utilizza invece la Posizione "
+"automatica"
+
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1746,7 +1762,7 @@ msgstr ""
 "percorso\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15486
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1754,58 +1770,58 @@ msgstr ""
 "Impossibile recuperare il contenuto del file di config nel percorso\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:16106
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Questo provider richiedere una chiave API per operare"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Punto di rugiada"
 
-#: 3.8/weather-applet.js:16178
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Le precipitazioni termineranno tra {precipEnd} minuti"
 
-#: 3.8/weather-applet.js:16180
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "Le precipitazioni non finiranno entro un'ora"
 
-#: 3.8/weather-applet.js:16183
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Le precipitazioni inizieranno entro {precipStart} minuti"
 
-#: 3.8/weather-applet.js:16395
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Analisi della previsione non riuscita, vedere i log per maggiori dettagli."
 
-#: 3.8/weather-applet.js:16927 3.8/weather-applet.js:17714
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "Alle {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:16933
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} da te"
 
-#: 3.8/weather-applet.js:16937
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "Nome Stazione: {stationName}"
 
-#: 3.8/weather-applet.js:16940
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "Area: {stationArea}"
 
-#: 3.8/weather-applet.js:17485 3.8/weather-applet.js:17495
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Errore durante il salvataggio delle informazioni di debug"
 
-#: 3.8/weather-applet.js:17507
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Informazioni di debug salvate con successo"
 
-#: 3.8/weather-applet.js:17507
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Salvate in {filePath}"
-
-#: 3.8/weather-applet.js:17638
-msgid "This provider requires an API key to operate"
-msgstr "Questo provider richiedere una chiave API per operare"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -2342,6 +2358,12 @@ msgstr ""
 "secondi senza digitare l'indirizzo che hai inserito viene sostituito "
 "automaticamente per convalidare la tua scelta."
 
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
+
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"
 msgstr "Salva posizione attuale nell'archivio"
@@ -2564,12 +2586,12 @@ msgid ""
 "automatically for validating your choice."
 msgstr ""
 "La tua posizione nella maggior parte dei casi funziona automaticamente, ma "
-"puoi inserirla manualmente tramite le coordinate \"Latitudine, "
-"Longitudine\" (ad es. 51.5085,-0.1257) o utilizzare \"Città, codice "
-"paese\" (ad es. Roma,IT) o provare a inserire {Numero civico} {Via} {Città/"
-"Paese} {Codice postale} {Nazione}. L'algoritmo di ricerca è molto flessibile "
-"con il formato. Dopo 3 secondi senza digitare l'indirizzo che hai inserito "
-"viene sostituito automaticamente per convalidare la tua scelta."
+"puoi inserirla manualmente tramite le coordinate \"Latitudine, Longitudine\" "
+"(ad es. 51.5085,-0.1257) o utilizzare \"Città, codice paese\" (ad es. Roma,"
+"IT) o provare a inserire {Numero civico} {Via} {Città/Paese} {Codice "
+"postale} {Nazione}. L'algoritmo di ricerca è molto flessibile con il "
+"formato. Dopo 3 secondi senza digitare l'indirizzo che hai inserito viene "
+"sostituito automaticamente per convalidare la tua scelta."
 
 #. 3.8->settings-schema.json->logLevel->description
 msgid "Log Level"
@@ -2604,62 +2626,3 @@ msgstr ""
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr "Percorso selezionato per salvare i log"
-
-#~ msgid "DarkSky"
-#~ msgstr "DarkSky"
-
-#~ msgid "This API has ceased to function, please use another one."
-#~ msgstr "Questa API ha smesso di funziona, per favore scegline un'altra."
-
-#~ msgid "Settings"
-#~ msgstr "Impostazioni"
-
-#~ msgid "Sunrise"
-#~ msgstr "Alba"
-
-#~ msgid "Sunset"
-#~ msgstr "Tramonto"
-
-#~ msgid "Service Unavailable"
-#~ msgstr "Servizio Non Disponibile"
-
-#~ msgid "Wrong API Key"
-#~ msgstr "Chiave API Errata"
-
-#~ msgid "City Not found"
-#~ msgstr "Città Non trovata"
-
-#~ msgid "Key Temp. Blocked"
-#~ msgstr "Temp. Chiave bloccata"
-
-#~ msgid "Settings for weather@mockturtl 1.8+"
-#~ msgstr "Impostazioni di weather@mockturtl 1.8+"
-
-#~ msgid ""
-#~ "Acceptable inputs: City,CountryCode or Zipcode,CountryCode or Latitude,"
-#~ "Longtitude"
-#~ msgstr ""
-#~ "Input validi: Città, Codice Paese o Codice postale, Codice Paese o "
-#~ "Latitudine, Longitudine"
-
-#~ msgid "Personal Settings"
-#~ msgstr "Impostazioni personali"
-
-#~ msgid "Vertical orientation"
-#~ msgstr "Orientamento verticale"
-
-#~ msgid "Translate condition"
-#~ msgstr "Condizione di traduzione"
-
-#~ msgid "Symbolic icons"
-#~ msgstr "Icone simboliche"
-
-#~ msgid ""
-#~ "powered by: OpenWeatherMap, DarkSky, ipapi. Big Thanks to OpenWeatherMap "
-#~ "for their support!"
-#~ msgstr ""
-#~ "realizzato da: OpenWeatherMap, DarkSky, ipapi. Grazie mille a "
-#~ "OpenWeatherMap per il suo supporto!"
-
-#~ msgid "Settings for weather@mockturtl 3.8+"
-#~ msgstr "Impostazioni di weather@mockturtl 3.8+"

--- a/weather@mockturtl/files/weather@mockturtl/po/ja.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/ja.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-weather 1.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-04 08:45+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2022-12-03 22:47+0900\n"
 "Last-Translator: Takeshi AIHANA <takeshi.aihana@gmail.com>\n"
 "Language-Team: Japanese <takeshi.aihana@gmail.com>\n"
@@ -18,65 +19,65 @@ msgstr ""
 "X-Generator: Poedit 2.4.2\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:16977
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr ""
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:16978 3.8/weather-applet.js:16980
-#: 3.8/weather-applet.js:16982 3.8/weather-applet.js:16985
-#: 3.8/weather-applet.js:16988 3.8/weather-applet.js:16989
-#: 3.8/weather-applet.js:16990 3.8/weather-applet.js:16991
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "サービスエラー"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:16979
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "不正なAPIキー"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:16981
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "不正な位置情報書式"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:16983
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr ""
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:16984
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr ""
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:16986
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "APIキーがありません"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:16987
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "位置情報がありません"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:16992
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr ""
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:16993
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "サポート外の地点"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9309
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "天気アプレット"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17312
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17313
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "開く"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:15699
-#: 3.8/weather-applet.js:17316
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "更新"
 
@@ -86,8 +87,8 @@ msgstr ""
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9475
-#: 3.8/weather-applet.js:9479 3.8/weather-applet.js:9483
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr ""
 
@@ -99,12 +100,12 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr ""
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17139
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:17394
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -118,7 +119,7 @@ msgstr ""
 msgid "As of"
 msgstr ""
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:16392
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "提供："
 
@@ -126,88 +127,86 @@ msgstr "提供："
 msgid "from you"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16313
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:10273
-#: 3.8/weather-applet.js:16313
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:9911
-#: 3.8/weather-applet.js:16470
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:9912
-#: 3.8/weather-applet.js:16471
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:16650
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "現在の天気を読み込んでいます ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:16653
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "天気予報を読み込んでいます ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:15652
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "読み込み中 ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:15673
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "気温"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:15674
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "湿度"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:15675
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "気圧"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12143 3.8/weather-applet.js:12150
-#: 3.8/weather-applet.js:12151 3.8/weather-applet.js:12157
-#: 3.8/weather-applet.js:14103 3.8/weather-applet.js:14104
-#: 3.8/weather-applet.js:15524
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "風向・風速"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:14935
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr "位置情報を入力するか位置の自動取得を有効にしてください"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9555
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr "住所による位置情報の取得に失敗しました。入力を確認してください"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9576
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9475
-#: 3.8/weather-applet.js:9479
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr ""
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9475
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9479
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr ""
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9483
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr ""
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9483
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr ""
 
@@ -243,15 +242,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10353 3.8/weather-applet.js:10645
-#: 3.8/weather-applet.js:11608 3.8/weather-applet.js:12046
-#: 3.8/weather-applet.js:12551 3.8/weather-applet.js:12913
-#: 3.8/weather-applet.js:14272
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "体感温度"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:10398
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr ""
 
@@ -262,13 +261,13 @@ msgid ""
 msgstr ""
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:10282 3.8/weather-applet.js:11778
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
 msgstr ""
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12012
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -277,264 +276,257 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10112 3.8/weather-applet.js:10119
-#: 3.8/weather-applet.js:10126 3.8/weather-applet.js:10127
-#: 3.8/weather-applet.js:11282 3.8/weather-applet.js:11283
-#: 3.8/weather-applet.js:11289 3.8/weather-applet.js:11296
-#: 3.8/weather-applet.js:11303 3.8/weather-applet.js:12186
-#: 3.8/weather-applet.js:13079
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "大雨"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11457 3.8/weather-applet.js:11458
-#: 3.8/weather-applet.js:11464 3.8/weather-applet.js:12171
-#: 3.8/weather-applet.js:12172 3.8/weather-applet.js:12178
-#: 3.8/weather-applet.js:12185 3.8/weather-applet.js:12227
-#: 3.8/weather-applet.js:12234 3.8/weather-applet.js:12241
-#: 3.8/weather-applet.js:12695 3.8/weather-applet.js:12744
-#: 3.8/weather-applet.js:12745 3.8/weather-applet.js:12752
-#: 3.8/weather-applet.js:13071 3.8/weather-applet.js:13338
-#: 3.8/weather-applet.js:13339 3.8/weather-applet.js:13380
-#: 3.8/weather-applet.js:14075 3.8/weather-applet.js:14076
-#: 3.8/weather-applet.js:14438 3.8/weather-applet.js:14439
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "雨"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10084
-#: 3.8/weather-applet.js:10091 3.8/weather-applet.js:10105
-#: 3.8/weather-applet.js:10106 3.8/weather-applet.js:10914
-#: 3.8/weather-applet.js:11366 3.8/weather-applet.js:11367
-#: 3.8/weather-applet.js:11373 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:11387 3.8/weather-applet.js:12179
-#: 3.8/weather-applet.js:13081
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "小雨"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12242 3.8/weather-applet.js:13055
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 #, fuzzy
-#| msgid "Freezing rain"
 msgid "Heavy freezing rain"
 msgstr "着氷性の雨"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:10919
-#: 3.8/weather-applet.js:12228 3.8/weather-applet.js:12716
-#: 3.8/weather-applet.js:12717 3.8/weather-applet.js:12723
-#: 3.8/weather-applet.js:12724 3.8/weather-applet.js:12730
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "着氷性の雨"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12235 3.8/weather-applet.js:13057
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 #, fuzzy
-#| msgid "Freezing rain"
 msgid "Light freezing rain"
 msgstr "着氷性の雨"
 
 #: 3.0/climacell.js:301
 #, fuzzy
-#| msgid "Freezing drizzle"
 msgid "Light freezing drizzle"
 msgstr "着氷性の霧雨"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12221
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "着氷性の霧雨"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13037
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 #, fuzzy
-#| msgid "Freezing drizzle"
 msgid "Light drizzle"
 msgstr "着氷性の霧雨"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12256
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12248 3.8/weather-applet.js:12249
-#: 3.8/weather-applet.js:12255 3.8/weather-applet.js:12262
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr ""
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12263
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10196
-#: 3.8/weather-applet.js:10203 3.8/weather-applet.js:10210
-#: 3.8/weather-applet.js:10211 3.8/weather-applet.js:10926
-#: 3.8/weather-applet.js:11338 3.8/weather-applet.js:11339
-#: 3.8/weather-applet.js:11345 3.8/weather-applet.js:11352
-#: 3.8/weather-applet.js:11359 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:13097 3.8/weather-applet.js:13415
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "大雪"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:10925 3.8/weather-applet.js:11513
-#: 3.8/weather-applet.js:11514 3.8/weather-applet.js:11520
-#: 3.8/weather-applet.js:12192 3.8/weather-applet.js:12193
-#: 3.8/weather-applet.js:12206 3.8/weather-applet.js:12213
-#: 3.8/weather-applet.js:12688 3.8/weather-applet.js:12689
-#: 3.8/weather-applet.js:13091 3.8/weather-applet.js:13324
-#: 3.8/weather-applet.js:13408 3.8/weather-applet.js:14089
-#: 3.8/weather-applet.js:14090 3.8/weather-applet.js:14466
-#: 3.8/weather-applet.js:14467
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "雪"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10175
-#: 3.8/weather-applet.js:10182 3.8/weather-applet.js:10189
-#: 3.8/weather-applet.js:10190 3.8/weather-applet.js:10924
-#: 3.8/weather-applet.js:11422 3.8/weather-applet.js:11423
-#: 3.8/weather-applet.js:11429 3.8/weather-applet.js:11436
-#: 3.8/weather-applet.js:11443 3.8/weather-applet.js:12207
-#: 3.8/weather-applet.js:13099
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "小雪"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12199
-#: 3.8/weather-applet.js:12200 3.8/weather-applet.js:14445
-#: 3.8/weather-applet.js:14446
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 #, fuzzy
-#| msgid "Snow flurries"
 msgid "Flurries"
 msgstr "にわか雪"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10899
-#: 3.8/weather-applet.js:12269 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12761 3.8/weather-applet.js:12762
-#: 3.8/weather-applet.js:13103 3.8/weather-applet.js:13422
-#: 3.8/weather-applet.js:13423 3.8/weather-applet.js:14096
-#: 3.8/weather-applet.js:14097
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 #, fuzzy
-#| msgid "Thunderstorms"
 msgid "Thunderstorm"
 msgstr "激しい雷雨"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12137
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr ""
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10063 3.8/weather-applet.js:10064
-#: 3.8/weather-applet.js:10938 3.8/weather-applet.js:11275
-#: 3.8/weather-applet.js:11276 3.8/weather-applet.js:12129
-#: 3.8/weather-applet.js:12130 3.8/weather-applet.js:12136
-#: 3.8/weather-applet.js:12831 3.8/weather-applet.js:12832
-#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:14047
-#: 3.8/weather-applet.js:14048 3.8/weather-applet.js:14494
-#: 3.8/weather-applet.js:14495
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "霧"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10070 3.8/weather-applet.js:10071
-#: 3.8/weather-applet.js:11261 3.8/weather-applet.js:11262
-#: 3.8/weather-applet.js:12101 3.8/weather-applet.js:12102
-#: 3.8/weather-applet.js:13317 3.8/weather-applet.js:13318
-#: 3.8/weather-applet.js:14040 3.8/weather-applet.js:14041
-#: 3.8/weather-applet.js:14536 3.8/weather-applet.js:14537
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "曇り"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12122
-#: 3.8/weather-applet.js:12123 3.8/weather-applet.js:12639
-#: 3.8/weather-applet.js:12640 3.8/weather-applet.js:12674
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "おおむね曇り"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10035
-#: 3.8/weather-applet.js:10036 3.8/weather-applet.js:10042
-#: 3.8/weather-applet.js:10043 3.8/weather-applet.js:11450
-#: 3.8/weather-applet.js:11451 3.8/weather-applet.js:12115
-#: 3.8/weather-applet.js:12116 3.8/weather-applet.js:12632
-#: 3.8/weather-applet.js:12633 3.8/weather-applet.js:12667
-#: 3.8/weather-applet.js:13310 3.8/weather-applet.js:13311
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "ところにより曇り"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12108
-#: 3.8/weather-applet.js:12109
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 #, fuzzy
-#| msgid "Mostly cloudy"
 msgid "Mostly clear"
 msgstr "おおむね曇り"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10021 3.8/weather-applet.js:10022
-#: 3.8/weather-applet.js:10944 3.8/weather-applet.js:12094
-#: 3.8/weather-applet.js:12095 3.8/weather-applet.js:12618
-#: 3.8/weather-applet.js:12619 3.8/weather-applet.js:12653
-#: 3.8/weather-applet.js:13115 3.8/weather-applet.js:13303
-#: 3.8/weather-applet.js:13304 3.8/weather-applet.js:14026
-#: 3.8/weather-applet.js:14027 3.8/weather-applet.js:14033
-#: 3.8/weather-applet.js:14034 3.8/weather-applet.js:14571
-#: 3.8/weather-applet.js:14572
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "快晴"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10028
-#: 3.8/weather-applet.js:10029 3.8/weather-applet.js:12094
-#: 3.8/weather-applet.js:12095 3.8/weather-applet.js:14578
-#: 3.8/weather-applet.js:14579
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "晴れ"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10014
-#: 3.8/weather-applet.js:10015 3.8/weather-applet.js:10049
-#: 3.8/weather-applet.js:10050 3.8/weather-applet.js:10238
-#: 3.8/weather-applet.js:10239 3.8/weather-applet.js:11244
-#: 3.8/weather-applet.js:11245 3.8/weather-applet.js:11542
-#: 3.8/weather-applet.js:11543 3.8/weather-applet.js:12086
-#: 3.8/weather-applet.js:12087 3.8/weather-applet.js:12609
-#: 3.8/weather-applet.js:12610 3.8/weather-applet.js:12838
-#: 3.8/weather-applet.js:12839 3.8/weather-applet.js:13959
-#: 3.8/weather-applet.js:13960 3.8/weather-applet.js:14110
-#: 3.8/weather-applet.js:14111 3.8/weather-applet.js:14682
-#: 3.8/weather-applet.js:14684
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr ""
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10273
+#: 3.0/darkSky.js:71
 msgid "and"
 msgstr ""
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10273
+#: 3.0/darkSky.js:71
 msgid "until"
 msgstr ""
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10273
+#: 3.0/darkSky.js:71
 msgid "Possible"
 msgstr ""
 
@@ -544,156 +536,146 @@ msgid ""
 "or get one first on https://darksky.net/dev/register"
 msgstr ""
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:10292
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
 msgstr ""
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:9254
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr ""
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:9260
+#: 3.0/ipApi.js:95
 msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11106
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "雲量"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:10945 3.8/weather-applet.js:11254
-#: 3.8/weather-applet.js:11255
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "快晴"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11268 3.8/weather-applet.js:11269
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "晴れ"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11290
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11297
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 #, fuzzy
-#| msgid "Heavy snow"
 msgid "Heavy rain showers"
 msgstr "大雪"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11304
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11310
-#: 3.8/weather-applet.js:11311 3.8/weather-applet.js:11317
-#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:11331
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 #, fuzzy
-#| msgid "Heavy snow"
 msgid "Heavy sleet"
 msgstr "大雪"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11318
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11325
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 #, fuzzy
-#| msgid "Heavy snow"
 msgid "Heavy sleet showers"
 msgstr "大雪"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11332
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11346
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 #, fuzzy
-#| msgid "Heavy snow"
 msgid "Heavy snow and thunder"
 msgstr "大雪"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11353
-#: 3.8/weather-applet.js:13416
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 #, fuzzy
-#| msgid "Snow showers"
 msgid "Heavy snow showers"
 msgstr "にわか雪"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11360
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11374
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11381
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "弱いにわか雨"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11388
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 #, fuzzy
-#| msgid "Light snow showers"
 msgid "Light rain showers and thunder"
 msgstr "弱いにわか雪"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11394
-#: 3.8/weather-applet.js:11395 3.8/weather-applet.js:11401
-#: 3.8/weather-applet.js:11408 3.8/weather-applet.js:11415
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11402
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11409
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 #, fuzzy
-#| msgid "Light snow showers"
 msgid "Light sleet showers"
 msgstr "弱いにわか雪"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11416
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 #, fuzzy
-#| msgid "Light snow showers"
 msgid "Light sleet showers and thunder"
 msgstr "弱いにわか雪"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11430
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 #, fuzzy
-#| msgid "Light snow showers"
 msgid "Light snow and thunder"
 msgstr "弱いにわか雪"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11437
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "弱いにわか雪"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11444
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 #, fuzzy
-#| msgid "Light snow showers"
 msgid "Light snow showers and thunder"
 msgstr "弱いにわか雪"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11465
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11471
-#: 3.8/weather-applet.js:11472 3.8/weather-applet.js:11478
-#: 3.8/weather-applet.js:12753 3.8/weather-applet.js:13077
-#: 3.8/weather-applet.js:13381 3.8/weather-applet.js:13387
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "にわか雨"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11479
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr ""
 
@@ -702,50 +684,47 @@ msgstr ""
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10133
-#: 3.8/weather-applet.js:10140 3.8/weather-applet.js:10147
-#: 3.8/weather-applet.js:10148 3.8/weather-applet.js:10927
-#: 3.8/weather-applet.js:11485 3.8/weather-applet.js:11486
-#: 3.8/weather-applet.js:11492 3.8/weather-applet.js:11499
-#: 3.8/weather-applet.js:11506 3.8/weather-applet.js:12702
-#: 3.8/weather-applet.js:12703 3.8/weather-applet.js:12709
-#: 3.8/weather-applet.js:12710 3.8/weather-applet.js:12737
-#: 3.8/weather-applet.js:12738 3.8/weather-applet.js:14082
-#: 3.8/weather-applet.js:14083 3.8/weather-applet.js:14480
-#: 3.8/weather-applet.js:14481
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "みぞれ"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11493
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 #, fuzzy
-#| msgid "Scattered thunderstorms"
 msgid "Sleet and thunder"
 msgstr "ところにより激しい雷雨"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11500
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 #, fuzzy
-#| msgid "Scattered showers"
 msgid "Sleet showers"
 msgstr "ところによりにわか雨"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11507
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11521
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11527 3.8/weather-applet.js:11528
-#: 3.8/weather-applet.js:11534 3.8/weather-applet.js:13095
-#: 3.8/weather-applet.js:13409
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "にわか雪"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11535
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 #, fuzzy
-#| msgid "Snow showers"
 msgid "Snow showers and thunder"
 msgstr "にわか雪"
 
@@ -754,20 +733,21 @@ msgstr "にわか雪"
 msgid "Unexpected response from API"
 msgstr ""
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:9836
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "視程"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:9864 3.8/weather-applet.js:10722
-#: 3.8/weather-applet.js:11619 3.8/weather-applet.js:12564
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr ""
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:9655
-#: 3.8/weather-applet.js:9689 3.8/weather-applet.js:11645
-#: 3.8/weather-applet.js:11679 3.8/weather-applet.js:12366
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr ""
 
@@ -796,342 +776,320 @@ msgid "Excellent - More than"
 msgstr "絶好調 ― >"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10056 3.8/weather-applet.js:10057
-#: 3.8/weather-applet.js:10934 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr ""
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10077
-#: 3.8/weather-applet.js:10078 3.8/weather-applet.js:12646
-#: 3.8/weather-applet.js:12647 3.8/weather-applet.js:12681
-#: 3.8/weather-applet.js:13111
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "どんよりした空"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10085
-#: 3.8/weather-applet.js:10092
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "弱いにわか雨"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10098 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:10906 3.8/weather-applet.js:12164
-#: 3.8/weather-applet.js:12165 3.8/weather-applet.js:12220
-#: 3.8/weather-applet.js:13033 3.8/weather-applet.js:14417
-#: 3.8/weather-applet.js:14418
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "霧雨"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10113
-#: 3.8/weather-applet.js:10120
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 #, fuzzy
-#| msgid "Heavy snow"
 msgid "Heavy rain shower"
 msgstr "大雪"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10134
-#: 3.8/weather-applet.js:10141
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 #, fuzzy
-#| msgid "Scattered showers"
 msgid "Sleet shower"
 msgstr "ところによりにわか雨"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10154 3.8/weather-applet.js:10161
-#: 3.8/weather-applet.js:10168 3.8/weather-applet.js:10169
-#: 3.8/weather-applet.js:13109 3.8/weather-applet.js:14054
-#: 3.8/weather-applet.js:14055 3.8/weather-applet.js:14473
-#: 3.8/weather-applet.js:14474
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "雹"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10155
-#: 3.8/weather-applet.js:10162
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 #, fuzzy
-#| msgid "Snow showers"
 msgid "Hail shower"
 msgstr "にわか雪"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10176
-#: 3.8/weather-applet.js:10183
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "弱いにわか雪"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10197
-#: 3.8/weather-applet.js:10204
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 #, fuzzy
-#| msgid "Heavy snow"
 msgid "Heavy snow shower"
 msgstr "大雪"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10217 3.8/weather-applet.js:10224
-#: 3.8/weather-applet.js:10231 3.8/weather-applet.js:10232
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 #, fuzzy
-#| msgid "Thunderstorms"
 msgid "Thunder"
 msgstr "激しい雷雨"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10218
-#: 3.8/weather-applet.js:10225
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 #, fuzzy
-#| msgid "Thundershowers"
 msgid "Thunder shower"
 msgstr "雷雨"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10777
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10781
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10785
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10789
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10793
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10895
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10896
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 #, fuzzy
-#| msgid "Thunderstorms"
 msgid "Thunderstorm with rain"
 msgstr "激しい雷雨"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10897
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10898
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 #, fuzzy
-#| msgid "Thunderstorms"
 msgid "Light thunderstorm"
 msgstr "激しい雷雨"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10900
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 #, fuzzy
-#| msgid "Severe thunderstorms"
 msgid "Heavy thunderstorm"
 msgstr "非常に激しい雷雨"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10901
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 #, fuzzy
-#| msgid "Isolated thunderstorms"
 msgid "Ragged thunderstorm"
 msgstr "局地的な激しい雷雨"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10902
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10903
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 #, fuzzy
-#| msgid "Thunderstorms"
 msgid "Thunderstorm with drizzle"
 msgstr "激しい雷雨"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10904
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:10905
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:10907
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:10908
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:10909
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "霧雨"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:10910
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:10911
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 #, fuzzy
-#| msgid "Mixed rain and hail"
 msgid "Shower rain and drizzle"
 msgstr "雨と雹"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:10912
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:10913
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 #, fuzzy
-#| msgid "Freezing drizzle"
 msgid "Shower drizzle"
 msgstr "着氷性の霧雨"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:10915
-#: 3.8/weather-applet.js:13345 3.8/weather-applet.js:13346
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:10916
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "大雨"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:10917
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:10918
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 #, fuzzy
-#| msgid "Freezing rain"
 msgid "Extreme rain"
 msgstr "着氷性の雨"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:10920
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 #, fuzzy
-#| msgid "Light snow showers"
 msgid "Light intensity shower rain"
 msgstr "弱いにわか雪"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:10921
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 #, fuzzy
-#| msgid "Showers"
 msgid "Shower rain"
 msgstr "にわか雨"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:10922
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:10923
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:10928
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 #, fuzzy
-#| msgid "Showers"
 msgid "Shower sleet"
 msgstr "にわか雨"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:10929
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 #, fuzzy
-#| msgid "Mixed rain and snow"
 msgid "Light rain and snow"
 msgstr "雨と雪"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:10930
-#: 3.8/weather-applet.js:13352 3.8/weather-applet.js:13353
-#: 3.8/weather-applet.js:13359 3.8/weather-applet.js:13394
-#: 3.8/weather-applet.js:13401
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 #, fuzzy
-#| msgid "Mixed rain and snow"
 msgid "Rain and snow"
 msgstr "雨と雪"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:10931
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "弱いにわか雪"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:10932
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 #, fuzzy
-#| msgid "Showers"
 msgid "Shower snow"
 msgstr "にわか雨"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:10933
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 #, fuzzy
-#| msgid "Heavy snow"
 msgid "Heavy shower snow"
 msgstr "大雪"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:10935 3.8/weather-applet.js:12796
-#: 3.8/weather-applet.js:12797 3.8/weather-applet.js:14508
-#: 3.8/weather-applet.js:14509
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 #, fuzzy
-#| msgid "Smoky"
 msgid "Smoke"
 msgstr "けむり"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:10936 3.8/weather-applet.js:12803
-#: 3.8/weather-applet.js:12804 3.8/weather-applet.js:14501
-#: 3.8/weather-applet.js:14502
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "もや"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:10937
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:10939
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:10940 3.8/weather-applet.js:12789
-#: 3.8/weather-applet.js:12790 3.8/weather-applet.js:14487
-#: 3.8/weather-applet.js:14488
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "砂塵"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:10941
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:10942
-#: 3.8/weather-applet.js:13101
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:10943 3.8/weather-applet.js:12768
-#: 3.8/weather-applet.js:12769 3.8/weather-applet.js:14360
-#: 3.8/weather-applet.js:14361
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "竜巻"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:10946
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:10947
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "曇り"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:10948
-#: 3.8/weather-applet.js:12625 3.8/weather-applet.js:12626
-#: 3.8/weather-applet.js:12660
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:10949
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "ちぎれ雲"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:10950
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "ちぎれ雲"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:10951
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "一面の曇り空"
 
@@ -1139,88 +1097,84 @@ msgstr "一面の曇り空"
 msgid "Could not get forecast for your area"
 msgstr ""
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12323
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12387
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr ""
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12654
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12661
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12668
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 #, fuzzy
-#| msgid "Partly cloudy"
 msgid "Partly cloudy and windy"
 msgstr "ところにより曇り"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12675
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 #, fuzzy
-#| msgid "Mostly cloudy"
 msgid "Mostly cloudy and windy"
 msgstr "おおむね曇り"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12682
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12696
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 #, fuzzy
-#| msgid "Snow flurries"
 msgid "Snowy rain"
 msgstr "にわか雪"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12731
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 #, fuzzy
-#| msgid "Freezing rain"
 msgid "Freezing rain and snow"
 msgstr "着氷性の雨"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:8715 3.8/weather-applet.js:12775
-#: 3.8/weather-applet.js:12776 3.8/weather-applet.js:14374
-#: 3.8/weather-applet.js:14375
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "風力12"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:8710
-#: 3.8/weather-applet.js:12782
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "風力10"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12783
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "熱帯暴風雨"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12810 3.8/weather-applet.js:12811
-#: 3.8/weather-applet.js:14606 3.8/weather-applet.js:14607
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "温暖"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12817 3.8/weather-applet.js:12818
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "寒冷"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12824 3.8/weather-applet.js:12825
-#: 3.8/weather-applet.js:14655 3.8/weather-applet.js:14656
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "大吹雪"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:8588
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "今日"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:8590
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "明日"
 
@@ -1252,79 +1206,79 @@ msgstr "金曜日"
 msgid "Saturday"
 msgstr "土曜日"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:8680
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "風力0"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:8683
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "風力1"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:8686
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "風力2"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:8689
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "風力3"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:8692
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "風力4"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:8695
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "風力5"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:8698
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "風力6"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:8701
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "風力7"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:8704
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "風力8"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:8707
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "風力9"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:8713
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "風力11"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8863
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "北"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8863
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "北東"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8863
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "東"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8863
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "南東"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8863
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "南"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8863
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "南西"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8863
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "西"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8863
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "北西"
 
@@ -1368,59 +1322,51 @@ msgid ""
 "more information"
 msgstr ""
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14367 3.8/weather-applet.js:14368
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 #, fuzzy
-#| msgid "Tropical storm"
 msgid "Tropical Storm"
 msgstr "熱帯暴風雨"
 
 #: 3.0/yahoo.js:439
 #, fuzzy
-#| msgid "Severe thunderstorms"
 msgid "Severe Thunderstorms"
 msgstr "非常に激しい雷雨"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14388 3.8/weather-applet.js:14389
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "激しい雷雨"
 
 #: 3.0/yahoo.js:441
 #, fuzzy
-#| msgid "Mixed rain and snow"
 msgid "Mixed Rain and Snow"
 msgstr "雨と雪"
 
 #: 3.0/yahoo.js:442
 #, fuzzy
-#| msgid "Mixed rain and sleet"
 msgid "Mixed Rain and Sleet"
 msgstr "雨とみぞれ"
 
 #: 3.0/yahoo.js:443
 #, fuzzy
-#| msgid "Mixed snow and sleet"
 msgid "Mixed Snow and Sleet"
 msgstr "雪とみぞれ"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14410 3.8/weather-applet.js:14411
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 #, fuzzy
-#| msgid "Freezing drizzle"
 msgid "Freezing Drizzle"
 msgstr "着氷性の霧雨"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14424 3.8/weather-applet.js:14425
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 #, fuzzy
-#| msgid "Freezing rain"
 msgid "Freezing Rain"
 msgstr "着氷性の雨"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14431 3.8/weather-applet.js:14432
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "にわか雨"
 
 #: 3.0/yahoo.js:449
 #, fuzzy
-#| msgid "Snow flurries"
 msgid "Snow Flurries"
 msgstr "にわか雪"
 
@@ -1428,11 +1374,11 @@ msgstr "にわか雪"
 msgid "Light Snow Showers"
 msgstr "弱いにわか雪"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14459 3.8/weather-applet.js:14460
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "吹雪"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13331 3.8/weather-applet.js:13332
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "霧"
 
@@ -1444,481 +1390,458 @@ msgstr "けむり"
 msgid "Blustery"
 msgstr "大荒れ"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14522 3.8/weather-applet.js:14523
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "強風"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:14543 3.8/weather-applet.js:14544
-#: 3.8/weather-applet.js:14550 3.8/weather-applet.js:14551
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 #, fuzzy
-#| msgid "Mostly cloudy"
 msgid "Mostly Cloudy"
 msgstr "おおむね曇り"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14061 3.8/weather-applet.js:14062
-#: 3.8/weather-applet.js:14068 3.8/weather-applet.js:14069
-#: 3.8/weather-applet.js:14557 3.8/weather-applet.js:14558
-#: 3.8/weather-applet.js:14564 3.8/weather-applet.js:14565
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 #, fuzzy
-#| msgid "Partly cloudy"
 msgid "Partly Cloudy"
 msgstr "ところにより曇り"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:14592 3.8/weather-applet.js:14593
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 #, fuzzy
-#| msgid "Mostly cloudy"
 msgid "Mostly Sunny"
 msgstr "おおむね曇り"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:14599 3.8/weather-applet.js:14600
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 #, fuzzy
-#| msgid "Mixed rain and hail"
 msgid "Mixed Rain and Hail"
 msgstr "雨と雹"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:14613 3.8/weather-applet.js:14614
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 #, fuzzy
-#| msgid "Isolated thunderstorms"
 msgid "Isolated Thunderstorms"
 msgstr "局地的な激しい雷雨"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:14620 3.8/weather-applet.js:14621
-#: 3.8/weather-applet.js:14676 3.8/weather-applet.js:14677
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 #, fuzzy
-#| msgid "Scattered thunderstorms"
 msgid "Scattered Thunderstorms"
 msgstr "ところにより激しい雷雨"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:14627 3.8/weather-applet.js:14628
-#: 3.8/weather-applet.js:14662 3.8/weather-applet.js:14663
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 #, fuzzy
-#| msgid "Scattered showers"
 msgid "Scattered Showers"
 msgstr "ところによりにわか雨"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:14634 3.8/weather-applet.js:14635
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "大雨"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:14641 3.8/weather-applet.js:14642
-#: 3.8/weather-applet.js:14669 3.8/weather-applet.js:14670
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 #, fuzzy
-#| msgid "Scattered snow showers"
 msgid "Scattered Snow Showers"
 msgstr "ところによりにわか雪"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:14648 3.8/weather-applet.js:14649
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "大雪"
 
 #: 3.0/yahoo.js:478
 #, fuzzy
-#| msgid "Not available"
 msgid "Not Available"
 msgstr "データなし"
 
 #: 3.0/yahoo.js:479
 #, fuzzy
-#| msgid "Scattered thunderstorms"
 msgid "Scattered Thundershowers"
 msgstr "ところにより激しい雷雨"
 
-#: 3.8/weather-applet.js:9193
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:9197
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:9616
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:9718
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:9796
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr ""
 
-#: 3.8/weather-applet.js:9877
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:9877
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:9881
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr ""
 
-#: 3.8/weather-applet.js:9881
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:9886
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:9886 3.8/weather-applet.js:9891
-#: 3.8/weather-applet.js:9896 3.8/weather-applet.js:9901
-#: 3.8/weather-applet.js:9906
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:9891
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr ""
 
-#: 3.8/weather-applet.js:9896
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr ""
 
-#: 3.8/weather-applet.js:9901 3.8/weather-applet.js:9906
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
-msgstr ""
-
-#: 3.8/weather-applet.js:10258
-msgid "DarkSky"
-msgstr "DarkSky"
-
-#: 3.8/weather-applet.js:10308
-msgid "This API has ceased to function, please use another one."
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10569
-#| msgid "Weather"
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11015
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:11558
-#| msgid "Weather"
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:11981
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12144
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr ""
 
-#: 3.8/weather-applet.js:12158
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr ""
 
-#: 3.8/weather-applet.js:12305
-#| msgid "Weather"
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:12856
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr ""
 
-#: 3.8/weather-applet.js:13031
+#: 3.8/weather-applet.js:13474
 #, fuzzy
-#| msgid "Blowing snow"
 msgid "Blowing or drifting snow"
 msgstr "吹雪"
 
-#: 3.8/weather-applet.js:13035
+#: 3.8/weather-applet.js:13478
 #, fuzzy
-#| msgid "Freezing drizzle"
 msgid "Heavy drizzle"
 msgstr "着氷性の霧雨"
 
-#: 3.8/weather-applet.js:13039
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr ""
 
-#: 3.8/weather-applet.js:13041
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr ""
 
-#: 3.8/weather-applet.js:13043
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "砂嵐"
 
-#: 3.8/weather-applet.js:13047
+#: 3.8/weather-applet.js:13490
 #, fuzzy
-#| msgid "Freezing drizzle"
 msgid "Freezing drizzle/freezing rain"
 msgstr "着氷性の霧雨"
 
-#: 3.8/weather-applet.js:13049
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr ""
 
-#: 3.8/weather-applet.js:13051
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr ""
 
-#: 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13496
 #, fuzzy
-#| msgid "Freezing rain"
 msgid "Freezing fog"
 msgstr "着氷性の雨"
 
-#: 3.8/weather-applet.js:13059
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr ""
 
-#: 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13504
 #, fuzzy
-#| msgid "Snow showers"
 msgid "Hail showers"
 msgstr "にわか雪"
 
-#: 3.8/weather-applet.js:13063
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr ""
 
-#: 3.8/weather-applet.js:13065
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr ""
 
-#: 3.8/weather-applet.js:13069
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr ""
 
-#: 3.8/weather-applet.js:13073 3.8/weather-applet.js:13360
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 #, fuzzy
-#| msgid "Mixed rain and snow"
 msgid "Heavy rain and snow"
 msgstr "雨と雪"
 
-#: 3.8/weather-applet.js:13075
+#: 3.8/weather-applet.js:13518
 #, fuzzy
-#| msgid "Mixed rain and snow"
 msgid "Light rain And snow"
 msgstr "雨と雪"
 
-#: 3.8/weather-applet.js:13083
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:13085
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:13087
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr ""
 
-#: 3.8/weather-applet.js:13089
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr ""
 
-#: 3.8/weather-applet.js:13093
+#: 3.8/weather-applet.js:13536
 #, fuzzy
-#| msgid "Snow showers"
 msgid "Snow and rain showers"
 msgstr "にわか雪"
 
-#: 3.8/weather-applet.js:13105
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr ""
 
-#: 3.8/weather-applet.js:13107
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "ダイアモンドダスト"
 
-#: 3.8/weather-applet.js:13113
+#: 3.8/weather-applet.js:13556
 #, fuzzy
-#| msgid "Partly cloudy"
 msgid "Partially cloudy"
 msgstr "ところにより曇り"
 
-#: 3.8/weather-applet.js:13135
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "正しいAPIキーを入力してください"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:13292 3.8/weather-applet.js:13293
-#: 3.8/weather-applet.js:13429 3.8/weather-applet.js:13430
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr ""
 
-#: 3.8/weather-applet.js:13325
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "吹雪"
 
-#: 3.8/weather-applet.js:13366 3.8/weather-applet.js:13367
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 #, fuzzy
-#| msgid "Blowing snow"
 msgid "Slight snow"
 msgstr "吹雪"
 
-#: 3.8/weather-applet.js:13373 3.8/weather-applet.js:13374
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 #, fuzzy
-#| msgid "Heavy snow"
 msgid "Moderate snow"
 msgstr "大雪"
 
-#: 3.8/weather-applet.js:13388
+#: 3.8/weather-applet.js:13842
 #, fuzzy
-#| msgid "Scattered showers"
 msgid "Moderate rain showers"
 msgstr "ところによりにわか雨"
 
-#: 3.8/weather-applet.js:13395
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "雨と雪"
 
-#: 3.8/weather-applet.js:13402
+#: 3.8/weather-applet.js:13856
 #, fuzzy
-#| msgid "Mixed rain and snow"
 msgid "Heavy mixed rain and snow"
 msgstr "雨と雪"
 
-#: 3.8/weather-applet.js:13499
-#| msgid "Weather"
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:13841
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:13852
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "別のプロバイダまたは位置情報を選んでください"
 
-#: 3.8/weather-applet.js:14149
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14338
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:14345
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:14381 3.8/weather-applet.js:14382
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr ""
 
-#: 3.8/weather-applet.js:14396 3.8/weather-applet.js:14397
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 #, fuzzy
-#| msgid "Mixed rain and snow"
 msgid "Rain and Snow"
 msgstr "雨と雪"
 
-#: 3.8/weather-applet.js:14403 3.8/weather-applet.js:14404
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 #, fuzzy
-#| msgid "Mixed rain and sleet"
 msgid "Rain and Sleet"
 msgstr "雨とみぞれ"
 
-#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14453
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 #, fuzzy
-#| msgid "Snow showers"
 msgid "Snow Showers"
 msgstr "にわか雪"
 
-#: 3.8/weather-applet.js:14515 3.8/weather-applet.js:14516
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:14529 3.8/weather-applet.js:14530
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:14585 3.8/weather-applet.js:14586
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 #, fuzzy
-#| msgid "Mostly cloudy"
 msgid "Mostly Clear"
 msgstr "おおむね曇り"
 
-#: 3.8/weather-applet.js:15064
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:15603
 msgid ""
-"Could not retrieve config, file was not found under path\n"
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr "位置情報を入力するか位置の自動取得を有効にしてください"
+
+#: 3.8/weather-applet.js:15968
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:15068
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:15676
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "このサービスプロバイダはAPIキーが必要です"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "露点"
 
-#: 3.8/weather-applet.js:15748
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:15750
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr ""
 
-#: 3.8/weather-applet.js:15753
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:15961
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:16399 3.8/weather-applet.js:17147
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "{lastUpdatedTime}現在"
 
-#: 3.8/weather-applet.js:16405
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr ""
 
-#: 3.8/weather-applet.js:16409
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:16412
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:16944 3.8/weather-applet.js:16954
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:16965
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "デバッグ情報が保存されました"
 
-#: 3.8/weather-applet.js:16965
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "保存先: {filePath}"
-
-#: 3.8/weather-applet.js:17106
-msgid "This provider requires an API key to operate"
-msgstr "このサービスプロバイダはAPIキーが必要です"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -1971,7 +1894,6 @@ msgid "Data service"
 msgstr "データサービス"
 
 #. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
 msgid "DarkSky (key needed)"
 msgstr "DarkSky（要APIキー）"
 
@@ -2402,6 +2324,11 @@ msgid "US National Weather (US only)"
 msgstr "US National Weather（米国限定）"
 
 #. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Pirate Weather (key needed)"
+msgstr "Weatherbit（要APIキー）"
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Visual Crossing (key needed)"
 msgstr "Visual Crossing（要APIキー）"
 
@@ -2424,6 +2351,12 @@ msgid ""
 "{City/Town} {Postcode} {Country}. The search algorithm is very flexible with "
 "the format. After 3 seconds without typing the address you entered is "
 "replaced automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
 msgstr ""
 
 #. 3.8->settings-schema.json->saveLocation->description
@@ -2466,8 +2399,8 @@ msgstr "毎分の降水量予報を有効化"
 #. 3.8->settings-schema.json->immediatePrecip->tooltip
 msgid ""
 "If you'd like to use this make sure you use your exact coordinates/address "
-"as location to help its accuracy. Currently implemented with OpenWeatherMap "
-"and MET Norway only."
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
 msgstr ""
 
 #. 3.8->settings-schema.json->showBothTempUnits->description
@@ -2480,6 +2413,16 @@ msgid ""
 "{u} is unit.\n"
 "Can be used if label does not fit on vertical panel, among other smart "
 "things."
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+#, fuzzy
+msgid "Override tooltip on panel"
+msgstr "パネルラベルを上書き"
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
 msgstr ""
 
 #. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
@@ -2632,36 +2575,3 @@ msgstr ""
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr ""
-
-#~ msgid "Settings"
-#~ msgstr "設定"
-
-#~ msgid "Sunrise"
-#~ msgstr "日の出"
-
-#~ msgid "Sunset"
-#~ msgstr "日の入"
-
-#~ msgid "Wind Chill:"
-#~ msgstr "体感温度:"
-
-#~ msgid "Isolated thundershowers"
-#~ msgstr "局地的雷雨"
-
-#~ msgid "Get WOEID"
-#~ msgstr "WOEID を取得"
-
-#~ msgid "Vertical orientation"
-#~ msgstr "縦に配置"
-
-#~ msgid "WOEID"
-#~ msgstr "WOEID"
-
-#~ msgid "kPa"
-#~ msgstr "kPa"
-
-#~ msgid "mbar"
-#~ msgstr "hPa"
-
-#~ msgid "Symbolic icons"
-#~ msgstr "シンボリック・アイコンにする"

--- a/weather@mockturtl/files/weather@mockturtl/po/ko.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/ko.po
@@ -9,13 +9,14 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
 "POT-Creation-Date: 2024-05-01 17:52+0100\n"
-"PO-Revision-Date: 2017-02-12 14:49+0900\n"
+"PO-Revision-Date: 2024-05-01 17:58+0100\n"
 "Last-Translator: Hang Park <hangpark@kaist.ac.kr>\n"
 "Language-Team: Korean <hangpark@kaist.ac.kr>\n"
-"Language: \n"
+"Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
 #: 3.8/weather-applet.js:17877

--- a/weather@mockturtl/files/weather@mockturtl/po/ko.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/ko.po
@@ -2,437 +2,2599 @@
 # Copyright (C) 2011
 # This file is distributed under the same license as the gnome-shell-extension-weather package.
 # Hang Park <hangpark@kaist.ac.kr>, 2017.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: weather@mockturtl 1.13.7\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-12 12:27-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2017-02-12 14:49+0900\n"
 "Last-Translator: Hang Park <hangpark@kaist.ac.kr>\n"
 "Language-Team: Korean <hangpark@kaist.ac.kr>\n"
-"Language: ko\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: \n"
 
-#: applet.js:249
+#: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
+#: 3.8/weather-applet.js:17877
+msgid "Error"
+msgstr ""
+
+#: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
+#: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
+msgid "Service Error"
+msgstr ""
+
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
+msgid "Incorrect API Key"
+msgstr ""
+
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
+msgid "Incorrect Location Format"
+msgstr ""
+
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
+msgid "Key Blocked"
+msgstr ""
+
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
+msgid "Can't find location"
+msgstr ""
+
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
+msgid "No Api Key"
+msgstr ""
+
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
+msgid "No Location"
+msgstr ""
+
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
+msgid "Missing Packages"
+msgstr ""
+
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
+msgid "Location not covered"
+msgstr ""
+
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
+#, fuzzy
+msgid "Weather Applet"
+msgstr "날씨"
+
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: applet.js:250
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "열기"
 
-#: applet.js:289
-msgid "Settings"
-msgstr "설정"
-
-#: applet.js:555
-msgid "Sunrise"
-msgstr "일출"
-
-#: applet.js:556
-msgid "Sunset"
-msgstr "일몰"
-
-#: applet.js:648
-msgid "Loading current weather ..."
-msgstr "현재 날씨를 가져오고 있습니다 ..."
-
-#: applet.js:649
-msgid "Loading future weather ..."
-msgstr "날씨 예보를 가져오고 있습니다 ..."
-
-#: applet.js:671
-msgid "Loading ..."
-msgstr "가져오는 중 ..."
-
-#: applet.js:677
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "새로고침"
 
-#: applet.js:740
-msgid "Temperature:"
+#: 3.0/applet.js:272
+msgid "API returned status code between 400 and 500"
+msgstr ""
+
+#: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
+#: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
+msgid "Location Store"
+msgstr ""
+
+#: 3.0/applet.js:426
+msgid "You can't save a location obtained automatically, sorry"
+msgstr ""
+
+#: 3.0/applet.js:601
+msgid "Could not get weather information"
+msgstr ""
+
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
+msgid ""
+"Unexpected Error While Refreshing Weather, please see log in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
+msgid ""
+"Could not update weather for a while...\n"
+"are you connected to the internet?"
+msgstr ""
+
+#: 3.0/applet.js:684
+msgid "Network Error, please check logs in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:969 3.0/applet.js:1110
+msgid "As of"
+msgstr ""
+
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
+msgid "Powered by"
+msgstr ""
+
+#: 3.0/applet.js:1113
+msgid "from you"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
+msgid "mm"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
+msgid "in"
+msgstr ""
+
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
+msgid "mi"
+msgstr ""
+
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
+msgid "km"
+msgstr ""
+
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
+msgid "Loading current weather ..."
+msgstr "현재 날씨를 가져오고 있습니다 ..."
+
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
+msgid "Loading future weather ..."
+msgstr "날씨 예보를 가져오고 있습니다 ..."
+
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
+msgid "Loading ..."
+msgstr "가져오는 중 ..."
+
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
+#, fuzzy
+msgid "Temperature"
 msgstr "기온:"
 
-#: applet.js:742
-msgid "Humidity:"
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
+#, fuzzy
+msgid "Humidity"
 msgstr "습도:"
 
-#: applet.js:744
-msgid "Pressure:"
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
+#, fuzzy
+msgid "Pressure"
 msgstr "기압:"
 
-#: applet.js:746
-msgid "Wind:"
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
+#, fuzzy
+msgid "Wind"
 msgstr "풍속:"
 
-#: applet.js:748
-msgid "Wind Chill:"
-msgstr "체감온도:"
+#: 3.0/applet.js:1639
+msgid "Make sure you entered a location or use Automatic location instead"
+msgstr ""
 
-#: applet.js:953
-msgid "Tornado"
-msgstr "토네이도"
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
+msgid "Could not find location based on address, please check if it's right"
+msgstr ""
 
-#: applet.js:955
-msgid "Tropical storm"
-msgstr "열대 폭풍우"
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
+msgid "Failed to call Geolocation API, see Looking Glass for errors."
+msgstr ""
 
-#: applet.js:957
-msgid "Hurricane"
-msgstr "허리케인"
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "Warning"
+msgstr ""
 
-#: applet.js:959
-msgid "Severe thunderstorms"
-msgstr "강한 뇌우"
+#: 3.0/applet.js:2032
+msgid "You can only save correct locations when the applet is not refreshing"
+msgstr ""
 
-#: applet.js:961
-msgid "Thunderstorms"
-msgstr "뇌우"
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "You can't save an incorrect location"
+msgstr ""
 
-#: applet.js:963
-msgid "Mixed rain and snow"
-msgstr "비와 눈"
+#. 3.8->settings-schema.json->logLevel->options
+#: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.8/weather-applet.js:9875
+msgid "Info"
+msgstr ""
 
-#: applet.js:965
-msgid "Mixed rain and sleet"
-msgstr "비와 진눈깨비"
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
+msgid "Location is already saved"
+msgstr ""
 
-#: applet.js:967
-msgid "Mixed snow and sleet"
-msgstr "눈과 진눈깨비"
+#: 3.0/applet.js:2049 3.0/applet.js:2083
+msgid "Success"
+msgstr ""
 
-#: applet.js:969
-msgid "Freezing drizzle"
-msgstr "착빙성 이슬비"
+#: 3.0/applet.js:2049
+msgid "Location is saved to library"
+msgstr ""
 
-#: applet.js:971
-msgid "Drizzle"
-msgstr "이슬비"
+#: 3.0/applet.js:2062
+msgid "You can't remove a location while the applet is refreshing"
+msgstr ""
 
-#: applet.js:973
+#: 3.0/applet.js:2066
+msgid "You can't remove an incorrect location"
+msgstr ""
+
+#: 3.0/applet.js:2070
+msgid "Location is not in storage, can't delete"
+msgstr ""
+
+#: 3.0/applet.js:2083
+msgid "Location is deleted from library"
+msgstr ""
+
+#: 3.0/applet.js:2131
+msgid ""
+"Failed to load in data from location storage, please see the logs for more "
+"information"
+msgstr ""
+
+#: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
+#: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
+msgid "Feels Like"
+msgstr ""
+
+#: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
+#: 3.8/weather-applet.js:15387
+msgid "Failed to Process Weather Info"
+msgstr ""
+
+#: 3.0/climacell.js:224
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://developer.climacell.co/sign-up"
+msgstr ""
+
+#: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
+msgid ""
+"Please Make sure you\n"
+"entered the API key correctly and your account is not locked"
+msgstr ""
+
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Climacell"
+msgstr ""
+
+#: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
+#: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
+#: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
+#, fuzzy
+msgid "Heavy rain"
+msgstr "폭설"
+
+#: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
+#: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
+#: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
+msgid "Rain"
+msgstr ""
+
+#: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
+#: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
+#: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
+#, fuzzy
+msgid "Light rain"
+msgstr "착빙성 비"
+
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
+#, fuzzy
+msgid "Heavy freezing rain"
+msgstr "착빙성 비"
+
+#: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
+#: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
+#: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "착빙성 비"
 
-#: applet.js:975 applet.js:977
-msgid "Showers"
-msgstr "소나기"
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
+#, fuzzy
+msgid "Light freezing rain"
+msgstr "착빙성 비"
 
-#: applet.js:979
-msgid "Snow flurries"
-msgstr "소낙눈"
+#: 3.0/climacell.js:301
+#, fuzzy
+msgid "Light freezing drizzle"
+msgstr "착빙성 이슬비"
 
-#: applet.js:981
-msgid "Light snow showers"
-msgstr "약한 소낙눈"
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
+msgid "Freezing drizzle"
+msgstr "착빙성 이슬비"
 
-#: applet.js:983
-msgid "Blowing snow"
-msgstr "날린 눈"
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
+#, fuzzy
+msgid "Light drizzle"
+msgstr "착빙성 이슬비"
 
-#: applet.js:985
-msgid "Snow"
-msgstr "눈"
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
+msgid "Heavy ice pellets"
+msgstr ""
 
-#: applet.js:987
-msgid "Hail"
-msgstr "우박"
+#: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
+msgid "Ice pellets"
+msgstr ""
 
-#: applet.js:989
-msgid "Sleet"
-msgstr "진눈깨비"
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
+msgid "Light ice pellets"
+msgstr ""
 
-#: applet.js:991
-msgid "Dust"
-msgstr "먼지"
-
-#: applet.js:993
-msgid "Foggy"
-msgstr "안개"
-
-#: applet.js:995
-msgid "Haze"
-msgstr "아지랑이"
-
-#: applet.js:997
-msgid "Smoky"
-msgstr "연기"
-
-#: applet.js:999
-msgid "Blustery"
-msgstr "바람 거셈"
-
-#: applet.js:1001
-msgid "Windy"
-msgstr "바람 많음"
-
-#: applet.js:1003
-msgid "Cold"
-msgstr "추움"
-
-#: applet.js:1005
-msgid "Cloudy"
-msgstr "구름"
-
-#: applet.js:1008
-msgid "Mostly cloudy"
-msgstr "구름 많음"
-
-#: applet.js:1011 applet.js:1037
-msgid "Partly cloudy"
-msgstr "구름 약간"
-
-#: applet.js:1013
-msgid "Clear"
-msgstr "맑음"
-
-#: applet.js:1015
-msgid "Sunny"
-msgstr "화창"
-
-#: applet.js:1018
-msgid "Fair"
-msgstr "맑음"
-
-#: applet.js:1020
-msgid "Mixed rain and hail"
-msgstr "비와 우박"
-
-#: applet.js:1022
-msgid "Hot"
-msgstr "더움"
-
-#: applet.js:1024
-msgid "Isolated thunderstorms"
-msgstr "고립형 뇌우"
-
-#: applet.js:1027
-msgid "Scattered thunderstorms"
-msgstr "산재형 뇌우"
-
-#: applet.js:1029
-msgid "Scattered showers"
-msgstr "산재형 소나기"
-
-#: applet.js:1031 applet.js:1035
+#: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
+#: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
+#: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "폭설"
 
-#: applet.js:1033
-msgid "Scattered snow showers"
-msgstr "산재형 소낙눈"
+#: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
+#: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
+#: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
+msgid "Snow"
+msgstr "눈"
 
-#: applet.js:1039
-msgid "Thundershowers"
-msgstr "천둥을 동반한 비"
+#: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
+#: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
+#: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
+#, fuzzy
+msgid "Light snow"
+msgstr "약한 소낙눈"
 
-#: applet.js:1041
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
+#, fuzzy
+msgid "Flurries"
+msgstr "소낙눈"
+
+#: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
+#, fuzzy
+msgid "Thunderstorm"
+msgstr "뇌우"
+
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
+msgid "Light fog"
+msgstr ""
+
+#: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
+#: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
+#: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
+#, fuzzy
+msgid "Fog"
+msgstr "안개"
+
+#: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
+#: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
+msgid "Cloudy"
+msgstr "구름"
+
+#: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
+msgid "Mostly cloudy"
+msgstr "구름 많음"
+
+#: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
+#: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
+#: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
+msgid "Partly cloudy"
+msgstr "구름 약간"
+
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
+#, fuzzy
+msgid "Mostly clear"
+msgstr "구름 많음"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
+#: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
+#: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
+msgid "Clear"
+msgstr "맑음"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
+msgid "Sunny"
+msgstr "화창"
+
+#: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
+#: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
+#: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
+msgid "Unknown"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "and"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "until"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "Possible"
+msgstr ""
+
+#: 3.0/darkSky.js:211
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://darksky.net/dev/register"
+msgstr ""
+
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from DarkSky"
+msgstr ""
+
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
+msgid "Could not obtain location"
+msgstr ""
+
+#: 3.0/ipApi.js:95
+msgid ""
+"Location Service responded with errors, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
+#, fuzzy
+msgid "Cloudiness"
+msgstr "구름"
+
+#: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
+#, fuzzy
+msgid "Clear sky"
+msgstr "맑음"
+
+#: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
+msgid "Fair"
+msgstr "맑음"
+
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
+msgid "Heavy rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
+#, fuzzy
+msgid "Heavy rain showers"
+msgstr "폭설"
+
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
+msgid "Heavy rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
+#, fuzzy
+msgid "Heavy sleet"
+msgstr "폭설"
+
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
+msgid "Heavy sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
+#, fuzzy
+msgid "Heavy sleet showers"
+msgstr "폭설"
+
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
+msgid "Heavy sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
+#, fuzzy
+msgid "Heavy snow and thunder"
+msgstr "폭설"
+
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
+#, fuzzy
+msgid "Heavy snow showers"
+msgstr "소낙눈"
+
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
+msgid "Heavy snow showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
+msgid "Light rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
+#, fuzzy
+msgid "Light rain showers"
+msgstr "약한 소낙눈"
+
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
+#, fuzzy
+msgid "Light rain showers and thunder"
+msgstr "약한 소낙눈"
+
+#: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
+msgid "Light sleet"
+msgstr ""
+
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
+msgid "Light sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
+#, fuzzy
+msgid "Light sleet showers"
+msgstr "약한 소낙눈"
+
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
+#, fuzzy
+msgid "Light sleet showers and thunder"
+msgstr "약한 소낙눈"
+
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
+#, fuzzy
+msgid "Light snow and thunder"
+msgstr "약한 소낙눈"
+
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
+msgid "Light snow showers"
+msgstr "약한 소낙눈"
+
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
+#, fuzzy
+msgid "Light snow showers and thunder"
+msgstr "약한 소낙눈"
+
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
+msgid "Rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
+#, fuzzy
+msgid "Rain showers"
+msgstr "소낙눈"
+
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
+msgid "Rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:511 3.0/met_norway.js:512 3.0/met_norway.js:518
+#: 3.0/met_norway.js:525 3.0/met_norway.js:532 3.0/met_uk.js:638
+#: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
+#: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
+#: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
+msgid "Sleet"
+msgstr "진눈깨비"
+
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
+#, fuzzy
+msgid "Sleet and thunder"
+msgstr "산재형 뇌우"
+
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
+#, fuzzy
+msgid "Sleet showers"
+msgstr "산재형 소나기"
+
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
+msgid "Sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
+msgid "Snow and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "소낙눈"
 
-#: applet.js:1043
-msgid "Isolated thundershowers"
-msgstr "고립형 소낙눈"
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
+#, fuzzy
+msgid "Snow showers and thunder"
+msgstr "소낙눈"
 
-#: applet.js:1046
-msgid "Not available"
-msgstr "이용할 수 없음"
+#: 3.0/met_uk.js:162 3.0/met_uk.js:192 3.0/met_uk.js:239 3.0/us_weather.js:151
+#: 3.0/us_weather.js:179
+msgid "Unexpected response from API"
+msgstr ""
 
-#: applet.js:1051
-msgid "Monday"
-msgstr "월요일"
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
+msgid "Visibility"
+msgstr ""
 
-#: applet.js:1051
-msgid "Tuesday"
-msgstr "화요일"
+#: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
+msgid "Failed to Process Current Weather Info"
+msgstr ""
 
-#: applet.js:1051
-msgid "Wednesday"
-msgstr "수요일"
+#: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
+msgid "Failed to Process Forecast Info"
+msgstr ""
 
-#: applet.js:1051
-msgid "Thursday"
-msgstr "목요일"
+#: 3.0/met_uk.js:408
+msgid "Very poor - Less than"
+msgstr ""
 
-#: applet.js:1051
-msgid "Friday"
-msgstr "금요일"
+#: 3.0/met_uk.js:410
+msgid "Poor - Between"
+msgstr ""
 
-#: applet.js:1051
-msgid "Saturday"
-msgstr "토요일"
+#: 3.0/met_uk.js:412
+msgid "Moderate - Between"
+msgstr ""
 
-#: applet.js:1051
+#: 3.0/met_uk.js:414
+msgid "Good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:416
+msgid "Very good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:417
+msgid "Excellent - More than"
+msgstr ""
+
+#: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
+msgid "Mist"
+msgstr ""
+
+#: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
+msgid "Overcast"
+msgstr ""
+
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
+#, fuzzy
+msgid "Light rain shower"
+msgstr "약한 소낙눈"
+
+#: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
+msgid "Drizzle"
+msgstr "이슬비"
+
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
+#, fuzzy
+msgid "Heavy rain shower"
+msgstr "폭설"
+
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
+#, fuzzy
+msgid "Sleet shower"
+msgstr "산재형 소나기"
+
+#: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
+msgid "Hail"
+msgstr "우박"
+
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
+#, fuzzy
+msgid "Hail shower"
+msgstr "소낙눈"
+
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
+#, fuzzy
+msgid "Light snow shower"
+msgstr "약한 소낙눈"
+
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
+#, fuzzy
+msgid "Heavy snow shower"
+msgstr "폭설"
+
+#: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
+#, fuzzy
+msgid "Thunder"
+msgstr "뇌우"
+
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
+#, fuzzy
+msgid "Thunder shower"
+msgstr "천둥을 동반한 비"
+
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
+msgid "Please make sure Location is in the correct format in the Settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
+msgid "Make sure you entered the correct key in settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
+msgid ""
+"Location not found, make sure location is available or it is in the correct "
+"format"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
+msgid "If this problem persists, please contact the Author of this applet"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
+msgid "Unknown Error, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
+msgid "Thunderstorm with light rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
+#, fuzzy
+msgid "Thunderstorm with rain"
+msgstr "뇌우"
+
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
+msgid "Thunderstorm with heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
+#, fuzzy
+msgid "Light thunderstorm"
+msgstr "뇌우"
+
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
+#, fuzzy
+msgid "Heavy thunderstorm"
+msgstr "강한 뇌우"
+
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
+#, fuzzy
+msgid "Ragged thunderstorm"
+msgstr "고립형 뇌우"
+
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
+msgid "Thunderstorm with light drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
+#, fuzzy
+msgid "Thunderstorm with drizzle"
+msgstr "뇌우"
+
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
+msgid "Thunderstorm with heavy drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
+msgid "Light intensity drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
+msgid "Heavy intensity drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
+msgid "Light intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Drizzle rain"
+msgstr "이슬비"
+
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
+msgid "Heavy intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
+#, fuzzy
+msgid "Shower rain and drizzle"
+msgstr "비와 우박"
+
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
+msgid "Heavy shower rain and drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
+#, fuzzy
+msgid "Shower drizzle"
+msgstr "착빙성 이슬비"
+
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
+msgid "Moderate rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
+msgid "Heavy intensity rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
+msgid "Very heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
+#, fuzzy
+msgid "Extreme rain"
+msgstr "착빙성 비"
+
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
+#, fuzzy
+msgid "Light intensity shower rain"
+msgstr "약한 소낙눈"
+
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
+#, fuzzy
+msgid "Shower rain"
+msgstr "소나기"
+
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
+msgid "Heavy intensity shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
+msgid "Ragged shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
+#, fuzzy
+msgid "Shower sleet"
+msgstr "소나기"
+
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
+#, fuzzy
+msgid "Light rain and snow"
+msgstr "비와 눈"
+
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
+#, fuzzy
+msgid "Rain and snow"
+msgstr "비와 눈"
+
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
+#, fuzzy
+msgid "Light shower snow"
+msgstr "약한 소낙눈"
+
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
+#, fuzzy
+msgid "Shower snow"
+msgstr "소나기"
+
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
+#, fuzzy
+msgid "Heavy shower snow"
+msgstr "폭설"
+
+#: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
+#, fuzzy
+msgid "Smoke"
+msgstr "연기"
+
+#: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
+msgid "Haze"
+msgstr "아지랑이"
+
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
+msgid "Sand, dust whirls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
+msgid "Sand"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
+msgid "Dust"
+msgstr "먼지"
+
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
+msgid "Volcanic ash"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
+msgid "Squalls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
+msgid "Tornado"
+msgstr "토네이도"
+
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
+msgid "Sky is clear"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
+#, fuzzy
+msgid "Clouds"
+msgstr "구름"
+
+#: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
+msgid "Few clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
+#, fuzzy
+msgid "Scattered clouds"
+msgstr "산재형 소나기"
+
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
+msgid "Broken clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
+msgid "Overcast clouds"
+msgstr ""
+
+#: 3.0/us_weather.js:120
+msgid "Could not get forecast for your area"
+msgstr ""
+
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
+msgid "Location is outside US, please use a different provider."
+msgstr ""
+
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
+msgid "Failed to Process Hourly Forecast Info"
+msgstr ""
+
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
+msgid "Clear and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
+msgid "Few clouds and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
+#, fuzzy
+msgid "Partly cloudy and windy"
+msgstr "구름 약간"
+
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
+#, fuzzy
+msgid "Mostly cloudy and windy"
+msgstr "구름 많음"
+
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
+msgid "Overcast and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
+#, fuzzy
+msgid "Snowy rain"
+msgstr "소낙눈"
+
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
+#, fuzzy
+msgid "Freezing rain and snow"
+msgstr "착빙성 비"
+
+#: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
+msgid "Hurricane"
+msgstr "허리케인"
+
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
+msgid "Storm"
+msgstr ""
+
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
+msgid "Tropical storm"
+msgstr "열대 폭풍우"
+
+#: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
+msgid "Hot"
+msgstr "더움"
+
+#: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
+msgid "Cold"
+msgstr "추움"
+
+#: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
+msgid "Blizzard"
+msgstr ""
+
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
+msgid "Today"
+msgstr ""
+
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
+msgid "Tomorrow"
+msgstr ""
+
+#: 3.0/utils.js:204
 msgid "Sunday"
 msgstr "일요일"
 
-#: applet.js:1056
+#: 3.0/utils.js:204
+msgid "Monday"
+msgstr "월요일"
+
+#: 3.0/utils.js:204
+msgid "Tuesday"
+msgstr "화요일"
+
+#: 3.0/utils.js:204
+msgid "Wednesday"
+msgstr "수요일"
+
+#: 3.0/utils.js:204
+msgid "Thursday"
+msgstr "목요일"
+
+#: 3.0/utils.js:204
+msgid "Friday"
+msgstr "금요일"
+
+#: 3.0/utils.js:204
+msgid "Saturday"
+msgstr "토요일"
+
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
+msgid "Calm"
+msgstr ""
+
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
+msgid "Light air"
+msgstr ""
+
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
+msgid "Light breeze"
+msgstr ""
+
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
+msgid "Gentle breeze"
+msgstr ""
+
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
+msgid "Moderate breeze"
+msgstr ""
+
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
+msgid "Fresh breeze"
+msgstr ""
+
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
+msgid "Strong breeze"
+msgstr ""
+
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
+msgid "Near gale"
+msgstr ""
+
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
+msgid "Gale"
+msgstr ""
+
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
+msgid "Strong gale"
+msgstr ""
+
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
+msgid "Violent storm"
+msgstr ""
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "북풍"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "북동풍"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "동풍"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "남동풍"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "남풍"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "남서풍"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "서풍"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "북서풍"
 
-#. cinnamon-weather->settings-schema.json->woeidLookup->description
-msgid "Get WOEID"
-msgstr "WOEID 얻기"
-
-#. cinnamon-weather->settings-schema.json->verticalOrientation->description
-msgid "Vertical orientation"
-msgstr "세로쓰기"
-
-#. cinnamon-weather->settings-schema.json->showTextInPanel->description
-msgid "Display current temperature in panel"
-msgstr "패널에 현재 기온 출력"
-
-#. cinnamon-weather->settings-schema.json->woeid->description
-msgid "WOEID"
+#: 3.0/weatherbit.js:312
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://www.weatherbit.io/account/create"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeid->tooltip
-msgid "Where On Earth ID"
-msgstr "위치 코드(Where On Earth ID)"
-
-#. cinnamon-weather->settings-schema.json->temperatureUnit->description
-msgid "Temperature unit"
-msgstr "기온 단위"
-
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "fahrenheit"
-msgstr "화씨"
-
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "celsius"
-msgstr "섭씨"
-
-#. cinnamon-weather->settings-schema.json->translateCondition->description
-msgid "Translate condition"
-msgstr "번역"
-
-#. cinnamon-weather->settings-schema.json->locationLabelOverride->description
-msgid "Override location label"
-msgstr "지역명 덮어쓰기"
-
-#. cinnamon-weather->settings-schema.json->show24Hours->description
-msgid "Display time in 24 hour format"
-msgstr "24시간제"
-
-#. cinnamon-weather->settings-schema.json->forecastDays->description
-msgid "Forecast length"
-msgstr "기상예보 기간"
-
-#. cinnamon-weather->settings-schema.json->forecastDays->units
-msgid "days"
-msgstr "일"
-
-#. cinnamon-weather->settings-schema.json->showSunrise->description
-msgid "Show sunrise / sunset times"
-msgstr "일출 / 일몰 시간 출력"
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->description
-msgid "Wind speed unit"
-msgstr "풍속 단위"
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "kph"
+#: 3.0/yahoo.js:78
+msgid ""
+"Unknown Error happened while calling Yahoo bridge,\n"
+" see Looking Glass log for errors"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "m/s"
+#: 3.0/yahoo.js:91
+msgid ""
+"Yahoo bridge responded in bad format,\n"
+" see Looking Glass log for errors"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "knots"
+#: 3.0/yahoo.js:177
+msgid "Missing package"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "mph"
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+msgid "Please install '"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showCommentInPanel->description
-msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
-msgstr "패널에 날씨 상태(\"바람\", \"맑음\" 등)를 출력"
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->description
-msgid "Atmospheric pressure unit"
-msgstr "기압 단위"
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "psi"
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+msgid "', then refresh manually."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "atm"
+#: 3.0/yahoo.js:182
+msgid "Could not connect to Yahoo API."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "kPa"
+#: 3.0/yahoo.js:186
+msgid ""
+"Unknown error happened while obtaining weather, see Looking Glass logs for "
+"more information"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "Pa"
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
+#, fuzzy
+msgid "Tropical Storm"
+msgstr "열대 폭풍우"
+
+#: 3.0/yahoo.js:439
+#, fuzzy
+msgid "Severe Thunderstorms"
+msgstr "강한 뇌우"
+
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
+msgid "Thunderstorms"
+msgstr "뇌우"
+
+#: 3.0/yahoo.js:441
+#, fuzzy
+msgid "Mixed Rain and Snow"
+msgstr "비와 눈"
+
+#: 3.0/yahoo.js:442
+#, fuzzy
+msgid "Mixed Rain and Sleet"
+msgstr "비와 진눈깨비"
+
+#: 3.0/yahoo.js:443
+#, fuzzy
+msgid "Mixed Snow and Sleet"
+msgstr "눈과 진눈깨비"
+
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
+#, fuzzy
+msgid "Freezing Drizzle"
+msgstr "착빙성 이슬비"
+
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
+#, fuzzy
+msgid "Freezing Rain"
+msgstr "착빙성 비"
+
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
+msgid "Showers"
+msgstr "소나기"
+
+#: 3.0/yahoo.js:449
+#, fuzzy
+msgid "Snow Flurries"
+msgstr "소낙눈"
+
+#: 3.0/yahoo.js:450
+#, fuzzy
+msgid "Light Snow Showers"
+msgstr "약한 소낙눈"
+
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
+#, fuzzy
+msgid "Blowing Snow"
+msgstr "날린 눈"
+
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
+msgid "Foggy"
+msgstr "안개"
+
+#: 3.0/yahoo.js:458
+msgid "Smoky"
+msgstr "연기"
+
+#: 3.0/yahoo.js:459
+msgid "Blustery"
+msgstr "바람 거셈"
+
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
+msgid "Windy"
+msgstr "바람 많음"
+
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
+#, fuzzy
+msgid "Mostly Cloudy"
+msgstr "구름 많음"
+
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
+#, fuzzy
+msgid "Partly Cloudy"
+msgstr "구름 약간"
+
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
+#, fuzzy
+msgid "Mostly Sunny"
+msgstr "구름 많음"
+
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
+#, fuzzy
+msgid "Mixed Rain and Hail"
+msgstr "비와 우박"
+
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
+#, fuzzy
+msgid "Isolated Thunderstorms"
+msgstr "고립형 뇌우"
+
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
+#, fuzzy
+msgid "Scattered Thunderstorms"
+msgstr "산재형 뇌우"
+
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
+#, fuzzy
+msgid "Scattered Showers"
+msgstr "산재형 소나기"
+
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
+#, fuzzy
+msgid "Heavy Rain"
+msgstr "폭설"
+
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
+#, fuzzy
+msgid "Scattered Snow Showers"
+msgstr "산재형 소낙눈"
+
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
+#, fuzzy
+msgid "Heavy Snow"
+msgstr "폭설"
+
+#: 3.0/yahoo.js:478
+#, fuzzy
+msgid "Not Available"
+msgstr "이용할 수 없음"
+
+#: 3.0/yahoo.js:479
+#, fuzzy
+msgid "Scattered Thundershowers"
+msgstr "산재형 뇌우"
+
+#: 3.8/weather-applet.js:9638
+msgid ""
+"Could not retrieve logs, log file was not found under path\n"
+" {logFilePath}"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mm Hg"
+#: 3.8/weather-applet.js:9642
+msgid ""
+"Could not get contents of log file under path\n"
+" {logFilePath}"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "at"
+#. 3.0->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10283
+msgid "Met Office UK"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mbar"
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "in Hg"
+#: 3.8/weather-applet.js:10476
+msgid "Data was not found for location"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->description
-msgid "Update interval"
-msgstr "업데이트 간격"
+#: 3.8/weather-applet.js:10557
+msgid "Very poor"
+msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->units
-msgid "minutes"
-msgstr "분"
+#: 3.8/weather-applet.js:10557
+msgid "Less than {distance} {distanceUnit}"
+msgstr ""
 
-#. cinnamon-weather->settings-schema.json->useSymbolicIcons->description
-msgid "Symbolic icons"
-msgstr "심볼릭 아이콘"
+#: 3.8/weather-applet.js:10561
+msgid "Excellent"
+msgstr ""
 
-#. cinnamon-weather->metadata.json->description
+#: 3.8/weather-applet.js:10561
+msgid "More than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566
+msgid "Poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
+msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10571
+msgid "Moderate"
+msgstr ""
+
+#: 3.8/weather-applet.js:10576
+msgid "Good"
+msgstr ""
+
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
+msgid "Very good"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10942
+#, fuzzy
+msgid "OpenWeatherMap"
+msgstr "날씨"
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:11396
+msgid "MET Norway"
+msgstr ""
+
+#: 3.8/weather-applet.js:11955
+#, fuzzy
+msgid "WeatherBit"
+msgstr "날씨"
+
+#: 3.8/weather-applet.js:12386
+msgid "Tomorrow.io"
+msgstr ""
+
+#: 3.8/weather-applet.js:12561
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12575
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12723
+#, fuzzy
+msgid "US Weather"
+msgstr "날씨"
+
+#: 3.8/weather-applet.js:13292
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13474
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "날린 눈"
+
+#: 3.8/weather-applet.js:13478
+#, fuzzy
+msgid "Heavy drizzle"
+msgstr "착빙성 이슬비"
+
+#: 3.8/weather-applet.js:13482
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13484
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13486
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:13490
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "착빙성 이슬비"
+
+#: 3.8/weather-applet.js:13492
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13494
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13496
+#, fuzzy
+msgid "Freezing fog"
+msgstr "착빙성 비"
+
+#: 3.8/weather-applet.js:13502
+msgid "Funnel cloud/tornado"
+msgstr ""
+
+#: 3.8/weather-applet.js:13504
+#, fuzzy
+msgid "Hail showers"
+msgstr "소낙눈"
+
+#: 3.8/weather-applet.js:13506
+msgid "Ice"
+msgstr ""
+
+#: 3.8/weather-applet.js:13508
+msgid "Lightning without thunder"
+msgstr ""
+
+#: 3.8/weather-applet.js:13512
+msgid "Precipitation in vicinity"
+msgstr ""
+
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
+#, fuzzy
+msgid "Heavy rain and snow"
+msgstr "비와 눈"
+
+#: 3.8/weather-applet.js:13518
+#, fuzzy
+msgid "Light rain And snow"
+msgstr "비와 눈"
+
+#: 3.8/weather-applet.js:13526
+msgid "Sky coverage decreasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13528
+msgid "Sky coverage increasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13530
+msgid "Sky unchanged"
+msgstr ""
+
+#: 3.8/weather-applet.js:13532
+msgid "Smoke or haze"
+msgstr ""
+
+#: 3.8/weather-applet.js:13536
+#, fuzzy
+msgid "Snow and rain showers"
+msgstr "소낙눈"
+
+#: 3.8/weather-applet.js:13548
+msgid "Thunderstorm without precipitation"
+msgstr ""
+
+#: 3.8/weather-applet.js:13550
+msgid "Diamond dust"
+msgstr ""
+
+#: 3.8/weather-applet.js:13556
+#, fuzzy
+msgid "Partially cloudy"
+msgstr "구름 약간"
+
+#: 3.8/weather-applet.js:13578
+msgid "Please make sure you entered the API key correctly"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:13595
+msgid "DMI Denmark"
+msgstr ""
+
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
+msgid "NOT FOUND"
+msgstr ""
+
+#: 3.8/weather-applet.js:13779
+msgid "Blowing snow"
+msgstr "날린 눈"
+
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
+#, fuzzy
+msgid "Slight snow"
+msgstr "날린 눈"
+
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
+#, fuzzy
+msgid "Moderate snow"
+msgstr "폭설"
+
+#: 3.8/weather-applet.js:13842
+#, fuzzy
+msgid "Moderate rain showers"
+msgstr "산재형 소나기"
+
+#: 3.8/weather-applet.js:13849
+msgid "Mixed rain and snow"
+msgstr "비와 눈"
+
+#: 3.8/weather-applet.js:13856
+#, fuzzy
+msgid "Heavy mixed rain and snow"
+msgstr "비와 눈"
+
+#: 3.8/weather-applet.js:14024
+#, fuzzy
+msgid "AccuWeather"
+msgstr "날씨"
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+msgid "Weather Underground"
+msgstr ""
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+msgid "The location you provided was not found."
+msgstr ""
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+msgid "Strong Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "비와 눈"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "비와 진눈깨비"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "소낙눈"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "구름 많음"
+
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "날씨"
+
+#: 3.8/weather-applet.js:15603
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+
+#: 3.8/weather-applet.js:15831
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+
+#: 3.8/weather-applet.js:15968
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:15975
+msgid ""
+"Could not get contents of config file under path\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr ""
+
+#: 3.8/weather-applet.js:16675
+msgid "Dew Point"
+msgstr ""
+
+#: 3.8/weather-applet.js:16747
+msgid "Precipitation will end in {precipEnd} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16749
+msgid "Precipitation won't end in within an hour"
+msgstr ""
+
+#: 3.8/weather-applet.js:16752
+msgid "Precipitation will start within {precipStart} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16964
+msgid "Forecast parsing failed, see logs for more details."
+msgstr ""
+
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
+msgid "As of {lastUpdatedTime}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17502
+msgid "{distance} {distanceUnit} from you"
+msgstr ""
+
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
+msgid "Error Saving Debug Information"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Debug Information saved successfully"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Saved to {filePath}"
+msgstr ""
+
+#: 3.8/LogSaver.py:16
+msgid "Save to File"
+msgstr ""
+
+#: 3.8/LogSaver.py:29
+msgid "Select a destination"
+msgstr ""
+
+#. metadata.json->name
+#. 3.8->settings-schema.json->providers->title
+msgid "Weather"
+msgstr "날씨"
+
+#. metadata.json->description
 msgid "View your local weather forecast"
 msgstr "당신의 지역 날씨정보를 보여줍니다"
 
-#. cinnamon-weather->metadata.json->name
-msgid "Weather"
-msgstr "날씨"
+#. 3.0->settings-schema.json->head->description
+msgid "Settings for weather@mockturtl 3.0+"
+msgstr ""
+
+#. 3.0->settings-schema.json->keybinding->description
+#. 3.8->settings-schema.json->keybinding->description
+msgid "Set the keybinding to call the menu"
+msgstr ""
+
+#. 3.0->settings-schema.json->descriptions->description
+msgid "Weather service information"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->description
+msgid "Click here for detailed description"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->tooltip
+#. 3.0->settings-schema.json->getLocation->tooltip
+#. 3.8->settings-schema.json->getLocation->tooltip
+msgid "Opens webpage guide"
+msgstr ""
+
+#. 3.0->settings-schema.json->providerSettings->description
+#. 3.8->settings-schema.json->provider-options->title
+msgid "Weather Provider Options"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->description
+#. 3.8->settings-schema.json->dataService->description
+msgid "Data service"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "DarkSky (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weatherbit (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Yahoo"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Climacell (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->description
+#. 3.8->settings-schema.json->apiKey->description
+msgid "API Key"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->tooltip
+#. 3.8->settings-schema.json->apiKey->tooltip
+msgid "Copy this from your account of the used Data service and paste it here."
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->description
+#. 3.8->settings-schema.json->manualLocation->description
+msgid "Manual Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->tooltip
+#. 3.8->settings-schema.json->manualLocation->tooltip
+msgid "Enable this if your location is not accurate"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->description
+msgid "Location - Coordinates"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->tooltip
+msgid ""
+"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an "
+"address.\n"
+"Waits for 3 seconds after you stop typing before refreshes the weather."
+msgstr ""
+
+#. 3.0->settings-schema.json->getLocation->description
+msgid "Setup API Key and Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->units
+#. 3.8->settings-schema.json->refreshInterval->units
+msgid "minutes"
+msgstr "분"
+
+#. 3.0->settings-schema.json->refreshInterval->description
+#. 3.8->settings-schema.json->refreshInterval->description
+msgid "Update interval"
+msgstr "업데이트 간격"
+
+#. 3.0->settings-schema.json->forecastDays->units
+#. 3.8->settings-schema.json->forecastDays->units
+msgid "days"
+msgstr "일"
+
+#. 3.0->settings-schema.json->forecastDays->description
+#. 3.8->settings-schema.json->forecastDays->description
+msgid "Forecast length"
+msgstr "기상예보 기간"
+
+#. 3.0->settings-schema.json->forecastHours->units
+#. 3.8->settings-schema.json->forecastHours->units
+msgid "hours"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastHours->description
+#. 3.8->settings-schema.json->forecastHours->description
+#, fuzzy
+msgid "Hourly Forecast length"
+msgstr "기상예보 기간"
+
+#. 3.0->settings-schema.json->unitSettings->description
+msgid "Units"
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureUnit->description
+#. 3.8->settings-schema.json->temperatureUnit->description
+msgid "Temperature unit"
+msgstr "기온 단위"
+
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Automatic"
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#, fuzzy
+msgid "Celsius"
+msgstr "섭씨"
+
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#, fuzzy
+msgid "Fahrenheit"
+msgstr "화씨"
+
+#. 3.0->settings-schema.json->temperatureUnit->tooltip
+#. 3.0->settings-schema.json->distanceUnit->tooltip
+#. 3.8->settings-schema.json->temperatureUnit->tooltip
+#. 3.8->settings-schema.json->distanceUnit->tooltip
+msgid ""
+"Automatic will try to guess your preference based your current display "
+"language."
+msgstr ""
+
+#. 3.0->settings-schema.json->windSpeedUnit->description
+#. 3.8->settings-schema.json->windSpeedUnit->description
+msgid "Wind speed unit"
+msgstr "풍속 단위"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "kph"
+msgstr ""
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "mph"
+msgstr ""
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "m/s"
+msgstr ""
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "knots"
+msgstr ""
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "Beaufort"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->description
+#. 3.8->settings-schema.json->pressureUnit->description
+msgid "Atmospheric pressure unit"
+msgstr "기압 단위"
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "hPa"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "in Hg"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "mm Hg"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "psi"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "at"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "atm"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "Pa"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->description
+#. 3.8->settings-schema.json->distanceUnit->description
+msgid "Distance unit"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Metric"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Imperial"
+msgstr ""
+
+#. 3.0->settings-schema.json->panelSettings->description
+msgid "Panel options"
+msgstr ""
+
+#. 3.0->settings-schema.json->showTextInPanel->description
+#. 3.8->settings-schema.json->showTextInPanel->description
+msgid "Display current temperature in panel"
+msgstr "패널에 현재 기온 출력"
+
+#. 3.0->settings-schema.json->showCommentInPanel->description
+#. 3.8->settings-schema.json->showCommentInPanel->description
+msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
+msgstr "패널에 날씨 상태(\"바람\", \"맑음\" 등)를 출력"
+
+#. 3.0->settings-schema.json->showCommentInPanel->tooltip
+#. 3.8->settings-schema.json->showCommentInPanel->tooltip
+msgid "Only works with horizontal panels"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempTextOverride->description
+#. 3.8->settings-schema.json->tempTextOverride->description
+#, fuzzy
+msgid "Override label on panel"
+msgstr "지역명 덮어쓰기"
+
+#. 3.0->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.0->settings-schema.json->useCustomMenuIcons->tooltip
+#. 3.8->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.8->settings-schema.json->useCustomMenuIcons->tooltip
+msgid "Iconset is weather-icons by Erik Flowers"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->description
+#. 3.8->settings-schema.json->useCustomAppletIcons->description
+msgid "Use custom icons on the panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->displaySettings->description
+#. 3.8->settings-schema.json->presentation-section->title
+msgid "Presentation"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->description
+#. 3.8->settings-schema.json->verticalOrientation->description
+msgid "Show forecast vertically"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->units
+#. 3.8->settings-schema.json->forecastColumns->units
+msgid "columns"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->description
+#. 3.8->settings-schema.json->forecastColumns->description
+msgid "Maximum number of columns for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->units
+#. 3.8->settings-schema.json->forecastRows->units
+msgid "rows"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->description
+#. 3.8->settings-schema.json->forecastRows->description
+msgid "Maximum number of rows for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->showSunrise->description
+#. 3.8->settings-schema.json->showSunrise->description
+msgid "Show sunrise / sunset times"
+msgstr "일출 / 일몰 시간 출력"
+
+#. 3.0->settings-schema.json->show24Hours->description
+#. 3.8->settings-schema.json->show24Hours->description
+msgid "Display time in 24 hour format"
+msgstr "24시간제"
+
+#. 3.0->settings-schema.json->shortHourlyTime->description
+#. 3.8->settings-schema.json->shortHourlyTime->description
+msgid "Only display hours for hourly forecast time"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->tooltip
+#. 3.8->settings-schema.json->shortHourlyTime->tooltip
+msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->description
+#. 3.8->settings-schema.json->showForecastDates->description
+#, fuzzy
+msgid "Display date for daily forecasts"
+msgstr "24시간제"
+
+#. 3.0->settings-schema.json->showForecastDates->tooltip
+#. 3.8->settings-schema.json->showForecastDates->tooltip
+msgid "Like \"Friday 15\""
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureHighFirst->description
+#. 3.8->settings-schema.json->temperatureHighFirst->description
+msgid "Show high temperature first in forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempRussianStyle->description
+#. 3.8->settings-schema.json->tempRussianStyle->description
+#, fuzzy
+msgid "Show temperature Russian style"
+msgstr "기온 단위"
+
+#. 3.0->settings-schema.json->locationLabelOverride->description
+#. 3.8->settings-schema.json->locationLabelOverride->description
+msgid "Override location label"
+msgstr "지역명 덮어쓰기"
+
+#. 3.0->settings-schema.json->conditionSettings->description
+#. 3.8->settings-schema.json->weather-conditions->title
+#, fuzzy
+msgid "Weather conditions"
+msgstr "번역"
+
+#. 3.0->settings-schema.json->translateCondition->description
+#. 3.8->settings-schema.json->translateCondition->description
+#, fuzzy
+msgid "Translate conditions"
+msgstr "번역"
+
+#. 3.0->settings-schema.json->shortConditions->description
+#. 3.8->settings-schema.json->shortConditions->description
+#, fuzzy
+msgid "Less verbose conditions"
+msgstr "번역"
+
+#. 3.0->settings-schema.json->iconSettings->description
+#. 3.8->settings-schema.json->icons->title
+msgid "Icons"
+msgstr ""
+
+#. 3.0->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons in the applet"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomMenuIcons->description
+#. 3.8->settings-schema.json->useCustomMenuIcons->description
+msgid "Use custom icons in the popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->locations-page->title
+#. 3.8->settings-schema.json->location->description
+msgid "Location"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-page->title
+msgid "Other options"
+msgstr ""
+
+#. 3.8->settings-schema.json->info-section->title
+msgid "Help"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-section->title
+msgid "Location settings"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-store->title
+msgid "Saved Locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->panel-options->title
+msgid "Panel (Taskbar)"
+msgstr ""
+
+#. 3.8->settings-schema.json->presentation->title
+msgid "Popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-section->title
+msgid "Other Units"
+msgstr ""
+
+#. 3.8->settings-schema.json->temp-unit-section->title
+#, fuzzy
+msgid "Temperature Unit"
+msgstr "기온 단위"
+
+#. 3.8->settings-schema.json->keybindings->title
+msgid "Keybindings"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info->title
+msgid "More about the Weather applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->submit-issue->title
+msgid "Report an issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->debug-options->title
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Debug"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->tooltip
+msgid ""
+"You can choose between several different weather forecast providers. Some "
+"providers require a API key to work, some have regional limits, differ in "
+"forecast length, and they all need a functional internet connection to work. "
+"The options are described in detail on the Cinnamon Spices Website which you "
+"can access with the button on the Help tab."
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Met Office UK (UK only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "US National Weather (US only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Pirate Weather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Visual Crossing (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Tomorrow.io (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "AccuWeather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weather Underground (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->location->tooltip
+msgid ""
+"You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use "
+"'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street} "
+"{City/Town} {Postcode} {Country}. The search algorithm is very flexible with "
+"the format. After 3 seconds without typing the address you entered is "
+"replaced automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->description
+#, fuzzy
+msgid "Save current location to storage"
+msgstr "지역명 덮어쓰기"
+
+#. 3.8->settings-schema.json->saveLocation->tooltip
+msgid ""
+"Saves location information to file so you can switch between them with "
+"buttons in the applet, which will appear if you have more than one."
+msgstr ""
+
+#. 3.8->settings-schema.json->getLocation->description
+msgid "Weather Applet at Cinnamon Spices Website"
+msgstr ""
+
+#. 3.8->settings-schema.json->refreshInterval->tooltip
+msgid ""
+"If you are using a provider with API keys set it to an interval you won't "
+"run out of your quota with."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastDays->tooltip
+msgid ""
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->description
+msgid "Enable minutely precipitation forecast"
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->tooltip
+msgid ""
+"If you'd like to use this make sure you use your exact coordinates/address "
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
+msgstr ""
+
+#. 3.8->settings-schema.json->showBothTempUnits->description
+msgid "Show both temperature units at the same time"
+msgstr ""
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+#, fuzzy
+msgid "Override tooltip on panel"
+msgstr "지역명 덮어쓰기"
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
+msgid "Always show Hourly Weather"
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->tooltip
+msgid ""
+"Hide/Show button will be hidden and Hourly weather will be permanently "
+"visible."
+msgstr ""
+
+#. 3.8->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->description
+msgid "Your saved locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->tooltip
+msgid ""
+"You have to make sure the Search entry field is unique and your Timezone is "
+"in the IANA time zone format (e.g. 'Europe/London')"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Latitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Longitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "City"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Country"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Timezone"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Search entry"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->description
+msgid "Display wind direction as text"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->tooltip
+msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->tooltip
+msgid "Does not apply to custom iconset, that is symbolic by default"
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons throughout the applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info-label->description
+msgid ""
+"For detailed information about the applet please go to the Spices Website to "
+"find info about known issues, troubleshooting, changelog and more by "
+"clicking the button below. Here you can ask questions etc in the comment "
+"section by logging in with your Github account."
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->description
+msgid "Submit an Issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->tooltip
+msgid ""
+"Opens webpage where you can fill out a new issue for the applet, needs a "
+"GitHub account.\n"
+" Please make sure that the issue is not already submitted."
+msgstr ""
+
+#. 3.8->settings-schema.json->maintainer->description
+msgid "Current maintainer: Gr3q"
+msgstr ""
+
+#. 3.8->settings-schema.json->issue-reporting-explanation->description
+msgid ""
+"If you find an issue with this applet please make a report by clicking on "
+"the button below and login in with your Github account.\n"
+"\n"
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
+msgstr ""
+
+#. 3.8->settings-schema.json->loc-info->description
+msgid ""
+"Your location in most cases work automatically but you can enter it manually "
+"by coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,"
+"Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/"
+"Town} {Postcode} {Country}. The search algorithm is very flexible with the "
+"format. After 3 seconds without typing the address you entered is replaced "
+"automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->description
+msgid "Log Level"
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->tooltip
+msgid ""
+"Info is the regular logging, Debug is debug, and Verbose also logs network "
+"request payloads. Changing this will only be effective on future logs. Only "
+"change it you are instructed or you know what you are doing."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Verbose"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->description
+msgid "Click Save to save debug information to a file"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->tooltip
+msgid ""
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
+msgstr ""
+
+#. 3.8->settings-schema.json->selectedLogPath->description
+msgid "Selected path to save Logs"
+msgstr ""

--- a/weather@mockturtl/files/weather@mockturtl/po/lt.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/lt.po
@@ -7,8 +7,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-01 22:49+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2024-04-08 16:49+0300\n"
 "Last-Translator: Ernestas Žaglinskas <virtualybe@gmail.com>\n"
 "Language-Team: \n"
@@ -21,65 +22,65 @@ msgstr ""
 "X-Generator: Poedit 3.2.2\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17615
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Klaida"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17616 3.8/weather-applet.js:17618
-#: 3.8/weather-applet.js:17620 3.8/weather-applet.js:17623
-#: 3.8/weather-applet.js:17626 3.8/weather-applet.js:17627
-#: 3.8/weather-applet.js:17628 3.8/weather-applet.js:17629
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Paslaugos Klaida"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17617
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Neteisingas API Raktas"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17619
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Neteisingas Vietos Formatas"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17621
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Raktas Užblokuotas"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17622
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Negalima rasti vietovės"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17624
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Nėra Api Rakto"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17625
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Nėra Vietovės"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17630
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Trūksta Paketų"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17631
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Vietovė neuždengta"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9711
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Orų Programa"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17929
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17930
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Spausti, kad atidaryti"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16220
-#: 3.8/weather-applet.js:17933
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Atnaujinti"
 
@@ -89,8 +90,8 @@ msgstr "API grąžino būsenos kodą tarp 400 ir 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Vietovių saugykla"
 
@@ -102,14 +103,14 @@ msgstr "Atsiprašome, automatiškai gautos vietos išsaugoti negalite"
 msgid "Could not get weather information"
 msgstr "Negalima gauti informacijos apie orą"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17768
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Netikėta klaida atnaujinant orų prognozę, prašau peržiūrėti įrašus ties "
 "Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:18011
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -125,7 +126,7 @@ msgstr "Tinklo klaida, prašau žiūrėti įrašus ties \"Looking Glass\""
 msgid "As of"
 msgstr "Atnaujinta"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:17011
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Sukurta"
 
@@ -133,52 +134,52 @@ msgstr "Sukurta"
 msgid "from you"
 msgstr "nuo tavęs"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16924
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:16924
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10312
-#: 3.8/weather-applet.js:17089
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10313
-#: 3.8/weather-applet.js:17090
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17267
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Įkeliami dabartiniai orai..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17270
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Įkeliami būsimi orai ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16173
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Įkeliama ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16194
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Temperatūra"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16195
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Drėgmė"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16196
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Slėgis"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12257 3.8/weather-applet.js:12263
-#: 3.8/weather-applet.js:14217 3.8/weather-applet.js:14218
-#: 3.8/weather-applet.js:16042
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Vėjas"
 
@@ -186,36 +187,35 @@ msgstr "Vėjas"
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr "Įsitikinkite, kad įvedėte vietą arba naudokite automatinę vietą"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9952
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr "Nepavyko rasti vietos pagal adresą, patikrinkite, ar tai teisinga"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9973
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Nepavyko susisiekti su Geografinės padėties API , dėl klaidų žr. „Looking "
 "Glass“."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Įspėjimas"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9872
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "Tinkamas vietoves galite įrašyti tik tada, kai programa neatnaujinama"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Negalite išsaugoti neteisingos vietovės"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9880
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Informacija"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Vietovė jau yra išsaugota"
 
@@ -253,15 +253,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10740 3.8/weather-applet.js:11711
-#: 3.8/weather-applet.js:12150 3.8/weather-applet.js:12659
-#: 3.8/weather-applet.js:13021 3.8/weather-applet.js:14388
-#: 3.8/weather-applet.js:14928
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Jutiminė"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:14990
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Nepavyko apdoroti orų informacijos"
 
@@ -274,7 +274,7 @@ msgstr ""
 "arba pirmiausia gaukite jį adresu https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:14870
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -282,7 +282,7 @@ msgstr ""
 "Prašome įsitikinti ar\n"
 "teisingai įvedėte API raktą ir Jūsų paskyra nėra užrakinta"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12113
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -293,60 +293,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10516 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10530 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:11379 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:11386 3.8/weather-applet.js:11393
-#: 3.8/weather-applet.js:11400 3.8/weather-applet.js:12292
-#: 3.8/weather-applet.js:13187
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Stiprus lietus"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11554 3.8/weather-applet.js:11555
-#: 3.8/weather-applet.js:11561 3.8/weather-applet.js:12277
-#: 3.8/weather-applet.js:12278 3.8/weather-applet.js:12284
-#: 3.8/weather-applet.js:12291 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12340 3.8/weather-applet.js:12347
-#: 3.8/weather-applet.js:12801 3.8/weather-applet.js:12850
-#: 3.8/weather-applet.js:12851 3.8/weather-applet.js:12858
-#: 3.8/weather-applet.js:13179 3.8/weather-applet.js:13448
-#: 3.8/weather-applet.js:13449 3.8/weather-applet.js:13490
-#: 3.8/weather-applet.js:14189 3.8/weather-applet.js:14190
-#: 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Lietus"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10495 3.8/weather-applet.js:10509
-#: 3.8/weather-applet.js:10510 3.8/weather-applet.js:11009
-#: 3.8/weather-applet.js:11463 3.8/weather-applet.js:11464
-#: 3.8/weather-applet.js:11470 3.8/weather-applet.js:11477
-#: 3.8/weather-applet.js:11484 3.8/weather-applet.js:12285
-#: 3.8/weather-applet.js:13189
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Nestiprus lietus"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12348 3.8/weather-applet.js:13163
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Stipri lijundra"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11014
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12822
-#: 3.8/weather-applet.js:12823 3.8/weather-applet.js:12829
-#: 3.8/weather-applet.js:12830 3.8/weather-applet.js:12836
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Lijundra"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12341 3.8/weather-applet.js:13165
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Nestipri lijundra"
 
@@ -354,177 +354,177 @@ msgstr "Nestipri lijundra"
 msgid "Light freezing drizzle"
 msgstr "Nestipri šąlanti dulksna"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12327
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Šąlanti dulksna"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13145
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Nestipri dulksna"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12362
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Sunkios ledo granulės"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12354 3.8/weather-applet.js:12355
-#: 3.8/weather-applet.js:12361 3.8/weather-applet.js:12368
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Ledo granulės"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12369
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Nestiprios ledo granulės"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10600
-#: 3.8/weather-applet.js:10607 3.8/weather-applet.js:10614
-#: 3.8/weather-applet.js:10615 3.8/weather-applet.js:11021
-#: 3.8/weather-applet.js:11435 3.8/weather-applet.js:11436
-#: 3.8/weather-applet.js:11442 3.8/weather-applet.js:11449
-#: 3.8/weather-applet.js:11456 3.8/weather-applet.js:12320
-#: 3.8/weather-applet.js:13205 3.8/weather-applet.js:13525
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Stipriai sninga"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:11610
-#: 3.8/weather-applet.js:11611 3.8/weather-applet.js:11617
-#: 3.8/weather-applet.js:12298 3.8/weather-applet.js:12299
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12795
-#: 3.8/weather-applet.js:13199 3.8/weather-applet.js:13434
-#: 3.8/weather-applet.js:13518 3.8/weather-applet.js:14203
-#: 3.8/weather-applet.js:14204 3.8/weather-applet.js:14581
-#: 3.8/weather-applet.js:14582
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Sninga"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11019
-#: 3.8/weather-applet.js:11519 3.8/weather-applet.js:11520
-#: 3.8/weather-applet.js:11526 3.8/weather-applet.js:11533
-#: 3.8/weather-applet.js:11540 3.8/weather-applet.js:12313
-#: 3.8/weather-applet.js:13207
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Lengvai sninga"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12305
-#: 3.8/weather-applet.js:12306 3.8/weather-applet.js:14560
-#: 3.8/weather-applet.js:14561
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Staigūs vėjo šuorai"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:12375 3.8/weather-applet.js:12376
-#: 3.8/weather-applet.js:12867 3.8/weather-applet.js:12868
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13532
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:14210
-#: 3.8/weather-applet.js:14211
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Perkūnija"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12243
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Lengvas rūkas"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11372
-#: 3.8/weather-applet.js:11373 3.8/weather-applet.js:12235
-#: 3.8/weather-applet.js:12236 3.8/weather-applet.js:12242
-#: 3.8/weather-applet.js:12937 3.8/weather-applet.js:12938
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:14161
-#: 3.8/weather-applet.js:14162 3.8/weather-applet.js:14609
-#: 3.8/weather-applet.js:14610
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Rūkas"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10474 3.8/weather-applet.js:10475
-#: 3.8/weather-applet.js:11358 3.8/weather-applet.js:11359
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:12208
-#: 3.8/weather-applet.js:13427 3.8/weather-applet.js:13428
-#: 3.8/weather-applet.js:14154 3.8/weather-applet.js:14155
-#: 3.8/weather-applet.js:14651 3.8/weather-applet.js:14652
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Debesuota"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12228
-#: 3.8/weather-applet.js:12229 3.8/weather-applet.js:12745
-#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:12780
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Daugiausia debesuota"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10439
-#: 3.8/weather-applet.js:10440 3.8/weather-applet.js:10446
-#: 3.8/weather-applet.js:10447 3.8/weather-applet.js:11547
-#: 3.8/weather-applet.js:11548 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12222 3.8/weather-applet.js:12738
-#: 3.8/weather-applet.js:12739 3.8/weather-applet.js:12773
-#: 3.8/weather-applet.js:13420 3.8/weather-applet.js:13421
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Protarpiais debesuota"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Daugiausia saulėta"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10425 3.8/weather-applet.js:10426
-#: 3.8/weather-applet.js:11039 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:12724
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12759
-#: 3.8/weather-applet.js:13223 3.8/weather-applet.js:13413
-#: 3.8/weather-applet.js:13414 3.8/weather-applet.js:14140
-#: 3.8/weather-applet.js:14141 3.8/weather-applet.js:14147
-#: 3.8/weather-applet.js:14148 3.8/weather-applet.js:14686
-#: 3.8/weather-applet.js:14687
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Saulėta"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10432
-#: 3.8/weather-applet.js:10433 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:14693
-#: 3.8/weather-applet.js:14694
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Saulėta"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10418
-#: 3.8/weather-applet.js:10419 3.8/weather-applet.js:10453
-#: 3.8/weather-applet.js:10454 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10643 3.8/weather-applet.js:11341
-#: 3.8/weather-applet.js:11342 3.8/weather-applet.js:11639
-#: 3.8/weather-applet.js:11640 3.8/weather-applet.js:12192
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12715
-#: 3.8/weather-applet.js:12716 3.8/weather-applet.js:12944
-#: 3.8/weather-applet.js:12945 3.8/weather-applet.js:14073
-#: 3.8/weather-applet.js:14074 3.8/weather-applet.js:14224
-#: 3.8/weather-applet.js:14225 3.8/weather-applet.js:14797
-#: 3.8/weather-applet.js:14799
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Nežinoma"
 
@@ -548,7 +548,7 @@ msgstr ""
 "Nustatymuose įveskite API raktą,\n"
 "arba pirmiausia gaukite jį https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:14880
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -556,7 +556,7 @@ msgstr ""
 "Prašome įsitikinti ar\n"
 "įvedėte API raktą, kurį turite iš DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:15196
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Nepavyko nustatyti vietovės"
 
@@ -565,121 +565,121 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr "Vietos paslauga atsakė su klaidomis. Žr. žurnalus Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11203
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Debesuotumas"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11351
-#: 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Giedra"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11365 3.8/weather-applet.js:11366
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Gražus oras"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11387
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Stiprus lietus ir perkūnija"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11394
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Stiprus lietus"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11401
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Stiprus lietus ir perkūnija"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11407
-#: 3.8/weather-applet.js:11408 3.8/weather-applet.js:11414
-#: 3.8/weather-applet.js:11421 3.8/weather-applet.js:11428
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Stipri šlapdriba"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11415
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Stipri šlapdriba ir perkūnija"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11422
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Stipri šlapdriba"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11429
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Stipri šlapdriba su perkūnija"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11443
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Stipriai sninga ir griaudi"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11450
-#: 3.8/weather-applet.js:13526
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Stipriai sninga"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11457
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Stirpiai sninga ir griaudi"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11471
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Lengvas lietus su perkūnija"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11478
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Nestiprus lietus"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11485
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Lengvas lietus su perkūnija"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11491
-#: 3.8/weather-applet.js:11492 3.8/weather-applet.js:11498
-#: 3.8/weather-applet.js:11505 3.8/weather-applet.js:11512
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Nestirpi šlapdriba"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11499
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Lengva šlapdriba su perkūnija"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11506
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Lengva šlapdriba"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11513
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Lengva šlapdriba su perkūnija"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11527
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Lengvai sninga ir griaudi"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11534
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Lengvai snyguriuoja"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11541
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Lengvai snyguriuoja ir griaudi"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11562
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Lietus ir perkūnija"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11568
-#: 3.8/weather-applet.js:11569 3.8/weather-applet.js:11575
-#: 3.8/weather-applet.js:12859 3.8/weather-applet.js:13185
-#: 3.8/weather-applet.js:13491 3.8/weather-applet.js:13497
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Trumpi lietūs"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11576
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Trumpi lietūs ir perkūnija"
 
@@ -688,44 +688,44 @@ msgstr "Trumpi lietūs ir perkūnija"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10537
-#: 3.8/weather-applet.js:10544 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11582 3.8/weather-applet.js:11583
-#: 3.8/weather-applet.js:11589 3.8/weather-applet.js:11596
-#: 3.8/weather-applet.js:11603 3.8/weather-applet.js:12808
-#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12815
-#: 3.8/weather-applet.js:12816 3.8/weather-applet.js:12843
-#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14196
-#: 3.8/weather-applet.js:14197 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Šlapdriba"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11590
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Šlapdriba ir perkūnija"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11597
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Šlapdriba"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11604
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Šlapdriba ir perkūnija"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11618
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Sninga ir griaudi"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11624 3.8/weather-applet.js:11625
-#: 3.8/weather-applet.js:11631 3.8/weather-applet.js:13203
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Vietomis pasnigs"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11632
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Vietomis pasnigs su perkūnija"
 
@@ -734,21 +734,21 @@ msgstr "Vietomis pasnigs su perkūnija"
 msgid "Unexpected response from API"
 msgstr "Netikėtas atsakymas iš API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10237
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Matomumas"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10265
-#: 3.8/weather-applet.js:10817 3.8/weather-applet.js:11722
-#: 3.8/weather-applet.js:12672
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Nepavyko apdoroti esamos orų informacijos"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10055
-#: 3.8/weather-applet.js:10089 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11782 3.8/weather-applet.js:12474
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Nepavyko apdoroti orų prognozės informacijos"
 
@@ -777,88 +777,88 @@ msgid "Excellent - More than"
 msgstr "Puikus – daugiau nei"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10460 3.8/weather-applet.js:10461
-#: 3.8/weather-applet.js:11029 3.8/weather-applet.js:13175
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Rūkas"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:12752
-#: 3.8/weather-applet.js:12753 3.8/weather-applet.js:12787
-#: 3.8/weather-applet.js:13219
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Apsiniaukę"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10489
-#: 3.8/weather-applet.js:10496
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Trumpalaikis lietus"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:12326
-#: 3.8/weather-applet.js:13141 3.8/weather-applet.js:14532
-#: 3.8/weather-applet.js:14533
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Lijundra"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:10524
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Stiprus, trumpalaikis lietus"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10538
-#: 3.8/weather-applet.js:10545
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Šlapdriba"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:13217 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14169 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:14589
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Kruša"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Trumpa kruša"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Protarpiais snyguriuoja"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Stipriai sninga"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10621 3.8/weather-applet.js:10628
-#: 3.8/weather-applet.js:10635 3.8/weather-applet.js:10636
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Perkūnija"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Perkūnija"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10872
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Įsitikinkite, kad nustatymuose Vietovės formatas yra teisingas"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10876
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Įsitikinkite, kad nustatymuose įvedėte teisingą raktą"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10681 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -866,211 +866,211 @@ msgstr ""
 "Vietovė nerasta, įsitikinkite, kad vietovė pasiekiama arba jos formatas yra "
 "tinkamas"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10884
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Jei ši problema išlieka, susisiekite su šios programėlės autoriumi"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10888
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Nežinoma klaida, žr. žurnalus Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10990
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Perkūnija su nedideliu lietumi"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10991
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Perkūnija su lietumi"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10992
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Perkūnija su stipriu lietumi"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10993
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Nedidelė perkūnija"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10995
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Stipri perkūnija"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10996
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Smarki perkūnija"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10997
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Perkūnija su silpna dulksna"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10998
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Perkūnija su dulksna"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10999
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Perkūnija ir stipri dulksna"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11000
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Lengvo intensyvumo dulksna"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11002
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Stipraus intensyvumo dulksna"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11003
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Nestipri dulksna ir lietus"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11004
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Dulksna ir lietus"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11005
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Didelio intensyvumo lietus ir dulksna"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11006
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Trumpas lietus ir dulksna"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11007
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Stiprus lietus ir dulksna"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11008
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Dulksna"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11010
-#: 3.8/weather-applet.js:13455 3.8/weather-applet.js:13456
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Vidutinis lietus"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11011
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Stipraus intensyvumo lietus"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11012
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Liūtis"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11013
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Liūtis"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11015
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Lengvo intensyvumo lietus"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11016
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Purškiantis lietus"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11017
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Stiprus lietus"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11018
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Smulkus lietus"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11023
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Smulki šlapdriba"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11024
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Lengvas lietus ir sniegas"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11025
-#: 3.8/weather-applet.js:13462 3.8/weather-applet.js:13463
-#: 3.8/weather-applet.js:13469 3.8/weather-applet.js:13504
-#: 3.8/weather-applet.js:13511
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Lietus ir sniegas"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11026
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Lengvai snyguriuoja"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11027
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Snyguriuoja"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11028
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Stipriai sninga"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:12902
-#: 3.8/weather-applet.js:12903 3.8/weather-applet.js:14623
-#: 3.8/weather-applet.js:14624
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Dūmai"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11031 3.8/weather-applet.js:12909
-#: 3.8/weather-applet.js:12910 3.8/weather-applet.js:14616
-#: 3.8/weather-applet.js:14617
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Migla"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11032
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Smėlio ir dulkių sūkuriai"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11034
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Smėlis"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11035 3.8/weather-applet.js:12895
-#: 3.8/weather-applet.js:12896 3.8/weather-applet.js:14602
-#: 3.8/weather-applet.js:14603
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Dulkės"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11036
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Vulkaniniai pelenai"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:13209
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Škvalas"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11038 3.8/weather-applet.js:12874
-#: 3.8/weather-applet.js:12875 3.8/weather-applet.js:14475
-#: 3.8/weather-applet.js:14476
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Tornadas"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11041
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Giedra"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11042
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Debesys"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11043
-#: 3.8/weather-applet.js:12731 3.8/weather-applet.js:12732
-#: 3.8/weather-applet.js:12766
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Mažai debesuota"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11044
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Išblaškyti debesys"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11045
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Debesuota"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11046
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Debesuota"
 
@@ -1078,80 +1078,80 @@ msgstr "Debesuota"
 msgid "Could not get forecast for your area"
 msgstr "Nepavyko gauti jūsų vietovės orų prognozės"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12431
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "Vietovė yra už JAV ribų, naudokite kitą teikėją."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12495
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Nepavyko apdoroti valandinės orų prognozės informacijos"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12760
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Giedra ir vėjuota"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12767
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Keli debesys ir vėjuota"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12774
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Protarpiais debesuota ir vėjuota"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Daugiausia debesuota ir vėjuota"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12788
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Debesuota ir vėjuota"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12802
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Sniegas ir lietus"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12837
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Šąlantis lietus ir sniegas"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9153 3.8/weather-applet.js:12881
-#: 3.8/weather-applet.js:12882 3.8/weather-applet.js:14489
-#: 3.8/weather-applet.js:14490
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Uraganas"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9148
-#: 3.8/weather-applet.js:12888
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Audra"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12889
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Tropinė audra"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12916 3.8/weather-applet.js:12917
-#: 3.8/weather-applet.js:14721 3.8/weather-applet.js:14722
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Karšta"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12923 3.8/weather-applet.js:12924
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Šalta"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12930 3.8/weather-applet.js:12931
-#: 3.8/weather-applet.js:14770 3.8/weather-applet.js:14771
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Pūga"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9025
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Šiandien"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9027
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Rytoj"
 
@@ -1183,79 +1183,79 @@ msgstr "Penktadienis"
 msgid "Saturday"
 msgstr "Šeštadienis"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9118
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Ramu"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9121
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Lengvas oras"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9124
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Lengvas vėjelis"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9127
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Švelnus vėjelis"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9130
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Vidutinis vėjas"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9133
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Gaivus vėjas"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9136
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Stiprus vėjas"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9139
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Netoliese audra"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9142
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Stiprus vėjas"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9145
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Labai stiprus vėjas"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9151
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Labai didelė audra"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "Š"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "ŠR"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "R"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "PR"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "P"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "PV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "V"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "ŠV"
 
@@ -1307,7 +1307,7 @@ msgstr ""
 "Įvyko nežinoma klaida, bandant gauti orų informaciją. Daugiau informacijos "
 "rasite Looking Glass žurnale"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14482 3.8/weather-applet.js:14483
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Tropinė audra"
 
@@ -1315,7 +1315,7 @@ msgstr "Tropinė audra"
 msgid "Severe Thunderstorms"
 msgstr "Smarki audra su perkūnija"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14503 3.8/weather-applet.js:14504
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Perkūnija (audringa)"
 
@@ -1331,15 +1331,15 @@ msgstr "Lietus bei šlapdriba"
 msgid "Mixed Snow and Sleet"
 msgstr "Sniegas bei šlapdriba"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Stingdanti dulksna (šlapdriba)"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Šąlantis lietus"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Purškiantis lietus"
 
@@ -1351,11 +1351,11 @@ msgstr "Sniego šuorai"
 msgid "Light Snow Showers"
 msgstr "Lengvai snyguriuoja"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14574 3.8/weather-applet.js:14575
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Pustomas sniegas"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13441 3.8/weather-applet.js:13442
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Migla"
 
@@ -1367,54 +1367,54 @@ msgstr "Dūmingas oras"
 msgid "Blustery"
 msgstr "Žvarbus oras"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14637 3.8/weather-applet.js:14638
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Vėjuota"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:14658 3.8/weather-applet.js:14659
-#: 3.8/weather-applet.js:14665 3.8/weather-applet.js:14666
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Daugiausia debesuota"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14175 3.8/weather-applet.js:14176
-#: 3.8/weather-applet.js:14182 3.8/weather-applet.js:14183
-#: 3.8/weather-applet.js:14672 3.8/weather-applet.js:14673
-#: 3.8/weather-applet.js:14679 3.8/weather-applet.js:14680
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Protarpiais debesuota"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Daugiausia saulėta"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:14714 3.8/weather-applet.js:14715
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Lietus bei kruša"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:14728 3.8/weather-applet.js:14729
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Izoliuotos perkūnijos"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:14735 3.8/weather-applet.js:14736
-#: 3.8/weather-applet.js:14791 3.8/weather-applet.js:14792
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Padrikos perkūnijos"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:14742 3.8/weather-applet.js:14743
-#: 3.8/weather-applet.js:14777 3.8/weather-applet.js:14778
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Padrikas lietus"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:14749 3.8/weather-applet.js:14750
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Sunkus lietus"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:14756 3.8/weather-applet.js:14757
-#: 3.8/weather-applet.js:14784 3.8/weather-applet.js:14785
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Vietomis sninga"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:14763 3.8/weather-applet.js:14764
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Sunkus sniegas"
 
@@ -1426,7 +1426,7 @@ msgstr "Nepasiekiama"
 msgid "Scattered Thundershowers"
 msgstr "Vietomis perkūnija"
 
-#: 3.8/weather-applet.js:9637
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1434,7 +1434,7 @@ msgstr ""
 "Nepavyko gauti žurnalų įrašų, žurnalo failas nerastas šioje vietoje\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9641
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1443,286 +1443,286 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10013
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office JK"
 
-#: 3.8/weather-applet.js:10118
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 "MET Office UK apima tik JK, įsitikinkite, kad jūsų vietovė yra šioje šalyje"
 
-#: 3.8/weather-applet.js:10197
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Vietoovės duomenų nerasta"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Labai prastas"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Mažiau nei {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Puikus"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Daugiau nei {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10287
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Prastas"
 
-#: 3.8/weather-applet.js:10287 3.8/weather-applet.js:10292
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:10302
-#: 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Tarp {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10292
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Vidutinis"
 
-#: 3.8/weather-applet.js:10297
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Geras"
 
-#: 3.8/weather-applet.js:10302 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Labai geras"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10662
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:11659
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12080
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12250
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Nestiprus vėjas"
 
-#: 3.8/weather-applet.js:12264
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Stiprus vėjas"
 
-#: 3.8/weather-applet.js:12411
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:12962
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Matomas kritimas"
 
-#: 3.8/weather-applet.js:13139
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Pustomas, slenkantis sniegas"
 
-#: 3.8/weather-applet.js:13143
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Stipri dulksna (šlapdriba)"
 
-#: 3.8/weather-applet.js:13147
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Stipri dulksna, lietus"
 
-#: 3.8/weather-applet.js:13149
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Lengva dulksna, lietus"
 
-#: 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Dulkių audra"
 
-#: 3.8/weather-applet.js:13155
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Stingdanti šlapdriba/šąlantis lietus"
 
-#: 3.8/weather-applet.js:13157
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Stipri šlapdriba, dulksna / šąlantis lietus"
 
-#: 3.8/weather-applet.js:13159
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Lengva šlapdriba, dulksna / šąlantis lietus"
 
-#: 3.8/weather-applet.js:13161
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Šąlantis rūkas"
 
-#: 3.8/weather-applet.js:13167
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Piltuvo debesis, tornadas"
 
-#: 3.8/weather-applet.js:13169
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Krušos lietus"
 
-#: 3.8/weather-applet.js:13171
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Ledas"
 
-#: 3.8/weather-applet.js:13173
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Žaibas be griaustinio"
 
-#: 3.8/weather-applet.js:13177
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Krituliai apylinkėse"
 
-#: 3.8/weather-applet.js:13181 3.8/weather-applet.js:13470
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Stiprus lietus ir sniegas"
 
-#: 3.8/weather-applet.js:13183
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Nestiprus lietus ir sniegas"
 
-#: 3.8/weather-applet.js:13191
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Dangaus aprėptis mažėja"
 
-#: 3.8/weather-applet.js:13193
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Dangaus aprėptis didėja"
 
-#: 3.8/weather-applet.js:13195
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Dangus nepakitęs"
 
-#: 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Dūmai ar migla"
 
-#: 3.8/weather-applet.js:13201
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Protarpiais sniegas ir lietus"
 
-#: 3.8/weather-applet.js:13213
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Perkūnija be kritulių"
 
-#: 3.8/weather-applet.js:13215
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Deimantų dulkės"
 
-#: 3.8/weather-applet.js:13221
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Protaroiais debesuota"
 
-#: 3.8/weather-applet.js:13243
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Įsitikinkite, kad API raktą įvedėte teisingai"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13259
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Danija"
 
-#: 3.8/weather-applet.js:13402 3.8/weather-applet.js:13403
-#: 3.8/weather-applet.js:13539 3.8/weather-applet.js:13540
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "Nerasta"
 
-#: 3.8/weather-applet.js:13435
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Pustomas sniegas"
 
-#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:13477
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Nedidelis sniegas"
 
-#: 3.8/weather-applet.js:13483 3.8/weather-applet.js:13484
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Vidutinis sniegas"
 
-#: 3.8/weather-applet.js:13498
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Vidutinis lietaus dulksna"
 
-#: 3.8/weather-applet.js:13505
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Lietus ir sniegas"
 
-#: 3.8/weather-applet.js:13512
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Stiprus lietus su sniegu"
 
-#: 3.8/weather-applet.js:13657
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:13953
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:13966
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "Pasirinkite kitą teikėją arba vietovę"
 
-#: 3.8/weather-applet.js:14263
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14453
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "Jūsų pateiktas API raktas neteisingas."
 
-#: 3.8/weather-applet.js:14460
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "Jūsų nurodyta vietovė nerasta."
 
-#: 3.8/weather-applet.js:14496 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Stipri Audra"
 
-#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:14512
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Lietus ir Sniegas"
 
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Lietus su Šlapdriba"
 
-#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Smulkiai Sninga"
 
-#: 3.8/weather-applet.js:14630 3.8/weather-applet.js:14631
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "Vėsu"
 
-#: 3.8/weather-applet.js:14644 3.8/weather-applet.js:14645
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr "Šalta"
 
-#: 3.8/weather-applet.js:14700 3.8/weather-applet.js:14701
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Daugiausia Giedra"
 
-#: 3.8/weather-applet.js:14853
+#: 3.8/weather-applet.js:15247
 msgid "Pirate Weather"
 msgstr "Piratų Orai"
 
-#: 3.8/weather-applet.js:15205
+#: 3.8/weather-applet.js:15603
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
@@ -1730,13 +1730,13 @@ msgstr ""
 "Vietos tarnybai nepavyko rasti jūsų vietovės. Žiūrėti įrašų žurnalą Looking "
 "Glass"
 
-#: 3.8/weather-applet.js:15433
+#: 3.8/weather-applet.js:15831
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Įsitikinkite, kad įvedėte vietovę arba naudokite automatinį vietovės "
 "nustatymą."
 
-#: 3.8/weather-applet.js:15570
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1744,7 +1744,7 @@ msgstr ""
 "Nepavyko gauti konfigūracijos, failas nerastas šioje vietoje\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15577
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1752,58 +1752,58 @@ msgstr ""
 "Nepavyko gauti konfigūracijos failo turinio šioje vietoje\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:16197
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Šiam teikėjui reikalingas API raktas, kad jis veiktų"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Rasos Taškas"
 
-#: 3.8/weather-applet.js:16269
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Krituliai baigsis po {precipEnd} min"
 
-#: 3.8/weather-applet.js:16271
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "Krituliai nesibaigs per valandą"
 
-#: 3.8/weather-applet.js:16274
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Krituliai prasidės po {precipStart} min"
 
-#: 3.8/weather-applet.js:16486
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Orų prognozės analizė nepavyko, daugiau informacijos rasite žurnaluose."
 
-#: 3.8/weather-applet.js:17018 3.8/weather-applet.js:17810
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "Atnaujinta {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:17024
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} nuo jūsų"
 
-#: 3.8/weather-applet.js:17028
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "Stoties Pavadinimas: {stationName}"
 
-#: 3.8/weather-applet.js:17031
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "Vietovė: {stationArea}"
 
-#: 3.8/weather-applet.js:17581 3.8/weather-applet.js:17591
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Klaida išsaugant derinimo informaciją"
 
-#: 3.8/weather-applet.js:17603
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Derinimo Informacija išsaugota sėkmingai"
 
-#: 3.8/weather-applet.js:17603
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Išsaugota šioje vietoje {filePath}"
-
-#: 3.8/weather-applet.js:17734
-msgid "This provider requires an API key to operate"
-msgstr "Šiam teikėjui reikalingas API raktas, kad jis veiktų"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"

--- a/weather@mockturtl/files/weather@mockturtl/po/lv.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/lv.po
@@ -6,449 +6,2586 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 3.2\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-12 12:27-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2021-02-16 11:25+0100\n"
 "Last-Translator: Reinis Danne <rei4dan@gmail.com>\n"
 "Language-Team: \n"
 "Language: lv\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
 "2);\n"
 "X-Poedit-SourceCharset: utf-8\n"
 "X-Generator: Poedit 2.3\n"
 
-#: applet.js:249
+#: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
+#: 3.8/weather-applet.js:17877
+msgid "Error"
+msgstr ""
+
+#: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
+#: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
+msgid "Service Error"
+msgstr ""
+
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
+msgid "Incorrect API Key"
+msgstr ""
+
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
+msgid "Incorrect Location Format"
+msgstr ""
+
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
+msgid "Key Blocked"
+msgstr ""
+
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
+msgid "Can't find location"
+msgstr ""
+
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
+msgid "No Api Key"
+msgstr ""
+
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
+msgid "No Location"
+msgstr ""
+
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
+msgid "Missing Packages"
+msgstr ""
+
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
+msgid "Location not covered"
+msgstr ""
+
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
+msgid "Weather Applet"
+msgstr ""
+
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: applet.js:250
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr ""
 
-#: applet.js:289
-msgid "Settings"
-msgstr ""
-
-#: applet.js:555
-msgid "Sunrise"
-msgstr "Saullēkts"
-
-#: applet.js:556
-msgid "Sunset"
-msgstr "Saulriets"
-
-#: applet.js:648
-msgid "Loading current weather ..."
-msgstr "Ielādē pašreizējos laikapstākļus ..."
-
-#: applet.js:649
-msgid "Loading future weather ..."
-msgstr "Ielādē gaidāmos laikapstākļus ..."
-
-#: applet.js:671
-msgid "Loading ..."
-msgstr "Ielādē ..."
-
-#: applet.js:677
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr ""
 
-#: applet.js:740
-msgid "Temperature:"
+#: 3.0/applet.js:272
+msgid "API returned status code between 400 and 500"
+msgstr ""
+
+#: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
+#: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
+msgid "Location Store"
+msgstr ""
+
+#: 3.0/applet.js:426
+msgid "You can't save a location obtained automatically, sorry"
+msgstr ""
+
+#: 3.0/applet.js:601
+msgid "Could not get weather information"
+msgstr ""
+
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
+msgid ""
+"Unexpected Error While Refreshing Weather, please see log in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
+msgid ""
+"Could not update weather for a while...\n"
+"are you connected to the internet?"
+msgstr ""
+
+#: 3.0/applet.js:684
+msgid "Network Error, please check logs in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:969 3.0/applet.js:1110
+msgid "As of"
+msgstr ""
+
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
+msgid "Powered by"
+msgstr ""
+
+#: 3.0/applet.js:1113
+msgid "from you"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
+msgid "mm"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
+msgid "in"
+msgstr ""
+
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
+msgid "mi"
+msgstr ""
+
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
+msgid "km"
+msgstr ""
+
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
+msgid "Loading current weather ..."
+msgstr "Ielādē pašreizējos laikapstākļus ..."
+
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
+msgid "Loading future weather ..."
+msgstr "Ielādē gaidāmos laikapstākļus ..."
+
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
+msgid "Loading ..."
+msgstr "Ielādē ..."
+
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
+#, fuzzy
+msgid "Temperature"
 msgstr "Temperatūra:"
 
-#: applet.js:742
-msgid "Humidity:"
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
+#, fuzzy
+msgid "Humidity"
 msgstr "Mitrums:"
 
-#: applet.js:744
-msgid "Pressure:"
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
+#, fuzzy
+msgid "Pressure"
 msgstr "Spiediens:"
 
-#: applet.js:746
-msgid "Wind:"
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
+#, fuzzy
+msgid "Wind"
 msgstr "Vējš:"
 
-#: applet.js:748
-msgid "Wind Chill:"
-msgstr "Vējš:"
+#: 3.0/applet.js:1639
+msgid "Make sure you entered a location or use Automatic location instead"
+msgstr ""
 
-#: applet.js:953
-msgid "Tornado"
-msgstr "Tornado"
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
+msgid "Could not find location based on address, please check if it's right"
+msgstr ""
 
-#: applet.js:955
-msgid "Tropical storm"
-msgstr "Tropiskā vētra"
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
+msgid "Failed to call Geolocation API, see Looking Glass for errors."
+msgstr ""
 
-#: applet.js:957
-msgid "Hurricane"
-msgstr "Viesuļvētra"
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "Warning"
+msgstr ""
 
-#: applet.js:959
-msgid "Severe thunderstorms"
-msgstr "Spēcīgs pērkona negaiss"
+#: 3.0/applet.js:2032
+msgid "You can only save correct locations when the applet is not refreshing"
+msgstr ""
 
-#: applet.js:961
-msgid "Thunderstorms"
-msgstr "Pērkona negaiss"
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "You can't save an incorrect location"
+msgstr ""
 
-#: applet.js:963
-msgid "Mixed rain and snow"
-msgstr "Lietus un sniegs"
+#. 3.8->settings-schema.json->logLevel->options
+#: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.8/weather-applet.js:9875
+msgid "Info"
+msgstr ""
 
-#: applet.js:965
-msgid "Mixed rain and sleet"
-msgstr "Slapjdraņķis"
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
+msgid "Location is already saved"
+msgstr ""
 
-#: applet.js:967
-msgid "Mixed snow and sleet"
-msgstr "Sniegs un slapjš sniegs"
+#: 3.0/applet.js:2049 3.0/applet.js:2083
+msgid "Success"
+msgstr ""
 
-#: applet.js:969
-msgid "Freezing drizzle"
-msgstr "Sasalstoša smidzināšana"
+#: 3.0/applet.js:2049
+msgid "Location is saved to library"
+msgstr ""
 
-#: applet.js:971
-msgid "Drizzle"
-msgstr "Smidzina"
+#: 3.0/applet.js:2062
+msgid "You can't remove a location while the applet is refreshing"
+msgstr ""
 
-#: applet.js:973
+#: 3.0/applet.js:2066
+msgid "You can't remove an incorrect location"
+msgstr ""
+
+#: 3.0/applet.js:2070
+msgid "Location is not in storage, can't delete"
+msgstr ""
+
+#: 3.0/applet.js:2083
+msgid "Location is deleted from library"
+msgstr ""
+
+#: 3.0/applet.js:2131
+msgid ""
+"Failed to load in data from location storage, please see the logs for more "
+"information"
+msgstr ""
+
+#: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
+#: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
+msgid "Feels Like"
+msgstr ""
+
+#: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
+#: 3.8/weather-applet.js:15387
+msgid "Failed to Process Weather Info"
+msgstr ""
+
+#: 3.0/climacell.js:224
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://developer.climacell.co/sign-up"
+msgstr ""
+
+#: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
+msgid ""
+"Please Make sure you\n"
+"entered the API key correctly and your account is not locked"
+msgstr ""
+
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Climacell"
+msgstr ""
+
+#: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
+#: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
+#: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
+#, fuzzy
+msgid "Heavy rain"
+msgstr "Spēcīgs sniegs"
+
+#: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
+#: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
+#: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
+msgid "Rain"
+msgstr ""
+
+#: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
+#: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
+#: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
+#, fuzzy
+msgid "Light rain"
+msgstr "Sasalstošs lietus"
+
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
+#, fuzzy
+msgid "Heavy freezing rain"
+msgstr "Sasalstošs lietus"
+
+#: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
+#: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
+#: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Sasalstošs lietus"
 
-#: applet.js:975 applet.js:977
-msgid "Showers"
-msgstr "Lietusgāzes"
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
+#, fuzzy
+msgid "Light freezing rain"
+msgstr "Sasalstošs lietus"
 
-#: applet.js:979
-msgid "Snow flurries"
-msgstr "Sniegputenis"
+#: 3.0/climacell.js:301
+#, fuzzy
+msgid "Light freezing drizzle"
+msgstr "Sasalstoša smidzināšana"
 
-#: applet.js:981
-msgid "Light snow showers"
-msgstr "Viegla snigšana"
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
+msgid "Freezing drizzle"
+msgstr "Sasalstoša smidzināšana"
 
-#: applet.js:983
-msgid "Blowing snow"
-msgstr "Sniega putenis"
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
+#, fuzzy
+msgid "Light drizzle"
+msgstr "Sasalstoša smidzināšana"
 
-#: applet.js:985
-msgid "Snow"
-msgstr "Sniegs"
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
+msgid "Heavy ice pellets"
+msgstr ""
 
-#: applet.js:987
-msgid "Hail"
-msgstr "Krusa"
+#: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
+msgid "Ice pellets"
+msgstr ""
 
-#: applet.js:989
-msgid "Sleet"
-msgstr "Slapjš sniegs"
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
+msgid "Light ice pellets"
+msgstr ""
 
-#: applet.js:991
-msgid "Dust"
-msgstr "Putekļi"
-
-#: applet.js:993
-msgid "Foggy"
-msgstr "Miglains"
-
-#: applet.js:995
-msgid "Haze"
-msgstr "Dūmaka"
-
-#: applet.js:997
-msgid "Smoky"
-msgstr "Dūmaka"
-
-#: applet.js:999
-msgid "Blustery"
-msgstr "Brāzmains"
-
-#: applet.js:1001
-msgid "Windy"
-msgstr "Vējains"
-
-#: applet.js:1003
-msgid "Cold"
-msgstr "Auksts"
-
-#: applet.js:1005
-msgid "Cloudy"
-msgstr "Apmācies"
-
-#: applet.js:1008
-msgid "Mostly cloudy"
-msgstr "Pārsvarā apmācies"
-
-#: applet.js:1011 applet.js:1037
-msgid "Partly cloudy"
-msgstr "Daļēji apmācies"
-
-#: applet.js:1013
-msgid "Clear"
-msgstr "Skaidrs"
-
-#: applet.js:1015
-msgid "Sunny"
-msgstr "Saulains"
-
-#: applet.js:1018
-msgid "Fair"
-msgstr "Skaidrs"
-
-#: applet.js:1020
-msgid "Mixed rain and hail"
-msgstr "Lietus un krusa"
-
-#: applet.js:1022
-msgid "Hot"
-msgstr "Karsts"
-
-#: applet.js:1024
-msgid "Isolated thunderstorms"
-msgstr "Atsevišķi pērkona negaisi"
-
-#: applet.js:1027
-msgid "Scattered thunderstorms"
-msgstr "Vietām pērkona negaiss"
-
-#: applet.js:1029
-msgid "Scattered showers"
-msgstr "Vietām lietusgāzes"
-
-#: applet.js:1031 applet.js:1035
+#: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
+#: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
+#: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Spēcīgs sniegs"
 
-#: applet.js:1033
-msgid "Scattered snow showers"
-msgstr "Vietām sniega putenis"
+#: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
+#: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
+#: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
+msgid "Snow"
+msgstr "Sniegs"
 
-#: applet.js:1039
-msgid "Thundershowers"
+#: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
+#: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
+#: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
+#, fuzzy
+msgid "Light snow"
+msgstr "Viegla snigšana"
+
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
+#, fuzzy
+msgid "Flurries"
+msgstr "Sniegputenis"
+
+#: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
+#, fuzzy
+msgid "Thunderstorm"
 msgstr "Pērkona negaiss"
 
-#: applet.js:1041
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
+msgid "Light fog"
+msgstr ""
+
+#: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
+#: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
+#: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
+#, fuzzy
+msgid "Fog"
+msgstr "Miglains"
+
+#: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
+#: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
+msgid "Cloudy"
+msgstr "Apmācies"
+
+#: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
+msgid "Mostly cloudy"
+msgstr "Pārsvarā apmācies"
+
+#: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
+#: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
+#: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
+msgid "Partly cloudy"
+msgstr "Daļēji apmācies"
+
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
+#, fuzzy
+msgid "Mostly clear"
+msgstr "Pārsvarā apmācies"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
+#: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
+#: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
+msgid "Clear"
+msgstr "Skaidrs"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
+msgid "Sunny"
+msgstr "Saulains"
+
+#: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
+#: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
+#: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
+msgid "Unknown"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "and"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "until"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "Possible"
+msgstr ""
+
+#: 3.0/darkSky.js:211
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://darksky.net/dev/register"
+msgstr ""
+
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from DarkSky"
+msgstr ""
+
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
+msgid "Could not obtain location"
+msgstr ""
+
+#: 3.0/ipApi.js:95
+msgid ""
+"Location Service responded with errors, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
+#, fuzzy
+msgid "Cloudiness"
+msgstr "Apmācies"
+
+#: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
+#, fuzzy
+msgid "Clear sky"
+msgstr "Skaidrs"
+
+#: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
+msgid "Fair"
+msgstr "Skaidrs"
+
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
+msgid "Heavy rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
+#, fuzzy
+msgid "Heavy rain showers"
+msgstr "Spēcīgs sniegs"
+
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
+msgid "Heavy rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
+#, fuzzy
+msgid "Heavy sleet"
+msgstr "Spēcīgs sniegs"
+
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
+msgid "Heavy sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
+#, fuzzy
+msgid "Heavy sleet showers"
+msgstr "Spēcīgs sniegs"
+
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
+msgid "Heavy sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
+#, fuzzy
+msgid "Heavy snow and thunder"
+msgstr "Spēcīgs sniegs"
+
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
+#, fuzzy
+msgid "Heavy snow showers"
+msgstr "Sniegs"
+
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
+msgid "Heavy snow showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
+msgid "Light rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
+#, fuzzy
+msgid "Light rain showers"
+msgstr "Viegla snigšana"
+
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
+#, fuzzy
+msgid "Light rain showers and thunder"
+msgstr "Viegla snigšana"
+
+#: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
+msgid "Light sleet"
+msgstr ""
+
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
+msgid "Light sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
+#, fuzzy
+msgid "Light sleet showers"
+msgstr "Viegla snigšana"
+
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
+#, fuzzy
+msgid "Light sleet showers and thunder"
+msgstr "Viegla snigšana"
+
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
+#, fuzzy
+msgid "Light snow and thunder"
+msgstr "Viegla snigšana"
+
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
+msgid "Light snow showers"
+msgstr "Viegla snigšana"
+
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
+#, fuzzy
+msgid "Light snow showers and thunder"
+msgstr "Viegla snigšana"
+
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
+msgid "Rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
+#, fuzzy
+msgid "Rain showers"
+msgstr "Sniegs"
+
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
+msgid "Rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:511 3.0/met_norway.js:512 3.0/met_norway.js:518
+#: 3.0/met_norway.js:525 3.0/met_norway.js:532 3.0/met_uk.js:638
+#: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
+#: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
+#: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
+msgid "Sleet"
+msgstr "Slapjš sniegs"
+
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
+#, fuzzy
+msgid "Sleet and thunder"
+msgstr "Vietām pērkona negaiss"
+
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
+#, fuzzy
+msgid "Sleet showers"
+msgstr "Vietām lietusgāzes"
+
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
+msgid "Sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
+msgid "Snow and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Sniegs"
 
-#: applet.js:1043
-msgid "Isolated thundershowers"
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
+#, fuzzy
+msgid "Snow showers and thunder"
+msgstr "Sniegs"
+
+#: 3.0/met_uk.js:162 3.0/met_uk.js:192 3.0/met_uk.js:239 3.0/us_weather.js:151
+#: 3.0/us_weather.js:179
+msgid "Unexpected response from API"
+msgstr ""
+
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
+msgid "Visibility"
+msgstr ""
+
+#: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
+msgid "Failed to Process Current Weather Info"
+msgstr ""
+
+#: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
+msgid "Failed to Process Forecast Info"
+msgstr ""
+
+#: 3.0/met_uk.js:408
+msgid "Very poor - Less than"
+msgstr ""
+
+#: 3.0/met_uk.js:410
+msgid "Poor - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:412
+msgid "Moderate - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:414
+msgid "Good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:416
+msgid "Very good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:417
+msgid "Excellent - More than"
+msgstr ""
+
+#: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
+msgid "Mist"
+msgstr ""
+
+#: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
+msgid "Overcast"
+msgstr ""
+
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
+#, fuzzy
+msgid "Light rain shower"
+msgstr "Viegla snigšana"
+
+#: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
+msgid "Drizzle"
+msgstr "Smidzina"
+
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
+#, fuzzy
+msgid "Heavy rain shower"
+msgstr "Spēcīgs sniegs"
+
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
+#, fuzzy
+msgid "Sleet shower"
+msgstr "Vietām lietusgāzes"
+
+#: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
+msgid "Hail"
+msgstr "Krusa"
+
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
+#, fuzzy
+msgid "Hail shower"
+msgstr "Sniegs"
+
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
+#, fuzzy
+msgid "Light snow shower"
+msgstr "Viegla snigšana"
+
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
+#, fuzzy
+msgid "Heavy snow shower"
+msgstr "Spēcīgs sniegs"
+
+#: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
+#, fuzzy
+msgid "Thunder"
+msgstr "Pērkona negaiss"
+
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
+#, fuzzy
+msgid "Thunder shower"
+msgstr "Pērkona negaiss"
+
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
+msgid "Please make sure Location is in the correct format in the Settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
+msgid "Make sure you entered the correct key in settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
+msgid ""
+"Location not found, make sure location is available or it is in the correct "
+"format"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
+msgid "If this problem persists, please contact the Author of this applet"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
+msgid "Unknown Error, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
+msgid "Thunderstorm with light rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
+#, fuzzy
+msgid "Thunderstorm with rain"
+msgstr "Pērkona negaiss"
+
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
+msgid "Thunderstorm with heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
+#, fuzzy
+msgid "Light thunderstorm"
+msgstr "Pērkona negaiss"
+
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
+#, fuzzy
+msgid "Heavy thunderstorm"
+msgstr "Spēcīgs pērkona negaiss"
+
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
+#, fuzzy
+msgid "Ragged thunderstorm"
 msgstr "Atsevišķi pērkona negaisi"
 
-#: applet.js:1046
-msgid "Not available"
-msgstr "Nav pieejams"
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
+msgid "Thunderstorm with light drizzle"
+msgstr ""
 
-#: applet.js:1051
-msgid "Monday"
-msgstr "Pirmdiena"
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
+#, fuzzy
+msgid "Thunderstorm with drizzle"
+msgstr "Pērkona negaiss"
 
-#: applet.js:1051
-msgid "Tuesday"
-msgstr "Otrdiena"
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
+msgid "Thunderstorm with heavy drizzle"
+msgstr ""
 
-#: applet.js:1051
-msgid "Wednesday"
-msgstr "Trešdiena"
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
+msgid "Light intensity drizzle"
+msgstr ""
 
-#: applet.js:1051
-msgid "Thursday"
-msgstr "Ceturtdiena"
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
+msgid "Heavy intensity drizzle"
+msgstr ""
 
-#: applet.js:1051
-msgid "Friday"
-msgstr "Piektdiena"
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
+msgid "Light intensity drizzle rain"
+msgstr ""
 
-#: applet.js:1051
-msgid "Saturday"
-msgstr "Sestdiena"
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Drizzle rain"
+msgstr "Smidzina"
 
-#: applet.js:1051
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
+msgid "Heavy intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
+#, fuzzy
+msgid "Shower rain and drizzle"
+msgstr "Lietus un krusa"
+
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
+msgid "Heavy shower rain and drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
+#, fuzzy
+msgid "Shower drizzle"
+msgstr "Sasalstoša smidzināšana"
+
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
+msgid "Moderate rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
+msgid "Heavy intensity rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
+msgid "Very heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
+#, fuzzy
+msgid "Extreme rain"
+msgstr "Sasalstošs lietus"
+
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
+#, fuzzy
+msgid "Light intensity shower rain"
+msgstr "Viegla snigšana"
+
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
+#, fuzzy
+msgid "Shower rain"
+msgstr "Lietusgāzes"
+
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
+msgid "Heavy intensity shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
+msgid "Ragged shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
+#, fuzzy
+msgid "Shower sleet"
+msgstr "Lietusgāzes"
+
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
+#, fuzzy
+msgid "Light rain and snow"
+msgstr "Lietus un sniegs"
+
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
+#, fuzzy
+msgid "Rain and snow"
+msgstr "Lietus un sniegs"
+
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
+#, fuzzy
+msgid "Light shower snow"
+msgstr "Viegla snigšana"
+
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
+#, fuzzy
+msgid "Shower snow"
+msgstr "Lietusgāzes"
+
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
+#, fuzzy
+msgid "Heavy shower snow"
+msgstr "Spēcīgs sniegs"
+
+#: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
+#, fuzzy
+msgid "Smoke"
+msgstr "Dūmaka"
+
+#: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
+msgid "Haze"
+msgstr "Dūmaka"
+
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
+msgid "Sand, dust whirls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
+msgid "Sand"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
+msgid "Dust"
+msgstr "Putekļi"
+
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
+msgid "Volcanic ash"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
+msgid "Squalls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
+msgid "Tornado"
+msgstr "Tornado"
+
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
+msgid "Sky is clear"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
+#, fuzzy
+msgid "Clouds"
+msgstr "Apmācies"
+
+#: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
+msgid "Few clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
+#, fuzzy
+msgid "Scattered clouds"
+msgstr "Vietām lietusgāzes"
+
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
+msgid "Broken clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
+msgid "Overcast clouds"
+msgstr ""
+
+#: 3.0/us_weather.js:120
+msgid "Could not get forecast for your area"
+msgstr ""
+
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
+msgid "Location is outside US, please use a different provider."
+msgstr ""
+
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
+msgid "Failed to Process Hourly Forecast Info"
+msgstr ""
+
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
+msgid "Clear and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
+msgid "Few clouds and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
+#, fuzzy
+msgid "Partly cloudy and windy"
+msgstr "Daļēji apmācies"
+
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
+#, fuzzy
+msgid "Mostly cloudy and windy"
+msgstr "Pārsvarā apmācies"
+
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
+msgid "Overcast and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
+#, fuzzy
+msgid "Snowy rain"
+msgstr "Sniegputenis"
+
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
+#, fuzzy
+msgid "Freezing rain and snow"
+msgstr "Sasalstošs lietus"
+
+#: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
+msgid "Hurricane"
+msgstr "Viesuļvētra"
+
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
+msgid "Storm"
+msgstr ""
+
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
+msgid "Tropical storm"
+msgstr "Tropiskā vētra"
+
+#: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
+msgid "Hot"
+msgstr "Karsts"
+
+#: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
+msgid "Cold"
+msgstr "Auksts"
+
+#: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
+msgid "Blizzard"
+msgstr ""
+
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
+msgid "Today"
+msgstr "Šodien"
+
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
+msgid "Tomorrow"
+msgstr "Rīt"
+
+#: 3.0/utils.js:204
 msgid "Sunday"
 msgstr "Svētdiena"
 
-#: applet.js:1056
+#: 3.0/utils.js:204
+msgid "Monday"
+msgstr "Pirmdiena"
+
+#: 3.0/utils.js:204
+msgid "Tuesday"
+msgstr "Otrdiena"
+
+#: 3.0/utils.js:204
+msgid "Wednesday"
+msgstr "Trešdiena"
+
+#: 3.0/utils.js:204
+msgid "Thursday"
+msgstr "Ceturtdiena"
+
+#: 3.0/utils.js:204
+msgid "Friday"
+msgstr "Piektdiena"
+
+#: 3.0/utils.js:204
+msgid "Saturday"
+msgstr "Sestdiena"
+
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
+msgid "Calm"
+msgstr ""
+
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
+msgid "Light air"
+msgstr ""
+
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
+msgid "Light breeze"
+msgstr ""
+
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
+msgid "Gentle breeze"
+msgstr ""
+
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
+msgid "Moderate breeze"
+msgstr ""
+
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
+msgid "Fresh breeze"
+msgstr ""
+
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
+msgid "Strong breeze"
+msgstr ""
+
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
+msgid "Near gale"
+msgstr ""
+
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
+msgid "Gale"
+msgstr ""
+
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
+msgid "Strong gale"
+msgstr ""
+
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
+msgid "Violent storm"
+msgstr ""
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "Z"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "ZA"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "A"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "DA"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "D"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "DR"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "R"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "ZR"
 
-#. cinnamon-weather->settings-schema.json->woeidLookup->description
-msgid "Get WOEID"
+#: 3.0/weatherbit.js:312
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://www.weatherbit.io/account/create"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->verticalOrientation->description
-msgid "Vertical orientation"
+#: 3.0/yahoo.js:78
+msgid ""
+"Unknown Error happened while calling Yahoo bridge,\n"
+" see Looking Glass log for errors"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showTextInPanel->description
-msgid "Display current temperature in panel"
+#: 3.0/yahoo.js:91
+msgid ""
+"Yahoo bridge responded in bad format,\n"
+" see Looking Glass log for errors"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeid->description
-msgid "WOEID"
+#: 3.0/yahoo.js:177
+msgid "Missing package"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeid->tooltip
-msgid "Where On Earth ID"
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+#, fuzzy
+msgid "Please install '"
+msgstr "Lūdzu uzgaidiet"
+
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+msgid "', then refresh manually."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->description
+#: 3.0/yahoo.js:182
+msgid "Could not connect to Yahoo API."
+msgstr ""
+
+#: 3.0/yahoo.js:186
+msgid ""
+"Unknown error happened while obtaining weather, see Looking Glass logs for "
+"more information"
+msgstr ""
+
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
+#, fuzzy
+msgid "Tropical Storm"
+msgstr "Tropiskā vētra"
+
+#: 3.0/yahoo.js:439
+#, fuzzy
+msgid "Severe Thunderstorms"
+msgstr "Spēcīgs pērkona negaiss"
+
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
+msgid "Thunderstorms"
+msgstr "Pērkona negaiss"
+
+#: 3.0/yahoo.js:441
+#, fuzzy
+msgid "Mixed Rain and Snow"
+msgstr "Lietus un sniegs"
+
+#: 3.0/yahoo.js:442
+#, fuzzy
+msgid "Mixed Rain and Sleet"
+msgstr "Slapjdraņķis"
+
+#: 3.0/yahoo.js:443
+#, fuzzy
+msgid "Mixed Snow and Sleet"
+msgstr "Sniegs un slapjš sniegs"
+
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
+#, fuzzy
+msgid "Freezing Drizzle"
+msgstr "Sasalstoša smidzināšana"
+
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
+#, fuzzy
+msgid "Freezing Rain"
+msgstr "Sasalstošs lietus"
+
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
+msgid "Showers"
+msgstr "Lietusgāzes"
+
+#: 3.0/yahoo.js:449
+#, fuzzy
+msgid "Snow Flurries"
+msgstr "Sniegputenis"
+
+#: 3.0/yahoo.js:450
+#, fuzzy
+msgid "Light Snow Showers"
+msgstr "Viegla snigšana"
+
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
+#, fuzzy
+msgid "Blowing Snow"
+msgstr "Sniega putenis"
+
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
+msgid "Foggy"
+msgstr "Miglains"
+
+#: 3.0/yahoo.js:458
+msgid "Smoky"
+msgstr "Dūmaka"
+
+#: 3.0/yahoo.js:459
+msgid "Blustery"
+msgstr "Brāzmains"
+
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
+msgid "Windy"
+msgstr "Vējains"
+
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
+#, fuzzy
+msgid "Mostly Cloudy"
+msgstr "Pārsvarā apmācies"
+
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
+#, fuzzy
+msgid "Partly Cloudy"
+msgstr "Daļēji apmācies"
+
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
+#, fuzzy
+msgid "Mostly Sunny"
+msgstr "Pārsvarā apmācies"
+
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
+#, fuzzy
+msgid "Mixed Rain and Hail"
+msgstr "Lietus un krusa"
+
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
+#, fuzzy
+msgid "Isolated Thunderstorms"
+msgstr "Atsevišķi pērkona negaisi"
+
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
+#, fuzzy
+msgid "Scattered Thunderstorms"
+msgstr "Vietām pērkona negaiss"
+
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
+#, fuzzy
+msgid "Scattered Showers"
+msgstr "Vietām lietusgāzes"
+
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
+#, fuzzy
+msgid "Heavy Rain"
+msgstr "Spēcīgs sniegs"
+
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
+#, fuzzy
+msgid "Scattered Snow Showers"
+msgstr "Vietām sniega putenis"
+
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
+#, fuzzy
+msgid "Heavy Snow"
+msgstr "Spēcīgs sniegs"
+
+#: 3.0/yahoo.js:478
+#, fuzzy
+msgid "Not Available"
+msgstr "Nav pieejams"
+
+#: 3.0/yahoo.js:479
+#, fuzzy
+msgid "Scattered Thundershowers"
+msgstr "Vietām pērkona negaiss"
+
+#: 3.8/weather-applet.js:9638
+msgid ""
+"Could not retrieve logs, log file was not found under path\n"
+" {logFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:9642
+msgid ""
+"Could not get contents of log file under path\n"
+" {logFilePath}"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10283
+msgid "Met Office UK"
+msgstr ""
+
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
+msgstr ""
+
+#: 3.8/weather-applet.js:10476
+msgid "Data was not found for location"
+msgstr ""
+
+#: 3.8/weather-applet.js:10557
+msgid "Very poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10557
+msgid "Less than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "Excellent"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "More than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566
+msgid "Poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
+msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10571
+msgid "Moderate"
+msgstr ""
+
+#: 3.8/weather-applet.js:10576
+msgid "Good"
+msgstr ""
+
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
+msgid "Very good"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10942
+msgid "OpenWeatherMap"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:11396
+msgid "MET Norway"
+msgstr ""
+
+#: 3.8/weather-applet.js:11955
+msgid "WeatherBit"
+msgstr ""
+
+#: 3.8/weather-applet.js:12386
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Rīt"
+
+#: 3.8/weather-applet.js:12561
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12575
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12723
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:13292
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13474
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "Sniega putenis"
+
+#: 3.8/weather-applet.js:13478
+#, fuzzy
+msgid "Heavy drizzle"
+msgstr "Sasalstoša smidzināšana"
+
+#: 3.8/weather-applet.js:13482
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13484
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13486
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:13490
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "Sasalstoša smidzināšana"
+
+#: 3.8/weather-applet.js:13492
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13494
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13496
+#, fuzzy
+msgid "Freezing fog"
+msgstr "Sasalstošs lietus"
+
+#: 3.8/weather-applet.js:13502
+msgid "Funnel cloud/tornado"
+msgstr ""
+
+#: 3.8/weather-applet.js:13504
+#, fuzzy
+msgid "Hail showers"
+msgstr "Sniegs"
+
+#: 3.8/weather-applet.js:13506
+msgid "Ice"
+msgstr ""
+
+#: 3.8/weather-applet.js:13508
+msgid "Lightning without thunder"
+msgstr ""
+
+#: 3.8/weather-applet.js:13512
+msgid "Precipitation in vicinity"
+msgstr ""
+
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
+#, fuzzy
+msgid "Heavy rain and snow"
+msgstr "Lietus un sniegs"
+
+#: 3.8/weather-applet.js:13518
+#, fuzzy
+msgid "Light rain And snow"
+msgstr "Lietus un sniegs"
+
+#: 3.8/weather-applet.js:13526
+msgid "Sky coverage decreasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13528
+msgid "Sky coverage increasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13530
+msgid "Sky unchanged"
+msgstr ""
+
+#: 3.8/weather-applet.js:13532
+msgid "Smoke or haze"
+msgstr ""
+
+#: 3.8/weather-applet.js:13536
+#, fuzzy
+msgid "Snow and rain showers"
+msgstr "Sniegs"
+
+#: 3.8/weather-applet.js:13548
+msgid "Thunderstorm without precipitation"
+msgstr ""
+
+#: 3.8/weather-applet.js:13550
+msgid "Diamond dust"
+msgstr ""
+
+#: 3.8/weather-applet.js:13556
+#, fuzzy
+msgid "Partially cloudy"
+msgstr "Daļēji apmācies"
+
+#: 3.8/weather-applet.js:13578
+msgid "Please make sure you entered the API key correctly"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:13595
+msgid "DMI Denmark"
+msgstr ""
+
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
+msgid "NOT FOUND"
+msgstr ""
+
+#: 3.8/weather-applet.js:13779
+msgid "Blowing snow"
+msgstr "Sniega putenis"
+
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
+#, fuzzy
+msgid "Slight snow"
+msgstr "Sniega putenis"
+
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
+#, fuzzy
+msgid "Moderate snow"
+msgstr "Spēcīgs sniegs"
+
+#: 3.8/weather-applet.js:13842
+#, fuzzy
+msgid "Moderate rain showers"
+msgstr "Vietām lietusgāzes"
+
+#: 3.8/weather-applet.js:13849
+msgid "Mixed rain and snow"
+msgstr "Lietus un sniegs"
+
+#: 3.8/weather-applet.js:13856
+#, fuzzy
+msgid "Heavy mixed rain and snow"
+msgstr "Lietus un sniegs"
+
+#: 3.8/weather-applet.js:14024
+msgid "AccuWeather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+msgid "Weather Underground"
+msgstr ""
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+msgid "The location you provided was not found."
+msgstr ""
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+msgid "Strong Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "Lietus un sniegs"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "Slapjdraņķis"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "Sniegs"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "Pārsvarā apmācies"
+
+#: 3.8/weather-applet.js:15247
+msgid "Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:15603
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+
+#: 3.8/weather-applet.js:15831
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+
+#: 3.8/weather-applet.js:15968
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:15975
+msgid ""
+"Could not get contents of config file under path\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr ""
+
+#: 3.8/weather-applet.js:16675
+msgid "Dew Point"
+msgstr ""
+
+#: 3.8/weather-applet.js:16747
+msgid "Precipitation will end in {precipEnd} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16749
+msgid "Precipitation won't end in within an hour"
+msgstr ""
+
+#: 3.8/weather-applet.js:16752
+msgid "Precipitation will start within {precipStart} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16964
+msgid "Forecast parsing failed, see logs for more details."
+msgstr ""
+
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
+msgid "As of {lastUpdatedTime}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17502
+msgid "{distance} {distanceUnit} from you"
+msgstr ""
+
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
+msgid "Error Saving Debug Information"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Debug Information saved successfully"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Saved to {filePath}"
+msgstr ""
+
+#: 3.8/LogSaver.py:16
+msgid "Save to File"
+msgstr ""
+
+#: 3.8/LogSaver.py:29
+msgid "Select a destination"
+msgstr ""
+
+#. metadata.json->name
+#. 3.8->settings-schema.json->providers->title
+msgid "Weather"
+msgstr ""
+
+#. metadata.json->description
+msgid "View your local weather forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->head->description
+msgid "Settings for weather@mockturtl 3.0+"
+msgstr ""
+
+#. 3.0->settings-schema.json->keybinding->description
+#. 3.8->settings-schema.json->keybinding->description
+msgid "Set the keybinding to call the menu"
+msgstr ""
+
+#. 3.0->settings-schema.json->descriptions->description
+msgid "Weather service information"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->description
+msgid "Click here for detailed description"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->tooltip
+#. 3.0->settings-schema.json->getLocation->tooltip
+#. 3.8->settings-schema.json->getLocation->tooltip
+msgid "Opens webpage guide"
+msgstr ""
+
+#. 3.0->settings-schema.json->providerSettings->description
+#. 3.8->settings-schema.json->provider-options->title
+msgid "Weather Provider Options"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->description
+#. 3.8->settings-schema.json->dataService->description
+msgid "Data service"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "DarkSky (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weatherbit (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Yahoo"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Climacell (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->description
+#. 3.8->settings-schema.json->apiKey->description
+msgid "API Key"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->tooltip
+#. 3.8->settings-schema.json->apiKey->tooltip
+msgid "Copy this from your account of the used Data service and paste it here."
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->description
+#. 3.8->settings-schema.json->manualLocation->description
+msgid "Manual Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->tooltip
+#. 3.8->settings-schema.json->manualLocation->tooltip
+msgid "Enable this if your location is not accurate"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->description
+msgid "Location - Coordinates"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->tooltip
+msgid ""
+"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an "
+"address.\n"
+"Waits for 3 seconds after you stop typing before refreshes the weather."
+msgstr ""
+
+#. 3.0->settings-schema.json->getLocation->description
+msgid "Setup API Key and Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->units
+#. 3.8->settings-schema.json->refreshInterval->units
+msgid "minutes"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->description
+#. 3.8->settings-schema.json->refreshInterval->description
+msgid "Update interval"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastDays->units
+#. 3.8->settings-schema.json->forecastDays->units
+msgid "days"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastDays->description
+#. 3.8->settings-schema.json->forecastDays->description
+msgid "Forecast length"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastHours->units
+#. 3.8->settings-schema.json->forecastHours->units
+msgid "hours"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastHours->description
+#. 3.8->settings-schema.json->forecastHours->description
+msgid "Hourly Forecast length"
+msgstr ""
+
+#. 3.0->settings-schema.json->unitSettings->description
+msgid "Units"
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureUnit->description
+#. 3.8->settings-schema.json->temperatureUnit->description
 #, fuzzy
 msgid "Temperature unit"
 msgstr "Temperatūra:"
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "fahrenheit"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Automatic"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "celsius"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+msgid "Celsius"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->translateCondition->description
-msgid "Translate condition"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+msgid "Fahrenheit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->locationLabelOverride->description
-msgid "Override location label"
+#. 3.0->settings-schema.json->temperatureUnit->tooltip
+#. 3.0->settings-schema.json->distanceUnit->tooltip
+#. 3.8->settings-schema.json->temperatureUnit->tooltip
+#. 3.8->settings-schema.json->distanceUnit->tooltip
+msgid ""
+"Automatic will try to guess your preference based your current display "
+"language."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->show24Hours->description
-msgid "Display time in 24 hour format"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->forecastDays->description
-msgid "Forecast length"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->forecastDays->units
-msgid "days"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->showSunrise->description
-msgid "Show sunrise / sunset times"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->description
+#. 3.0->settings-schema.json->windSpeedUnit->description
+#. 3.8->settings-schema.json->windSpeedUnit->description
 msgid "Wind speed unit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
 msgid "kph"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "m/s"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "knots"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
 msgid "mph"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showCommentInPanel->description
-msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "m/s"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->description
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "knots"
+msgstr ""
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "Beaufort"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->description
+#. 3.8->settings-schema.json->pressureUnit->description
 msgid "Atmospheric pressure unit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "psi"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "hPa"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "atm"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "kPa"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "Pa"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mm Hg"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "at"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mbar"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
 msgid "in Hg"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->description
-msgid "Update interval"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "mm Hg"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->units
-msgid "minutes"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "psi"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->useSymbolicIcons->description
-msgid "Symbolic icons"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "at"
 msgstr ""
 
-#. cinnamon-weather->metadata.json->description
-msgid "View your local weather forecast"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "atm"
 msgstr ""
 
-#. cinnamon-weather->metadata.json->name
-msgid "Weather"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "Pa"
 msgstr ""
 
-#~ msgid "Please wait"
-#~ msgstr "Lūdzu uzgaidiet"
+#. 3.0->settings-schema.json->distanceUnit->description
+#. 3.8->settings-schema.json->distanceUnit->description
+msgid "Distance unit"
+msgstr ""
 
-#~ msgid "Today"
-#~ msgstr "Šodien"
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Metric"
+msgstr ""
 
-#~ msgid "Tomorrow"
-#~ msgstr "Rīt"
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Imperial"
+msgstr ""
 
-#~ msgid "Schema \"%s\" not found."
-#~ msgstr "Shēma \"%s\" nav atrasta."
+#. 3.0->settings-schema.json->panelSettings->description
+msgid "Panel options"
+msgstr ""
+
+#. 3.0->settings-schema.json->showTextInPanel->description
+#. 3.8->settings-schema.json->showTextInPanel->description
+msgid "Display current temperature in panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->showCommentInPanel->description
+#. 3.8->settings-schema.json->showCommentInPanel->description
+msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->showCommentInPanel->tooltip
+#. 3.8->settings-schema.json->showCommentInPanel->tooltip
+msgid "Only works with horizontal panels"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempTextOverride->description
+#. 3.8->settings-schema.json->tempTextOverride->description
+msgid "Override label on panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.0->settings-schema.json->useCustomMenuIcons->tooltip
+#. 3.8->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.8->settings-schema.json->useCustomMenuIcons->tooltip
+msgid "Iconset is weather-icons by Erik Flowers"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->description
+#. 3.8->settings-schema.json->useCustomAppletIcons->description
+msgid "Use custom icons on the panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->displaySettings->description
+#. 3.8->settings-schema.json->presentation-section->title
+msgid "Presentation"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->description
+#. 3.8->settings-schema.json->verticalOrientation->description
+msgid "Show forecast vertically"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->units
+#. 3.8->settings-schema.json->forecastColumns->units
+msgid "columns"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->description
+#. 3.8->settings-schema.json->forecastColumns->description
+msgid "Maximum number of columns for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->units
+#. 3.8->settings-schema.json->forecastRows->units
+msgid "rows"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->description
+#. 3.8->settings-schema.json->forecastRows->description
+msgid "Maximum number of rows for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->showSunrise->description
+#. 3.8->settings-schema.json->showSunrise->description
+msgid "Show sunrise / sunset times"
+msgstr ""
+
+#. 3.0->settings-schema.json->show24Hours->description
+#. 3.8->settings-schema.json->show24Hours->description
+msgid "Display time in 24 hour format"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->description
+#. 3.8->settings-schema.json->shortHourlyTime->description
+msgid "Only display hours for hourly forecast time"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->tooltip
+#. 3.8->settings-schema.json->shortHourlyTime->tooltip
+msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->description
+#. 3.8->settings-schema.json->showForecastDates->description
+msgid "Display date for daily forecasts"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->tooltip
+#. 3.8->settings-schema.json->showForecastDates->tooltip
+msgid "Like \"Friday 15\""
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureHighFirst->description
+#. 3.8->settings-schema.json->temperatureHighFirst->description
+msgid "Show high temperature first in forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempRussianStyle->description
+#. 3.8->settings-schema.json->tempRussianStyle->description
+#, fuzzy
+msgid "Show temperature Russian style"
+msgstr "Temperatūra:"
+
+#. 3.0->settings-schema.json->locationLabelOverride->description
+#. 3.8->settings-schema.json->locationLabelOverride->description
+msgid "Override location label"
+msgstr ""
+
+#. 3.0->settings-schema.json->conditionSettings->description
+#. 3.8->settings-schema.json->weather-conditions->title
+msgid "Weather conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->translateCondition->description
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Translate conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortConditions->description
+#. 3.8->settings-schema.json->shortConditions->description
+msgid "Less verbose conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->iconSettings->description
+#. 3.8->settings-schema.json->icons->title
+msgid "Icons"
+msgstr ""
+
+#. 3.0->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons in the applet"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomMenuIcons->description
+#. 3.8->settings-schema.json->useCustomMenuIcons->description
+msgid "Use custom icons in the popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->locations-page->title
+#. 3.8->settings-schema.json->location->description
+msgid "Location"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-page->title
+msgid "Other options"
+msgstr ""
+
+#. 3.8->settings-schema.json->info-section->title
+msgid "Help"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-section->title
+msgid "Location settings"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-store->title
+msgid "Saved Locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->panel-options->title
+msgid "Panel (Taskbar)"
+msgstr ""
+
+#. 3.8->settings-schema.json->presentation->title
+msgid "Popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-section->title
+msgid "Other Units"
+msgstr ""
+
+#. 3.8->settings-schema.json->temp-unit-section->title
+#, fuzzy
+msgid "Temperature Unit"
+msgstr "Temperatūra:"
+
+#. 3.8->settings-schema.json->keybindings->title
+msgid "Keybindings"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info->title
+msgid "More about the Weather applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->submit-issue->title
+msgid "Report an issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->debug-options->title
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Debug"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->tooltip
+msgid ""
+"You can choose between several different weather forecast providers. Some "
+"providers require a API key to work, some have regional limits, differ in "
+"forecast length, and they all need a functional internet connection to work. "
+"The options are described in detail on the Cinnamon Spices Website which you "
+"can access with the button on the Help tab."
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Met Office UK (UK only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "US National Weather (US only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Pirate Weather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Visual Crossing (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Tomorrow.io (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "AccuWeather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weather Underground (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->location->tooltip
+msgid ""
+"You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use "
+"'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street} "
+"{City/Town} {Postcode} {Country}. The search algorithm is very flexible with "
+"the format. After 3 seconds without typing the address you entered is "
+"replaced automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->description
+msgid "Save current location to storage"
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->tooltip
+msgid ""
+"Saves location information to file so you can switch between them with "
+"buttons in the applet, which will appear if you have more than one."
+msgstr ""
+
+#. 3.8->settings-schema.json->getLocation->description
+msgid "Weather Applet at Cinnamon Spices Website"
+msgstr ""
+
+#. 3.8->settings-schema.json->refreshInterval->tooltip
+msgid ""
+"If you are using a provider with API keys set it to an interval you won't "
+"run out of your quota with."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastDays->tooltip
+msgid ""
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->description
+msgid "Enable minutely precipitation forecast"
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->tooltip
+msgid ""
+"If you'd like to use this make sure you use your exact coordinates/address "
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
+msgstr ""
+
+#. 3.8->settings-schema.json->showBothTempUnits->description
+msgid "Show both temperature units at the same time"
+msgstr ""
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+msgid "Override tooltip on panel"
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
+msgid "Always show Hourly Weather"
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->tooltip
+msgid ""
+"Hide/Show button will be hidden and Hourly weather will be permanently "
+"visible."
+msgstr ""
+
+#. 3.8->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->description
+msgid "Your saved locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->tooltip
+msgid ""
+"You have to make sure the Search entry field is unique and your Timezone is "
+"in the IANA time zone format (e.g. 'Europe/London')"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Latitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Longitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "City"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Country"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Timezone"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Search entry"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->description
+msgid "Display wind direction as text"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->tooltip
+msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->tooltip
+msgid "Does not apply to custom iconset, that is symbolic by default"
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons throughout the applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info-label->description
+msgid ""
+"For detailed information about the applet please go to the Spices Website to "
+"find info about known issues, troubleshooting, changelog and more by "
+"clicking the button below. Here you can ask questions etc in the comment "
+"section by logging in with your Github account."
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->description
+msgid "Submit an Issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->tooltip
+msgid ""
+"Opens webpage where you can fill out a new issue for the applet, needs a "
+"GitHub account.\n"
+" Please make sure that the issue is not already submitted."
+msgstr ""
+
+#. 3.8->settings-schema.json->maintainer->description
+msgid "Current maintainer: Gr3q"
+msgstr ""
+
+#. 3.8->settings-schema.json->issue-reporting-explanation->description
+msgid ""
+"If you find an issue with this applet please make a report by clicking on "
+"the button below and login in with your Github account.\n"
+"\n"
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
+msgstr ""
+
+#. 3.8->settings-schema.json->loc-info->description
+msgid ""
+"Your location in most cases work automatically but you can enter it manually "
+"by coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,"
+"Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/"
+"Town} {Postcode} {Country}. The search algorithm is very flexible with the "
+"format. After 3 seconds without typing the address you entered is replaced "
+"automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->description
+msgid "Log Level"
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->tooltip
+msgid ""
+"Info is the regular logging, Debug is debug, and Verbose also logs network "
+"request payloads. Changing this will only be effective on future logs. Only "
+"change it you are instructed or you know what you are doing."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Verbose"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->description
+msgid "Click Save to save debug information to a file"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->tooltip
+msgid ""
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
+msgstr ""
+
+#. 3.8->settings-schema.json->selectedLogPath->description
+msgid "Selected path to save Logs"
+msgstr ""

--- a/weather@mockturtl/files/weather@mockturtl/po/nb.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/nb.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 3.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-12 12:27-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2011-06-02 23:04+0200\n"
 "Last-Translator: Stian Ellingsen <stiell@stiell.org>\n"
 "Language-Team: \n"
@@ -16,432 +17,2571 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:249
+#: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
+#: 3.8/weather-applet.js:17877
+msgid "Error"
+msgstr ""
+
+#: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
+#: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
+msgid "Service Error"
+msgstr ""
+
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
+msgid "Incorrect API Key"
+msgstr ""
+
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
+msgid "Incorrect Location Format"
+msgstr ""
+
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
+msgid "Key Blocked"
+msgstr ""
+
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
+msgid "Can't find location"
+msgstr ""
+
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
+msgid "No Api Key"
+msgstr ""
+
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
+msgid "No Location"
+msgstr ""
+
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
+msgid "Missing Packages"
+msgstr ""
+
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
+msgid "Location not covered"
+msgstr ""
+
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
+msgid "Weather Applet"
+msgstr ""
+
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "…"
 
-#: applet.js:250
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr ""
 
-#: applet.js:289
-msgid "Settings"
-msgstr ""
-
-#: applet.js:555
-msgid "Sunrise"
-msgstr ""
-
-#: applet.js:556
-msgid "Sunset"
-msgstr ""
-
-#: applet.js:648
-msgid "Loading current weather ..."
-msgstr "Laster værobservasjon …"
-
-#: applet.js:649
-msgid "Loading future weather ..."
-msgstr "Laster værvarsel …"
-
-#: applet.js:671
-msgid "Loading ..."
-msgstr "Laster …"
-
-#: applet.js:677
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr ""
 
-#: applet.js:740
-msgid "Temperature:"
+#: 3.0/applet.js:272
+msgid "API returned status code between 400 and 500"
+msgstr ""
+
+#: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
+#: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
+msgid "Location Store"
+msgstr ""
+
+#: 3.0/applet.js:426
+msgid "You can't save a location obtained automatically, sorry"
+msgstr ""
+
+#: 3.0/applet.js:601
+msgid "Could not get weather information"
+msgstr ""
+
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
+msgid ""
+"Unexpected Error While Refreshing Weather, please see log in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
+msgid ""
+"Could not update weather for a while...\n"
+"are you connected to the internet?"
+msgstr ""
+
+#: 3.0/applet.js:684
+msgid "Network Error, please check logs in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:969 3.0/applet.js:1110
+msgid "As of"
+msgstr ""
+
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
+msgid "Powered by"
+msgstr ""
+
+#: 3.0/applet.js:1113
+msgid "from you"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
+msgid "mm"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
+msgid "in"
+msgstr ""
+
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
+msgid "mi"
+msgstr ""
+
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
+msgid "km"
+msgstr ""
+
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
+msgid "Loading current weather ..."
+msgstr "Laster værobservasjon …"
+
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
+msgid "Loading future weather ..."
+msgstr "Laster værvarsel …"
+
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
+msgid "Loading ..."
+msgstr "Laster …"
+
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
+#, fuzzy
+msgid "Temperature"
 msgstr "Temperatur:"
 
-#: applet.js:742
-msgid "Humidity:"
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
+#, fuzzy
+msgid "Humidity"
 msgstr "Fuktighet:"
 
-#: applet.js:744
-msgid "Pressure:"
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
+#, fuzzy
+msgid "Pressure"
 msgstr "Lufttrykk:"
 
-#: applet.js:746
-msgid "Wind:"
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
+#, fuzzy
+msgid "Wind"
 msgstr "Vind:"
 
-#: applet.js:748
-msgid "Wind Chill:"
-msgstr "Vind:"
+#: 3.0/applet.js:1639
+msgid "Make sure you entered a location or use Automatic location instead"
+msgstr ""
 
-#: applet.js:953
-msgid "Tornado"
-msgstr "Tornado"
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
+msgid "Could not find location based on address, please check if it's right"
+msgstr ""
 
-#: applet.js:955
-msgid "Tropical storm"
-msgstr "Tropisk storm"
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
+msgid "Failed to call Geolocation API, see Looking Glass for errors."
+msgstr ""
 
-#: applet.js:957
-msgid "Hurricane"
-msgstr "Orkan"
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "Warning"
+msgstr ""
 
-#: applet.js:959
-msgid "Severe thunderstorms"
-msgstr "Kraftig tordenvær"
+#: 3.0/applet.js:2032
+msgid "You can only save correct locations when the applet is not refreshing"
+msgstr ""
 
-#: applet.js:961
-msgid "Thunderstorms"
-msgstr "Tordenvær"
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "You can't save an incorrect location"
+msgstr ""
 
-#: applet.js:963
-msgid "Mixed rain and snow"
-msgstr "Regn og snø"
+#. 3.8->settings-schema.json->logLevel->options
+#: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.8/weather-applet.js:9875
+msgid "Info"
+msgstr ""
 
-#: applet.js:965
-msgid "Mixed rain and sleet"
-msgstr "Regn og sludd"
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
+msgid "Location is already saved"
+msgstr ""
 
-#: applet.js:967
-msgid "Mixed snow and sleet"
-msgstr "Snø og sludd"
+#: 3.0/applet.js:2049 3.0/applet.js:2083
+msgid "Success"
+msgstr ""
 
-#: applet.js:969
-msgid "Freezing drizzle"
-msgstr "Underkjølt yr"
+#: 3.0/applet.js:2049
+msgid "Location is saved to library"
+msgstr ""
 
-#: applet.js:971
-msgid "Drizzle"
-msgstr "Yr"
+#: 3.0/applet.js:2062
+msgid "You can't remove a location while the applet is refreshing"
+msgstr ""
 
-#: applet.js:973
+#: 3.0/applet.js:2066
+msgid "You can't remove an incorrect location"
+msgstr ""
+
+#: 3.0/applet.js:2070
+msgid "Location is not in storage, can't delete"
+msgstr ""
+
+#: 3.0/applet.js:2083
+msgid "Location is deleted from library"
+msgstr ""
+
+#: 3.0/applet.js:2131
+msgid ""
+"Failed to load in data from location storage, please see the logs for more "
+"information"
+msgstr ""
+
+#: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
+#: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
+msgid "Feels Like"
+msgstr ""
+
+#: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
+#: 3.8/weather-applet.js:15387
+msgid "Failed to Process Weather Info"
+msgstr ""
+
+#: 3.0/climacell.js:224
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://developer.climacell.co/sign-up"
+msgstr ""
+
+#: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
+msgid ""
+"Please Make sure you\n"
+"entered the API key correctly and your account is not locked"
+msgstr ""
+
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Climacell"
+msgstr ""
+
+#: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
+#: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
+#: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
+#, fuzzy
+msgid "Heavy rain"
+msgstr "Kraftig snøfall"
+
+#: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
+#: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
+#: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
+msgid "Rain"
+msgstr ""
+
+#: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
+#: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
+#: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
+#, fuzzy
+msgid "Light rain"
+msgstr "Underkjølt regn"
+
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
+#, fuzzy
+msgid "Heavy freezing rain"
+msgstr "Underkjølt regn"
+
+#: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
+#: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
+#: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Underkjølt regn"
 
-#: applet.js:975 applet.js:977
-msgid "Showers"
-msgstr "Regnbyger"
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
+#, fuzzy
+msgid "Light freezing rain"
+msgstr "Underkjølt regn"
 
-#: applet.js:979
-msgid "Snow flurries"
-msgstr "Lett snøfall"
+#: 3.0/climacell.js:301
+#, fuzzy
+msgid "Light freezing drizzle"
+msgstr "Underkjølt yr"
 
-#: applet.js:981
-msgid "Light snow showers"
-msgstr "Lette snøbyger"
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
+msgid "Freezing drizzle"
+msgstr "Underkjølt yr"
 
-#: applet.js:983
-msgid "Blowing snow"
-msgstr "Snøføyke"
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
+#, fuzzy
+msgid "Light drizzle"
+msgstr "Underkjølt yr"
 
-#: applet.js:985
-msgid "Snow"
-msgstr "Snø"
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
+msgid "Heavy ice pellets"
+msgstr ""
 
-#: applet.js:987
-msgid "Hail"
-msgstr "Hagl"
+#: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
+msgid "Ice pellets"
+msgstr ""
 
-#: applet.js:989
-msgid "Sleet"
-msgstr "Sludd"
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
+msgid "Light ice pellets"
+msgstr ""
 
-#: applet.js:991
-msgid "Dust"
-msgstr "Støv"
-
-#: applet.js:993
-msgid "Foggy"
-msgstr "Tåke"
-
-#: applet.js:995
-msgid "Haze"
-msgstr "Dis"
-
-#: applet.js:997
-msgid "Smoky"
-msgstr "Røyk"
-
-#: applet.js:999
-msgid "Blustery"
-msgstr "Vindbyger"
-
-#: applet.js:1001
-msgid "Windy"
-msgstr "Vind"
-
-#: applet.js:1003
-msgid "Cold"
-msgstr "Kaldt"
-
-#: applet.js:1005
-msgid "Cloudy"
-msgstr "Skyet"
-
-#: applet.js:1008
-msgid "Mostly cloudy"
-msgstr "Stort sett skyet"
-
-#: applet.js:1011 applet.js:1037
-msgid "Partly cloudy"
-msgstr "Delvis skyet"
-
-#: applet.js:1013
-msgid "Clear"
-msgstr "Klarvær"
-
-#: applet.js:1015
-msgid "Sunny"
-msgstr "Sol"
-
-#: applet.js:1018
-msgid "Fair"
-msgstr "Lettskyet"
-
-#: applet.js:1020
-msgid "Mixed rain and hail"
-msgstr "Regn og hagl"
-
-#: applet.js:1022
-msgid "Hot"
-msgstr "Varmt"
-
-#: applet.js:1024
-msgid "Isolated thunderstorms"
-msgstr "Lokalt tordenvær"
-
-#: applet.js:1027
-msgid "Scattered thunderstorms"
-msgstr "Spredt tordenvær"
-
-#: applet.js:1029
-msgid "Scattered showers"
-msgstr "Spredte regnbyger"
-
-#: applet.js:1031 applet.js:1035
+#: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
+#: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
+#: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Kraftig snøfall"
 
-#: applet.js:1033
-msgid "Scattered snow showers"
-msgstr "Spredte snøbyger"
+#: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
+#: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
+#: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
+msgid "Snow"
+msgstr "Snø"
 
-#: applet.js:1039
-msgid "Thundershowers"
-msgstr "Tordenbyger"
+#: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
+#: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
+#: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
+#, fuzzy
+msgid "Light snow"
+msgstr "Lette snøbyger"
 
-#: applet.js:1041
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
+#, fuzzy
+msgid "Flurries"
+msgstr "Lett snøfall"
+
+#: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
+#, fuzzy
+msgid "Thunderstorm"
+msgstr "Tordenvær"
+
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
+msgid "Light fog"
+msgstr ""
+
+#: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
+#: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
+#: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
+#, fuzzy
+msgid "Fog"
+msgstr "Tåke"
+
+#: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
+#: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
+msgid "Cloudy"
+msgstr "Skyet"
+
+#: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
+msgid "Mostly cloudy"
+msgstr "Stort sett skyet"
+
+#: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
+#: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
+#: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
+msgid "Partly cloudy"
+msgstr "Delvis skyet"
+
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
+#, fuzzy
+msgid "Mostly clear"
+msgstr "Stort sett skyet"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
+#: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
+#: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
+msgid "Clear"
+msgstr "Klarvær"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
+msgid "Sunny"
+msgstr "Sol"
+
+#: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
+#: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
+#: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
+msgid "Unknown"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "and"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "until"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "Possible"
+msgstr ""
+
+#: 3.0/darkSky.js:211
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://darksky.net/dev/register"
+msgstr ""
+
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from DarkSky"
+msgstr ""
+
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
+msgid "Could not obtain location"
+msgstr ""
+
+#: 3.0/ipApi.js:95
+msgid ""
+"Location Service responded with errors, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
+#, fuzzy
+msgid "Cloudiness"
+msgstr "Skyet"
+
+#: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
+#, fuzzy
+msgid "Clear sky"
+msgstr "Klarvær"
+
+#: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
+msgid "Fair"
+msgstr "Lettskyet"
+
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
+msgid "Heavy rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
+#, fuzzy
+msgid "Heavy rain showers"
+msgstr "Kraftig snøfall"
+
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
+msgid "Heavy rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
+#, fuzzy
+msgid "Heavy sleet"
+msgstr "Kraftig snøfall"
+
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
+msgid "Heavy sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
+#, fuzzy
+msgid "Heavy sleet showers"
+msgstr "Kraftig snøfall"
+
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
+msgid "Heavy sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
+#, fuzzy
+msgid "Heavy snow and thunder"
+msgstr "Kraftig snøfall"
+
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
+#, fuzzy
+msgid "Heavy snow showers"
+msgstr "Snøbyger"
+
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
+msgid "Heavy snow showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
+msgid "Light rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
+#, fuzzy
+msgid "Light rain showers"
+msgstr "Lette snøbyger"
+
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
+#, fuzzy
+msgid "Light rain showers and thunder"
+msgstr "Lette snøbyger"
+
+#: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
+msgid "Light sleet"
+msgstr ""
+
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
+msgid "Light sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
+#, fuzzy
+msgid "Light sleet showers"
+msgstr "Lette snøbyger"
+
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
+#, fuzzy
+msgid "Light sleet showers and thunder"
+msgstr "Lette snøbyger"
+
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
+#, fuzzy
+msgid "Light snow and thunder"
+msgstr "Lette snøbyger"
+
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
+msgid "Light snow showers"
+msgstr "Lette snøbyger"
+
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
+#, fuzzy
+msgid "Light snow showers and thunder"
+msgstr "Lette snøbyger"
+
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
+msgid "Rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
+#, fuzzy
+msgid "Rain showers"
+msgstr "Snøbyger"
+
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
+msgid "Rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:511 3.0/met_norway.js:512 3.0/met_norway.js:518
+#: 3.0/met_norway.js:525 3.0/met_norway.js:532 3.0/met_uk.js:638
+#: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
+#: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
+#: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
+msgid "Sleet"
+msgstr "Sludd"
+
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
+#, fuzzy
+msgid "Sleet and thunder"
+msgstr "Spredt tordenvær"
+
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
+#, fuzzy
+msgid "Sleet showers"
+msgstr "Spredte regnbyger"
+
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
+msgid "Sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
+msgid "Snow and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Snøbyger"
 
-#: applet.js:1043
-msgid "Isolated thundershowers"
-msgstr "Lokale tordenbyger"
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
+#, fuzzy
+msgid "Snow showers and thunder"
+msgstr "Snøbyger"
 
-#: applet.js:1046
-msgid "Not available"
-msgstr "Ikke tilgjengelig"
+#: 3.0/met_uk.js:162 3.0/met_uk.js:192 3.0/met_uk.js:239 3.0/us_weather.js:151
+#: 3.0/us_weather.js:179
+msgid "Unexpected response from API"
+msgstr ""
 
-#: applet.js:1051
-msgid "Monday"
-msgstr "mandag"
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
+msgid "Visibility"
+msgstr ""
 
-#: applet.js:1051
-msgid "Tuesday"
-msgstr "tirsdag"
+#: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
+msgid "Failed to Process Current Weather Info"
+msgstr ""
 
-#: applet.js:1051
-msgid "Wednesday"
-msgstr "onsdag"
+#: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
+msgid "Failed to Process Forecast Info"
+msgstr ""
 
-#: applet.js:1051
-msgid "Thursday"
-msgstr "torsdag"
+#: 3.0/met_uk.js:408
+msgid "Very poor - Less than"
+msgstr ""
 
-#: applet.js:1051
-msgid "Friday"
-msgstr "fredag"
+#: 3.0/met_uk.js:410
+msgid "Poor - Between"
+msgstr ""
 
-#: applet.js:1051
-msgid "Saturday"
-msgstr "lørdag"
+#: 3.0/met_uk.js:412
+msgid "Moderate - Between"
+msgstr ""
 
-#: applet.js:1051
+#: 3.0/met_uk.js:414
+msgid "Good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:416
+msgid "Very good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:417
+msgid "Excellent - More than"
+msgstr ""
+
+#: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
+msgid "Mist"
+msgstr ""
+
+#: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
+msgid "Overcast"
+msgstr ""
+
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
+#, fuzzy
+msgid "Light rain shower"
+msgstr "Lette snøbyger"
+
+#: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
+msgid "Drizzle"
+msgstr "Yr"
+
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
+#, fuzzy
+msgid "Heavy rain shower"
+msgstr "Kraftig snøfall"
+
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
+#, fuzzy
+msgid "Sleet shower"
+msgstr "Spredte regnbyger"
+
+#: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
+msgid "Hail"
+msgstr "Hagl"
+
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
+#, fuzzy
+msgid "Hail shower"
+msgstr "Snøbyger"
+
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
+#, fuzzy
+msgid "Light snow shower"
+msgstr "Lette snøbyger"
+
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
+#, fuzzy
+msgid "Heavy snow shower"
+msgstr "Kraftig snøfall"
+
+#: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
+#, fuzzy
+msgid "Thunder"
+msgstr "Tordenvær"
+
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
+#, fuzzy
+msgid "Thunder shower"
+msgstr "Tordenbyger"
+
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
+msgid "Please make sure Location is in the correct format in the Settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
+msgid "Make sure you entered the correct key in settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
+msgid ""
+"Location not found, make sure location is available or it is in the correct "
+"format"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
+msgid "If this problem persists, please contact the Author of this applet"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
+msgid "Unknown Error, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
+msgid "Thunderstorm with light rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
+#, fuzzy
+msgid "Thunderstorm with rain"
+msgstr "Tordenvær"
+
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
+msgid "Thunderstorm with heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
+#, fuzzy
+msgid "Light thunderstorm"
+msgstr "Tordenvær"
+
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
+#, fuzzy
+msgid "Heavy thunderstorm"
+msgstr "Kraftig tordenvær"
+
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
+#, fuzzy
+msgid "Ragged thunderstorm"
+msgstr "Lokalt tordenvær"
+
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
+msgid "Thunderstorm with light drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
+#, fuzzy
+msgid "Thunderstorm with drizzle"
+msgstr "Tordenvær"
+
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
+msgid "Thunderstorm with heavy drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
+msgid "Light intensity drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
+msgid "Heavy intensity drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
+msgid "Light intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Drizzle rain"
+msgstr "Yr"
+
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
+msgid "Heavy intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
+#, fuzzy
+msgid "Shower rain and drizzle"
+msgstr "Regn og hagl"
+
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
+msgid "Heavy shower rain and drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
+#, fuzzy
+msgid "Shower drizzle"
+msgstr "Underkjølt yr"
+
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
+msgid "Moderate rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
+msgid "Heavy intensity rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
+msgid "Very heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
+#, fuzzy
+msgid "Extreme rain"
+msgstr "Underkjølt regn"
+
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
+#, fuzzy
+msgid "Light intensity shower rain"
+msgstr "Lette snøbyger"
+
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
+#, fuzzy
+msgid "Shower rain"
+msgstr "Regnbyger"
+
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
+msgid "Heavy intensity shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
+msgid "Ragged shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
+#, fuzzy
+msgid "Shower sleet"
+msgstr "Regnbyger"
+
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
+#, fuzzy
+msgid "Light rain and snow"
+msgstr "Regn og snø"
+
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
+#, fuzzy
+msgid "Rain and snow"
+msgstr "Regn og snø"
+
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
+#, fuzzy
+msgid "Light shower snow"
+msgstr "Lette snøbyger"
+
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
+#, fuzzy
+msgid "Shower snow"
+msgstr "Regnbyger"
+
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
+#, fuzzy
+msgid "Heavy shower snow"
+msgstr "Kraftig snøfall"
+
+#: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
+#, fuzzy
+msgid "Smoke"
+msgstr "Røyk"
+
+#: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
+msgid "Haze"
+msgstr "Dis"
+
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
+msgid "Sand, dust whirls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
+msgid "Sand"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
+msgid "Dust"
+msgstr "Støv"
+
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
+msgid "Volcanic ash"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
+msgid "Squalls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
+msgid "Tornado"
+msgstr "Tornado"
+
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
+msgid "Sky is clear"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
+#, fuzzy
+msgid "Clouds"
+msgstr "Skyet"
+
+#: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
+msgid "Few clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
+#, fuzzy
+msgid "Scattered clouds"
+msgstr "Spredte regnbyger"
+
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
+msgid "Broken clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
+msgid "Overcast clouds"
+msgstr ""
+
+#: 3.0/us_weather.js:120
+msgid "Could not get forecast for your area"
+msgstr ""
+
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
+msgid "Location is outside US, please use a different provider."
+msgstr ""
+
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
+msgid "Failed to Process Hourly Forecast Info"
+msgstr ""
+
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
+msgid "Clear and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
+msgid "Few clouds and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
+#, fuzzy
+msgid "Partly cloudy and windy"
+msgstr "Delvis skyet"
+
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
+#, fuzzy
+msgid "Mostly cloudy and windy"
+msgstr "Stort sett skyet"
+
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
+msgid "Overcast and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
+#, fuzzy
+msgid "Snowy rain"
+msgstr "Lett snøfall"
+
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
+#, fuzzy
+msgid "Freezing rain and snow"
+msgstr "Underkjølt regn"
+
+#: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
+msgid "Hurricane"
+msgstr "Orkan"
+
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
+msgid "Storm"
+msgstr ""
+
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
+msgid "Tropical storm"
+msgstr "Tropisk storm"
+
+#: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
+msgid "Hot"
+msgstr "Varmt"
+
+#: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
+msgid "Cold"
+msgstr "Kaldt"
+
+#: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
+msgid "Blizzard"
+msgstr ""
+
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
+msgid "Today"
+msgstr "I dag"
+
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
+msgid "Tomorrow"
+msgstr "I morgen"
+
+#: 3.0/utils.js:204
 msgid "Sunday"
 msgstr "søndag"
 
-#: applet.js:1056
+#: 3.0/utils.js:204
+msgid "Monday"
+msgstr "mandag"
+
+#: 3.0/utils.js:204
+msgid "Tuesday"
+msgstr "tirsdag"
+
+#: 3.0/utils.js:204
+msgid "Wednesday"
+msgstr "onsdag"
+
+#: 3.0/utils.js:204
+msgid "Thursday"
+msgstr "torsdag"
+
+#: 3.0/utils.js:204
+msgid "Friday"
+msgstr "fredag"
+
+#: 3.0/utils.js:204
+msgid "Saturday"
+msgstr "lørdag"
+
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
+msgid "Calm"
+msgstr ""
+
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
+msgid "Light air"
+msgstr ""
+
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
+msgid "Light breeze"
+msgstr ""
+
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
+msgid "Gentle breeze"
+msgstr ""
+
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
+msgid "Moderate breeze"
+msgstr ""
+
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
+msgid "Fresh breeze"
+msgstr ""
+
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
+msgid "Strong breeze"
+msgstr ""
+
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
+msgid "Near gale"
+msgstr ""
+
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
+msgid "Gale"
+msgstr ""
+
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
+msgid "Strong gale"
+msgstr ""
+
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
+msgid "Violent storm"
+msgstr ""
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeidLookup->description
-msgid "Get WOEID"
+#: 3.0/weatherbit.js:312
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://www.weatherbit.io/account/create"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->verticalOrientation->description
-msgid "Vertical orientation"
+#: 3.0/yahoo.js:78
+msgid ""
+"Unknown Error happened while calling Yahoo bridge,\n"
+" see Looking Glass log for errors"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showTextInPanel->description
-msgid "Display current temperature in panel"
+#: 3.0/yahoo.js:91
+msgid ""
+"Yahoo bridge responded in bad format,\n"
+" see Looking Glass log for errors"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeid->description
-msgid "WOEID"
+#: 3.0/yahoo.js:177
+msgid "Missing package"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeid->tooltip
-msgid "Where On Earth ID"
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+#, fuzzy
+msgid "Please install '"
+msgstr "Vent litt"
+
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+msgid "', then refresh manually."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->description
+#: 3.0/yahoo.js:182
+msgid "Could not connect to Yahoo API."
+msgstr ""
+
+#: 3.0/yahoo.js:186
+msgid ""
+"Unknown error happened while obtaining weather, see Looking Glass logs for "
+"more information"
+msgstr ""
+
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
+#, fuzzy
+msgid "Tropical Storm"
+msgstr "Tropisk storm"
+
+#: 3.0/yahoo.js:439
+#, fuzzy
+msgid "Severe Thunderstorms"
+msgstr "Kraftig tordenvær"
+
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
+msgid "Thunderstorms"
+msgstr "Tordenvær"
+
+#: 3.0/yahoo.js:441
+#, fuzzy
+msgid "Mixed Rain and Snow"
+msgstr "Regn og snø"
+
+#: 3.0/yahoo.js:442
+#, fuzzy
+msgid "Mixed Rain and Sleet"
+msgstr "Regn og sludd"
+
+#: 3.0/yahoo.js:443
+#, fuzzy
+msgid "Mixed Snow and Sleet"
+msgstr "Snø og sludd"
+
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
+#, fuzzy
+msgid "Freezing Drizzle"
+msgstr "Underkjølt yr"
+
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
+#, fuzzy
+msgid "Freezing Rain"
+msgstr "Underkjølt regn"
+
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
+msgid "Showers"
+msgstr "Regnbyger"
+
+#: 3.0/yahoo.js:449
+#, fuzzy
+msgid "Snow Flurries"
+msgstr "Lett snøfall"
+
+#: 3.0/yahoo.js:450
+#, fuzzy
+msgid "Light Snow Showers"
+msgstr "Lette snøbyger"
+
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
+#, fuzzy
+msgid "Blowing Snow"
+msgstr "Snøføyke"
+
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
+msgid "Foggy"
+msgstr "Tåke"
+
+#: 3.0/yahoo.js:458
+msgid "Smoky"
+msgstr "Røyk"
+
+#: 3.0/yahoo.js:459
+msgid "Blustery"
+msgstr "Vindbyger"
+
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
+msgid "Windy"
+msgstr "Vind"
+
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
+#, fuzzy
+msgid "Mostly Cloudy"
+msgstr "Stort sett skyet"
+
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
+#, fuzzy
+msgid "Partly Cloudy"
+msgstr "Delvis skyet"
+
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
+#, fuzzy
+msgid "Mostly Sunny"
+msgstr "Stort sett skyet"
+
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
+#, fuzzy
+msgid "Mixed Rain and Hail"
+msgstr "Regn og hagl"
+
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
+#, fuzzy
+msgid "Isolated Thunderstorms"
+msgstr "Lokalt tordenvær"
+
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
+#, fuzzy
+msgid "Scattered Thunderstorms"
+msgstr "Spredt tordenvær"
+
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
+#, fuzzy
+msgid "Scattered Showers"
+msgstr "Spredte regnbyger"
+
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
+#, fuzzy
+msgid "Heavy Rain"
+msgstr "Kraftig snøfall"
+
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
+#, fuzzy
+msgid "Scattered Snow Showers"
+msgstr "Spredte snøbyger"
+
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
+#, fuzzy
+msgid "Heavy Snow"
+msgstr "Kraftig snøfall"
+
+#: 3.0/yahoo.js:478
+#, fuzzy
+msgid "Not Available"
+msgstr "Ikke tilgjengelig"
+
+#: 3.0/yahoo.js:479
+#, fuzzy
+msgid "Scattered Thundershowers"
+msgstr "Spredt tordenvær"
+
+#: 3.8/weather-applet.js:9638
+msgid ""
+"Could not retrieve logs, log file was not found under path\n"
+" {logFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:9642
+msgid ""
+"Could not get contents of log file under path\n"
+" {logFilePath}"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10283
+msgid "Met Office UK"
+msgstr ""
+
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
+msgstr ""
+
+#: 3.8/weather-applet.js:10476
+msgid "Data was not found for location"
+msgstr ""
+
+#: 3.8/weather-applet.js:10557
+msgid "Very poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10557
+msgid "Less than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "Excellent"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "More than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566
+msgid "Poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
+msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10571
+msgid "Moderate"
+msgstr ""
+
+#: 3.8/weather-applet.js:10576
+msgid "Good"
+msgstr ""
+
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
+msgid "Very good"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10942
+msgid "OpenWeatherMap"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:11396
+msgid "MET Norway"
+msgstr ""
+
+#: 3.8/weather-applet.js:11955
+msgid "WeatherBit"
+msgstr ""
+
+#: 3.8/weather-applet.js:12386
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "I morgen"
+
+#: 3.8/weather-applet.js:12561
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12575
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12723
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:13292
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13474
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "Snøføyke"
+
+#: 3.8/weather-applet.js:13478
+#, fuzzy
+msgid "Heavy drizzle"
+msgstr "Underkjølt yr"
+
+#: 3.8/weather-applet.js:13482
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13484
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13486
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:13490
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "Underkjølt yr"
+
+#: 3.8/weather-applet.js:13492
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13494
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13496
+#, fuzzy
+msgid "Freezing fog"
+msgstr "Underkjølt regn"
+
+#: 3.8/weather-applet.js:13502
+msgid "Funnel cloud/tornado"
+msgstr ""
+
+#: 3.8/weather-applet.js:13504
+#, fuzzy
+msgid "Hail showers"
+msgstr "Snøbyger"
+
+#: 3.8/weather-applet.js:13506
+msgid "Ice"
+msgstr ""
+
+#: 3.8/weather-applet.js:13508
+msgid "Lightning without thunder"
+msgstr ""
+
+#: 3.8/weather-applet.js:13512
+msgid "Precipitation in vicinity"
+msgstr ""
+
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
+#, fuzzy
+msgid "Heavy rain and snow"
+msgstr "Regn og snø"
+
+#: 3.8/weather-applet.js:13518
+#, fuzzy
+msgid "Light rain And snow"
+msgstr "Regn og snø"
+
+#: 3.8/weather-applet.js:13526
+msgid "Sky coverage decreasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13528
+msgid "Sky coverage increasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13530
+msgid "Sky unchanged"
+msgstr ""
+
+#: 3.8/weather-applet.js:13532
+msgid "Smoke or haze"
+msgstr ""
+
+#: 3.8/weather-applet.js:13536
+#, fuzzy
+msgid "Snow and rain showers"
+msgstr "Snøbyger"
+
+#: 3.8/weather-applet.js:13548
+msgid "Thunderstorm without precipitation"
+msgstr ""
+
+#: 3.8/weather-applet.js:13550
+msgid "Diamond dust"
+msgstr ""
+
+#: 3.8/weather-applet.js:13556
+#, fuzzy
+msgid "Partially cloudy"
+msgstr "Delvis skyet"
+
+#: 3.8/weather-applet.js:13578
+msgid "Please make sure you entered the API key correctly"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:13595
+msgid "DMI Denmark"
+msgstr ""
+
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
+msgid "NOT FOUND"
+msgstr ""
+
+#: 3.8/weather-applet.js:13779
+msgid "Blowing snow"
+msgstr "Snøføyke"
+
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
+#, fuzzy
+msgid "Slight snow"
+msgstr "Snøføyke"
+
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
+#, fuzzy
+msgid "Moderate snow"
+msgstr "Kraftig snøfall"
+
+#: 3.8/weather-applet.js:13842
+#, fuzzy
+msgid "Moderate rain showers"
+msgstr "Spredte regnbyger"
+
+#: 3.8/weather-applet.js:13849
+msgid "Mixed rain and snow"
+msgstr "Regn og snø"
+
+#: 3.8/weather-applet.js:13856
+#, fuzzy
+msgid "Heavy mixed rain and snow"
+msgstr "Regn og snø"
+
+#: 3.8/weather-applet.js:14024
+msgid "AccuWeather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+msgid "Weather Underground"
+msgstr ""
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+msgid "The location you provided was not found."
+msgstr ""
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+msgid "Strong Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "Regn og snø"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "Regn og sludd"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "Snøbyger"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "Stort sett skyet"
+
+#: 3.8/weather-applet.js:15247
+msgid "Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:15603
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+
+#: 3.8/weather-applet.js:15831
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+
+#: 3.8/weather-applet.js:15968
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:15975
+msgid ""
+"Could not get contents of config file under path\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr ""
+
+#: 3.8/weather-applet.js:16675
+msgid "Dew Point"
+msgstr ""
+
+#: 3.8/weather-applet.js:16747
+msgid "Precipitation will end in {precipEnd} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16749
+msgid "Precipitation won't end in within an hour"
+msgstr ""
+
+#: 3.8/weather-applet.js:16752
+msgid "Precipitation will start within {precipStart} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16964
+msgid "Forecast parsing failed, see logs for more details."
+msgstr ""
+
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
+msgid "As of {lastUpdatedTime}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17502
+msgid "{distance} {distanceUnit} from you"
+msgstr ""
+
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
+msgid "Error Saving Debug Information"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Debug Information saved successfully"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Saved to {filePath}"
+msgstr ""
+
+#: 3.8/LogSaver.py:16
+msgid "Save to File"
+msgstr ""
+
+#: 3.8/LogSaver.py:29
+msgid "Select a destination"
+msgstr ""
+
+#. metadata.json->name
+#. 3.8->settings-schema.json->providers->title
+msgid "Weather"
+msgstr ""
+
+#. metadata.json->description
+msgid "View your local weather forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->head->description
+msgid "Settings for weather@mockturtl 3.0+"
+msgstr ""
+
+#. 3.0->settings-schema.json->keybinding->description
+#. 3.8->settings-schema.json->keybinding->description
+msgid "Set the keybinding to call the menu"
+msgstr ""
+
+#. 3.0->settings-schema.json->descriptions->description
+msgid "Weather service information"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->description
+msgid "Click here for detailed description"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->tooltip
+#. 3.0->settings-schema.json->getLocation->tooltip
+#. 3.8->settings-schema.json->getLocation->tooltip
+msgid "Opens webpage guide"
+msgstr ""
+
+#. 3.0->settings-schema.json->providerSettings->description
+#. 3.8->settings-schema.json->provider-options->title
+msgid "Weather Provider Options"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->description
+#. 3.8->settings-schema.json->dataService->description
+msgid "Data service"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "DarkSky (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weatherbit (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Yahoo"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Climacell (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->description
+#. 3.8->settings-schema.json->apiKey->description
+msgid "API Key"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->tooltip
+#. 3.8->settings-schema.json->apiKey->tooltip
+msgid "Copy this from your account of the used Data service and paste it here."
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->description
+#. 3.8->settings-schema.json->manualLocation->description
+msgid "Manual Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->tooltip
+#. 3.8->settings-schema.json->manualLocation->tooltip
+msgid "Enable this if your location is not accurate"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->description
+msgid "Location - Coordinates"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->tooltip
+msgid ""
+"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an "
+"address.\n"
+"Waits for 3 seconds after you stop typing before refreshes the weather."
+msgstr ""
+
+#. 3.0->settings-schema.json->getLocation->description
+msgid "Setup API Key and Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->units
+#. 3.8->settings-schema.json->refreshInterval->units
+msgid "minutes"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->description
+#. 3.8->settings-schema.json->refreshInterval->description
+msgid "Update interval"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastDays->units
+#. 3.8->settings-schema.json->forecastDays->units
+msgid "days"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastDays->description
+#. 3.8->settings-schema.json->forecastDays->description
+msgid "Forecast length"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastHours->units
+#. 3.8->settings-schema.json->forecastHours->units
+msgid "hours"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastHours->description
+#. 3.8->settings-schema.json->forecastHours->description
+msgid "Hourly Forecast length"
+msgstr ""
+
+#. 3.0->settings-schema.json->unitSettings->description
+msgid "Units"
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureUnit->description
+#. 3.8->settings-schema.json->temperatureUnit->description
 #, fuzzy
 msgid "Temperature unit"
 msgstr "Temperatur:"
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "fahrenheit"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Automatic"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "celsius"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+msgid "Celsius"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->translateCondition->description
-msgid "Translate condition"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+msgid "Fahrenheit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->locationLabelOverride->description
-msgid "Override location label"
+#. 3.0->settings-schema.json->temperatureUnit->tooltip
+#. 3.0->settings-schema.json->distanceUnit->tooltip
+#. 3.8->settings-schema.json->temperatureUnit->tooltip
+#. 3.8->settings-schema.json->distanceUnit->tooltip
+msgid ""
+"Automatic will try to guess your preference based your current display "
+"language."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->show24Hours->description
-msgid "Display time in 24 hour format"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->forecastDays->description
-msgid "Forecast length"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->forecastDays->units
-msgid "days"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->showSunrise->description
-msgid "Show sunrise / sunset times"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->description
+#. 3.0->settings-schema.json->windSpeedUnit->description
+#. 3.8->settings-schema.json->windSpeedUnit->description
 msgid "Wind speed unit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
 msgid "kph"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "m/s"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "knots"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
 msgid "mph"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showCommentInPanel->description
-msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "m/s"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->description
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "knots"
+msgstr ""
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "Beaufort"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->description
+#. 3.8->settings-schema.json->pressureUnit->description
 msgid "Atmospheric pressure unit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "psi"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "hPa"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "atm"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "kPa"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "Pa"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mm Hg"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "at"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mbar"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
 msgid "in Hg"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->description
-msgid "Update interval"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "mm Hg"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->units
-msgid "minutes"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "psi"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->useSymbolicIcons->description
-msgid "Symbolic icons"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "at"
 msgstr ""
 
-#. cinnamon-weather->metadata.json->description
-msgid "View your local weather forecast"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "atm"
 msgstr ""
 
-#. cinnamon-weather->metadata.json->name
-msgid "Weather"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "Pa"
 msgstr ""
 
-#~ msgid "Please wait"
-#~ msgstr "Vent litt"
+#. 3.0->settings-schema.json->distanceUnit->description
+#. 3.8->settings-schema.json->distanceUnit->description
+msgid "Distance unit"
+msgstr ""
 
-#~ msgid "Today"
-#~ msgstr "I dag"
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Metric"
+msgstr ""
 
-#~ msgid "Tomorrow"
-#~ msgstr "I morgen"
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Imperial"
+msgstr ""
+
+#. 3.0->settings-schema.json->panelSettings->description
+msgid "Panel options"
+msgstr ""
+
+#. 3.0->settings-schema.json->showTextInPanel->description
+#. 3.8->settings-schema.json->showTextInPanel->description
+msgid "Display current temperature in panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->showCommentInPanel->description
+#. 3.8->settings-schema.json->showCommentInPanel->description
+msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->showCommentInPanel->tooltip
+#. 3.8->settings-schema.json->showCommentInPanel->tooltip
+msgid "Only works with horizontal panels"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempTextOverride->description
+#. 3.8->settings-schema.json->tempTextOverride->description
+msgid "Override label on panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.0->settings-schema.json->useCustomMenuIcons->tooltip
+#. 3.8->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.8->settings-schema.json->useCustomMenuIcons->tooltip
+msgid "Iconset is weather-icons by Erik Flowers"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->description
+#. 3.8->settings-schema.json->useCustomAppletIcons->description
+msgid "Use custom icons on the panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->displaySettings->description
+#. 3.8->settings-schema.json->presentation-section->title
+msgid "Presentation"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->description
+#. 3.8->settings-schema.json->verticalOrientation->description
+msgid "Show forecast vertically"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->units
+#. 3.8->settings-schema.json->forecastColumns->units
+msgid "columns"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->description
+#. 3.8->settings-schema.json->forecastColumns->description
+msgid "Maximum number of columns for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->units
+#. 3.8->settings-schema.json->forecastRows->units
+msgid "rows"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->description
+#. 3.8->settings-schema.json->forecastRows->description
+msgid "Maximum number of rows for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->showSunrise->description
+#. 3.8->settings-schema.json->showSunrise->description
+msgid "Show sunrise / sunset times"
+msgstr ""
+
+#. 3.0->settings-schema.json->show24Hours->description
+#. 3.8->settings-schema.json->show24Hours->description
+msgid "Display time in 24 hour format"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->description
+#. 3.8->settings-schema.json->shortHourlyTime->description
+msgid "Only display hours for hourly forecast time"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->tooltip
+#. 3.8->settings-schema.json->shortHourlyTime->tooltip
+msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->description
+#. 3.8->settings-schema.json->showForecastDates->description
+msgid "Display date for daily forecasts"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->tooltip
+#. 3.8->settings-schema.json->showForecastDates->tooltip
+msgid "Like \"Friday 15\""
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureHighFirst->description
+#. 3.8->settings-schema.json->temperatureHighFirst->description
+msgid "Show high temperature first in forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempRussianStyle->description
+#. 3.8->settings-schema.json->tempRussianStyle->description
+#, fuzzy
+msgid "Show temperature Russian style"
+msgstr "Temperatur:"
+
+#. 3.0->settings-schema.json->locationLabelOverride->description
+#. 3.8->settings-schema.json->locationLabelOverride->description
+msgid "Override location label"
+msgstr ""
+
+#. 3.0->settings-schema.json->conditionSettings->description
+#. 3.8->settings-schema.json->weather-conditions->title
+msgid "Weather conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->translateCondition->description
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Translate conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortConditions->description
+#. 3.8->settings-schema.json->shortConditions->description
+msgid "Less verbose conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->iconSettings->description
+#. 3.8->settings-schema.json->icons->title
+msgid "Icons"
+msgstr ""
+
+#. 3.0->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons in the applet"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomMenuIcons->description
+#. 3.8->settings-schema.json->useCustomMenuIcons->description
+msgid "Use custom icons in the popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->locations-page->title
+#. 3.8->settings-schema.json->location->description
+msgid "Location"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-page->title
+msgid "Other options"
+msgstr ""
+
+#. 3.8->settings-schema.json->info-section->title
+msgid "Help"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-section->title
+msgid "Location settings"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-store->title
+msgid "Saved Locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->panel-options->title
+msgid "Panel (Taskbar)"
+msgstr ""
+
+#. 3.8->settings-schema.json->presentation->title
+msgid "Popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-section->title
+msgid "Other Units"
+msgstr ""
+
+#. 3.8->settings-schema.json->temp-unit-section->title
+#, fuzzy
+msgid "Temperature Unit"
+msgstr "Temperatur:"
+
+#. 3.8->settings-schema.json->keybindings->title
+msgid "Keybindings"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info->title
+msgid "More about the Weather applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->submit-issue->title
+msgid "Report an issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->debug-options->title
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Debug"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->tooltip
+msgid ""
+"You can choose between several different weather forecast providers. Some "
+"providers require a API key to work, some have regional limits, differ in "
+"forecast length, and they all need a functional internet connection to work. "
+"The options are described in detail on the Cinnamon Spices Website which you "
+"can access with the button on the Help tab."
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Met Office UK (UK only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "US National Weather (US only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Pirate Weather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Visual Crossing (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Tomorrow.io (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "AccuWeather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weather Underground (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->location->tooltip
+msgid ""
+"You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use "
+"'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street} "
+"{City/Town} {Postcode} {Country}. The search algorithm is very flexible with "
+"the format. After 3 seconds without typing the address you entered is "
+"replaced automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->description
+msgid "Save current location to storage"
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->tooltip
+msgid ""
+"Saves location information to file so you can switch between them with "
+"buttons in the applet, which will appear if you have more than one."
+msgstr ""
+
+#. 3.8->settings-schema.json->getLocation->description
+msgid "Weather Applet at Cinnamon Spices Website"
+msgstr ""
+
+#. 3.8->settings-schema.json->refreshInterval->tooltip
+msgid ""
+"If you are using a provider with API keys set it to an interval you won't "
+"run out of your quota with."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastDays->tooltip
+msgid ""
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->description
+msgid "Enable minutely precipitation forecast"
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->tooltip
+msgid ""
+"If you'd like to use this make sure you use your exact coordinates/address "
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
+msgstr ""
+
+#. 3.8->settings-schema.json->showBothTempUnits->description
+msgid "Show both temperature units at the same time"
+msgstr ""
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+msgid "Override tooltip on panel"
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
+msgid "Always show Hourly Weather"
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->tooltip
+msgid ""
+"Hide/Show button will be hidden and Hourly weather will be permanently "
+"visible."
+msgstr ""
+
+#. 3.8->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->description
+msgid "Your saved locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->tooltip
+msgid ""
+"You have to make sure the Search entry field is unique and your Timezone is "
+"in the IANA time zone format (e.g. 'Europe/London')"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Latitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Longitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "City"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Country"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Timezone"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Search entry"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->description
+msgid "Display wind direction as text"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->tooltip
+msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->tooltip
+msgid "Does not apply to custom iconset, that is symbolic by default"
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons throughout the applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info-label->description
+msgid ""
+"For detailed information about the applet please go to the Spices Website to "
+"find info about known issues, troubleshooting, changelog and more by "
+"clicking the button below. Here you can ask questions etc in the comment "
+"section by logging in with your Github account."
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->description
+msgid "Submit an Issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->tooltip
+msgid ""
+"Opens webpage where you can fill out a new issue for the applet, needs a "
+"GitHub account.\n"
+" Please make sure that the issue is not already submitted."
+msgstr ""
+
+#. 3.8->settings-schema.json->maintainer->description
+msgid "Current maintainer: Gr3q"
+msgstr ""
+
+#. 3.8->settings-schema.json->issue-reporting-explanation->description
+msgid ""
+"If you find an issue with this applet please make a report by clicking on "
+"the button below and login in with your Github account.\n"
+"\n"
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
+msgstr ""
+
+#. 3.8->settings-schema.json->loc-info->description
+msgid ""
+"Your location in most cases work automatically but you can enter it manually "
+"by coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,"
+"Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/"
+"Town} {Postcode} {Country}. The search algorithm is very flexible with the "
+"format. After 3 seconds without typing the address you entered is replaced "
+"automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->description
+msgid "Log Level"
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->tooltip
+msgid ""
+"Info is the regular logging, Debug is debug, and Verbose also logs network "
+"request payloads. Changing this will only be effective on future logs. Only "
+"change it you are instructed or you know what you are doing."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Verbose"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->description
+msgid "Click Save to save debug information to a file"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->tooltip
+msgid ""
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
+msgstr ""
+
+#. 3.8->settings-schema.json->selectedLogPath->description
+msgid "Selected path to save Logs"
+msgstr ""

--- a/weather@mockturtl/files/weather@mockturtl/po/nl.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/nl.po
@@ -7,8 +7,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: cinnamon-weather (weather@mockturtl or Weather)\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-01 22:49+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2024-02-23 23:47+0100\n"
 "Last-Translator: Pjotr <pjotrvertaalt@gmail.com>\n"
 "Language-Team: Dutch\n"
@@ -20,65 +21,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17615
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Fout"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17616 3.8/weather-applet.js:17618
-#: 3.8/weather-applet.js:17620 3.8/weather-applet.js:17623
-#: 3.8/weather-applet.js:17626 3.8/weather-applet.js:17627
-#: 3.8/weather-applet.js:17628 3.8/weather-applet.js:17629
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Dienstfout"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17617
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Verkeerde API-sleutel"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17619
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Onjuiste locatie-opmaak"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17621
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Sleutel geblokkeerd"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17622
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Kan locatie niet vinden"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17624
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Geen API-sleutel"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17625
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Geen locatie"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17630
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Ontbrekende pakketten"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17631
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Locatie niet gedekt"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9711
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Werkbalkhulpje voor weer"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17929
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17930
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Klik om te openen"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16220
-#: 3.8/weather-applet.js:17933
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Verversen"
 
@@ -88,8 +89,8 @@ msgstr "API retourneerde statuscode tussen 400 en 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Locatie-opslag"
 
@@ -101,13 +102,13 @@ msgstr "U kunt een automatisch verkregen locatie helaas niet opslaan"
 msgid "Could not get weather information"
 msgstr "Kon geen weersinformatie verkrijgen voor uw gebied"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17768
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Onverwachte fout tijdens verversen, zie a.u.b. logboek in Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:18011
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -123,7 +124,7 @@ msgstr "Netwerkfout, controleer a.u.b. de logboeken in Looking Glass"
 msgid "As of"
 msgstr "Met ingang van"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:17011
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Mogelijk gemaakt door"
 
@@ -131,52 +132,52 @@ msgstr "Mogelijk gemaakt door"
 msgid "from you"
 msgstr "van u"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16924
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:16924
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10312
-#: 3.8/weather-applet.js:17089
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10313
-#: 3.8/weather-applet.js:17090
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17267
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Huidig weer aan het laden..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17270
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Weersverwachting aan het laden..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16173
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Bezig met laden..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16194
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Temperatuur"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16195
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Luchtvochtigheid"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16196
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Luchtdruk"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12257 3.8/weather-applet.js:12263
-#: 3.8/weather-applet.js:14217 3.8/weather-applet.js:14218
-#: 3.8/weather-applet.js:16042
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Wind"
 
@@ -186,37 +187,36 @@ msgstr ""
 "Zorg ervoor dat u een locatie hebt ingevoerd of gebruik in plaats daarvan "
 "Automatische locatie"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9952
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Kon geen locatie vinden op basis van adres, controleer a.u.b. of het juist is"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9973
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "Geolocatie-API aanroepen is mislukt, zie Looking Glass voor fouten."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Waarschuwing"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9872
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "U kunt alleen correcte locaties opslaan wanneer het werkbalkhulpje niet "
 "wordt ververst"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "U kunt een foutieve locatie niet opslaan"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9880
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Informatie"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Locatie is reeds opgeslagen"
 
@@ -255,15 +255,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10740 3.8/weather-applet.js:11711
-#: 3.8/weather-applet.js:12150 3.8/weather-applet.js:12659
-#: 3.8/weather-applet.js:13021 3.8/weather-applet.js:14388
-#: 3.8/weather-applet.js:14928
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Voelt als"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:14990
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Kon weersinformatie niet verwerken"
 
@@ -276,7 +276,7 @@ msgstr ""
 "of verkrijg er eerst een op https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:14870
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -284,7 +284,7 @@ msgstr ""
 "Zorg er a.u.b. voor dat u\n"
 "de API-sleutel correct hebt ingevoerd en dat uw account niet is vergrendeld"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12113
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -295,60 +295,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10516 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10530 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:11379 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:11386 3.8/weather-applet.js:11393
-#: 3.8/weather-applet.js:11400 3.8/weather-applet.js:12292
-#: 3.8/weather-applet.js:13187
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Zware regenval"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11554 3.8/weather-applet.js:11555
-#: 3.8/weather-applet.js:11561 3.8/weather-applet.js:12277
-#: 3.8/weather-applet.js:12278 3.8/weather-applet.js:12284
-#: 3.8/weather-applet.js:12291 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12340 3.8/weather-applet.js:12347
-#: 3.8/weather-applet.js:12801 3.8/weather-applet.js:12850
-#: 3.8/weather-applet.js:12851 3.8/weather-applet.js:12858
-#: 3.8/weather-applet.js:13179 3.8/weather-applet.js:13448
-#: 3.8/weather-applet.js:13449 3.8/weather-applet.js:13490
-#: 3.8/weather-applet.js:14189 3.8/weather-applet.js:14190
-#: 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Regen"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10495 3.8/weather-applet.js:10509
-#: 3.8/weather-applet.js:10510 3.8/weather-applet.js:11009
-#: 3.8/weather-applet.js:11463 3.8/weather-applet.js:11464
-#: 3.8/weather-applet.js:11470 3.8/weather-applet.js:11477
-#: 3.8/weather-applet.js:11484 3.8/weather-applet.js:12285
-#: 3.8/weather-applet.js:13189
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Lichte regenval"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12348 3.8/weather-applet.js:13163
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Zware ijzel"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11014
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12822
-#: 3.8/weather-applet.js:12823 3.8/weather-applet.js:12829
-#: 3.8/weather-applet.js:12830 3.8/weather-applet.js:12836
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "IJzel"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12341 3.8/weather-applet.js:13165
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Lichte ijzel"
 
@@ -356,177 +356,177 @@ msgstr "Lichte ijzel"
 msgid "Light freezing drizzle"
 msgstr "Lichte motregenijzel"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12327
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Motregenijzel"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13145
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Lichte motregen"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12362
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Grote hagelstenen"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12354 3.8/weather-applet.js:12355
-#: 3.8/weather-applet.js:12361 3.8/weather-applet.js:12368
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Hagelstenen"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12369
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Kleine hagelstenen"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10600
-#: 3.8/weather-applet.js:10607 3.8/weather-applet.js:10614
-#: 3.8/weather-applet.js:10615 3.8/weather-applet.js:11021
-#: 3.8/weather-applet.js:11435 3.8/weather-applet.js:11436
-#: 3.8/weather-applet.js:11442 3.8/weather-applet.js:11449
-#: 3.8/weather-applet.js:11456 3.8/weather-applet.js:12320
-#: 3.8/weather-applet.js:13205 3.8/weather-applet.js:13525
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Zware sneeuwval"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:11610
-#: 3.8/weather-applet.js:11611 3.8/weather-applet.js:11617
-#: 3.8/weather-applet.js:12298 3.8/weather-applet.js:12299
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12795
-#: 3.8/weather-applet.js:13199 3.8/weather-applet.js:13434
-#: 3.8/weather-applet.js:13518 3.8/weather-applet.js:14203
-#: 3.8/weather-applet.js:14204 3.8/weather-applet.js:14581
-#: 3.8/weather-applet.js:14582
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Sneeuw"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11019
-#: 3.8/weather-applet.js:11519 3.8/weather-applet.js:11520
-#: 3.8/weather-applet.js:11526 3.8/weather-applet.js:11533
-#: 3.8/weather-applet.js:11540 3.8/weather-applet.js:12313
-#: 3.8/weather-applet.js:13207
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Lichte sneeuwval"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12305
-#: 3.8/weather-applet.js:12306 3.8/weather-applet.js:14560
-#: 3.8/weather-applet.js:14561
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Stuifsneeuw"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:12375 3.8/weather-applet.js:12376
-#: 3.8/weather-applet.js:12867 3.8/weather-applet.js:12868
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13532
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:14210
-#: 3.8/weather-applet.js:14211
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Onweer"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12243
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Lichte mist"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11372
-#: 3.8/weather-applet.js:11373 3.8/weather-applet.js:12235
-#: 3.8/weather-applet.js:12236 3.8/weather-applet.js:12242
-#: 3.8/weather-applet.js:12937 3.8/weather-applet.js:12938
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:14161
-#: 3.8/weather-applet.js:14162 3.8/weather-applet.js:14609
-#: 3.8/weather-applet.js:14610
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Mist"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10474 3.8/weather-applet.js:10475
-#: 3.8/weather-applet.js:11358 3.8/weather-applet.js:11359
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:12208
-#: 3.8/weather-applet.js:13427 3.8/weather-applet.js:13428
-#: 3.8/weather-applet.js:14154 3.8/weather-applet.js:14155
-#: 3.8/weather-applet.js:14651 3.8/weather-applet.js:14652
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Bewolkt"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12228
-#: 3.8/weather-applet.js:12229 3.8/weather-applet.js:12745
-#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:12780
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Overwegend bewolkt"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10439
-#: 3.8/weather-applet.js:10440 3.8/weather-applet.js:10446
-#: 3.8/weather-applet.js:10447 3.8/weather-applet.js:11547
-#: 3.8/weather-applet.js:11548 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12222 3.8/weather-applet.js:12738
-#: 3.8/weather-applet.js:12739 3.8/weather-applet.js:12773
-#: 3.8/weather-applet.js:13420 3.8/weather-applet.js:13421
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Deels bewolkt"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Overwegend helder"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10425 3.8/weather-applet.js:10426
-#: 3.8/weather-applet.js:11039 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:12724
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12759
-#: 3.8/weather-applet.js:13223 3.8/weather-applet.js:13413
-#: 3.8/weather-applet.js:13414 3.8/weather-applet.js:14140
-#: 3.8/weather-applet.js:14141 3.8/weather-applet.js:14147
-#: 3.8/weather-applet.js:14148 3.8/weather-applet.js:14686
-#: 3.8/weather-applet.js:14687
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Helder"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10432
-#: 3.8/weather-applet.js:10433 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:14693
-#: 3.8/weather-applet.js:14694
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Zonnig"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10418
-#: 3.8/weather-applet.js:10419 3.8/weather-applet.js:10453
-#: 3.8/weather-applet.js:10454 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10643 3.8/weather-applet.js:11341
-#: 3.8/weather-applet.js:11342 3.8/weather-applet.js:11639
-#: 3.8/weather-applet.js:11640 3.8/weather-applet.js:12192
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12715
-#: 3.8/weather-applet.js:12716 3.8/weather-applet.js:12944
-#: 3.8/weather-applet.js:12945 3.8/weather-applet.js:14073
-#: 3.8/weather-applet.js:14074 3.8/weather-applet.js:14224
-#: 3.8/weather-applet.js:14225 3.8/weather-applet.js:14797
-#: 3.8/weather-applet.js:14799
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Onbekend"
 
@@ -550,7 +550,7 @@ msgstr ""
 "Voer a.u.b. de API-sleutel in de instellingen in,\n"
 "of verkrijg er eerst een op https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:14880
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -558,7 +558,7 @@ msgstr ""
 "Zorg er a.u.b. voor dat u\n"
 "de API-sleutel van DarkSky hebt ingevoerd"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:15196
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Kon locatie niet verkrijgen"
 
@@ -568,121 +568,121 @@ msgid ""
 msgstr ""
 "Locatiedienst reageerde met fouten, zie a.u.b. de logboeken in Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11203
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Bewolking"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11351
-#: 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Heldere lucht"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11365 3.8/weather-applet.js:11366
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Mooi"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11387
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Zware regenval en onweer"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11394
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Zware regenbuien"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11401
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Zware regenbuien en onweer"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11407
-#: 3.8/weather-applet.js:11408 3.8/weather-applet.js:11414
-#: 3.8/weather-applet.js:11421 3.8/weather-applet.js:11428
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Zware hagelbuien"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11415
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Zware hagelbuien met onweer"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11422
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Zware hagelbuien"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11429
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Zware hagelbuien en onweer"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11443
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Zware sneeuwval en onweer"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11450
-#: 3.8/weather-applet.js:13526
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Zware sneeuwbuien"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11457
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Zware sneeuwbuien en onweer"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11471
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Lichte regen en onweer"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11478
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Lichte regenbuien"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11485
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Lichte regenbuien en onweer"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11491
-#: 3.8/weather-applet.js:11492 3.8/weather-applet.js:11498
-#: 3.8/weather-applet.js:11505 3.8/weather-applet.js:11512
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Lichte hagelbui"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11499
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Lichte hagelbui en onweer"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11506
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Lichte hagelbuien"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11513
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Lichte hagelbuien en onweer"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11527
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Lichte sneeuwval en onweer"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11534
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Lichte sneeuwbuien"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11541
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Lichte sneeuwbuien en onweer"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11562
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Regen en onweer"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11568
-#: 3.8/weather-applet.js:11569 3.8/weather-applet.js:11575
-#: 3.8/weather-applet.js:12859 3.8/weather-applet.js:13185
-#: 3.8/weather-applet.js:13491 3.8/weather-applet.js:13497
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Regenbuien"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11576
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Regenbuien en onweer"
 
@@ -691,44 +691,44 @@ msgstr "Regenbuien en onweer"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10537
-#: 3.8/weather-applet.js:10544 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11582 3.8/weather-applet.js:11583
-#: 3.8/weather-applet.js:11589 3.8/weather-applet.js:11596
-#: 3.8/weather-applet.js:11603 3.8/weather-applet.js:12808
-#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12815
-#: 3.8/weather-applet.js:12816 3.8/weather-applet.js:12843
-#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14196
-#: 3.8/weather-applet.js:14197 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Hagel"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11590
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Hagel en onweer"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11597
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Hagelbuien"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11604
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Hagelbuien en onweer"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11618
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Sneeuw en onweer"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11624 3.8/weather-applet.js:11625
-#: 3.8/weather-applet.js:11631 3.8/weather-applet.js:13203
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Sneeuwbuien"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11632
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Sneeuwbuien en onweer"
 
@@ -737,21 +737,21 @@ msgstr "Sneeuwbuien en onweer"
 msgid "Unexpected response from API"
 msgstr "Onverwachte respons van de API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10237
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Zicht"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10265
-#: 3.8/weather-applet.js:10817 3.8/weather-applet.js:11722
-#: 3.8/weather-applet.js:12672
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Kon de huidige weerinformatie niet verwerken"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10055
-#: 3.8/weather-applet.js:10089 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11782 3.8/weather-applet.js:12474
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Kon voorspellingsinformatie niet verwerken"
 
@@ -780,88 +780,88 @@ msgid "Excellent - More than"
 msgstr "Uitstekend - Meer dan"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10460 3.8/weather-applet.js:10461
-#: 3.8/weather-applet.js:11029 3.8/weather-applet.js:13175
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Mist"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:12752
-#: 3.8/weather-applet.js:12753 3.8/weather-applet.js:12787
-#: 3.8/weather-applet.js:13219
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Zwaar bewolkt"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10489
-#: 3.8/weather-applet.js:10496
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Lichte regenbui"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:12326
-#: 3.8/weather-applet.js:13141 3.8/weather-applet.js:14532
-#: 3.8/weather-applet.js:14533
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Motregen"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:10524
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Zware regenbui"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10538
-#: 3.8/weather-applet.js:10545
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Natte-sneeuwbui"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:13217 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14169 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:14589
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Hagel"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Hagelbui"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Lichte sneeuwbui"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Zware sneeuwbui"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10621 3.8/weather-applet.js:10628
-#: 3.8/weather-applet.js:10635 3.8/weather-applet.js:10636
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Onweer"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Onweersbui"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10872
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Zorg a.u.b. voor de juiste locatie-opmaak in de instellingen"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10876
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Zorg a.u.b. voor de juiste sleutel in de instellingen"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10681 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -869,213 +869,213 @@ msgstr ""
 "Locatie niet gevonden, zorg ervoor dat de locatie beschikbaar is en in de "
 "juiste opmaak is ingevoerd"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10884
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 "Als dit probleem aanhoudt, neem dan a.u.b. contact op met de maker van dit "
 "werkbalkhulpje"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10888
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Onbekende fout, zie a.u.b. de logboeken in Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10990
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Onweersbui met lichte regen"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10991
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Onweersbui met regen"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10992
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Onweersbui met zware regenval"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10993
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Lichte onweersbui"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10995
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Zware onweersbui"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10996
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Plaatselijke onweersbui"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10997
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Onweersbui met lichte motregen"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10998
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Onweersbui met motregen"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10999
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Onweersbui met zware motregen"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11000
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Motregen met lichte intensiteit"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11002
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Motregen met zware intensiteit"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11003
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Motregen met lichte intensiteit"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11004
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Motregen"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11005
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Motregen met zware intensiteit"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11006
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Regen- en motregenbuien"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11007
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Zware regen- en motregenbuien"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11008
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Motregenbuien"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11010
-#: 3.8/weather-applet.js:13455 3.8/weather-applet.js:13456
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Matige regenval"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11011
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Zware regenval"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11012
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Zeer zware regenval"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11013
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Extreme regenval"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11015
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Lichte regenbuien"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11016
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Regenbuien"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11017
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Zware regenbuien"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11018
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Verspreide regenbuien"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11023
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Hagelbuien"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11024
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Lichte regen- en sneeuwval"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11025
-#: 3.8/weather-applet.js:13462 3.8/weather-applet.js:13463
-#: 3.8/weather-applet.js:13469 3.8/weather-applet.js:13504
-#: 3.8/weather-applet.js:13511
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Regen en sneeuw"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11026
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Lichte sneeuwbuien"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11027
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Sneeuwbuien"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11028
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Zware sneeuwbuien"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:12902
-#: 3.8/weather-applet.js:12903 3.8/weather-applet.js:14623
-#: 3.8/weather-applet.js:14624
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Rook"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11031 3.8/weather-applet.js:12909
-#: 3.8/weather-applet.js:12910 3.8/weather-applet.js:14616
-#: 3.8/weather-applet.js:14617
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Nevel"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11032
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Zand- en stofwervelwinden"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11034
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Zand"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11035 3.8/weather-applet.js:12895
-#: 3.8/weather-applet.js:12896 3.8/weather-applet.js:14602
-#: 3.8/weather-applet.js:14603
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Stof"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11036
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Vulkanische as"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:13209
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Windstoten"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11038 3.8/weather-applet.js:12874
-#: 3.8/weather-applet.js:12875 3.8/weather-applet.js:14475
-#: 3.8/weather-applet.js:14476
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Wervelwind"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11041
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Lucht is helder"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11042
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Wolken"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11043
-#: 3.8/weather-applet.js:12731 3.8/weather-applet.js:12732
-#: 3.8/weather-applet.js:12766
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Weinig bewolking"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11044
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Verspreide bewolking"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11045
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Wisselend bewolkt"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11046
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Laaghangende bewolking"
 
@@ -1083,80 +1083,80 @@ msgstr "Laaghangende bewolking"
 msgid "Could not get forecast for your area"
 msgstr "Kon geen voorspelling krijgen voor uw gebied"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12431
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "Locatie is buiten de VS, maak a.u.b. gebruik van een andere aanbieder."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12495
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Kon uurlijkse voorspellingsinformatie niet verwerken"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12760
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Helder en winderig"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12767
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Weinig bewolking en winderig"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12774
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Deels bewolkt en winderig"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Overwegend bewolkt en winderig"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12788
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Zwaar bewolkt en winderig"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12802
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Natte sneeuw"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12837
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "IJzel en sneeuw"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9153 3.8/weather-applet.js:12881
-#: 3.8/weather-applet.js:12882 3.8/weather-applet.js:14489
-#: 3.8/weather-applet.js:14490
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Orkaan"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9148
-#: 3.8/weather-applet.js:12888
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Storm"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12889
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Tropische storm"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12916 3.8/weather-applet.js:12917
-#: 3.8/weather-applet.js:14721 3.8/weather-applet.js:14722
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Zeer warm"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12923 3.8/weather-applet.js:12924
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Koud"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12930 3.8/weather-applet.js:12931
-#: 3.8/weather-applet.js:14770 3.8/weather-applet.js:14771
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Sneeuwstorm"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9025
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Vandaag"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9027
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Morgen"
 
@@ -1188,79 +1188,79 @@ msgstr "Vrijdag"
 msgid "Saturday"
 msgstr "Zaterdag"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9118
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Rustig"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9121
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Zeer licht briesje"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9124
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Licht briesje"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9127
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Zacht briesje"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9130
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Gematigd briesje"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9133
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Fris briesje"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9136
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Sterk briesje"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9139
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Bijna storm"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9142
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Storm"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9145
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Harde storm"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9151
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Heftige storm"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "NO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "O"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "ZO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "Z"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "ZW"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "W"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "NW"
 
@@ -1312,7 +1312,7 @@ msgstr ""
 "Onbekende fout trad op tijdens het verkrijgen van het weer, zie Looking "
 "Glass-logboeken voor meer informatie"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14482 3.8/weather-applet.js:14483
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Tropische storm"
 
@@ -1320,7 +1320,7 @@ msgstr "Tropische storm"
 msgid "Severe Thunderstorms"
 msgstr "Zware onweersbuien"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14503 3.8/weather-applet.js:14504
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Onweersbuien"
 
@@ -1336,15 +1336,15 @@ msgstr "Mengsel van regen en hagel"
 msgid "Mixed Snow and Sleet"
 msgstr "Mengsel van sneeuw en hagel"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Motregenijzel"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "IJzel"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Buien"
 
@@ -1356,11 +1356,11 @@ msgstr "Sneeuwvlagen"
 msgid "Light Snow Showers"
 msgstr "Lichte sneeuwbuien"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14574 3.8/weather-applet.js:14575
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Stuifsneeuw"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13441 3.8/weather-applet.js:13442
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Mistig"
 
@@ -1372,54 +1372,54 @@ msgstr "Rokerig"
 msgid "Blustery"
 msgstr "Onstuimig"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14637 3.8/weather-applet.js:14638
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Winderig"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:14658 3.8/weather-applet.js:14659
-#: 3.8/weather-applet.js:14665 3.8/weather-applet.js:14666
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Overwegend bewolkt"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14175 3.8/weather-applet.js:14176
-#: 3.8/weather-applet.js:14182 3.8/weather-applet.js:14183
-#: 3.8/weather-applet.js:14672 3.8/weather-applet.js:14673
-#: 3.8/weather-applet.js:14679 3.8/weather-applet.js:14680
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Deels bewolkt"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Overwegend zonnig"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:14714 3.8/weather-applet.js:14715
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Mengsel van regen en hagel"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:14728 3.8/weather-applet.js:14729
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Plaatselijke onweersbuien"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:14735 3.8/weather-applet.js:14736
-#: 3.8/weather-applet.js:14791 3.8/weather-applet.js:14792
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Verspreide onweersbuien"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:14742 3.8/weather-applet.js:14743
-#: 3.8/weather-applet.js:14777 3.8/weather-applet.js:14778
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Verspreide buien"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:14749 3.8/weather-applet.js:14750
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Zware regenval"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:14756 3.8/weather-applet.js:14757
-#: 3.8/weather-applet.js:14784 3.8/weather-applet.js:14785
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Verspreide sneeuwbuien"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:14763 3.8/weather-applet.js:14764
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Zware sneeuwval"
 
@@ -1431,7 +1431,7 @@ msgstr "Niet beschikbaar"
 msgid "Scattered Thundershowers"
 msgstr "Verspreide onweersbuien"
 
-#: 3.8/weather-applet.js:9637
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1439,7 +1439,7 @@ msgstr ""
 "Kon logboek niet ophalen, logboek niet gevonden onder pad\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9641
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1448,11 +1448,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10013
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10118
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1460,275 +1460,275 @@ msgstr ""
 "MET Office UK beslaat alleen het Verenigd Koninkrijk, dus deze keuze heeft "
 "alleen zin wanneer u zich in Groot-Brittannië bevindt"
 
-#: 3.8/weather-applet.js:10197
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Geen gegevens gevonden voor locatie"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Zeer slecht"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Minder dan {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Uitstekend"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Meer dan {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10287
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Slecht"
 
-#: 3.8/weather-applet.js:10287 3.8/weather-applet.js:10292
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:10302
-#: 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Tussen {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10292
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Matig"
 
-#: 3.8/weather-applet.js:10297
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Goed"
 
-#: 3.8/weather-applet.js:10302 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Zeer goed"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10662
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:11659
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12080
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12250
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Zwakke wind"
 
-#: 3.8/weather-applet.js:12264
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Harde wind"
 
-#: 3.8/weather-applet.js:12411
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:12962
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:13139
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Rondwaaiende of stuivende sneeuw"
 
-#: 3.8/weather-applet.js:13143
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Zware motregen"
 
-#: 3.8/weather-applet.js:13147
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Zware motregen/regen"
 
-#: 3.8/weather-applet.js:13149
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Lichte motregen/regen"
 
-#: 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Stofstorm"
 
-#: 3.8/weather-applet.js:13155
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Motregenijzel/ijzel"
 
-#: 3.8/weather-applet.js:13157
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Zware motregenijzel/ijzel"
 
-#: 3.8/weather-applet.js:13159
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Lichte motregenijzel/ijzel"
 
-#: 3.8/weather-applet.js:13161
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Aanvriezende mist"
 
-#: 3.8/weather-applet.js:13167
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Trechtervormige wolk/tornado"
 
-#: 3.8/weather-applet.js:13169
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Hagelbuien"
 
-#: 3.8/weather-applet.js:13171
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "IJs"
 
-#: 3.8/weather-applet.js:13173
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Bliksem zonder donder"
 
-#: 3.8/weather-applet.js:13177
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Neerslag in de omgeving"
 
-#: 3.8/weather-applet.js:13181 3.8/weather-applet.js:13470
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Zware regen- en sneeuwval"
 
-#: 3.8/weather-applet.js:13183
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Lichte regen- en sneeuwval"
 
-#: 3.8/weather-applet.js:13191
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Bewolking neemt af"
 
-#: 3.8/weather-applet.js:13193
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Bewolking neemt toe"
 
-#: 3.8/weather-applet.js:13195
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Bewolking ongewijzigd"
 
-#: 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Rook of nevel"
 
-#: 3.8/weather-applet.js:13201
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Sneeuw- en regenbuien"
 
-#: 3.8/weather-applet.js:13213
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Onweer zonder neerslag"
 
-#: 3.8/weather-applet.js:13215
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "IJsstof"
 
-#: 3.8/weather-applet.js:13221
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Deels bewolkt"
 
-#: 3.8/weather-applet.js:13243
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Zorg er a.u.b. voor dat u de API-sleutel correct hebt ingevoerd"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13259
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:13402 3.8/weather-applet.js:13403
-#: 3.8/weather-applet.js:13539 3.8/weather-applet.js:13540
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "Niet gevonden"
 
-#: 3.8/weather-applet.js:13435
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Stuifsneeuw"
 
-#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:13477
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Lichte sneeuwval"
 
-#: 3.8/weather-applet.js:13483 3.8/weather-applet.js:13484
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Matige sneeuw"
 
-#: 3.8/weather-applet.js:13498
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Matige regenbuien"
 
-#: 3.8/weather-applet.js:13505
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Mengsel van regen en sneeuw"
 
-#: 3.8/weather-applet.js:13512
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Zware mengeling van regen en sneeuw"
 
-#: 3.8/weather-applet.js:13657
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:13953
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:13966
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "Kies a.u.b. een andere aanbieder of locatie"
 
-#: 3.8/weather-applet.js:14263
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14453
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "De API-sleutel die u opgaf is ongeldig."
 
-#: 3.8/weather-applet.js:14460
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "De locatie die u opgaf was onvindbaar."
 
-#: 3.8/weather-applet.js:14496 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Flinke storm"
 
-#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:14512
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Regen en sneeuw"
 
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Regen en natte sneeuw of hagel"
 
-#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Sneeuwbuien"
 
-#: 3.8/weather-applet.js:14630 3.8/weather-applet.js:14631
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "Winderig"
 
-#: 3.8/weather-applet.js:14644 3.8/weather-applet.js:14645
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr "Koud"
 
-#: 3.8/weather-applet.js:14700 3.8/weather-applet.js:14701
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Overwegend helder"
 
-#: 3.8/weather-applet.js:14853
+#: 3.8/weather-applet.js:15247
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:15205
+#: 3.8/weather-applet.js:15603
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
@@ -1736,13 +1736,13 @@ msgstr ""
 "Locatiedienst kon uw locatie niet vinden, zie a.u.b. de logboeken in Looking "
 "Glass"
 
-#: 3.8/weather-applet.js:15433
+#: 3.8/weather-applet.js:15831
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Zorg ervoor dat u een locatie hebt ingevoerd of gebruik in plaats daarvan "
 "Automatische locatie."
 
-#: 3.8/weather-applet.js:15570
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1750,7 +1750,7 @@ msgstr ""
 "Kon instellingen niet ophalen, bestand niet gevonden onder paden\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15577
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1758,58 +1758,58 @@ msgstr ""
 "Kon inhoud van instellingenbestand niet verkrijgen onder pad\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:16197
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Deze aanbieder heeft een API-sleutel nodig om te kunnen werken"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Dauwpunt"
 
-#: 3.8/weather-applet.js:16269
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Neerslag zal ophouden over {precipEnd} minuten"
 
-#: 3.8/weather-applet.js:16271
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "Neerslag zal niet binnen een uur ophouden"
 
-#: 3.8/weather-applet.js:16274
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Neerslag zal beginnen over {precipStart} minuten"
 
-#: 3.8/weather-applet.js:16486
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Lezen van voorspelling mislukt, zie logboeken voor meer bijzonderheden."
 
-#: 3.8/weather-applet.js:17018 3.8/weather-applet.js:17810
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "Met ingang van {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:17024
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance}{distanceUnit} van u vandaan"
 
-#: 3.8/weather-applet.js:17028
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "Stationsnaam: {stationName}"
 
-#: 3.8/weather-applet.js:17031
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "Gebied: {stationArea}"
 
-#: 3.8/weather-applet.js:17581 3.8/weather-applet.js:17591
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Fout bij opslaan van foutopsporingsinformatie"
 
-#: 3.8/weather-applet.js:17603
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Foutopsporingsinformatie met succes opgeslagen"
 
-#: 3.8/weather-applet.js:17603
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Opgeslagen naar {filePath}"
-
-#: 3.8/weather-applet.js:17734
-msgid "This provider requires an API key to operate"
-msgstr "Deze aanbieder heeft een API-sleutel nodig om te kunnen werken"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -2608,12 +2608,3 @@ msgstr ""
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr "Gekozen bestandpad voor het opslaan van logboekbestanden"
-
-#~ msgid "DarkSky"
-#~ msgstr "DarkSky"
-
-#~ msgid "This API has ceased to function, please use another one."
-#~ msgstr "Deze API doet het niet meer, gebruik a.u.b. een andere."
-
-#~ msgid "Instead of 15:00 or 3 pm it will show up as 15 or 3 pm"
-#~ msgstr "In plaats van 15.00 of 3 nm wordt het 15 of 3 nm"

--- a/weather@mockturtl/files/weather@mockturtl/po/pl.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/pl.po
@@ -7,79 +7,80 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Polish translation for cinnamon-spices-applets-"
 "weather@mockturtl\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-19 07:23+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2021-08-23 18:23+0200\n"
+"Last-Translator: \n"
 "Language-Team: lukaszdabrowski80@gmail.com\n"
+"Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0\n"
-"Last-Translator: \n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 "
 "|| n%100>14) ? 1 : 2);\n"
-"Language: pl_PL\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:14911
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Błąd"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:14912 3.8/weather-applet.js:14914
-#: 3.8/weather-applet.js:14916 3.8/weather-applet.js:14919
-#: 3.8/weather-applet.js:14922 3.8/weather-applet.js:14923
-#: 3.8/weather-applet.js:14924 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Błąd usługi"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:14913
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Nieprawidłowy klucz API"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:14915
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Nieprawidłowy format lokalizacji"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:14917
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Klucz zablokowany"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:14918
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Nie mogę znaleźć lokalizacji"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:14920
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Brak klucza API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:14921
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Brak lokalizacji"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:14926
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Brakujące pakiety"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:14927
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Lokalizacja nie jest objęta"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9111
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Aplet Pogoda"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:15144
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:15145
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Kliknij, aby otworzyć"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:10673
-#: 3.8/weather-applet.js:15156
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Odśwież"
 
@@ -89,8 +90,8 @@ msgstr "API zwróciło kod statusu między 400 a 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9278
-#: 3.8/weather-applet.js:9282 3.8/weather-applet.js:9286
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Lokalizacja sklepu"
 
@@ -102,14 +103,14 @@ msgstr "Nie możesz zapisać lokalizacji uzyskanej automatycznie, przepraszam"
 msgid "Could not get weather information"
 msgstr "Nie udało się uzyskać informacji o pogodzie"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:15017
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Nieoczekiwany błąd podczas odświeżania pogody, zobacz logowanie w Looking "
 "Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:15273
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -125,7 +126,7 @@ msgstr "Błąd sieci, sprawdź logi w Looking Glass"
 msgid "As of"
 msgstr "Od"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:11332
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Obsługiwane przez"
 
@@ -133,93 +134,93 @@ msgstr "Obsługiwane przez"
 msgid "from you"
 msgstr "od Ciebie"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:11266
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:11266
-#: 3.8/weather-applet.js:11596
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10104
-#: 3.8/weather-applet.js:11393
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mile"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10105
-#: 3.8/weather-applet.js:11394
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:11545
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Ładowanie aktualnej pogody ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:11548
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Ładowanie przyszłej pogody ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:10616
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Ładowanie ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:10640
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:10641
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Wilgotność"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:10642
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Ciśnienie"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:10643 3.8/weather-applet.js:14385
-#: 3.8/weather-applet.js:14392 3.8/weather-applet.js:14393
-#: 3.8/weather-applet.js:14399
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Wiatr"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:9573
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Upewnij się, że wprowadzono lokalizację lub zamiast tego użyj funkcji "
 "Lokalizacja automatyczna"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9358
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Nie można znaleźć lokalizacji na podstawie adresu, sprawdź, czy jest poprawna"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9379
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Nie udało się wywołać interfejsu API geolokalizacji, zobacz Looking Glass "
 "dla błędów."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9278
-#: 3.8/weather-applet.js:9282
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Ostrzeżenie"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9278
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Poprawne lokalizacje można zapisywać tylko wtedy, gdy aplet nie jest "
 "odświeżany"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9282
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Nie możesz zapisać nieprawidłowej lokalizacji"
 
+#. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9286
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Informacja"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9286
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Lokalizacja jest już zapisana"
 
@@ -257,14 +258,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11655 3.8/weather-applet.js:11973
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:12884
-#: 3.8/weather-applet.js:13980 3.8/weather-applet.js:14286
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Odczuwalna"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:11701
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Nie udało się przetworzyć informacji o pogodzie"
 
@@ -277,7 +279,7 @@ msgstr ""
 "lub uzyskaj go najpierw na stronie https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11731 3.8/weather-applet.js:13050
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -285,7 +287,7 @@ msgstr ""
 "Upewnij się, że\n"
 "wprowadziłeś klucz API poprawnie, a Twoje konto nie jest zablokowane"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:14253
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -296,58 +298,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10303 3.8/weather-applet.js:10310
-#: 3.8/weather-applet.js:10317 3.8/weather-applet.js:10318
-#: 3.8/weather-applet.js:13494 3.8/weather-applet.js:13495
-#: 3.8/weather-applet.js:13501 3.8/weather-applet.js:13508
-#: 3.8/weather-applet.js:13515 3.8/weather-applet.js:14150
-#: 3.8/weather-applet.js:14428
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Ulewny deszcz"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12674 3.8/weather-applet.js:12723
-#: 3.8/weather-applet.js:12724 3.8/weather-applet.js:12731
-#: 3.8/weather-applet.js:13669 3.8/weather-applet.js:13670
-#: 3.8/weather-applet.js:13676 3.8/weather-applet.js:14142
-#: 3.8/weather-applet.js:14413 3.8/weather-applet.js:14414
-#: 3.8/weather-applet.js:14420 3.8/weather-applet.js:14427
-#: 3.8/weather-applet.js:14469 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14730
-#: 3.8/weather-applet.js:14731 3.8/weather-applet.js:14772
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Deszcz"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10275
-#: 3.8/weather-applet.js:10282 3.8/weather-applet.js:10296
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:13578 3.8/weather-applet.js:13579
-#: 3.8/weather-applet.js:13585 3.8/weather-applet.js:13592
-#: 3.8/weather-applet.js:13599 3.8/weather-applet.js:14152
-#: 3.8/weather-applet.js:14421
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Lekki deszcz"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:14126 3.8/weather-applet.js:14484
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Silne opady marznącego deszczu"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:12248
-#: 3.8/weather-applet.js:12695 3.8/weather-applet.js:12696
-#: 3.8/weather-applet.js:12702 3.8/weather-applet.js:12703
-#: 3.8/weather-applet.js:12709 3.8/weather-applet.js:14470
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Marznący deszcz"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:14128 3.8/weather-applet.js:14477
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Lekki marznący deszcz"
 
@@ -355,174 +359,189 @@ msgstr "Lekki marznący deszcz"
 msgid "Light freezing drizzle"
 msgstr "Lekka marznąca mżawka"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:14463
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Mrożąca mżawka"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14108
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Lekka mżawka"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:14498
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Duże granulki lodu"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:14497 3.8/weather-applet.js:14504
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Granulki lodu"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:14505
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Lekkie granulki lodu"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10387
-#: 3.8/weather-applet.js:10394 3.8/weather-applet.js:10401
-#: 3.8/weather-applet.js:10402 3.8/weather-applet.js:12255
-#: 3.8/weather-applet.js:13550 3.8/weather-applet.js:13551
-#: 3.8/weather-applet.js:13557 3.8/weather-applet.js:13564
-#: 3.8/weather-applet.js:13571 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14456 3.8/weather-applet.js:14807
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Obfite opady śniegu"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:12254 3.8/weather-applet.js:12667
-#: 3.8/weather-applet.js:12668 3.8/weather-applet.js:13725
-#: 3.8/weather-applet.js:13726 3.8/weather-applet.js:13732
-#: 3.8/weather-applet.js:14162 3.8/weather-applet.js:14434
-#: 3.8/weather-applet.js:14435 3.8/weather-applet.js:14448
-#: 3.8/weather-applet.js:14455 3.8/weather-applet.js:14716
-#: 3.8/weather-applet.js:14800
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Śnieg"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10366
-#: 3.8/weather-applet.js:10373 3.8/weather-applet.js:10380
-#: 3.8/weather-applet.js:10381 3.8/weather-applet.js:12253
-#: 3.8/weather-applet.js:13634 3.8/weather-applet.js:13635
-#: 3.8/weather-applet.js:13641 3.8/weather-applet.js:13648
-#: 3.8/weather-applet.js:13655 3.8/weather-applet.js:14170
-#: 3.8/weather-applet.js:14449
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Lekki śnieg"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:14441
-#: 3.8/weather-applet.js:14442
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Śnieżyca"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:12228
-#: 3.8/weather-applet.js:12740 3.8/weather-applet.js:12741
-#: 3.8/weather-applet.js:14174 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14814
-#: 3.8/weather-applet.js:14815
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Burza z piorunami"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:14379
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Lekka mgła"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10254 3.8/weather-applet.js:10255
-#: 3.8/weather-applet.js:12267 3.8/weather-applet.js:12810
-#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:13487
-#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14116
-#: 3.8/weather-applet.js:14371 3.8/weather-applet.js:14372
-#: 3.8/weather-applet.js:14378
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Mgła"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10261 3.8/weather-applet.js:10262
-#: 3.8/weather-applet.js:13473 3.8/weather-applet.js:13474
-#: 3.8/weather-applet.js:14343 3.8/weather-applet.js:14344
-#: 3.8/weather-applet.js:14709 3.8/weather-applet.js:14710
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Chmury"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12618
-#: 3.8/weather-applet.js:12619 3.8/weather-applet.js:12653
-#: 3.8/weather-applet.js:14364 3.8/weather-applet.js:14365
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Przeważnie pochmurno"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10226
-#: 3.8/weather-applet.js:10227 3.8/weather-applet.js:10233
-#: 3.8/weather-applet.js:10234 3.8/weather-applet.js:12611
-#: 3.8/weather-applet.js:12612 3.8/weather-applet.js:12646
-#: 3.8/weather-applet.js:13662 3.8/weather-applet.js:13663
-#: 3.8/weather-applet.js:14357 3.8/weather-applet.js:14358
-#: 3.8/weather-applet.js:14702 3.8/weather-applet.js:14703
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Częściowe zachmurzenie"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:14350
-#: 3.8/weather-applet.js:14351
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Przeważnie bezchmurnie"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10212 3.8/weather-applet.js:10213
-#: 3.8/weather-applet.js:12273 3.8/weather-applet.js:12597
-#: 3.8/weather-applet.js:12598 3.8/weather-applet.js:12632
-#: 3.8/weather-applet.js:14186 3.8/weather-applet.js:14336
-#: 3.8/weather-applet.js:14337 3.8/weather-applet.js:14695
-#: 3.8/weather-applet.js:14696
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Przejrzyście"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10219
-#: 3.8/weather-applet.js:10220 3.8/weather-applet.js:14336
-#: 3.8/weather-applet.js:14337
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Słonecznie"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10205
-#: 3.8/weather-applet.js:10206 3.8/weather-applet.js:10240
-#: 3.8/weather-applet.js:10241 3.8/weather-applet.js:10429
-#: 3.8/weather-applet.js:10430 3.8/weather-applet.js:12588
-#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12817
-#: 3.8/weather-applet.js:12818 3.8/weather-applet.js:13456
-#: 3.8/weather-applet.js:13457 3.8/weather-applet.js:13754
-#: 3.8/weather-applet.js:13755 3.8/weather-applet.js:14328
-#: 3.8/weather-applet.js:14329
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Nieznane"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:11596
+#: 3.0/darkSky.js:71
 msgid "and"
 msgstr "oraz"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:11596
+#: 3.0/darkSky.js:71
 msgid "until"
 msgstr "do"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:11596
+#: 3.0/darkSky.js:71
 msgid "Possible"
 msgstr "Możliwy"
 
@@ -534,7 +553,7 @@ msgstr ""
 "Proszę wprowadzić klucz API w ustawieniach.\n"
 "lub uzyskaj go najpierw na stronie https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:11741
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -542,132 +561,132 @@ msgstr ""
 "Upewnij się, że\n"
 "wprowadziłeś klucz API, który masz od DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:9062
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Nie udało się uzyskać lokalizacji"
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:9068
+#: 3.0/ipApi.js:95
 msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 "Usługa lokalizacji odpowiedziała z błędami, proszę zobaczyć logi w Looking "
 "Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:13310
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Zachmurzenie"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:13466
-#: 3.8/weather-applet.js:13467
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Bezchmurne niebo"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:13480 3.8/weather-applet.js:13481
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Raczej"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:13502
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Ulewny deszcz i burze"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:13509
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Ulewne deszcze"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:13516
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Duże opady deszczu i burze"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:13522
-#: 3.8/weather-applet.js:13523 3.8/weather-applet.js:13529
-#: 3.8/weather-applet.js:13536 3.8/weather-applet.js:13543
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Duże opady śniegu"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:13530
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Duże opady śniegu i burze"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:13537
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Silne opady śniegu"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:13544
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Silne opady deszczu i burze"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:13558
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Obfite opady śniegu i burze"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:13565
-#: 3.8/weather-applet.js:14808
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Silne opady śniegu"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:13572
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Silne opady śniegu i burze"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:13586
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Lekki deszcz i burze"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:13593
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Lekkie opady deszczu"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:13600
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Lekkie opady deszczu i burze"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:13606
-#: 3.8/weather-applet.js:13607 3.8/weather-applet.js:13613
-#: 3.8/weather-applet.js:13620 3.8/weather-applet.js:13627
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Lekki śnieg"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:13614
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Lekki śnieg i burze"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:13621
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Lekkie opady śniegu"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:13628
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Lekkie opady śniegu i burze"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:13642
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Lekki śnieg i burze"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:13649
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Lekkie opady śniegu"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:13656
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Lekkie opady śniegu i burze"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:13677
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Deszcz i pioruny"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12732
-#: 3.8/weather-applet.js:13683 3.8/weather-applet.js:13684
-#: 3.8/weather-applet.js:13690 3.8/weather-applet.js:14148
-#: 3.8/weather-applet.js:14773 3.8/weather-applet.js:14779
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Przelotne deszcze"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:13691
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Przelotne deszcze i burze"
 
@@ -676,42 +695,44 @@ msgstr "Przelotne deszcze i burze"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10324
-#: 3.8/weather-applet.js:10331 3.8/weather-applet.js:10338
-#: 3.8/weather-applet.js:10339 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12681 3.8/weather-applet.js:12682
-#: 3.8/weather-applet.js:12688 3.8/weather-applet.js:12689
-#: 3.8/weather-applet.js:12716 3.8/weather-applet.js:12717
-#: 3.8/weather-applet.js:13697 3.8/weather-applet.js:13698
-#: 3.8/weather-applet.js:13704 3.8/weather-applet.js:13711
-#: 3.8/weather-applet.js:13718
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Śnieg z deszczem"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:13705
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Deszcz ze śniegiem i burze"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:13712
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Przelotny śnieg"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:13719
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Przelotny śnieg i burze"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:13733
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Śnieg i burze"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:13739 3.8/weather-applet.js:13740
-#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:14166
-#: 3.8/weather-applet.js:14801
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Opady śniegu"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:13747
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Opady śniegu i burze"
 
@@ -720,21 +741,21 @@ msgstr "Opady śniegu i burze"
 msgid "Unexpected response from API"
 msgstr "Niespodziewana odpowiedź z API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10033
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Widoczność"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10057
-#: 3.8/weather-applet.js:12053 3.8/weather-applet.js:12543
-#: 3.8/weather-applet.js:12894
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Nie udało się przetworzyć aktualnych informacji o pogodzie"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:9853
-#: 3.8/weather-applet.js:9888 3.8/weather-applet.js:12351
-#: 3.8/weather-applet.js:12920 3.8/weather-applet.js:12954
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Nie udało się przetworzyć informacji o prognozie"
 
@@ -763,85 +784,88 @@ msgid "Excellent - More than"
 msgstr "Doskonały - Więcej niż"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10247 3.8/weather-applet.js:10248
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:14138
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Mgła"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10268
-#: 3.8/weather-applet.js:10269 3.8/weather-applet.js:12625
-#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:12660
-#: 3.8/weather-applet.js:14182
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Zachmurzenie"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10276
-#: 3.8/weather-applet.js:10283
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Lekki deszczyk"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10289 3.8/weather-applet.js:10290
-#: 3.8/weather-applet.js:12235 3.8/weather-applet.js:14104
-#: 3.8/weather-applet.js:14406 3.8/weather-applet.js:14407
-#: 3.8/weather-applet.js:14462
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Mżawka"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10304
-#: 3.8/weather-applet.js:10311
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Ulewny deszcz"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10325
-#: 3.8/weather-applet.js:10332
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Deszcz ze śniegiem"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10345 3.8/weather-applet.js:10352
-#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:10360
-#: 3.8/weather-applet.js:14180
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Grad"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10346
-#: 3.8/weather-applet.js:10353
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Deszcz gradowy"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10367
-#: 3.8/weather-applet.js:10374
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Lekki śnieg z deszczem"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10388
-#: 3.8/weather-applet.js:10395
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Silny śnieg z deszczem"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10408 3.8/weather-applet.js:10415
-#: 3.8/weather-applet.js:10422 3.8/weather-applet.js:10423
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Zagrzmi"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10409
-#: 3.8/weather-applet.js:10416
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Przelotnie zagrzmi"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:12106
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Upewnij się, że Lokalizacja jest w prawidłowym formacie w Ustawieniach"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:12110
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Upewnij się, że wprowadziłeś prawidłowy klucz w ustawieniach"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11922 3.8/weather-applet.js:12114
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -849,207 +873,211 @@ msgstr ""
 "Nie znaleziono lokalizacji, upewnij się, że lokalizacja jest dostępna lub "
 "jest w prawidłowym formacie"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:12118
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Jeśli problem nadal występuje, prosimy o kontakt z autorem tego apletu"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:12122
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Nieznany błąd, proszę zobaczyć logi w Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:12224
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Burza z lekkim deszczem"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:12225
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Burza z deszczem"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:12226
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Burza z ulewnym deszczem"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:12227
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Lekka burza"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:12229
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Silna burza"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:12230
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Gwałtowna burza z piorunami"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:12231
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Burza z lekką mżawką"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:12232
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Burza z mżawką"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:12233
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Burza z silną mżawką"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:12234
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Lekkie opady mżawki"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:12236
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Silne opady mżawki"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:12237
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Lekka mżawka deszcz"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:12238
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Mżawka deszcz"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:12239
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Intensywna mżawka deszcz"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:12240
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Deszcz i mżawka"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:12241
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Ulewny deszcz i mżawka"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:12242
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Przelotna mżawka"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:12244
-#: 3.8/weather-applet.js:14737 3.8/weather-applet.js:14738
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Umiarkowany deszcz"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:12245
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Intensywny deszcz"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:12246
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Bardzo silny deszcz"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:12247
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Ekstremalny deszcz"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:12249
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Przelotny deszcz o lekkiej intensywności"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:12250
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Przelotny deszcz"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:12251
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Intensywny przelotny deszcz"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:12252
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Poszarpany przelotny deszcz"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:12257
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Deszcz ze śniegiem"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:12258
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Lekki deszcz i śnieg"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:12259
-#: 3.8/weather-applet.js:14744 3.8/weather-applet.js:14745
-#: 3.8/weather-applet.js:14751 3.8/weather-applet.js:14786
-#: 3.8/weather-applet.js:14793
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Deszcz i śnieg"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:12260
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Lekki przelotny śnieg"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:12261
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Przelotny śnieg"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:12262
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Silny przelotny śnieg"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:12264 3.8/weather-applet.js:12775
-#: 3.8/weather-applet.js:12776
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Zadymiony"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:12265 3.8/weather-applet.js:12782
-#: 3.8/weather-applet.js:12783
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Mgła"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:12266
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Piasek, wiry pyłowe"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:12268
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Piasek"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:12269 3.8/weather-applet.js:12768
-#: 3.8/weather-applet.js:12769
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Pył"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:12270
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Popiół wulkaniczny"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:12271
-#: 3.8/weather-applet.js:14172
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Szkwał"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:12272 3.8/weather-applet.js:12747
-#: 3.8/weather-applet.js:12748
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:12275
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Niebo jest czyste"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:12276
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Chmury"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:12277
-#: 3.8/weather-applet.js:12604 3.8/weather-applet.js:12605
-#: 3.8/weather-applet.js:12639
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Nieliczne chmury"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:12278
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Rozproszone chmury"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:12279
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Rozbite chmury"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:12280
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Pochmurno"
 
@@ -1057,77 +1085,80 @@ msgstr "Pochmurno"
 msgid "Could not get forecast for your area"
 msgstr "Nie można uzyskać prognozy dla Twojego obszaru"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12309
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "Lokalizacja jest poza USA, proszę użyć innego dostawcy."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12373
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Nie udało się przetworzyć informacji o prognozie godzinowej"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12633
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Bezchmurnie i wietrznie"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12640
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Niewiele chmur i wietrznie"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12647
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Nieliczne chmury i wietrznie"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12654
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Przeważnie pochmurno i wietrznie"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12661
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Pochmurno i wietrznie"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12675
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Śnieżno deszczowo"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12710
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Marznący deszcz i śnieg"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:8750 3.8/weather-applet.js:12754
-#: 3.8/weather-applet.js:12755
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Huragan"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:8745
-#: 3.8/weather-applet.js:12761
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Burza"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12762
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Tropical storm"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12789 3.8/weather-applet.js:12790
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Gorąco"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12797
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Zimno"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12804
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Blizzard"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:8634
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Dzisiaj"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:8636
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Jutro"
 
@@ -1159,79 +1190,79 @@ msgstr "Piątek"
 msgid "Saturday"
 msgstr "Sobota"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:8715
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Spokój"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:8718
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Lekki powiew"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:8721
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Lekki powiew"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:8724
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Delikatny powiew"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:8727
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Umiarkowany wiatr"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:8730
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Świeży powiew"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:8733
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Silny wiatr"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:8736
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "W pobliżu wichury"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:8739
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Wichura"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:8742
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Silna wichura"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:8748
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Gwałtowna burza"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "NE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "E"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "SE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "SW"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "W"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "NW"
 
@@ -1285,7 +1316,7 @@ msgstr ""
 "Wystąpił nieznany błąd podczas uzyskiwania pogody, zobacz logi Looking Glass "
 "aby uzyskać więcej informacji"
 
-#: 3.0/yahoo.js:437
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Tropikalna burza"
 
@@ -1293,7 +1324,7 @@ msgstr "Tropikalna burza"
 msgid "Severe Thunderstorms"
 msgstr "Silne burze"
 
-#: 3.0/yahoo.js:440
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Burze"
 
@@ -1309,15 +1340,15 @@ msgstr "Trochę deszczu i deszczu ze śniegiem"
 msgid "Mixed Snow and Sleet"
 msgstr "Śnieg i deszcz ze śniegiem"
 
-#: 3.0/yahoo.js:444
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Marznąca mżawka"
 
-#: 3.0/yahoo.js:446
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Marznący deszcz"
 
-#: 3.0/yahoo.js:447
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Przelotny deszcz"
 
@@ -1329,11 +1360,11 @@ msgstr "Zamiecie śnieżne"
 msgid "Light Snow Showers"
 msgstr "Lekkie opady śniegu"
 
-#: 3.0/yahoo.js:451
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Zamiecie śnieżne"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14723 3.8/weather-applet.js:14724
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Mglisto"
 
@@ -1345,47 +1376,54 @@ msgstr "Zadyniony"
 msgid "Blustery"
 msgstr "Burzowo"
 
-#: 3.0/yahoo.js:460
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Wietrzny"
 
-#: 3.0/yahoo.js:463
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Przeważnie pochmurno"
 
-#: 3.0/yahoo.js:464
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Częściowe zachmurzenie"
 
-#: 3.0/yahoo.js:467
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Przeważnie słonecznie"
 
-#: 3.0/yahoo.js:469
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Deszcz i grad"
 
-#: 3.0/yahoo.js:471
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Pojedyncze burze"
 
-#: 3.0/yahoo.js:472
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Rozproszone burze"
 
-#: 3.0/yahoo.js:473
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Przelotne opady"
 
-#: 3.0/yahoo.js:474
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Ulewa"
 
-#: 3.0/yahoo.js:475
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Rozległe opady śniegu"
 
-#: 3.0/yahoo.js:476
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Duże opady śniegu"
 
@@ -1397,256 +1435,397 @@ msgstr "Niedostępne"
 msgid "Scattered Thundershowers"
 msgstr "Rozproszone burze z piorunami"
 
+#: 3.8/weather-applet.js:9638
+msgid ""
+"Could not retrieve logs, log file was not found under path\n"
+" {logFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:9642
+msgid ""
+"Could not get contents of log file under path\n"
+" {logFilePath}"
+msgstr ""
+
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:9815
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Urząd Meteorologiczny UK"
 
-#: 3.8/weather-applet.js:9999
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
+msgstr ""
+
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Nie znaleziono danych dla lokalizacji"
 
-#: 3.8/weather-applet.js:10070
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Bardzo słabe"
 
-#: 3.8/weather-applet.js:10070
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Mniej niż {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10074
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Doskonała"
 
-#: 3.8/weather-applet.js:10074
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Więcej niż {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10079
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Słaba"
 
-#: 3.8/weather-applet.js:10079 3.8/weather-applet.js:10084
-#: 3.8/weather-applet.js:10089 3.8/weather-applet.js:10094
-#: 3.8/weather-applet.js:10099
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Pomiędzy {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10084
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Umiarkowane"
 
-#: 3.8/weather-applet.js:10089
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Dobra"
 
-#: 3.8/weather-applet.js:10094 3.8/weather-applet.js:10099
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Bardzo dobra"
 
-#: 3.8/weather-applet.js:10761
-msgid "Precipitation will end in {precipEnd} minutes"
-msgstr "Opady zakończą się za {precipEnd} minut"
-
-#: 3.8/weather-applet.js:10763
-msgid "Precipitation won't end in within an hour"
-msgstr "Opady nie ustaną w ciągu godziny"
-
-#: 3.8/weather-applet.js:10766
-msgid "Precipitation will start within {precipStart} minutes"
-msgstr "Opady rozpoczną się w ciągu {precipStart} minut"
-
-#: 3.8/weather-applet.js:11335 3.8/weather-applet.js:15025
-msgid "As of {lastUpdatedTime}"
-msgstr "Od {lastUpdatedTime}"
-
-#: 3.8/weather-applet.js:11341
-msgid "{distance}{distanceUnit} from you"
-msgstr "{distance}{distanceUnit} od ciebie"
-
-#: 3.8/weather-applet.js:11582
-msgid "DarkSky"
-msgstr "Ciemne niebo"
-
-#: 3.8/weather-applet.js:11606
-msgid "This API has ceased to function, please use another one."
-msgstr "To API przestało działać, proszę użyć innego."
-
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11907
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
-#: 3.8/weather-applet.js:12290
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:12834
-msgid "WeatherBit"
-msgstr "WeatherBit"
-
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13251
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:13924
+#: 3.8/weather-applet.js:11955
+msgid "WeatherBit"
+msgstr "WeatherBit"
+
+#: 3.8/weather-applet.js:12386
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Jutro"
+
+#: 3.8/weather-applet.js:12561
+msgid "Light wind"
+msgstr "Lekki wiatr"
+
+#: 3.8/weather-applet.js:12575
+msgid "Strong wind"
+msgstr "Silny wiatr"
+
+#: 3.8/weather-applet.js:12723
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:14102
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Nawiewy lub zaspy śnieżne"
 
-#: 3.8/weather-applet.js:14106
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Silna mżawka"
 
-#: 3.8/weather-applet.js:14110
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Silna mżawka/deszcz"
 
-#: 3.8/weather-applet.js:14112
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Lekka mżawka/deszcz"
 
-#: 3.8/weather-applet.js:14114
-msgid "Duststorm"
+#: 3.8/weather-applet.js:13486
+#, fuzzy
+msgid "Dust Storm"
 msgstr "Burza pyłowa"
 
-#: 3.8/weather-applet.js:14118
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Marznąca mżawka/ marznący deszcz"
 
-#: 3.8/weather-applet.js:14120
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Silna marznąca mżawka/ marznący deszcz"
 
-#: 3.8/weather-applet.js:14122
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Lekka marznąca mżawka/ marznący deszcz"
 
-#: 3.8/weather-applet.js:14124
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Zamarzająca mgła"
 
-#: 3.8/weather-applet.js:14130
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Chmura lejkowata/tornado"
 
-#: 3.8/weather-applet.js:14132
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Gradobicie"
 
-#: 3.8/weather-applet.js:14134
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Lód"
 
-#: 3.8/weather-applet.js:14136
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Błyskawica bez grzmotu"
 
-#: 3.8/weather-applet.js:14140
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Opady w okolicy"
 
-#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14752
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Ulewny deszcz i śnieg"
 
-#: 3.8/weather-applet.js:14146
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Lekki deszcz i śnieg"
 
-#: 3.8/weather-applet.js:14154
+#: 3.8/weather-applet.js:13526
 #, fuzzy
 msgid "Sky coverage decreasing"
 msgstr "Coraz mniejszy zasięg nieba"
 
-#: 3.8/weather-applet.js:14156
+#: 3.8/weather-applet.js:13528
 #, fuzzy
 msgid "Sky coverage increasing"
 msgstr "Zwiększający się zasięg nieba"
 
-#: 3.8/weather-applet.js:14158
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Niebo bez zmian"
 
-#: 3.8/weather-applet.js:14160
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Dym lub mgła"
 
-#: 3.8/weather-applet.js:14164
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Opady śniegu i deszczu"
 
-#: 3.8/weather-applet.js:14176
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Burza bez opadów"
 
-#: 3.8/weather-applet.js:14178
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Diamentowy pył"
 
-#: 3.8/weather-applet.js:14184
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Częściowe zachmurzenie"
 
-#: 3.8/weather-applet.js:14207
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Upewnij się, że wprowadziłeś klucz API poprawnie"
 
-#: 3.8/weather-applet.js:14221
-msgid "Climacell"
-msgstr "Climacell"
-
-#: 3.8/weather-applet.js:14386
-msgid "Light wind"
-msgstr "Lekki wiatr"
-
-#: 3.8/weather-applet.js:14400
-msgid "Strong wind"
-msgstr "Silny wiatr"
-
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14544
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14684 3.8/weather-applet.js:14685
-#: 3.8/weather-applet.js:14821 3.8/weather-applet.js:14822
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "NIE ZNALEZIONO"
 
-#: 3.8/weather-applet.js:14717
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Zawieje śnieg"
 
-#: 3.8/weather-applet.js:14758 3.8/weather-applet.js:14759
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Lekki śnieg"
 
-#: 3.8/weather-applet.js:14765 3.8/weather-applet.js:14766
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Umiarkowany śnieg"
 
-#: 3.8/weather-applet.js:14780
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Umiarkowany deszcz"
 
-#: 3.8/weather-applet.js:14787
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Deszcz ze śniegiem"
 
-#: 3.8/weather-applet.js:14794
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Silny deszcz ze śniegiem"
 
-#: 3.8/weather-applet.js:14986
+#: 3.8/weather-applet.js:14024
+#, fuzzy
+msgid "AccuWeather"
+msgstr "Pogoda"
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+#, fuzzy
+msgid "Weather Underground"
+msgstr "Warunki pogodowe"
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+msgid "The location you provided was not found."
+msgstr ""
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+#, fuzzy
+msgid "Strong Storm"
+msgstr "Silny wiatr"
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "Deszcz i śnieg"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "Trochę deszczu i deszczu ze śniegiem"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "Opady śniegu"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "Przeważnie bezchmurnie"
+
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:15603
+#, fuzzy
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+"Usługa lokalizacji odpowiedziała z błędami, proszę zobaczyć logi w Looking "
+"Glass"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+"Upewnij się, że wprowadzono lokalizację lub zamiast tego użyj funkcji "
+"Lokalizacja automatyczna"
+
+#: 3.8/weather-applet.js:15968
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:15975
+msgid ""
+"Could not get contents of config file under path\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:16233
 msgid "This provider requires an API key to operate"
 msgstr "Ten dostawca wymaga klucza API do działania"
+
+#: 3.8/weather-applet.js:16675
+msgid "Dew Point"
+msgstr ""
+
+#: 3.8/weather-applet.js:16747
+msgid "Precipitation will end in {precipEnd} minutes"
+msgstr "Opady zakończą się za {precipEnd} minut"
+
+#: 3.8/weather-applet.js:16749
+msgid "Precipitation won't end in within an hour"
+msgstr "Opady nie ustaną w ciągu godziny"
+
+#: 3.8/weather-applet.js:16752
+msgid "Precipitation will start within {precipStart} minutes"
+msgstr "Opady rozpoczną się w ciągu {precipStart} minut"
+
+#: 3.8/weather-applet.js:16964
+msgid "Forecast parsing failed, see logs for more details."
+msgstr ""
+
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
+msgid "As of {lastUpdatedTime}"
+msgstr "Od {lastUpdatedTime}"
+
+#: 3.8/weather-applet.js:17502
+#, fuzzy
+msgid "{distance} {distanceUnit} from you"
+msgstr "{distance}{distanceUnit} od ciebie"
+
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
+msgid "Error Saving Debug Information"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Debug Information saved successfully"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Saved to {filePath}"
+msgstr ""
+
+#: 3.8/LogSaver.py:16
+msgid "Save to File"
+msgstr ""
+
+#: 3.8/LogSaver.py:29
+msgid "Select a destination"
+msgstr ""
 
 #. metadata.json->name
 #. 3.8->settings-schema.json->providers->title
@@ -1691,7 +1870,6 @@ msgid "Data service"
 msgstr "Serwis danych"
 
 #. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
 msgid "DarkSky (key needed)"
 msgstr "DarkSky (potrzebny jest klucz)"
 
@@ -1925,7 +2103,6 @@ msgid "Override label on panel"
 msgstr "Zastąp etykietę na panelu"
 
 #. 3.0->settings-schema.json->tempTextOverride->tooltip
-#. 3.8->settings-schema.json->tempTextOverride->tooltip
 msgid ""
 "Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
 "Can be used if label does not fit on vertical panel, among other smart "
@@ -1998,7 +2175,8 @@ msgid "Only display hours for hourly forecast time"
 msgstr "Wyświetlaj tylko godziny dla godzinowego czasu prognozy"
 
 #. 3.0->settings-schema.json->shortHourlyTime->tooltip
-msgid "Instead of 15:00 or 3 pm it will show up as 15 or 3 pm"
+#. 3.8->settings-schema.json->shortHourlyTime->tooltip
+msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
 msgstr "Zamiast 15:00 lub 3:00 pojawi się 15 lub 3"
 
 #. 3.0->settings-schema.json->showForecastDates->description
@@ -2104,6 +2282,11 @@ msgstr "Więcej o aplecie Pogoda"
 msgid "Report an issue"
 msgstr "Zgłoś problem"
 
+#. 3.8->settings-schema.json->debug-options->title
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Debug"
+msgstr ""
+
 #. 3.8->settings-schema.json->dataService->tooltip
 msgid ""
 "You can choose between several different weather forecast providers. Some "
@@ -2120,6 +2303,10 @@ msgstr ""
 "przycisku w zakładce Pomoc."
 
 #. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Met Office UK (UK only)"
 msgstr "Met Office UK (tylko Wielka Brytania)"
 
@@ -2128,12 +2315,28 @@ msgid "US National Weather (US only)"
 msgstr "US National Weather (tylko USA)"
 
 #. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Pirate Weather (key needed)"
+msgstr "Weatherbit (potrzebny jest klucz)"
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Visual Crossing (key needed)"
 msgstr "Visual Crossing (potrzebny klucz)"
 
 #. 3.8->settings-schema.json->dataService->options
-msgid "ClimacellV4 (key needed)"
-msgstr "ClimacellV4 (potrzebny klucz)"
+#, fuzzy
+msgid "Tomorrow.io (key needed)"
+msgstr "Weatherbit (potrzebny jest klucz)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "AccuWeather (key needed)"
+msgstr "Weatherbit (potrzebny jest klucz)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Weather Underground (key needed)"
+msgstr "Weatherbit (potrzebny jest klucz)"
 
 #. 3.8->settings-schema.json->location->tooltip
 msgid ""
@@ -2148,6 +2351,12 @@ msgstr ""
 "{Street} {City/Town} {Postcode} {Country}. Algorytm wyszukiwania jest bardzo "
 "elastyczny jeśli chodzi o format. Po 3 sekundach bez wpisywania wprowadzony "
 "adres jest automatycznie zastępowany w celu sprawdzenia poprawności wyboru."
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
 
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"
@@ -2175,9 +2384,20 @@ msgstr ""
 "wyczerpiesz swojego limitu."
 
 #. 3.8->settings-schema.json->forecastDays->tooltip
+#, fuzzy
 msgid ""
-"Maximum number of days that can be displayed, maximum rows and columns "
-"setting in the Presentation tab will affect the final number."
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+"Maksymalna liczba dni, które można wyświetlić, maksymalne ustawienie wierszy "
+"i kolumn w zakładce Prezentacja będzie miało wpływ na ostateczną liczbę."
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+#, fuzzy
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
 msgstr ""
 "Maksymalna liczba dni, które można wyświetlić, maksymalne ustawienie wierszy "
 "i kolumn w zakładce Prezentacja będzie miało wpływ na ostateczną liczbę."
@@ -2187,10 +2407,11 @@ msgid "Enable minutely precipitation forecast"
 msgstr "Włączenie szczegółowej prognozy opadów"
 
 #. 3.8->settings-schema.json->immediatePrecip->tooltip
+#, fuzzy
 msgid ""
 "If you'd like to use this make sure you use your exact coordinates/address "
-"as location to help its accuracy. Currently implemented with OpenWeatherMap "
-"only."
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
 msgstr ""
 "Jeśli chcesz tego użyć, upewnij się, że używasz swoich dokładnych "
 "współrzędnych/adresu jako lokalizacji, aby pomóc w dokładności. Obecnie "
@@ -2199,6 +2420,39 @@ msgstr ""
 #. 3.8->settings-schema.json->showBothTempUnits->description
 msgid "Show both temperature units at the same time"
 msgstr "Jednoczesne wyświetlanie obu jednostek temperatury"
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+#, fuzzy
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+"Dostępne wartości to: {c} to stan, {t} to temperatura, a {u} to jednostka."
+"\\n\n"
+"Może być użyty w przypadku, gdy etykieta nie mieści się na pionowym panelu, "
+"między innymi."
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+#, fuzzy
+msgid "Override tooltip on panel"
+msgstr "Zastąp etykietę na panelu"
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
+msgid "Always show Hourly Weather"
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->tooltip
+msgid ""
+"Hide/Show button will be hidden and Hourly weather will be permanently "
+"visible."
+msgstr ""
 
 #. 3.8->settings-schema.json->verticalOrientation->tooltip
 msgid "Displaying forecasts from top to bottom instead from left to right."
@@ -2248,10 +2502,6 @@ msgstr "Wyświetlanie kierunku wiatru jako tekst"
 msgid "Like SE, N instead of direction icons."
 msgstr "Jak SE, N zamiast ikon kierunków."
 
-#. 3.8->settings-schema.json->shortHourlyTime->tooltip
-msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
-msgstr "Zamiast 15:00 lub 3:00 pojawi się 15 lub 3"
-
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"
 msgstr ""
@@ -2293,13 +2543,17 @@ msgid "Current maintainer: Gr3q"
 msgstr "Obecny opiekun: Gr3q"
 
 #. 3.8->settings-schema.json->issue-reporting-explanation->description
+#, fuzzy
 msgid ""
 "If you find an issue with this applet please make a report by clicking on "
-"the button below and login in with your Github account. Before you start "
-"writing please make sure that the issue is not already submitted in the "
-"issues section. Don't forget to write weather@mockturtl in the top Title "
-"field to make it easier for everyone to know that the issue is about the "
-"weather applet (the form is for all Cinnamon applets)."
+"the button below and login in with your Github account.\n"
+"\n"
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
 msgstr ""
 "Jeśli znalazłeś problem z tym apletem, zgłoś go klikając na poniższy "
 "przycisk i zaloguj się na swoje konto Github. Zanim zaczniesz pisać upewnij "
@@ -2324,3 +2578,32 @@ msgstr ""
 "wyszukiwania jest bardzo elastyczny jeśli chodzi o format. Po 3 sekundach "
 "bez wpisywania wprowadzony adres jest automatycznie zastępowany w celu "
 "sprawdzenia poprawności wyboru."
+
+#. 3.8->settings-schema.json->logLevel->description
+msgid "Log Level"
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->tooltip
+msgid ""
+"Info is the regular logging, Debug is debug, and Verbose also logs network "
+"request payloads. Changing this will only be effective on future logs. Only "
+"change it you are instructed or you know what you are doing."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Verbose"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->description
+msgid "Click Save to save debug information to a file"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->tooltip
+msgid ""
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
+msgstr ""
+
+#. 3.8->settings-schema.json->selectedLogPath->description
+msgid "Selected path to save Logs"
+msgstr ""

--- a/weather@mockturtl/files/weather@mockturtl/po/pt.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/pt.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 3.0.1\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-30 08:55+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2024-02-01 16:18-0100\n"
 "Last-Translator: \n"
 "Language-Team: Português ; Daniel Miranda <dmiranda@gmail.com>, Luiz Rodrigo "
@@ -20,65 +21,65 @@ msgstr ""
 "X-Generator: Poedit 3.4.2\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17607
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Erro"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17608 3.8/weather-applet.js:17610
-#: 3.8/weather-applet.js:17612 3.8/weather-applet.js:17615
-#: 3.8/weather-applet.js:17618 3.8/weather-applet.js:17619
-#: 3.8/weather-applet.js:17620 3.8/weather-applet.js:17621
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Erro de Serviço"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17609
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Chave Incorreta da API"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17611
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Formatação Incorreta de Local"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17613
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Chave Bloquiada"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17614
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Não foi possível encontrar a localização"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17616
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Sem Chave da Api"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17617
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Sem Localização"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17622
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Pacotes em Falta"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17623
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Localização não Coberta"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9711
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Applet de Clima"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17921
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17922
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Clique para abrir"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16215
-#: 3.8/weather-applet.js:17925
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Recarregar"
 
@@ -88,8 +89,8 @@ msgstr "API retornou código de estado entre 400 e 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Armazém de Localização"
 
@@ -101,14 +102,14 @@ msgstr "Não pode guardar uma localização obtida automaticamente, desculpe"
 msgid "Could not get weather information"
 msgstr "Não foi possível obter informação do clima"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17760
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Erro inesperado enquanto recarregando o Clima, por favor verifique o registo "
 "no Looking Glass (Aparência Vidrada)"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:18003
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -126,7 +127,7 @@ msgstr ""
 msgid "As of"
 msgstr "Às"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:17006
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Fornecido por"
 
@@ -134,52 +135,52 @@ msgstr "Fornecido por"
 msgid "from you"
 msgstr "de ti"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16919
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:16919
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr ""
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10312
-#: 3.8/weather-applet.js:17084
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr ""
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10313
-#: 3.8/weather-applet.js:17085
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr ""
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17262
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Carregando as condições meteorológicas atuais ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17265
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Carregando as condições meteorológicas futuras ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16168
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Carregando ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16189
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16190
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Humidade"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16191
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Pressão"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12257 3.8/weather-applet.js:12263
-#: 3.8/weather-applet.js:14217 3.8/weather-applet.js:14218
-#: 3.8/weather-applet.js:16037
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Vento"
 
@@ -189,40 +190,39 @@ msgstr ""
 "Confira que já introduziste um localização ou então use uma localização "
 "automática"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9952
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Não foi possível encontrar localizações baseadas no endereço, por favor "
 "verifique se está correto"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9973
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Não foi possível chamar a API de geolocalização, verifique o Looking Glass "
 "(Aparência Vidrada) por erros."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Aviso"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9872
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Pode guardar as localizações corretas apenas quando o applet não está "
 "recarregando"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Não pode guardar uma localização incorreta"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9880
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Informação"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "A localização já está guardada"
 
@@ -260,15 +260,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10740 3.8/weather-applet.js:11711
-#: 3.8/weather-applet.js:12150 3.8/weather-applet.js:12659
-#: 3.8/weather-applet.js:13021 3.8/weather-applet.js:14388
-#: 3.8/weather-applet.js:14929
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Sensação térmica"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:14991
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Não foi possível processar a informação do clima"
 
@@ -281,7 +281,7 @@ msgstr ""
 "ou antes obtenha uma em https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:14871
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -289,7 +289,7 @@ msgstr ""
 "Por favor confirme que\n"
 "já introduziste a chave da API corretamente e a sua conta não está bloquiada"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12113
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -300,242 +300,240 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10516 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10530 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:11379 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:11386 3.8/weather-applet.js:11393
-#: 3.8/weather-applet.js:11400 3.8/weather-applet.js:12292
-#: 3.8/weather-applet.js:13187
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Chuva forte"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11554 3.8/weather-applet.js:11555
-#: 3.8/weather-applet.js:11561 3.8/weather-applet.js:12277
-#: 3.8/weather-applet.js:12278 3.8/weather-applet.js:12284
-#: 3.8/weather-applet.js:12291 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12340 3.8/weather-applet.js:12347
-#: 3.8/weather-applet.js:12801 3.8/weather-applet.js:12850
-#: 3.8/weather-applet.js:12851 3.8/weather-applet.js:12858
-#: 3.8/weather-applet.js:13179 3.8/weather-applet.js:13448
-#: 3.8/weather-applet.js:13449 3.8/weather-applet.js:13490
-#: 3.8/weather-applet.js:14189 3.8/weather-applet.js:14190
-#: 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Chuva"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10495 3.8/weather-applet.js:10509
-#: 3.8/weather-applet.js:10510 3.8/weather-applet.js:11009
-#: 3.8/weather-applet.js:11463 3.8/weather-applet.js:11464
-#: 3.8/weather-applet.js:11470 3.8/weather-applet.js:11477
-#: 3.8/weather-applet.js:11484 3.8/weather-applet.js:12285
-#: 3.8/weather-applet.js:13189
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Chuva leve"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12348 3.8/weather-applet.js:13163
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Chuva pesada congelante"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11014
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12822
-#: 3.8/weather-applet.js:12823 3.8/weather-applet.js:12829
-#: 3.8/weather-applet.js:12830 3.8/weather-applet.js:12836
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Chuva congelante"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12341 3.8/weather-applet.js:13165
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Chuva congelante"
 
 #: 3.0/climacell.js:301
 #, fuzzy
-#| msgid "Freezing drizzle"
 msgid "Light freezing drizzle"
 msgstr "Geada"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12327
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Geada"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13145
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 #, fuzzy
-#| msgid "Freezing drizzle"
 msgid "Light drizzle"
 msgstr "Geada"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12362
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Granizo pesado"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12354 3.8/weather-applet.js:12355
-#: 3.8/weather-applet.js:12361 3.8/weather-applet.js:12368
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Granizo de gelo"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12369
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Granizo leve de gelo"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10600
-#: 3.8/weather-applet.js:10607 3.8/weather-applet.js:10614
-#: 3.8/weather-applet.js:10615 3.8/weather-applet.js:11021
-#: 3.8/weather-applet.js:11435 3.8/weather-applet.js:11436
-#: 3.8/weather-applet.js:11442 3.8/weather-applet.js:11449
-#: 3.8/weather-applet.js:11456 3.8/weather-applet.js:12320
-#: 3.8/weather-applet.js:13205 3.8/weather-applet.js:13525
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Forte nevada"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:11610
-#: 3.8/weather-applet.js:11611 3.8/weather-applet.js:11617
-#: 3.8/weather-applet.js:12298 3.8/weather-applet.js:12299
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12795
-#: 3.8/weather-applet.js:13199 3.8/weather-applet.js:13434
-#: 3.8/weather-applet.js:13518 3.8/weather-applet.js:14203
-#: 3.8/weather-applet.js:14204 3.8/weather-applet.js:14581
-#: 3.8/weather-applet.js:14582
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Neve"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11019
-#: 3.8/weather-applet.js:11519 3.8/weather-applet.js:11520
-#: 3.8/weather-applet.js:11526 3.8/weather-applet.js:11533
-#: 3.8/weather-applet.js:11540 3.8/weather-applet.js:12313
-#: 3.8/weather-applet.js:13207
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Neve fraca"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12305
-#: 3.8/weather-applet.js:12306 3.8/weather-applet.js:14560
-#: 3.8/weather-applet.js:14561
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Flocos de neve"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:12375 3.8/weather-applet.js:12376
-#: 3.8/weather-applet.js:12867 3.8/weather-applet.js:12868
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13532
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:14210
-#: 3.8/weather-applet.js:14211
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Tempestade"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12243
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Neblina leve"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11372
-#: 3.8/weather-applet.js:11373 3.8/weather-applet.js:12235
-#: 3.8/weather-applet.js:12236 3.8/weather-applet.js:12242
-#: 3.8/weather-applet.js:12937 3.8/weather-applet.js:12938
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:14161
-#: 3.8/weather-applet.js:14162 3.8/weather-applet.js:14609
-#: 3.8/weather-applet.js:14610
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Neblina"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10474 3.8/weather-applet.js:10475
-#: 3.8/weather-applet.js:11358 3.8/weather-applet.js:11359
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:12208
-#: 3.8/weather-applet.js:13427 3.8/weather-applet.js:13428
-#: 3.8/weather-applet.js:14154 3.8/weather-applet.js:14155
-#: 3.8/weather-applet.js:14651 3.8/weather-applet.js:14652
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Nublado"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12228
-#: 3.8/weather-applet.js:12229 3.8/weather-applet.js:12745
-#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:12780
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Muito nublado"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10439
-#: 3.8/weather-applet.js:10440 3.8/weather-applet.js:10446
-#: 3.8/weather-applet.js:10447 3.8/weather-applet.js:11547
-#: 3.8/weather-applet.js:11548 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12222 3.8/weather-applet.js:12738
-#: 3.8/weather-applet.js:12739 3.8/weather-applet.js:12773
-#: 3.8/weather-applet.js:13420 3.8/weather-applet.js:13421
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Maioritariamente limpo"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10425 3.8/weather-applet.js:10426
-#: 3.8/weather-applet.js:11039 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:12724
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12759
-#: 3.8/weather-applet.js:13223 3.8/weather-applet.js:13413
-#: 3.8/weather-applet.js:13414 3.8/weather-applet.js:14140
-#: 3.8/weather-applet.js:14141 3.8/weather-applet.js:14147
-#: 3.8/weather-applet.js:14148 3.8/weather-applet.js:14686
-#: 3.8/weather-applet.js:14687
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Limpo"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10432
-#: 3.8/weather-applet.js:10433 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:14693
-#: 3.8/weather-applet.js:14694
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Ensolarado"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10418
-#: 3.8/weather-applet.js:10419 3.8/weather-applet.js:10453
-#: 3.8/weather-applet.js:10454 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10643 3.8/weather-applet.js:11341
-#: 3.8/weather-applet.js:11342 3.8/weather-applet.js:11639
-#: 3.8/weather-applet.js:11640 3.8/weather-applet.js:12192
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12715
-#: 3.8/weather-applet.js:12716 3.8/weather-applet.js:12944
-#: 3.8/weather-applet.js:12945 3.8/weather-applet.js:14073
-#: 3.8/weather-applet.js:14074 3.8/weather-applet.js:14224
-#: 3.8/weather-applet.js:14225 3.8/weather-applet.js:14797
-#: 3.8/weather-applet.js:14799
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -559,7 +557,7 @@ msgstr ""
 "Por favor insira a chave da API nas definições,\n"
 "ou primeiro obtenha uma em https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:14881
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -567,7 +565,7 @@ msgstr ""
 "Por favor confirme que já,\n"
 "introduziste a chave da API que já tens do DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:15197
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Não foi possível obter a localização"
 
@@ -578,121 +576,121 @@ msgstr ""
 "Serviço de localização respondido com erros, por favor verifique os registos "
 "no Looking Glass (Aparência Vidrada)"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11203
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Nublado"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11351
-#: 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Limpo"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11365 3.8/weather-applet.js:11366
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Limpo"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11387
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Chuva pesada com trovões"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11394
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Fortes pancadas de chuva"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11401
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Fortes pancadas de chuva com trovões"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11407
-#: 3.8/weather-applet.js:11408 3.8/weather-applet.js:11414
-#: 3.8/weather-applet.js:11421 3.8/weather-applet.js:11428
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Granizo forte"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11415
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Granizo"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11422
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Fortes pancadas de granizo"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11429
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Fortes pancadas de granizo com trovões"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11443
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Neve com trovadas"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11450
-#: 3.8/weather-applet.js:13526
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Fortes pancadas de neve"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11457
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Fortes pancadas de neve com trovões"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11471
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Chuva leve com trovoadas"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11478
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Pancada de chuva fraca"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11485
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Pancada de chuva fraca com trovões"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11491
-#: 3.8/weather-applet.js:11492 3.8/weather-applet.js:11498
-#: 3.8/weather-applet.js:11505 3.8/weather-applet.js:11512
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Granizo leve"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11499
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Granizo leve com trovoadas"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11506
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Pancadas de granizo leve"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11513
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Pancadas de granizo leve com trovões"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11527
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Nevada leve com trovoada"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11534
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Pancadas leves de neve"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11541
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Pancadas leves de neve com trovões"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11562
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Chuva e trovões"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11568
-#: 3.8/weather-applet.js:11569 3.8/weather-applet.js:11575
-#: 3.8/weather-applet.js:12859 3.8/weather-applet.js:13185
-#: 3.8/weather-applet.js:13491 3.8/weather-applet.js:13497
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Pancadas de chuva"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11576
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Pancadas de chuva com trovoadas"
 
@@ -701,44 +699,44 @@ msgstr "Pancadas de chuva com trovoadas"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10537
-#: 3.8/weather-applet.js:10544 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11582 3.8/weather-applet.js:11583
-#: 3.8/weather-applet.js:11589 3.8/weather-applet.js:11596
-#: 3.8/weather-applet.js:11603 3.8/weather-applet.js:12808
-#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12815
-#: 3.8/weather-applet.js:12816 3.8/weather-applet.js:12843
-#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14196
-#: 3.8/weather-applet.js:14197 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Granizo"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11590
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Granizo e trovão"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11597
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Pancadas de granizo"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11604
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Pancadas de granizo com trovões"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11618
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Neve e trovões"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11624 3.8/weather-applet.js:11625
-#: 3.8/weather-applet.js:11631 3.8/weather-applet.js:13203
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Pancadas de neve"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11632
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Pancadas de neve e trovões"
 
@@ -747,21 +745,21 @@ msgstr "Pancadas de neve e trovões"
 msgid "Unexpected response from API"
 msgstr "Resposta inesperada da API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10237
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Visibilidade"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10265
-#: 3.8/weather-applet.js:10817 3.8/weather-applet.js:11722
-#: 3.8/weather-applet.js:12672
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Falha no processamento da informação atual do clima"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10055
-#: 3.8/weather-applet.js:10089 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11782 3.8/weather-applet.js:12474
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Falha no processamento da informação das previsões"
 
@@ -790,90 +788,90 @@ msgid "Excellent - More than"
 msgstr "Excelente - Mais que"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10460 3.8/weather-applet.js:10461
-#: 3.8/weather-applet.js:11029 3.8/weather-applet.js:13175
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Névoa"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:12752
-#: 3.8/weather-applet.js:12753 3.8/weather-applet.js:12787
-#: 3.8/weather-applet.js:13219
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Nublado"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10489
-#: 3.8/weather-applet.js:10496
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Pancadas leve de chuva"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:12326
-#: 3.8/weather-applet.js:13141 3.8/weather-applet.js:14532
-#: 3.8/weather-applet.js:14533
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Chuvisco"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:10524
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Fortes pancadas de chuva"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10538
-#: 3.8/weather-applet.js:10545
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Chuvas de granizo"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:13217 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14169 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:14589
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Granizo"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Nevadas"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Neve fraca"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Forte nevada"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10621 3.8/weather-applet.js:10628
-#: 3.8/weather-applet.js:10635 3.8/weather-applet.js:10636
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Tempestade"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Tempestades"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10872
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 "Certifique-se de que a localização esteja no formato correto nas "
 "configurações"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10876
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Certifique-se de inserir a chave correta nas configurações"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10681 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -881,212 +879,212 @@ msgstr ""
 "Local não encontrado, verifique se o local está disponível ou no formato "
 "correto"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10884
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Se o problema persistir, entre em contato com o autor deste applet"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10888
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 "Erro desconhecido, consulte os registos no Looking Glass (Aparência Vidrada)"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10990
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Trovoada com chuva fraca"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10991
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Tempestade com chuva"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10992
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Trovoada com chuva forte"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10993
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Tempestade leve"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10995
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Tempestade severa"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10996
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Tempestades isoladas"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10997
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Trovoada com chuvisco leve"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10998
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Tempestade com chuvisco"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10999
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Trovoada com chuvisco forte"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11000
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Chuvisco de intensidade leve"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11002
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Chuvisco de intensidade forte"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11003
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Chuva chuvisca de intensidade leve"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11004
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Chuvisco"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11005
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Chuva chuvisca de intensidade forte"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11006
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Pancadas de chuva e chuvisco"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11007
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Pancadas fortes de chuva e chuvisco"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11008
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Chuvisco"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11010
-#: 3.8/weather-applet.js:13455 3.8/weather-applet.js:13456
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Chuva moderada"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11011
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Chuva pesada"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11012
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Chuva muito pesada"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11013
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Chuva extrema"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11015
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Chuva de intensidade leve"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11016
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Chuva"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11017
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Chuva de alta intensidade"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11018
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Chuva irregular"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11023
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Chuva de granizo"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11024
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Chuva leve com neve"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11025
-#: 3.8/weather-applet.js:13462 3.8/weather-applet.js:13463
-#: 3.8/weather-applet.js:13469 3.8/weather-applet.js:13504
-#: 3.8/weather-applet.js:13511
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Chuva e neve"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11026
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Neve fraca"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11027
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Neve"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11028
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Forte nevada"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:12902
-#: 3.8/weather-applet.js:12903 3.8/weather-applet.js:14623
-#: 3.8/weather-applet.js:14624
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Fumaça"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11031 3.8/weather-applet.js:12909
-#: 3.8/weather-applet.js:12910 3.8/weather-applet.js:14616
-#: 3.8/weather-applet.js:14617
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Neblina"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11032
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Areia, redemoinhos de poeira"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11034
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Areia"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11035 3.8/weather-applet.js:12895
-#: 3.8/weather-applet.js:12896 3.8/weather-applet.js:14602
-#: 3.8/weather-applet.js:14603
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Neblina"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11036
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Cinza vulcanica"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:13209
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Rajadas"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11038 3.8/weather-applet.js:12874
-#: 3.8/weather-applet.js:12875 3.8/weather-applet.js:14475
-#: 3.8/weather-applet.js:14476
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11041
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "O céu está limp"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11042
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Nublado"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11043
-#: 3.8/weather-applet.js:12731 3.8/weather-applet.js:12732
-#: 3.8/weather-applet.js:12766
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Poucas núvens"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11044
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Nuvens dispersas"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11045
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Nuvens quebradas"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11046
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Nuvens nublados"
 
@@ -1094,80 +1092,80 @@ msgstr "Nuvens nublados"
 msgid "Could not get forecast for your area"
 msgstr "Não foi possível obter a previsão para sua área"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12431
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "A localização é fora dos EUA. Use um provedor diferente."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12495
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Falha ao processar informações de previsão por hora"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12760
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Claro e ventoso"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12767
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Ventoso e com poucas nuvens"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12774
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Parcialmente nublado e ventoso"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Muito nublado e ventoso"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12788
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Nublado e ventoso"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12802
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Flocos de neve"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12837
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Chuva congelada"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9153 3.8/weather-applet.js:12881
-#: 3.8/weather-applet.js:12882 3.8/weather-applet.js:14489
-#: 3.8/weather-applet.js:14490
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Furacão"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9148
-#: 3.8/weather-applet.js:12888
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Tempestade"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12889
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Tempestade tropical"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12916 3.8/weather-applet.js:12917
-#: 3.8/weather-applet.js:14721 3.8/weather-applet.js:14722
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Quente"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12923 3.8/weather-applet.js:12924
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Frio"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12930 3.8/weather-applet.js:12931
-#: 3.8/weather-applet.js:14770 3.8/weather-applet.js:14771
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Nevasca"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9025
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Hoje"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9027
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Amanhã"
 
@@ -1199,79 +1197,79 @@ msgstr "Sexta-feira"
 msgid "Saturday"
 msgstr "Sábado"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9118
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Calmo"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9121
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Ar leve"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9124
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Brisa leve"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9127
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Brisa gentil"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9130
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Brisa moderada"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9133
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Brisa fresca"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9136
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Brisa forte"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9139
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Quase ventania"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9142
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Ventania"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9145
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Ventania forte"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9151
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Tempestade violenta"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr ""
 
@@ -1323,7 +1321,7 @@ msgstr ""
 "Ocorreu um erro desconhecido ao obter o clima, consulte os registos do "
 "Looking Glass (Aparência Vidrada) para obter mais informações"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14482 3.8/weather-applet.js:14483
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Tempestade tropical"
 
@@ -1331,7 +1329,7 @@ msgstr "Tempestade tropical"
 msgid "Severe Thunderstorms"
 msgstr "Tempestade severa"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14503 3.8/weather-applet.js:14504
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Tempestade"
 
@@ -1347,15 +1345,15 @@ msgstr "Granizo e chuva"
 msgid "Mixed Snow and Sleet"
 msgstr "Granizo e neve"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Geada"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Chuva congelada"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Chuva"
 
@@ -1367,11 +1365,11 @@ msgstr "Flocos de neve"
 msgid "Light Snow Showers"
 msgstr "Neve fraca"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14574 3.8/weather-applet.js:14575
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Nevasca"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13441 3.8/weather-applet.js:13442
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Neblina"
 
@@ -1383,88 +1381,77 @@ msgstr "Niebla"
 msgid "Blustery"
 msgstr "Rajadas de vento"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14637 3.8/weather-applet.js:14638
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Ventoso"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:14658 3.8/weather-applet.js:14659
-#: 3.8/weather-applet.js:14665 3.8/weather-applet.js:14666
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Muito nublado"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14175 3.8/weather-applet.js:14176
-#: 3.8/weather-applet.js:14182 3.8/weather-applet.js:14183
-#: 3.8/weather-applet.js:14672 3.8/weather-applet.js:14673
-#: 3.8/weather-applet.js:14679 3.8/weather-applet.js:14680
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 #, fuzzy
-#| msgid "Partly cloudy"
 msgid "Partly Cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 #, fuzzy
-#| msgid "Mostly cloudy"
 msgid "Mostly Sunny"
 msgstr "Muito nublado"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:14714 3.8/weather-applet.js:14715
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 #, fuzzy
-#| msgid "Mixed rain and hail"
 msgid "Mixed Rain and Hail"
 msgstr "Chuva e granizo"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:14728 3.8/weather-applet.js:14729
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 #, fuzzy
-#| msgid "Isolated thunderstorms"
 msgid "Isolated Thunderstorms"
 msgstr "Tempestades isoladas"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:14735 3.8/weather-applet.js:14736
-#: 3.8/weather-applet.js:14791 3.8/weather-applet.js:14792
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 #, fuzzy
-#| msgid "Scattered thunderstorms"
 msgid "Scattered Thunderstorms"
 msgstr "Tempestades isoladas"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:14742 3.8/weather-applet.js:14743
-#: 3.8/weather-applet.js:14777 3.8/weather-applet.js:14778
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 #, fuzzy
-#| msgid "Scattered showers"
 msgid "Scattered Showers"
 msgstr "Chuvas Isoladas"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:14749 3.8/weather-applet.js:14750
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 #, fuzzy
-#| msgid "Heavy snow"
 msgid "Heavy Rain"
 msgstr "Forte nevada"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:14756 3.8/weather-applet.js:14757
-#: 3.8/weather-applet.js:14784 3.8/weather-applet.js:14785
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 #, fuzzy
-#| msgid "Scattered snow showers"
 msgid "Scattered Snow Showers"
 msgstr "Nevadas isoladas"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:14763 3.8/weather-applet.js:14764
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 #, fuzzy
-#| msgid "Heavy snow"
 msgid "Heavy Snow"
 msgstr "Forte nevada"
 
 #: 3.0/yahoo.js:478
 #, fuzzy
-#| msgid "Not available"
 msgid "Not Available"
 msgstr "Não disponível"
 
 #: 3.0/yahoo.js:479
 #, fuzzy
-#| msgid "Scattered thunderstorms"
 msgid "Scattered Thundershowers"
 msgstr "Tempestades isoladas"
 
-#: 3.8/weather-applet.js:9637
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1473,18 +1460,18 @@ msgstr ""
 "caminho\n"
 "  {logFilePath}"
 
-#: 3.8/weather-applet.js:9641
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10013
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr ""
 
-#: 3.8/weather-applet.js:10118
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1492,277 +1479,276 @@ msgstr ""
 "MET Office UK cobre apenas o Reino Unido, certifique-se de que sua "
 "localização esteja neste país"
 
-#: 3.8/weather-applet.js:10197
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Não foram encontrados dados para localização"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Muito fraco"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Menos que {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Excelente"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Mais que {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10287
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Fraco"
 
-#: 3.8/weather-applet.js:10287 3.8/weather-applet.js:10292
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:10302
-#: 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Entre {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10292
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Moderado"
 
-#: 3.8/weather-applet.js:10297
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Bom"
 
-#: 3.8/weather-applet.js:10302 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Muito bom"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10662
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr ""
 
-#: 3.8/weather-applet.js:11659
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr ""
 
-#: 3.8/weather-applet.js:12080
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr ""
 
-#: 3.8/weather-applet.js:12250
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Vento leve"
 
-#: 3.8/weather-applet.js:12264
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Vento forte"
 
-#: 3.8/weather-applet.js:12411
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr ""
 
-#: 3.8/weather-applet.js:12962
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Atravessamento visual"
 
-#: 3.8/weather-applet.js:13139
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Nevasca"
 
-#: 3.8/weather-applet.js:13143
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Geada pesada"
 
-#: 3.8/weather-applet.js:13147
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Geada pesada/chuva"
 
-#: 3.8/weather-applet.js:13149
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Chuvisco pesado/chuva"
 
-#: 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Tempestade de poeira"
 
-#: 3.8/weather-applet.js:13155
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Geada congelante/chuva congelante"
 
-#: 3.8/weather-applet.js:13157
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Geada forte congelante/chuva congelante"
 
-#: 3.8/weather-applet.js:13159
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Geada leve congelante/chuva congelante"
 
-#: 3.8/weather-applet.js:13161
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Névoa congelante"
 
-#: 3.8/weather-applet.js:13167
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Nuvem funil/tornado"
 
-#: 3.8/weather-applet.js:13169
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Chuvas de granizo"
 
-#: 3.8/weather-applet.js:13171
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Gelo"
 
-#: 3.8/weather-applet.js:13173
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Relâmpago sem trovão"
 
-#: 3.8/weather-applet.js:13177
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Precipitação nas proximidades"
 
-#: 3.8/weather-applet.js:13181 3.8/weather-applet.js:13470
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Chuva pesada e neve"
 
-#: 3.8/weather-applet.js:13183
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Chuva leve e neve"
 
-#: 3.8/weather-applet.js:13191
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Cobertura do céu diminuindo"
 
-#: 3.8/weather-applet.js:13193
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Cobertura do céu aumentando"
 
-#: 3.8/weather-applet.js:13195
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Céu inalterado"
 
-#: 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Fumaça ou neblina"
 
-#: 3.8/weather-applet.js:13201
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Pancadas de neve e chuva"
 
-#: 3.8/weather-applet.js:13213
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Trovoada sem precipitação"
 
-#: 3.8/weather-applet.js:13215
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Pó de diamante"
 
-#: 3.8/weather-applet.js:13221
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.8/weather-applet.js:13243
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Certifique-se de inserir a chave API corretamente"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13259
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr ""
 
-#: 3.8/weather-applet.js:13402 3.8/weather-applet.js:13403
-#: 3.8/weather-applet.js:13539 3.8/weather-applet.js:13540
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "NÂO ENCONTRADO"
 
-#: 3.8/weather-applet.js:13435
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Nevasca"
 
-#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:13477
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 #, fuzzy
-#| msgid "Blowing snow"
 msgid "Slight snow"
 msgstr "Nevasca"
 
-#: 3.8/weather-applet.js:13483 3.8/weather-applet.js:13484
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Nevada moderada"
 
-#: 3.8/weather-applet.js:13498
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Pancadas moderadas de chuva"
 
-#: 3.8/weather-applet.js:13505
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Chuva e neve"
 
-#: 3.8/weather-applet.js:13512
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Chuva e neve fortes"
 
-#: 3.8/weather-applet.js:13657
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr ""
 
-#: 3.8/weather-applet.js:13953
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:13966
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "Selecione um provedor ou local diferente"
 
-#: 3.8/weather-applet.js:14263
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Clima subterrâneo"
 
-#: 3.8/weather-applet.js:14453
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "A chave de API que você forneceu é inválida."
 
-#: 3.8/weather-applet.js:14460
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "O local que você forneceu não foi encontrado."
 
-#: 3.8/weather-applet.js:14496 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Tempestade forte"
 
-#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:14512
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Chuva e neve"
 
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Granizo e chuva"
 
-#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Nevadas"
 
-#: 3.8/weather-applet.js:14630 3.8/weather-applet.js:14631
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "Brisado"
 
-#: 3.8/weather-applet.js:14644 3.8/weather-applet.js:14645
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr "Gelado"
 
-#: 3.8/weather-applet.js:14700 3.8/weather-applet.js:14701
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Muito claro"
 
-#: 3.8/weather-applet.js:14853
+#: 3.8/weather-applet.js:15247
 msgid "Pirate Weather"
 msgstr ""
 
-#: 3.8/weather-applet.js:15206
+#: 3.8/weather-applet.js:15603
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
@@ -1770,11 +1756,11 @@ msgstr ""
 "O Serviço de localização não conseguiu encontrar sua localização. Consulte "
 "os registros no Looking Glass"
 
-#: 3.8/weather-applet.js:15428
+#: 3.8/weather-applet.js:15831
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr "Certifique-se de inserir um local ou use a localização automática."
 
-#: 3.8/weather-applet.js:15565
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1783,7 +1769,7 @@ msgstr ""
 "caminhos\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15572
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1791,58 +1777,58 @@ msgstr ""
 "Não foi possível obter o conteúdo do arquivo de configuração no caminho\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Este provedor requer uma chave de API para operar"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Ponto de condensação da água"
 
-#: 3.8/weather-applet.js:16264
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "A precipitação terminará em {precipEnd} minutos"
 
-#: 3.8/weather-applet.js:16266
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "A precipitação não terminará dentro de uma hora"
 
-#: 3.8/weather-applet.js:16269
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "A precipitação começará dentro de {precipStart} minutos"
 
-#: 3.8/weather-applet.js:16481
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Falha na análise da previsão. Consulte os registos para obter mais detalhes."
 
-#: 3.8/weather-applet.js:17013 3.8/weather-applet.js:17802
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "Às {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:17019
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} de ti"
 
-#: 3.8/weather-applet.js:17023
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "Nome da estação: {stationName}"
 
-#: 3.8/weather-applet.js:17026
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "Área: {stationArea}"
 
-#: 3.8/weather-applet.js:17573 3.8/weather-applet.js:17583
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Erro ao salvar informações de depuração"
 
-#: 3.8/weather-applet.js:17595
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Erro ao salvar informações de depuração"
 
-#: 3.8/weather-applet.js:17595
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Guardado em {filePath}"
-
-#: 3.8/weather-applet.js:17726
-msgid "This provider requires an API key to operate"
-msgstr "Este provedor requer uma chave de API para operar"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -2642,30 +2628,3 @@ msgstr ""
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr "Caminho selecionado para salvar os registos"
-
-#~ msgid "Settings"
-#~ msgstr "Preferências"
-
-#~ msgid "Sunrise"
-#~ msgstr "Nascer do sol"
-
-#~ msgid "Sunset"
-#~ msgstr "Pôr do sol"
-
-#~ msgid "Wind Chill:"
-#~ msgstr "Vento:"
-
-#~ msgid "Isolated thundershowers"
-#~ msgstr "Tempestades isoladas"
-
-#~ msgid "Get WOEID"
-#~ msgstr "Obter WOEID"
-
-#~ msgid "Vertical orientation"
-#~ msgstr "Orientação vertical"
-
-#~ msgid "WOEID"
-#~ msgstr "WOEID"
-
-#~ msgid "Symbolic icons"
-#~ msgstr "Ícones simbólicos"

--- a/weather@mockturtl/files/weather@mockturtl/po/pt_BR.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/pt_BR.po
@@ -8,8 +8,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: weather@mockturtl 2.6.5\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-05 09:30+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2023-04-14 18:10-0300\n"
 "Last-Translator: Fúlvio Alves <fga.fulvio@gmail.com>\n"
 "Language-Team: Português <jorgebadad@gmail.com>\n"
@@ -20,65 +21,65 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:15288
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Erro"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:15289 3.8/weather-applet.js:15291
-#: 3.8/weather-applet.js:15293 3.8/weather-applet.js:15296
-#: 3.8/weather-applet.js:15299 3.8/weather-applet.js:15300
-#: 3.8/weather-applet.js:15301 3.8/weather-applet.js:15302
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Erro de serviço"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:15290
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Chave API Incorreta"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:15292
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Formato de local incorreto"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:15294
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Chave bloqueada"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:15295
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Não pode encontrar o local"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:15297
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Sem chave API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:15298
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Sem local"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:15303
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Pacotes ausentes"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:15304
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Local não coberto"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9288
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Miniaplicativo Meteorológico"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:15549
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:15550
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Clique para abrir"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:14133
-#: 3.8/weather-applet.js:15561
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Atualizar"
 
@@ -88,8 +89,8 @@ msgstr "A API retornou o código de status entre 400 e 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9454
-#: 3.8/weather-applet.js:9458 3.8/weather-applet.js:9462
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Loja de Locais"
 
@@ -101,13 +102,13 @@ msgstr "Você não pode salvar um local obtido automaticamente, desculpe"
 msgid "Could not get weather information"
 msgstr "Não foi possível obter informações meteorológicas"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:15398
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Erro inesperado ao atualizar o tempo. Consulte o registro em Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:15639
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -123,7 +124,7 @@ msgstr "Erro de rede. Verifique o registro em Looking Glass"
 msgid "As of"
 msgstr "A partir de"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:14817
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Distribuído por"
 
@@ -131,91 +132,90 @@ msgstr "Distribuído por"
 msgid "from you"
 msgstr "de você"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:14748
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:10244
-#: 3.8/weather-applet.js:14748
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "pol"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:9883
-#: 3.8/weather-applet.js:14878
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:9884
-#: 3.8/weather-applet.js:14879
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:15049
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Carregando as condições meteorológicas atuais ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:15052
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Carregando as condições meteorológicas futuras ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:14072
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Carregando ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:14098
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:14099
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Umidade"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:14100
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Pressão"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12083 3.8/weather-applet.js:12090
-#: 3.8/weather-applet.js:12091 3.8/weather-applet.js:12097
-#: 3.8/weather-applet.js:14101
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Vento"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:13650
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr "Verifique se você inseriu um local ou use a localização automática"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9534
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Não foi possível encontrar o local com base no endereço. Verifique se está "
 "correto"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9555
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Falha ao chamar a API de geolocalização. Consulte Looking Glass para erros."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9454
-#: 3.8/weather-applet.js:9458
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Aviso"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9454
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 "Você só pode salvar locais corretos quando o applet não estiver atualizando"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9458
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Você não pode salvar um local incorreto"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9462
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Informação"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9462
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "O local já está salvo"
 
@@ -253,14 +253,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10303 3.8/weather-applet.js:10629
-#: 3.8/weather-applet.js:11553 3.8/weather-applet.js:11986
-#: 3.8/weather-applet.js:12489 3.8/weather-applet.js:12850
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Sensação Térmica"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:10348
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Falha ao processar informações meteorológicas"
 
@@ -273,7 +274,7 @@ msgstr ""
 "ou obtenha uma primeiro em https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:10378 3.8/weather-applet.js:11719
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -281,7 +282,7 @@ msgstr ""
 "Tenha certeza de que você \n"
 "informou a chave API correta e que sua conta não está bloqueada"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:11952
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -292,58 +293,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10084 3.8/weather-applet.js:10091
-#: 3.8/weather-applet.js:10098 3.8/weather-applet.js:10099
-#: 3.8/weather-applet.js:11184 3.8/weather-applet.js:11185
-#: 3.8/weather-applet.js:11191 3.8/weather-applet.js:11198
-#: 3.8/weather-applet.js:11205 3.8/weather-applet.js:12126
-#: 3.8/weather-applet.js:13016
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Chuva forte"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11359 3.8/weather-applet.js:11360
-#: 3.8/weather-applet.js:11366 3.8/weather-applet.js:12111
-#: 3.8/weather-applet.js:12112 3.8/weather-applet.js:12118
-#: 3.8/weather-applet.js:12125 3.8/weather-applet.js:12167
-#: 3.8/weather-applet.js:12174 3.8/weather-applet.js:12181
-#: 3.8/weather-applet.js:12633 3.8/weather-applet.js:12682
-#: 3.8/weather-applet.js:12683 3.8/weather-applet.js:12690
-#: 3.8/weather-applet.js:13008 3.8/weather-applet.js:13274
-#: 3.8/weather-applet.js:13275 3.8/weather-applet.js:13316
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Chuva"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10056
-#: 3.8/weather-applet.js:10063 3.8/weather-applet.js:10077
-#: 3.8/weather-applet.js:10078 3.8/weather-applet.js:10898
-#: 3.8/weather-applet.js:11268 3.8/weather-applet.js:11269
-#: 3.8/weather-applet.js:11275 3.8/weather-applet.js:11282
-#: 3.8/weather-applet.js:11289 3.8/weather-applet.js:12119
-#: 3.8/weather-applet.js:13018
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Chuva leve"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12182 3.8/weather-applet.js:12992
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Chuva congelante forte"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:10903
-#: 3.8/weather-applet.js:12168 3.8/weather-applet.js:12654
-#: 3.8/weather-applet.js:12655 3.8/weather-applet.js:12661
-#: 3.8/weather-applet.js:12662 3.8/weather-applet.js:12668
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Chuva congelante"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12175 3.8/weather-applet.js:12994
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Chuva congelante fraca"
 
@@ -351,173 +354,189 @@ msgstr "Chuva congelante fraca"
 msgid "Light freezing drizzle"
 msgstr "Garoa congelante leve"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12161
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Garoa congelante"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:12974
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Garoa leve"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12196
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Granizo forte"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12188 3.8/weather-applet.js:12189
-#: 3.8/weather-applet.js:12195 3.8/weather-applet.js:12202
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Granizo"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12203
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Granizo leve"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10168
-#: 3.8/weather-applet.js:10175 3.8/weather-applet.js:10182
-#: 3.8/weather-applet.js:10183 3.8/weather-applet.js:10910
-#: 3.8/weather-applet.js:11240 3.8/weather-applet.js:11241
-#: 3.8/weather-applet.js:11247 3.8/weather-applet.js:11254
-#: 3.8/weather-applet.js:11261 3.8/weather-applet.js:12154
-#: 3.8/weather-applet.js:13034 3.8/weather-applet.js:13351
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Neve forte"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:10909 3.8/weather-applet.js:11415
-#: 3.8/weather-applet.js:11416 3.8/weather-applet.js:11422
-#: 3.8/weather-applet.js:12132 3.8/weather-applet.js:12133
-#: 3.8/weather-applet.js:12146 3.8/weather-applet.js:12153
-#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:12627
-#: 3.8/weather-applet.js:13028 3.8/weather-applet.js:13260
-#: 3.8/weather-applet.js:13344
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Neve"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10147
-#: 3.8/weather-applet.js:10154 3.8/weather-applet.js:10161
-#: 3.8/weather-applet.js:10162 3.8/weather-applet.js:10908
-#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:11325
-#: 3.8/weather-applet.js:11331 3.8/weather-applet.js:11338
-#: 3.8/weather-applet.js:11345 3.8/weather-applet.js:12147
-#: 3.8/weather-applet.js:13036
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Neve leve"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12139
-#: 3.8/weather-applet.js:12140
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Rajadas"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10883
-#: 3.8/weather-applet.js:12209 3.8/weather-applet.js:12210
-#: 3.8/weather-applet.js:12699 3.8/weather-applet.js:12700
-#: 3.8/weather-applet.js:13040 3.8/weather-applet.js:13358
-#: 3.8/weather-applet.js:13359
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Tempestade"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12077
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Nevoeiro leve"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10035 3.8/weather-applet.js:10036
-#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11177
-#: 3.8/weather-applet.js:11178 3.8/weather-applet.js:12069
-#: 3.8/weather-applet.js:12070 3.8/weather-applet.js:12076
-#: 3.8/weather-applet.js:12769 3.8/weather-applet.js:12770
-#: 3.8/weather-applet.js:12982
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Névoa"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10042 3.8/weather-applet.js:10043
-#: 3.8/weather-applet.js:11163 3.8/weather-applet.js:11164
-#: 3.8/weather-applet.js:12041 3.8/weather-applet.js:12042
-#: 3.8/weather-applet.js:13253 3.8/weather-applet.js:13254
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Nublado"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12062
-#: 3.8/weather-applet.js:12063 3.8/weather-applet.js:12577
-#: 3.8/weather-applet.js:12578 3.8/weather-applet.js:12612
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Predominantemente nublado"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10007
-#: 3.8/weather-applet.js:10008 3.8/weather-applet.js:10014
-#: 3.8/weather-applet.js:10015 3.8/weather-applet.js:11352
-#: 3.8/weather-applet.js:11353 3.8/weather-applet.js:12055
-#: 3.8/weather-applet.js:12056 3.8/weather-applet.js:12570
-#: 3.8/weather-applet.js:12571 3.8/weather-applet.js:12605
-#: 3.8/weather-applet.js:13246 3.8/weather-applet.js:13247
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12048
-#: 3.8/weather-applet.js:12049
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Predominantemente limpo"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:9993 3.8/weather-applet.js:9994
-#: 3.8/weather-applet.js:10928 3.8/weather-applet.js:12034
-#: 3.8/weather-applet.js:12035 3.8/weather-applet.js:12556
-#: 3.8/weather-applet.js:12557 3.8/weather-applet.js:12591
-#: 3.8/weather-applet.js:13052 3.8/weather-applet.js:13239
-#: 3.8/weather-applet.js:13240
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Limpo"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10000
-#: 3.8/weather-applet.js:10001 3.8/weather-applet.js:12034
-#: 3.8/weather-applet.js:12035
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Ensolarado"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:9986 3.8/weather-applet.js:9987
-#: 3.8/weather-applet.js:10021 3.8/weather-applet.js:10022
-#: 3.8/weather-applet.js:10210 3.8/weather-applet.js:10211
-#: 3.8/weather-applet.js:11146 3.8/weather-applet.js:11147
-#: 3.8/weather-applet.js:11444 3.8/weather-applet.js:11445
-#: 3.8/weather-applet.js:12026 3.8/weather-applet.js:12027
-#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12548
-#: 3.8/weather-applet.js:12776 3.8/weather-applet.js:12777
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10244
+#: 3.0/darkSky.js:71
 msgid "and"
 msgstr "e"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10244
+#: 3.0/darkSky.js:71
 msgid "until"
 msgstr "até"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10244
+#: 3.0/darkSky.js:71
 msgid "Possible"
 msgstr "Possível"
 
@@ -529,7 +548,7 @@ msgstr ""
 "Favor insira a chave API nas configurações, \n"
 "ou obtenha uma primeiro em https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:10388
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -537,132 +556,132 @@ msgstr ""
 "Tenha certeza de que você \n"
 "inseriu a chave API que você tem de DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:9240
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Não foi possível obter o local"
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:9246
+#: 3.0/ipApi.js:95
 msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 "O Serviço de Localização respondeu com erros. Consulte os registros em "
 "Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11005
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Nebulosidade"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:10929 3.8/weather-applet.js:11156
-#: 3.8/weather-applet.js:11157
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Céu limpo"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11170 3.8/weather-applet.js:11171
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Tempo calmo e claro"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11192
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Chuva forte e trovões"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11199
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Chuvas fortes isoladas"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11206
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Chuvas fortes isoladas e trovões"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11212
-#: 3.8/weather-applet.js:11213 3.8/weather-applet.js:11219
-#: 3.8/weather-applet.js:11226 3.8/weather-applet.js:11233
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Granizo forte"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11220
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Granizo forte e trovões"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11227
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Granizo forte isolado"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11234
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Granizo forte isolado e trovões"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11248
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Neve intensa e trovões"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11255
-#: 3.8/weather-applet.js:13352
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Neve intensa e isolada"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11262
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Neve intensa, isolada e trovões"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11276
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Chuva leve e trovões"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11283
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Chuva leve isolada"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11290
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Chuva leve isolada e trovões"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11296
-#: 3.8/weather-applet.js:11297 3.8/weather-applet.js:11303
-#: 3.8/weather-applet.js:11310 3.8/weather-applet.js:11317
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Granizo fraco"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11304
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Granizo fraco e trovões"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11311
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Granizo fraco isolado"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11318
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Granizo fraco isolado e trovões"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11332
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Neve fraca e trovões"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11339
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Neve fraca isolada"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11346
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Neve fraca isolada e trovões"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11367
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Chuva e trovões"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11373
-#: 3.8/weather-applet.js:11374 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:12691 3.8/weather-applet.js:13014
-#: 3.8/weather-applet.js:13317 3.8/weather-applet.js:13323
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Chuvas isoladas"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11381
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Chuva isoladas e trovões"
 
@@ -671,42 +690,44 @@ msgstr "Chuva isoladas e trovões"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10105
-#: 3.8/weather-applet.js:10112 3.8/weather-applet.js:10119
-#: 3.8/weather-applet.js:10120 3.8/weather-applet.js:10911
-#: 3.8/weather-applet.js:11387 3.8/weather-applet.js:11388
-#: 3.8/weather-applet.js:11394 3.8/weather-applet.js:11401
-#: 3.8/weather-applet.js:11408 3.8/weather-applet.js:12640
-#: 3.8/weather-applet.js:12641 3.8/weather-applet.js:12647
-#: 3.8/weather-applet.js:12648 3.8/weather-applet.js:12675
-#: 3.8/weather-applet.js:12676
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Granizo"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11395
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Granizo e trovões"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11402
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Granizo isolado"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11409
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Granizo isolado e trovões"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11423
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Neve e trovões"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11429 3.8/weather-applet.js:11430
-#: 3.8/weather-applet.js:11436 3.8/weather-applet.js:13032
-#: 3.8/weather-applet.js:13345
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Neve isolada"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11437
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Neve isolada e trovões"
 
@@ -715,20 +736,21 @@ msgstr "Neve isolada e trovões"
 msgid "Unexpected response from API"
 msgstr "Resposta inesperada de API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:9808
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Visibilidade"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:9836 3.8/weather-applet.js:10706
-#: 3.8/weather-applet.js:11564 3.8/weather-applet.js:12502
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Falha ao processar informações meteorológicas atuais"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:9633
-#: 3.8/weather-applet.js:9667 3.8/weather-applet.js:11590
-#: 3.8/weather-applet.js:11624 3.8/weather-applet.js:12307
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Falha ao processar informações de previsão"
 
@@ -757,85 +779,88 @@ msgid "Excellent - More than"
 msgstr "Excelente - Mais de"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10028 3.8/weather-applet.js:10029
-#: 3.8/weather-applet.js:10918 3.8/weather-applet.js:13004
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Névoa"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10049
-#: 3.8/weather-applet.js:10050 3.8/weather-applet.js:12584
-#: 3.8/weather-applet.js:12585 3.8/weather-applet.js:12619
-#: 3.8/weather-applet.js:13048
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Muito nublado"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10057
-#: 3.8/weather-applet.js:10064
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Chuva leve isolada"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10070 3.8/weather-applet.js:10071
-#: 3.8/weather-applet.js:10890 3.8/weather-applet.js:12104
-#: 3.8/weather-applet.js:12105 3.8/weather-applet.js:12160
-#: 3.8/weather-applet.js:12970
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Garoa"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10085
-#: 3.8/weather-applet.js:10092
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Chuva intensa isolada"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10106
-#: 3.8/weather-applet.js:10113
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Granizo isolado"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10126 3.8/weather-applet.js:10133
-#: 3.8/weather-applet.js:10140 3.8/weather-applet.js:10141
-#: 3.8/weather-applet.js:13046
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Bolas de granizo"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10127
-#: 3.8/weather-applet.js:10134
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Bolas de granizo isoladas"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10148
-#: 3.8/weather-applet.js:10155
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Neve leve isolada"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10169
-#: 3.8/weather-applet.js:10176
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Neve intensa isolada"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10189 3.8/weather-applet.js:10196
-#: 3.8/weather-applet.js:10203 3.8/weather-applet.js:10204
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Trovões"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10190
-#: 3.8/weather-applet.js:10197
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Trovões isolados"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10761
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Tenha certeza de que o local está no formato correto nas Configurações"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10765
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Tenha certeza de que você introduziu a chave correta nas configurações"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10573 3.8/weather-applet.js:10769
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -843,207 +868,211 @@ msgstr ""
 "Local não encontrado. Tenha certeza que seu local está disponível ou que "
 "está no formato correto"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10773
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Se este problema persistir, contate o Autor deste applet"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10777
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Erro desconhecido. Consulte o registro em Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10879
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Tempestade com chuva leve"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10880
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Tempestade com chuva"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10881
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Tempestade com chuva forte"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10882
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Tempestade leve"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10884
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Tempestade forte"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10885
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Tempestade irregular"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10886
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Tempestade com garoa leve"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10887
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Tempestade com garoa"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10888
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Tempestade com garoa forte"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:10889
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Garoa leve"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:10891
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Garoa forte"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:10892
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Chuva com garoa de intensidade leve"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:10893
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Chuva com garoa"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:10894
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Chuva com garoa de intensidade forte"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:10895
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Chuva isolada e garoa"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:10896
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Chuva isolada forte e garoa"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:10897
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Garoa isolada"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:10899
-#: 3.8/weather-applet.js:13281 3.8/weather-applet.js:13282
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Chuva moderada"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:10900
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Chuva forte"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:10901
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Chuva muito forte"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:10902
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Chuva extrema"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:10904
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Chuva isolada leve"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:10905
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Chuva isolada"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:10906
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Chuva isolada forte"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:10907
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Chuva isolada irregular"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:10912
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Granizo isolado"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:10913
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Chuva leve e neve"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:10914
-#: 3.8/weather-applet.js:13288 3.8/weather-applet.js:13289
-#: 3.8/weather-applet.js:13295 3.8/weather-applet.js:13330
-#: 3.8/weather-applet.js:13337
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Chuva e neve"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:10915
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Neve leve isolada"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:10916
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Neve isolada"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:10917
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Neve isolada intensa"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:10919 3.8/weather-applet.js:12734
-#: 3.8/weather-applet.js:12735
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Fumaça"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:10920 3.8/weather-applet.js:12741
-#: 3.8/weather-applet.js:12742
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Neblina"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:10921
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Areia, redemoinhos de poeira"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:10923
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Areia"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:10924 3.8/weather-applet.js:12727
-#: 3.8/weather-applet.js:12728
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Poeira"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:10925
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Cinza vulcânica"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:10926
-#: 3.8/weather-applet.js:13038
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Rajadas"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:10927 3.8/weather-applet.js:12706
-#: 3.8/weather-applet.js:12707
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:10930
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "O céu está limpo"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:10931
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Nuvens"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:10932
-#: 3.8/weather-applet.js:12563 3.8/weather-applet.js:12564
-#: 3.8/weather-applet.js:12598
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Poucas nuvens"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:10933
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Nuvens dispersas"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:10934
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Nuvens quebradas"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:10935
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Muito nublado"
 
@@ -1051,77 +1080,80 @@ msgstr "Muito nublado"
 msgid "Could not get forecast for your area"
 msgstr "Não foi possível obter a previsão para sua área"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12264
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "O local fica fora dos EUA. Utilize um provedor diferente."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12328
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Falha ao processar informações de previsão por hora"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12592
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Limpo e ventoso"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12599
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Poucas nuvens e ventoso"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12606
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Parcialmente nublado e ventoso"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12613
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Maiormente nublado e ventoso"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12620
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Muito nublado e ventoso"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12634
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Chuva com neve"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12669
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Chuva Congelante e neve"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:8701 3.8/weather-applet.js:12713
-#: 3.8/weather-applet.js:12714
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Furacão"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:8696
-#: 3.8/weather-applet.js:12720
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Tempestade"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12721
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Tempestade tropical"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12748 3.8/weather-applet.js:12749
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Quente"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12755 3.8/weather-applet.js:12756
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Frio"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12762 3.8/weather-applet.js:12763
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Nevasca"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:8587
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Hoje"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:8589
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Amanhã"
 
@@ -1153,79 +1185,79 @@ msgstr "Sexta-feira"
 msgid "Saturday"
 msgstr "Sábado"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:8666
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Calmo"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:8669
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Ar leve"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:8672
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Brisa leve"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:8675
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Brisa suave"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:8678
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Brisa moderada"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:8681
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Brisa fresca"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:8684
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Brisa forte"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:8687
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Perto de vendaval"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:8690
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Vendaval"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:8693
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Vendaval forte"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:8699
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Tempestade violenta"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8851
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8851
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "NE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8851
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "L"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8851
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "SE"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8851
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8851
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "SO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8851
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "O"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8851
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "NO"
 
@@ -1277,7 +1309,7 @@ msgstr ""
 "Ocorreu um erro desconhecido ao obter o clima. Consulte os registros no "
 "Looking Glass para mais informações"
 
-#: 3.0/yahoo.js:437
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Tempestade tropical"
 
@@ -1285,7 +1317,7 @@ msgstr "Tempestade tropical"
 msgid "Severe Thunderstorms"
 msgstr "Tempestades severas"
 
-#: 3.0/yahoo.js:440
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Tempestades"
 
@@ -1301,15 +1333,15 @@ msgstr "Chuva e granizo misturados"
 msgid "Mixed Snow and Sleet"
 msgstr "Neve e granizo misturados"
 
-#: 3.0/yahoo.js:444
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Garoa gelada"
 
-#: 3.0/yahoo.js:446
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Chuva gelada"
 
-#: 3.0/yahoo.js:447
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Chuvas isoladas"
 
@@ -1321,11 +1353,11 @@ msgstr "Flocos de neve"
 msgid "Light Snow Showers"
 msgstr "Neve leve isolada"
 
-#: 3.0/yahoo.js:451
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Neve com vento"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13267 3.8/weather-applet.js:13268
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Nebuloso"
 
@@ -1337,47 +1369,54 @@ msgstr "Esfumaçado"
 msgid "Blustery"
 msgstr "Tempestuoso"
 
-#: 3.0/yahoo.js:460
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Ventoso"
 
-#: 3.0/yahoo.js:463
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Predominantemente nublado"
 
-#: 3.0/yahoo.js:464
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.0/yahoo.js:467
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Predominantemente ensolarado"
 
-#: 3.0/yahoo.js:469
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Chuva e granizo misturados"
 
-#: 3.0/yahoo.js:471
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Tempestades isoladas"
 
-#: 3.0/yahoo.js:472
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Tempestades dispersas"
 
-#: 3.0/yahoo.js:473
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Chuvas isoladas dispersas"
 
-#: 3.0/yahoo.js:474
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Chuva forte"
 
-#: 3.0/yahoo.js:475
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Neve dispersa isolada"
 
-#: 3.0/yahoo.js:476
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Neve intensa"
 
@@ -1389,7 +1428,7 @@ msgstr "Não disponível"
 msgid "Scattered Thundershowers"
 msgstr "Trovoadas dispersas"
 
-#: 3.8/weather-applet.js:9179
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1398,7 +1437,7 @@ msgstr ""
 "encontrado no caminho\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9183
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1407,242 +1446,319 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:9595
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:9774
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
+msgstr ""
+
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Não foram encontrados dados para o local"
 
-#: 3.8/weather-applet.js:9849
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Muito pouca"
 
-#: 3.8/weather-applet.js:9849
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Menos que {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:9853
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Excelente"
 
-#: 3.8/weather-applet.js:9853
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Mais de {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:9858
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Pouca"
 
-#: 3.8/weather-applet.js:9858 3.8/weather-applet.js:9863
-#: 3.8/weather-applet.js:9868 3.8/weather-applet.js:9873
-#: 3.8/weather-applet.js:9878
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Entre {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:9863
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Moderada"
 
-#: 3.8/weather-applet.js:9868
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Bom"
 
-#: 3.8/weather-applet.js:9873 3.8/weather-applet.js:9878
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Muito boa"
 
-#: 3.8/weather-applet.js:10230
-msgid "DarkSky"
-msgstr "DarkSky"
-
-#: 3.8/weather-applet.js:10253
-msgid "This API has ceased to function, please use another one."
-msgstr "Esta API deixou de funcionar; utilize outra."
-
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10557
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10947
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET da Noruega"
 
-#: 3.8/weather-applet.js:11503
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:11921
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12084
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Vento leve"
 
-#: 3.8/weather-applet.js:12098
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Vendaval forte"
 
-#: 3.8/weather-applet.js:12245
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "USWeather"
 
-#: 3.8/weather-applet.js:12794
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:12968
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Soprando ou arrastando neve"
 
-#: 3.8/weather-applet.js:12972
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Garoa forte"
 
-#: 3.8/weather-applet.js:12976
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Garoa forte/chuva"
 
-#: 3.8/weather-applet.js:12978
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Garoa leve/chuva"
 
-#: 3.8/weather-applet.js:12980
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Tempestade de areia"
 
-#: 3.8/weather-applet.js:12984
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Garoa gelada/chuva gelada"
 
-#: 3.8/weather-applet.js:12986
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Garoa gelada forte/chuva gelada"
 
-#: 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Garoa gelada leve/chuva gelada"
 
-#: 3.8/weather-applet.js:12990
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Névoa gelada"
 
-#: 3.8/weather-applet.js:12996
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Nuvem em funil/tornado"
 
-#: 3.8/weather-applet.js:12998
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Granizo"
 
-#: 3.8/weather-applet.js:13000
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Gelo"
 
-#: 3.8/weather-applet.js:13002
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Relâmpagos sem trovão"
 
-#: 3.8/weather-applet.js:13006
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Precipitação na vizinhança"
 
-#: 3.8/weather-applet.js:13010 3.8/weather-applet.js:13296
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Chuva forte e trovões"
 
-#: 3.8/weather-applet.js:13012
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Chuva leve e neve"
 
-#: 3.8/weather-applet.js:13020
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Cobertura do céu diminuindo"
 
-#: 3.8/weather-applet.js:13022
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Cobertura do céu aumentando"
 
-#: 3.8/weather-applet.js:13024
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Céu inalterado"
 
-#: 3.8/weather-applet.js:13026
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Fumaça ou neblina"
 
-#: 3.8/weather-applet.js:13030
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Pancadas de neve e chuva"
 
-#: 3.8/weather-applet.js:13042
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Tempestade sem precipitação"
 
-#: 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Cristais de gelo"
 
-#: 3.8/weather-applet.js:13050
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Parcialmente nublado"
 
-#: 3.8/weather-applet.js:13072
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 "Favor tenha certeza que você \n"
 "inseriu a chave API corretamente"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:13228 3.8/weather-applet.js:13229
-#: 3.8/weather-applet.js:13365 3.8/weather-applet.js:13366
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "NÃO ENCONTRADO"
 
-#: 3.8/weather-applet.js:13261
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Neve com vento"
 
-#: 3.8/weather-applet.js:13302 3.8/weather-applet.js:13303
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Neve leve"
 
-#: 3.8/weather-applet.js:13309 3.8/weather-applet.js:13310
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Neve moderada"
 
-#: 3.8/weather-applet.js:13324
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Pancadas de chuva moderada"
 
-#: 3.8/weather-applet.js:13331
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Chuva e neve misturadas"
 
-#: 3.8/weather-applet.js:13338
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Chuva e neve misturadas fortemente"
 
-#: 3.8/weather-applet.js:13763
+#: 3.8/weather-applet.js:14024
+#, fuzzy
+msgid "AccuWeather"
+msgstr "Clima"
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+#, fuzzy
+msgid "Weather Underground"
+msgstr "Condições meteorológicas"
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+#, fuzzy
+msgid "The location you provided was not found."
+msgstr "Nenhum local fornecido"
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+#, fuzzy
+msgid "Strong Storm"
+msgstr "Brisa forte"
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "Chuva e neve"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "Chuva e granizo misturados"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+msgid "Snow Showers"
+msgstr "Neve Isolada"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "Predominantemente limpo"
+
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "USWeather"
+
+#: 3.8/weather-applet.js:15603
+#, fuzzy
 msgid ""
-"Could not retrieve config, file was not found under path\n"
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+"O Serviço de Localização respondeu com erros. Consulte os registros em "
+"Looking Glass"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr "Verifique se você inseriu um local ou use a localização automática"
+
+#: 3.8/weather-applet.js:15968
+#, fuzzy
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 "Não foi possível recuperar a configuração; o arquivo não foi encontrado no "
 "caminho\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:13767
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1650,50 +1766,58 @@ msgstr ""
 "Não foi possível obter o conteúdo do arquivo de configuração no caminho\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:14095
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Este provedor requer uma chave API para operar"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Ponto de orvalho"
 
-#: 3.8/weather-applet.js:14221
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "A precipitação terminará em {precipEnd} minutos"
 
-#: 3.8/weather-applet.js:14223
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "A precipitação não terminará dentro de uma hora"
 
-#: 3.8/weather-applet.js:14226
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "A precipitação começará dentro de {precipStart} minutos"
 
-#: 3.8/weather-applet.js:14427
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Falha na análise da previsão. Consulte os registros para obter mais detalhes."
 
-#: 3.8/weather-applet.js:14820 3.8/weather-applet.js:15406
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "A partir de {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:14826
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} de você"
 
-#: 3.8/weather-applet.js:15264 3.8/weather-applet.js:15274
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Erro ao salvar informações de depuração"
 
-#: 3.8/weather-applet.js:15285
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Informações de depuração salvas com sucesso"
 
-#: 3.8/weather-applet.js:15285
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Salvo em {filePath}"
-
-#: 3.8/weather-applet.js:15366
-msgid "This provider requires an API key to operate"
-msgstr "Este provedor requer uma chave API para operar"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -1746,7 +1870,6 @@ msgid "Data service"
 msgstr "Serviço de dados"
 
 #. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
 msgid "DarkSky (key needed)"
 msgstr "DarkSky (chave necessária)"
 
@@ -1982,7 +2105,6 @@ msgid "Override label on panel"
 msgstr "Substituir rótulo no painel"
 
 #. 3.0->settings-schema.json->tempTextOverride->tooltip
-#. 3.8->settings-schema.json->tempTextOverride->tooltip
 msgid ""
 "Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
 "Can be used if label does not fit on vertical panel, among other smart "
@@ -2183,6 +2305,10 @@ msgstr ""
 "site Cinnamon Spices, que você pode acessar com o botão na guia Ajuda."
 
 #. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Met Office UK (UK only)"
 msgstr "Escritório do Met Office UK (somente Reino Unido)"
 
@@ -2191,12 +2317,27 @@ msgid "US National Weather (US only)"
 msgstr "US National Weather (somente nos EUA)"
 
 #. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Pirate Weather (key needed)"
+msgstr "Weatherbit (chave necessária)"
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Visual Crossing (key needed)"
 msgstr "Visual Crossing (chave necessária)"
 
 #. 3.8->settings-schema.json->dataService->options
 msgid "Tomorrow.io (key needed)"
 msgstr "Tomorrow.io (chave necessária)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "AccuWeather (key needed)"
+msgstr "Weatherbit (chave necessária)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Weather Underground (key needed)"
+msgstr "Weatherbit (chave necessária)"
 
 #. 3.8->settings-schema.json->location->tooltip
 msgid ""
@@ -2211,6 +2352,12 @@ msgstr ""
 "{Street} {Cidade/País} {Postcode} {Country}. O algoritmo de procura é bem "
 "flexível com o formato. Depois de 3 segundos sem digitar, o endereço que "
 "você ingressou é substituído automaticamente para validar sua escolha."
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
 
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"
@@ -2238,9 +2385,20 @@ msgstr ""
 "intervalo com o qual sua cota não ficará esgotada."
 
 #. 3.8->settings-schema.json->forecastDays->tooltip
+#, fuzzy
 msgid ""
-"Maximum number of days that can be displayed, maximum rows and columns "
-"setting in the Presentation tab will affect the final number."
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+"Número máximo de dias que podem ser exibidos, configuração máxima de linhas "
+"e colunas na guia Apresentação afetará o número final."
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+#, fuzzy
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
 msgstr ""
 "Número máximo de dias que podem ser exibidos, configuração máxima de linhas "
 "e colunas na guia Apresentação afetará o número final."
@@ -2250,10 +2408,11 @@ msgid "Enable minutely precipitation forecast"
 msgstr "Habilitar previsão de precipitação minuciosa"
 
 #. 3.8->settings-schema.json->immediatePrecip->tooltip
+#, fuzzy
 msgid ""
 "If you'd like to use this make sure you use your exact coordinates/address "
-"as location to help its accuracy. Currently implemented with OpenWeatherMap "
-"only."
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
 msgstr ""
 "Se você quiser usar isso, certifique-se de usar suas coordenadas/endereço "
 "exatos como localização para ajudar na precisão. Atualmente implementado "
@@ -2262,6 +2421,29 @@ msgstr ""
 #. 3.8->settings-schema.json->showBothTempUnits->description
 msgid "Show both temperature units at the same time"
 msgstr "Mostra ambas as unidades de temperatura ao mesmo tempo"
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+#, fuzzy
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+"Os valores disponíveis são: {c} é a condição, {t} é a temperatura e {u} é a "
+"unidade.\n"
+"Pode ser usado se o rótulo não couber no painel vertical, entre outras "
+"coisas inteligentes."
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+#, fuzzy
+msgid "Override tooltip on panel"
+msgstr "Substituir rótulo no painel"
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
 
 #. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
 msgid "Always show Hourly Weather"
@@ -2436,118 +2618,3 @@ msgstr ""
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr "Caminho selecionado para salvar os registros"
-
-#~ msgid "Climacell"
-#~ msgstr "Climacell"
-
-#~ msgid "Light Snow"
-#~ msgstr "Neve leve"
-
-#~ msgid "API key doesn't provide access to Hourly Weather, skipping"
-#~ msgstr "A chave API não fornece acesso à previsão de hora em hora, pulando"
-
-#~ msgid "Instead of 15:00 or 3 pm it will show up as 15 or 3 pm"
-#~ msgstr "Em vez de 15:00 ou 3 pm, aparecerá como 15 ou 3 pm"
-
-#~ msgid "ClimacellV4 (key needed)"
-#~ msgstr "ClimacellV4 (chave necessária)"
-
-#~ msgid "ClimacellV3 (key needed)"
-#~ msgstr "ClimacellV3 (chave necessária)"
-
-#~ msgid "Settings"
-#~ msgstr "Configurações"
-
-#~ msgid "No location provided"
-#~ msgstr "Nenhum local fornecido"
-
-#~ msgid "Cloudiness:"
-#~ msgstr "Nebulosidade:"
-
-#~ msgid "Sunrise"
-#~ msgstr "Nascer do sol"
-
-#~ msgid "Sunset"
-#~ msgstr "Pôr do sol"
-
-#~ msgid "Service Unavailable"
-#~ msgstr "Serviço Indisponível"
-
-#~ msgid "Wrong API Key"
-#~ msgstr "Chave API errada"
-
-#~ msgid "City Not found"
-#~ msgstr "Cidade Não encontrada"
-
-#~ msgid "Key Temp. Blocked"
-#~ msgstr "Chave de Temp. Bloqueada"
-
-#~ msgid "Clear Sky"
-#~ msgstr "Céu Limpo"
-
-#~ msgid "Light Rain"
-#~ msgstr "Chuva leve"
-
-#~ msgid "Rain Showers"
-#~ msgstr "Chuvas Isoladas"
-
-#~ msgid "Snow Showers"
-#~ msgstr "Neve Isolada"
-
-#~ msgid "Few Clouds"
-#~ msgstr "Poucas Nuvens"
-
-#~ msgid "Substantial Rain"
-#~ msgstr "Chuva Abundante"
-
-#~ msgid "Substantial Freezing Rain"
-#~ msgstr "Chuva Congelante Abundante"
-
-#~ msgid "Substantial Ice Pellets"
-#~ msgstr "Pelotas de Gelo Abundante"
-
-#~ msgid "Substantial Snow"
-#~ msgstr "Neve Abundante"
-
-#~ msgid "Weather Provider Settings"
-#~ msgstr "Configurações do Proveedor de Clima"
-
-#~ msgid ""
-#~ "Acceptable inputs: City,CountryCode or Zipcode,CountryCode or Latitude,"
-#~ "Longitude"
-#~ msgstr ""
-#~ "Entradas aceitáveis: Cidade, Código do Pais ou Código de Loalização, "
-#~ "Código do País ouLatitude, Longitude"
-
-#~ msgid "Personal Settings"
-#~ msgstr "Configurações Pessoais"
-
-#~ msgid "Vertical orientation"
-#~ msgstr "Orientação vertical"
-
-#~ msgid "Translate condition"
-#~ msgstr "Traduzir condição"
-
-#~ msgid "Acceptable inputs is Latitude,Longitude"
-#~ msgstr "As entradas aceitáveis são Latitude,Longitude"
-
-#~ msgid "Currently only used with DarkSky "
-#~ msgstr "Atualmente usado apenas com DarkSky "
-
-#~ msgid "Units, Icons and Keys"
-#~ msgstr "Unidades, Ícones e Teclas"
-
-#~ msgid "How to choose a weather provider"
-#~ msgstr "Como escolher um proveedor de meteorologia"
-
-#~ msgid "Allowed location formats"
-#~ msgstr "Formatos de local permitidos"
-
-#~ msgid "View additional information"
-#~ msgstr "Ver informação adicional"
-
-#~ msgid "Delete current location from storage"
-#~ msgstr "Apagar local atual do armazenamento"
-
-#~ msgid "Removes location information from storage file."
-#~ msgstr "Remove as informações de local do arquivo de armazenamento."

--- a/weather@mockturtl/files/weather@mockturtl/po/ro.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/ro.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: simon04-gnome-shell-extension-weather\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-12 12:27-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2021-02-16 11:25+0100\n"
 "Last-Translator: Marian Vasile <marianvasile@upcmail.ro> și Dorian Baciu\n"
 "Language-Team: \n"
@@ -20,440 +21,2578 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 "X-Generator: Poedit 2.3\n"
 
-#: applet.js:249
+#: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
+#: 3.8/weather-applet.js:17877
+msgid "Error"
+msgstr ""
+
+#: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
+#: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
+msgid "Service Error"
+msgstr ""
+
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
+msgid "Incorrect API Key"
+msgstr ""
+
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
+msgid "Incorrect Location Format"
+msgstr ""
+
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
+msgid "Key Blocked"
+msgstr ""
+
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
+msgid "Can't find location"
+msgstr ""
+
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
+msgid "No Api Key"
+msgstr ""
+
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
+msgid "No Location"
+msgstr ""
+
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
+msgid "Missing Packages"
+msgstr ""
+
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
+msgid "Location not covered"
+msgstr ""
+
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
+msgid "Weather Applet"
+msgstr ""
+
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: applet.js:250
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Clic pentru a deschide"
 
-#: applet.js:289
-msgid "Settings"
-msgstr "Setări"
-
-#: applet.js:555
-msgid "Sunrise"
-msgstr "Răsărit"
-
-#: applet.js:556
-msgid "Sunset"
-msgstr "Apus de soare"
-
-#: applet.js:648
-msgid "Loading current weather ..."
-msgstr "Se încarcă vremea curentă..."
-
-#: applet.js:649
-msgid "Loading future weather ..."
-msgstr "Se încarcă prognoza..."
-
-#: applet.js:671
-msgid "Loading ..."
-msgstr "Se încarcă"
-
-#: applet.js:677
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr ""
 
-#: applet.js:740
-msgid "Temperature:"
+#: 3.0/applet.js:272
+msgid "API returned status code between 400 and 500"
+msgstr ""
+
+#: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
+#: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
+msgid "Location Store"
+msgstr ""
+
+#: 3.0/applet.js:426
+msgid "You can't save a location obtained automatically, sorry"
+msgstr ""
+
+#: 3.0/applet.js:601
+msgid "Could not get weather information"
+msgstr ""
+
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
+msgid ""
+"Unexpected Error While Refreshing Weather, please see log in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
+msgid ""
+"Could not update weather for a while...\n"
+"are you connected to the internet?"
+msgstr ""
+
+#: 3.0/applet.js:684
+msgid "Network Error, please check logs in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:969 3.0/applet.js:1110
+msgid "As of"
+msgstr ""
+
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
+msgid "Powered by"
+msgstr ""
+
+#: 3.0/applet.js:1113
+msgid "from you"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
+msgid "mm"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
+msgid "in"
+msgstr ""
+
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
+msgid "mi"
+msgstr ""
+
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
+msgid "km"
+msgstr ""
+
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
+msgid "Loading current weather ..."
+msgstr "Se încarcă vremea curentă..."
+
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
+msgid "Loading future weather ..."
+msgstr "Se încarcă prognoza..."
+
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
+msgid "Loading ..."
+msgstr "Se încarcă"
+
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
+#, fuzzy
+msgid "Temperature"
 msgstr "Temperatură:"
 
-#: applet.js:742
-msgid "Humidity:"
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
+#, fuzzy
+msgid "Humidity"
 msgstr "Umiditate:"
 
-#: applet.js:744
-msgid "Pressure:"
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
+#, fuzzy
+msgid "Pressure"
 msgstr "Presiune:"
 
-#: applet.js:746
-msgid "Wind:"
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
+#, fuzzy
+msgid "Wind"
 msgstr "Vânt:"
 
-#: applet.js:748
-msgid "Wind Chill:"
-msgstr "Vânt:"
+#: 3.0/applet.js:1639
+msgid "Make sure you entered a location or use Automatic location instead"
+msgstr ""
 
-#: applet.js:953
-msgid "Tornado"
-msgstr "Tornadă"
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
+msgid "Could not find location based on address, please check if it's right"
+msgstr ""
 
-#: applet.js:955
-msgid "Tropical storm"
-msgstr "Furtună tropicală"
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
+msgid "Failed to call Geolocation API, see Looking Glass for errors."
+msgstr ""
 
-#: applet.js:957
-msgid "Hurricane"
-msgstr "Uragan"
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "Warning"
+msgstr ""
 
-#: applet.js:959
-msgid "Severe thunderstorms"
-msgstr "Furtuni severe"
+#: 3.0/applet.js:2032
+msgid "You can only save correct locations when the applet is not refreshing"
+msgstr ""
 
-#: applet.js:961
-msgid "Thunderstorms"
-msgstr "Furtuni"
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "You can't save an incorrect location"
+msgstr ""
 
-#: applet.js:963
-msgid "Mixed rain and snow"
-msgstr "Lapoviță"
+#. 3.8->settings-schema.json->logLevel->options
+#: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.8/weather-applet.js:9875
+msgid "Info"
+msgstr ""
 
-#: applet.js:965
-msgid "Mixed rain and sleet"
-msgstr "Măzăriche"
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
+msgid "Location is already saved"
+msgstr ""
 
-#: applet.js:967
-msgid "Mixed snow and sleet"
-msgstr "Măzăriche"
+#: 3.0/applet.js:2049 3.0/applet.js:2083
+msgid "Success"
+msgstr ""
 
-#: applet.js:969
-msgid "Freezing drizzle"
-msgstr "Burniță rece"
+#: 3.0/applet.js:2049
+msgid "Location is saved to library"
+msgstr ""
 
-#: applet.js:971
-msgid "Drizzle"
-msgstr "Burniță"
+#: 3.0/applet.js:2062
+msgid "You can't remove a location while the applet is refreshing"
+msgstr ""
 
-#: applet.js:973
+#: 3.0/applet.js:2066
+msgid "You can't remove an incorrect location"
+msgstr ""
+
+#: 3.0/applet.js:2070
+msgid "Location is not in storage, can't delete"
+msgstr ""
+
+#: 3.0/applet.js:2083
+msgid "Location is deleted from library"
+msgstr ""
+
+#: 3.0/applet.js:2131
+msgid ""
+"Failed to load in data from location storage, please see the logs for more "
+"information"
+msgstr ""
+
+#: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
+#: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
+msgid "Feels Like"
+msgstr ""
+
+#: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
+#: 3.8/weather-applet.js:15387
+msgid "Failed to Process Weather Info"
+msgstr ""
+
+#: 3.0/climacell.js:224
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://developer.climacell.co/sign-up"
+msgstr ""
+
+#: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
+msgid ""
+"Please Make sure you\n"
+"entered the API key correctly and your account is not locked"
+msgstr ""
+
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Climacell"
+msgstr ""
+
+#: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
+#: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
+#: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
+#, fuzzy
+msgid "Heavy rain"
+msgstr "Ninsoare abundentă"
+
+#: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
+#: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
+#: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
+msgid "Rain"
+msgstr ""
+
+#: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
+#: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
+#: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
+#, fuzzy
+msgid "Light rain"
+msgstr "Ploaie rece"
+
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
+#, fuzzy
+msgid "Heavy freezing rain"
+msgstr "Ploaie rece"
+
+#: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
+#: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
+#: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Ploaie rece"
 
-#: applet.js:975 applet.js:977
-msgid "Showers"
-msgstr "Averse"
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
+#, fuzzy
+msgid "Light freezing rain"
+msgstr "Ploaie rece"
 
-#: applet.js:979
-msgid "Snow flurries"
-msgstr "Ninsoare ușoară"
+#: 3.0/climacell.js:301
+#, fuzzy
+msgid "Light freezing drizzle"
+msgstr "Burniță rece"
 
-#: applet.js:981
-msgid "Light snow showers"
-msgstr "Ninsoare ușoară în averse"
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
+msgid "Freezing drizzle"
+msgstr "Burniță rece"
 
-#: applet.js:983
-msgid "Blowing snow"
-msgstr "Ninsoare viscolită"
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
+#, fuzzy
+msgid "Light drizzle"
+msgstr "Burniță rece"
 
-#: applet.js:985
-msgid "Snow"
-msgstr "Ninsoare"
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
+msgid "Heavy ice pellets"
+msgstr ""
 
-#: applet.js:987
-msgid "Hail"
-msgstr "Grindină"
+#: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
+msgid "Ice pellets"
+msgstr ""
 
-#: applet.js:989
-msgid "Sleet"
-msgstr "Lapoviță"
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
+msgid "Light ice pellets"
+msgstr ""
 
-#: applet.js:991
-msgid "Dust"
-msgstr "Praf"
-
-#: applet.js:993
-msgid "Foggy"
-msgstr "Ceață"
-
-#: applet.js:995
-msgid "Haze"
-msgstr "Ceață ușoară"
-
-#: applet.js:997
-msgid "Smoky"
-msgstr "Întunecat"
-
-#: applet.js:999
-msgid "Blustery"
-msgstr "Zgomotos"
-
-#: applet.js:1001
-msgid "Windy"
-msgstr "Rafale de vânt"
-
-#: applet.js:1003
-msgid "Cold"
-msgstr "Rece"
-
-#: applet.js:1005
-msgid "Cloudy"
-msgstr "Înnorat"
-
-#: applet.js:1008
-msgid "Mostly cloudy"
-msgstr "Majoritar înnorat"
-
-#: applet.js:1011 applet.js:1037
-msgid "Partly cloudy"
-msgstr "Parțial înnorat"
-
-#: applet.js:1013
-msgid "Clear"
-msgstr "Senin"
-
-#: applet.js:1015
-msgid "Sunny"
-msgstr "Însorit"
-
-#: applet.js:1018
-msgid "Fair"
-msgstr "Vreme bună"
-
-#: applet.js:1020
-msgid "Mixed rain and hail"
-msgstr "Ploaie cu grindină"
-
-#: applet.js:1022
-msgid "Hot"
-msgstr "Foarte cald"
-
-#: applet.js:1024
-msgid "Isolated thunderstorms"
-msgstr "Furtuni izolate"
-
-#: applet.js:1027
-msgid "Scattered thunderstorms"
-msgstr "Furtuni răzlețe"
-
-#: applet.js:1029
-msgid "Scattered showers"
-msgstr "Averse răzlețe"
-
-#: applet.js:1031 applet.js:1035
+#: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
+#: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
+#: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Ninsoare abundentă"
 
-#: applet.js:1033
-msgid "Scattered snow showers"
-msgstr "Ninsori răzlețe"
+#: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
+#: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
+#: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
+msgid "Snow"
+msgstr "Ninsoare"
 
-#: applet.js:1039
-msgid "Thundershowers"
-msgstr "Ploi abundente în averse"
+#: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
+#: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
+#: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
+#, fuzzy
+msgid "Light snow"
+msgstr "Ninsoare ușoară în averse"
 
-#: applet.js:1041
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
+#, fuzzy
+msgid "Flurries"
+msgstr "Ninsoare ușoară"
+
+#: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
+#, fuzzy
+msgid "Thunderstorm"
+msgstr "Furtuni"
+
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
+msgid "Light fog"
+msgstr ""
+
+#: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
+#: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
+#: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
+#, fuzzy
+msgid "Fog"
+msgstr "Ceață"
+
+#: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
+#: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
+msgid "Cloudy"
+msgstr "Înnorat"
+
+#: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
+msgid "Mostly cloudy"
+msgstr "Majoritar înnorat"
+
+#: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
+#: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
+#: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
+msgid "Partly cloudy"
+msgstr "Parțial înnorat"
+
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
+#, fuzzy
+msgid "Mostly clear"
+msgstr "Majoritar înnorat"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
+#: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
+#: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
+msgid "Clear"
+msgstr "Senin"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
+msgid "Sunny"
+msgstr "Însorit"
+
+#: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
+#: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
+#: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
+msgid "Unknown"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "and"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "until"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "Possible"
+msgstr ""
+
+#: 3.0/darkSky.js:211
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://darksky.net/dev/register"
+msgstr ""
+
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from DarkSky"
+msgstr ""
+
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
+msgid "Could not obtain location"
+msgstr ""
+
+#: 3.0/ipApi.js:95
+msgid ""
+"Location Service responded with errors, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
+#, fuzzy
+msgid "Cloudiness"
+msgstr "Înnorat"
+
+#: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
+#, fuzzy
+msgid "Clear sky"
+msgstr "Senin"
+
+#: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
+msgid "Fair"
+msgstr "Vreme bună"
+
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
+msgid "Heavy rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
+#, fuzzy
+msgid "Heavy rain showers"
+msgstr "Ninsoare abundentă"
+
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
+msgid "Heavy rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
+#, fuzzy
+msgid "Heavy sleet"
+msgstr "Ninsoare abundentă"
+
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
+msgid "Heavy sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
+#, fuzzy
+msgid "Heavy sleet showers"
+msgstr "Ninsoare abundentă"
+
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
+msgid "Heavy sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
+#, fuzzy
+msgid "Heavy snow and thunder"
+msgstr "Ninsoare abundentă"
+
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
+#, fuzzy
+msgid "Heavy snow showers"
+msgstr "Ninsori în averse"
+
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
+msgid "Heavy snow showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
+msgid "Light rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
+#, fuzzy
+msgid "Light rain showers"
+msgstr "Ninsoare ușoară în averse"
+
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
+#, fuzzy
+msgid "Light rain showers and thunder"
+msgstr "Ninsoare ușoară în averse"
+
+#: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
+msgid "Light sleet"
+msgstr ""
+
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
+msgid "Light sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
+#, fuzzy
+msgid "Light sleet showers"
+msgstr "Ninsoare ușoară în averse"
+
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
+#, fuzzy
+msgid "Light sleet showers and thunder"
+msgstr "Ninsoare ușoară în averse"
+
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
+#, fuzzy
+msgid "Light snow and thunder"
+msgstr "Ninsoare ușoară în averse"
+
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
+msgid "Light snow showers"
+msgstr "Ninsoare ușoară în averse"
+
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
+#, fuzzy
+msgid "Light snow showers and thunder"
+msgstr "Ninsoare ușoară în averse"
+
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
+msgid "Rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
+#, fuzzy
+msgid "Rain showers"
+msgstr "Ninsori în averse"
+
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
+msgid "Rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:511 3.0/met_norway.js:512 3.0/met_norway.js:518
+#: 3.0/met_norway.js:525 3.0/met_norway.js:532 3.0/met_uk.js:638
+#: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
+#: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
+#: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
+msgid "Sleet"
+msgstr "Lapoviță"
+
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
+#, fuzzy
+msgid "Sleet and thunder"
+msgstr "Furtuni răzlețe"
+
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
+#, fuzzy
+msgid "Sleet showers"
+msgstr "Averse răzlețe"
+
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
+msgid "Sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
+msgid "Snow and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Ninsori în averse"
 
-#: applet.js:1043
-msgid "Isolated thundershowers"
-msgstr "Ploi izolate"
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
+#, fuzzy
+msgid "Snow showers and thunder"
+msgstr "Ninsori în averse"
 
-#: applet.js:1046
-msgid "Not available"
-msgstr "Indisponibil"
+#: 3.0/met_uk.js:162 3.0/met_uk.js:192 3.0/met_uk.js:239 3.0/us_weather.js:151
+#: 3.0/us_weather.js:179
+msgid "Unexpected response from API"
+msgstr ""
 
-#: applet.js:1051
-msgid "Monday"
-msgstr "Luni"
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
+msgid "Visibility"
+msgstr ""
 
-#: applet.js:1051
-msgid "Tuesday"
-msgstr "Marți"
+#: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
+msgid "Failed to Process Current Weather Info"
+msgstr ""
 
-#: applet.js:1051
-msgid "Wednesday"
-msgstr "Miercuri"
+#: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
+msgid "Failed to Process Forecast Info"
+msgstr ""
 
-#: applet.js:1051
-msgid "Thursday"
-msgstr "Joi"
+#: 3.0/met_uk.js:408
+msgid "Very poor - Less than"
+msgstr ""
 
-#: applet.js:1051
-msgid "Friday"
-msgstr "Vineri"
+#: 3.0/met_uk.js:410
+msgid "Poor - Between"
+msgstr ""
 
-#: applet.js:1051
-msgid "Saturday"
-msgstr "Sâmbătă"
+#: 3.0/met_uk.js:412
+msgid "Moderate - Between"
+msgstr ""
 
-#: applet.js:1051
+#: 3.0/met_uk.js:414
+msgid "Good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:416
+msgid "Very good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:417
+msgid "Excellent - More than"
+msgstr ""
+
+#: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
+msgid "Mist"
+msgstr ""
+
+#: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
+msgid "Overcast"
+msgstr ""
+
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
+#, fuzzy
+msgid "Light rain shower"
+msgstr "Ninsoare ușoară în averse"
+
+#: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
+msgid "Drizzle"
+msgstr "Burniță"
+
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
+#, fuzzy
+msgid "Heavy rain shower"
+msgstr "Ninsoare abundentă"
+
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
+#, fuzzy
+msgid "Sleet shower"
+msgstr "Averse răzlețe"
+
+#: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
+msgid "Hail"
+msgstr "Grindină"
+
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
+#, fuzzy
+msgid "Hail shower"
+msgstr "Ninsori în averse"
+
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
+#, fuzzy
+msgid "Light snow shower"
+msgstr "Ninsoare ușoară în averse"
+
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
+#, fuzzy
+msgid "Heavy snow shower"
+msgstr "Ninsoare abundentă"
+
+#: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
+#, fuzzy
+msgid "Thunder"
+msgstr "Furtuni"
+
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
+#, fuzzy
+msgid "Thunder shower"
+msgstr "Ploi abundente în averse"
+
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
+msgid "Please make sure Location is in the correct format in the Settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
+msgid "Make sure you entered the correct key in settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
+msgid ""
+"Location not found, make sure location is available or it is in the correct "
+"format"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
+msgid "If this problem persists, please contact the Author of this applet"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
+msgid "Unknown Error, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
+msgid "Thunderstorm with light rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
+#, fuzzy
+msgid "Thunderstorm with rain"
+msgstr "Furtuni"
+
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
+msgid "Thunderstorm with heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
+#, fuzzy
+msgid "Light thunderstorm"
+msgstr "Furtuni"
+
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
+#, fuzzy
+msgid "Heavy thunderstorm"
+msgstr "Furtuni severe"
+
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
+#, fuzzy
+msgid "Ragged thunderstorm"
+msgstr "Furtuni izolate"
+
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
+msgid "Thunderstorm with light drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
+#, fuzzy
+msgid "Thunderstorm with drizzle"
+msgstr "Furtuni"
+
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
+msgid "Thunderstorm with heavy drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
+msgid "Light intensity drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
+msgid "Heavy intensity drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
+msgid "Light intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Drizzle rain"
+msgstr "Burniță"
+
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
+msgid "Heavy intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
+#, fuzzy
+msgid "Shower rain and drizzle"
+msgstr "Ploaie cu grindină"
+
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
+msgid "Heavy shower rain and drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
+#, fuzzy
+msgid "Shower drizzle"
+msgstr "Burniță rece"
+
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
+msgid "Moderate rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
+msgid "Heavy intensity rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
+msgid "Very heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
+#, fuzzy
+msgid "Extreme rain"
+msgstr "Ploaie rece"
+
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
+#, fuzzy
+msgid "Light intensity shower rain"
+msgstr "Ninsoare ușoară în averse"
+
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
+#, fuzzy
+msgid "Shower rain"
+msgstr "Averse"
+
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
+msgid "Heavy intensity shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
+msgid "Ragged shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
+#, fuzzy
+msgid "Shower sleet"
+msgstr "Averse"
+
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
+#, fuzzy
+msgid "Light rain and snow"
+msgstr "Lapoviță"
+
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
+#, fuzzy
+msgid "Rain and snow"
+msgstr "Lapoviță"
+
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
+#, fuzzy
+msgid "Light shower snow"
+msgstr "Ninsoare ușoară în averse"
+
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
+#, fuzzy
+msgid "Shower snow"
+msgstr "Averse"
+
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
+#, fuzzy
+msgid "Heavy shower snow"
+msgstr "Ninsoare abundentă"
+
+#: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
+#, fuzzy
+msgid "Smoke"
+msgstr "Întunecat"
+
+#: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
+msgid "Haze"
+msgstr "Ceață ușoară"
+
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
+msgid "Sand, dust whirls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
+msgid "Sand"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
+msgid "Dust"
+msgstr "Praf"
+
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
+msgid "Volcanic ash"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
+msgid "Squalls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
+msgid "Tornado"
+msgstr "Tornadă"
+
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
+msgid "Sky is clear"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
+#, fuzzy
+msgid "Clouds"
+msgstr "Înnorat"
+
+#: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
+msgid "Few clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
+#, fuzzy
+msgid "Scattered clouds"
+msgstr "Averse răzlețe"
+
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
+msgid "Broken clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
+msgid "Overcast clouds"
+msgstr ""
+
+#: 3.0/us_weather.js:120
+msgid "Could not get forecast for your area"
+msgstr ""
+
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
+msgid "Location is outside US, please use a different provider."
+msgstr ""
+
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
+msgid "Failed to Process Hourly Forecast Info"
+msgstr ""
+
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
+msgid "Clear and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
+msgid "Few clouds and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
+#, fuzzy
+msgid "Partly cloudy and windy"
+msgstr "Parțial înnorat"
+
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
+#, fuzzy
+msgid "Mostly cloudy and windy"
+msgstr "Majoritar înnorat"
+
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
+msgid "Overcast and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
+#, fuzzy
+msgid "Snowy rain"
+msgstr "Ninsoare ușoară"
+
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
+#, fuzzy
+msgid "Freezing rain and snow"
+msgstr "Ploaie rece"
+
+#: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
+msgid "Hurricane"
+msgstr "Uragan"
+
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
+msgid "Storm"
+msgstr ""
+
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
+msgid "Tropical storm"
+msgstr "Furtună tropicală"
+
+#: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
+msgid "Hot"
+msgstr "Foarte cald"
+
+#: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
+msgid "Cold"
+msgstr "Rece"
+
+#: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
+msgid "Blizzard"
+msgstr ""
+
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
+msgid "Today"
+msgstr "Azi"
+
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
+msgid "Tomorrow"
+msgstr "Mâine"
+
+#: 3.0/utils.js:204
 msgid "Sunday"
 msgstr "Duminică"
 
-#: applet.js:1056
+#: 3.0/utils.js:204
+msgid "Monday"
+msgstr "Luni"
+
+#: 3.0/utils.js:204
+msgid "Tuesday"
+msgstr "Marți"
+
+#: 3.0/utils.js:204
+msgid "Wednesday"
+msgstr "Miercuri"
+
+#: 3.0/utils.js:204
+msgid "Thursday"
+msgstr "Joi"
+
+#: 3.0/utils.js:204
+msgid "Friday"
+msgstr "Vineri"
+
+#: 3.0/utils.js:204
+msgid "Saturday"
+msgstr "Sâmbătă"
+
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
+msgid "Calm"
+msgstr ""
+
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
+msgid "Light air"
+msgstr ""
+
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
+msgid "Light breeze"
+msgstr ""
+
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
+msgid "Gentle breeze"
+msgstr ""
+
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
+msgid "Moderate breeze"
+msgstr ""
+
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
+msgid "Fresh breeze"
+msgstr ""
+
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
+msgid "Strong breeze"
+msgstr ""
+
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
+msgid "Near gale"
+msgstr ""
+
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
+msgid "Gale"
+msgstr ""
+
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
+msgid "Strong gale"
+msgstr ""
+
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
+msgid "Violent storm"
+msgstr ""
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "N"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "NE"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "E"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "SE"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "S"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "SV"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "V"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "NV"
 
-#. cinnamon-weather->settings-schema.json->woeidLookup->description
+#: 3.0/weatherbit.js:312
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://www.weatherbit.io/account/create"
+msgstr ""
+
+#: 3.0/yahoo.js:78
+msgid ""
+"Unknown Error happened while calling Yahoo bridge,\n"
+" see Looking Glass log for errors"
+msgstr ""
+
+#: 3.0/yahoo.js:91
+msgid ""
+"Yahoo bridge responded in bad format,\n"
+" see Looking Glass log for errors"
+msgstr ""
+
+#: 3.0/yahoo.js:177
+msgid "Missing package"
+msgstr ""
+
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
 #, fuzzy
-msgid "Get WOEID"
-msgstr "WOEID"
+msgid "Please install '"
+msgstr "Așteptați"
 
-#. cinnamon-weather->settings-schema.json->verticalOrientation->description
-msgid "Vertical orientation"
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+msgid "', then refresh manually."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showTextInPanel->description
-msgid "Display current temperature in panel"
-msgstr "Afișarea temperaturii curente în panou"
+#: 3.0/yahoo.js:182
+msgid "Could not connect to Yahoo API."
+msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeid->description
-msgid "WOEID"
-msgstr "WOEID"
+#: 3.0/yahoo.js:186
+msgid ""
+"Unknown error happened while obtaining weather, see Looking Glass logs for "
+"more information"
+msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeid->tooltip
-msgid "Where On Earth ID"
-msgstr "Locația pe Pământ"
-
-#. cinnamon-weather->settings-schema.json->temperatureUnit->description
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 #, fuzzy
-msgid "Temperature unit"
-msgstr "Temperatură:"
+msgid "Tropical Storm"
+msgstr "Furtună tropicală"
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "fahrenheit"
-msgstr "fahrenheit"
+#: 3.0/yahoo.js:439
+#, fuzzy
+msgid "Severe Thunderstorms"
+msgstr "Furtuni severe"
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "celsius"
-msgstr "celsius"
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
+msgid "Thunderstorms"
+msgstr "Furtuni"
 
-#. cinnamon-weather->settings-schema.json->translateCondition->description
-msgid "Translate condition"
+#: 3.0/yahoo.js:441
+#, fuzzy
+msgid "Mixed Rain and Snow"
+msgstr "Lapoviță"
+
+#: 3.0/yahoo.js:442
+#, fuzzy
+msgid "Mixed Rain and Sleet"
+msgstr "Măzăriche"
+
+#: 3.0/yahoo.js:443
+#, fuzzy
+msgid "Mixed Snow and Sleet"
+msgstr "Măzăriche"
+
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
+#, fuzzy
+msgid "Freezing Drizzle"
+msgstr "Burniță rece"
+
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
+#, fuzzy
+msgid "Freezing Rain"
+msgstr "Ploaie rece"
+
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
+msgid "Showers"
+msgstr "Averse"
+
+#: 3.0/yahoo.js:449
+#, fuzzy
+msgid "Snow Flurries"
+msgstr "Ninsoare ușoară"
+
+#: 3.0/yahoo.js:450
+#, fuzzy
+msgid "Light Snow Showers"
+msgstr "Ninsoare ușoară în averse"
+
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
+#, fuzzy
+msgid "Blowing Snow"
+msgstr "Ninsoare viscolită"
+
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
+msgid "Foggy"
+msgstr "Ceață"
+
+#: 3.0/yahoo.js:458
+msgid "Smoky"
+msgstr "Întunecat"
+
+#: 3.0/yahoo.js:459
+msgid "Blustery"
+msgstr "Zgomotos"
+
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
+msgid "Windy"
+msgstr "Rafale de vânt"
+
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
+#, fuzzy
+msgid "Mostly Cloudy"
+msgstr "Majoritar înnorat"
+
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
+#, fuzzy
+msgid "Partly Cloudy"
+msgstr "Parțial înnorat"
+
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
+#, fuzzy
+msgid "Mostly Sunny"
+msgstr "Majoritar înnorat"
+
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
+#, fuzzy
+msgid "Mixed Rain and Hail"
+msgstr "Ploaie cu grindină"
+
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
+#, fuzzy
+msgid "Isolated Thunderstorms"
+msgstr "Furtuni izolate"
+
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
+#, fuzzy
+msgid "Scattered Thunderstorms"
+msgstr "Furtuni răzlețe"
+
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
+#, fuzzy
+msgid "Scattered Showers"
+msgstr "Averse răzlețe"
+
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
+#, fuzzy
+msgid "Heavy Rain"
+msgstr "Ninsoare abundentă"
+
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
+#, fuzzy
+msgid "Scattered Snow Showers"
+msgstr "Ninsori răzlețe"
+
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
+#, fuzzy
+msgid "Heavy Snow"
+msgstr "Ninsoare abundentă"
+
+#: 3.0/yahoo.js:478
+#, fuzzy
+msgid "Not Available"
+msgstr "Indisponibil"
+
+#: 3.0/yahoo.js:479
+#, fuzzy
+msgid "Scattered Thundershowers"
+msgstr "Furtuni răzlețe"
+
+#: 3.8/weather-applet.js:9638
+msgid ""
+"Could not retrieve logs, log file was not found under path\n"
+" {logFilePath}"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->locationLabelOverride->description
-msgid "Override location label"
-msgstr "Suprapunere locație"
-
-#. cinnamon-weather->settings-schema.json->show24Hours->description
-msgid "Display time in 24 hour format"
+#: 3.8/weather-applet.js:9642
+msgid ""
+"Could not get contents of log file under path\n"
+" {logFilePath}"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->forecastDays->description
-msgid "Forecast length"
+#. 3.0->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10283
+msgid "Met Office UK"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->forecastDays->units
-msgid "days"
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showSunrise->description
-msgid "Show sunrise / sunset times"
-msgstr "Arată timpul pentru răsărit/apus de soare"
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->description
-msgid "Wind speed unit"
-msgstr "Initatea de măsură pt. viteza vântului"
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "kph"
-msgstr "km/oră"
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "m/s"
-msgstr "m/s"
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "knots"
+#: 3.8/weather-applet.js:10476
+msgid "Data was not found for location"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "mph"
-msgstr "mile/oră"
-
-#. cinnamon-weather->settings-schema.json->showCommentInPanel->description
-msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
-msgstr "Arată condițiile vremii (de ex. \"Vânt\", \"Clar\") în panou"
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->description
-msgid "Atmospheric pressure unit"
+#: 3.8/weather-applet.js:10557
+msgid "Very poor"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "psi"
+#: 3.8/weather-applet.js:10557
+msgid "Less than {distance} {distanceUnit}"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "atm"
+#: 3.8/weather-applet.js:10561
+msgid "Excellent"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "kPa"
+#: 3.8/weather-applet.js:10561
+msgid "More than {distance} {distanceUnit}"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "Pa"
+#: 3.8/weather-applet.js:10566
+msgid "Poor"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mm Hg"
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
+msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "at"
+#: 3.8/weather-applet.js:10571
+msgid "Moderate"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mbar"
+#: 3.8/weather-applet.js:10576
+msgid "Good"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "in Hg"
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
+msgid "Very good"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->description
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10942
+msgid "OpenWeatherMap"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:11396
+msgid "MET Norway"
+msgstr ""
+
+#: 3.8/weather-applet.js:11955
+msgid "WeatherBit"
+msgstr ""
+
+#: 3.8/weather-applet.js:12386
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Mâine"
+
+#: 3.8/weather-applet.js:12561
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12575
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12723
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:13292
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13474
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "Ninsoare viscolită"
+
+#: 3.8/weather-applet.js:13478
+#, fuzzy
+msgid "Heavy drizzle"
+msgstr "Burniță rece"
+
+#: 3.8/weather-applet.js:13482
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13484
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13486
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:13490
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "Burniță rece"
+
+#: 3.8/weather-applet.js:13492
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13494
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13496
+#, fuzzy
+msgid "Freezing fog"
+msgstr "Ploaie rece"
+
+#: 3.8/weather-applet.js:13502
+msgid "Funnel cloud/tornado"
+msgstr ""
+
+#: 3.8/weather-applet.js:13504
+#, fuzzy
+msgid "Hail showers"
+msgstr "Ninsori în averse"
+
+#: 3.8/weather-applet.js:13506
+msgid "Ice"
+msgstr ""
+
+#: 3.8/weather-applet.js:13508
+msgid "Lightning without thunder"
+msgstr ""
+
+#: 3.8/weather-applet.js:13512
+msgid "Precipitation in vicinity"
+msgstr ""
+
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
+#, fuzzy
+msgid "Heavy rain and snow"
+msgstr "Lapoviță"
+
+#: 3.8/weather-applet.js:13518
+#, fuzzy
+msgid "Light rain And snow"
+msgstr "Lapoviță"
+
+#: 3.8/weather-applet.js:13526
+msgid "Sky coverage decreasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13528
+msgid "Sky coverage increasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13530
+msgid "Sky unchanged"
+msgstr ""
+
+#: 3.8/weather-applet.js:13532
+msgid "Smoke or haze"
+msgstr ""
+
+#: 3.8/weather-applet.js:13536
+#, fuzzy
+msgid "Snow and rain showers"
+msgstr "Ninsori în averse"
+
+#: 3.8/weather-applet.js:13548
+msgid "Thunderstorm without precipitation"
+msgstr ""
+
+#: 3.8/weather-applet.js:13550
+msgid "Diamond dust"
+msgstr ""
+
+#: 3.8/weather-applet.js:13556
+#, fuzzy
+msgid "Partially cloudy"
+msgstr "Parțial înnorat"
+
+#: 3.8/weather-applet.js:13578
+msgid "Please make sure you entered the API key correctly"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:13595
+msgid "DMI Denmark"
+msgstr ""
+
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
+msgid "NOT FOUND"
+msgstr ""
+
+#: 3.8/weather-applet.js:13779
+msgid "Blowing snow"
+msgstr "Ninsoare viscolită"
+
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
+#, fuzzy
+msgid "Slight snow"
+msgstr "Ninsoare viscolită"
+
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
+#, fuzzy
+msgid "Moderate snow"
+msgstr "Ninsoare abundentă"
+
+#: 3.8/weather-applet.js:13842
+#, fuzzy
+msgid "Moderate rain showers"
+msgstr "Averse răzlețe"
+
+#: 3.8/weather-applet.js:13849
+msgid "Mixed rain and snow"
+msgstr "Lapoviță"
+
+#: 3.8/weather-applet.js:13856
+#, fuzzy
+msgid "Heavy mixed rain and snow"
+msgstr "Lapoviță"
+
+#: 3.8/weather-applet.js:14024
+msgid "AccuWeather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+msgid "Weather Underground"
+msgstr ""
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+msgid "The location you provided was not found."
+msgstr ""
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+msgid "Strong Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "Lapoviță"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "Măzăriche"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "Ninsori în averse"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "Majoritar înnorat"
+
+#: 3.8/weather-applet.js:15247
+msgid "Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:15603
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+
+#: 3.8/weather-applet.js:15831
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+
+#: 3.8/weather-applet.js:15968
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:15975
+msgid ""
+"Could not get contents of config file under path\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr ""
+
+#: 3.8/weather-applet.js:16675
+msgid "Dew Point"
+msgstr ""
+
+#: 3.8/weather-applet.js:16747
+msgid "Precipitation will end in {precipEnd} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16749
+msgid "Precipitation won't end in within an hour"
+msgstr ""
+
+#: 3.8/weather-applet.js:16752
+msgid "Precipitation will start within {precipStart} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16964
+msgid "Forecast parsing failed, see logs for more details."
+msgstr ""
+
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
+msgid "As of {lastUpdatedTime}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17502
+msgid "{distance} {distanceUnit} from you"
+msgstr ""
+
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
+msgid "Error Saving Debug Information"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Debug Information saved successfully"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Saved to {filePath}"
+msgstr ""
+
+#: 3.8/LogSaver.py:16
+msgid "Save to File"
+msgstr ""
+
+#: 3.8/LogSaver.py:29
+msgid "Select a destination"
+msgstr ""
+
+#. metadata.json->name
+#. 3.8->settings-schema.json->providers->title
+msgid "Weather"
+msgstr ""
+
+#. metadata.json->description
+msgid "View your local weather forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->head->description
+msgid "Settings for weather@mockturtl 3.0+"
+msgstr ""
+
+#. 3.0->settings-schema.json->keybinding->description
+#. 3.8->settings-schema.json->keybinding->description
+msgid "Set the keybinding to call the menu"
+msgstr ""
+
+#. 3.0->settings-schema.json->descriptions->description
+msgid "Weather service information"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->description
+msgid "Click here for detailed description"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->tooltip
+#. 3.0->settings-schema.json->getLocation->tooltip
+#. 3.8->settings-schema.json->getLocation->tooltip
+msgid "Opens webpage guide"
+msgstr ""
+
+#. 3.0->settings-schema.json->providerSettings->description
+#. 3.8->settings-schema.json->provider-options->title
+msgid "Weather Provider Options"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->description
+#. 3.8->settings-schema.json->dataService->description
+msgid "Data service"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "DarkSky (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weatherbit (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Yahoo"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Climacell (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->description
+#. 3.8->settings-schema.json->apiKey->description
+msgid "API Key"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->tooltip
+#. 3.8->settings-schema.json->apiKey->tooltip
+msgid "Copy this from your account of the used Data service and paste it here."
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->description
+#. 3.8->settings-schema.json->manualLocation->description
+msgid "Manual Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->tooltip
+#. 3.8->settings-schema.json->manualLocation->tooltip
+msgid "Enable this if your location is not accurate"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->description
+msgid "Location - Coordinates"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->tooltip
+msgid ""
+"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an "
+"address.\n"
+"Waits for 3 seconds after you stop typing before refreshes the weather."
+msgstr ""
+
+#. 3.0->settings-schema.json->getLocation->description
+msgid "Setup API Key and Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->units
+#. 3.8->settings-schema.json->refreshInterval->units
+msgid "minutes"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->description
+#. 3.8->settings-schema.json->refreshInterval->description
 #, fuzzy
 msgid "Update interval"
 msgstr "Actualizare interval de timp (minute)"
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->units
-msgid "minutes"
+#. 3.0->settings-schema.json->forecastDays->units
+#. 3.8->settings-schema.json->forecastDays->units
+msgid "days"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->useSymbolicIcons->description
-msgid "Symbolic icons"
-msgstr "Pictograme (iconițe)"
-
-#. cinnamon-weather->metadata.json->description
-msgid "View your local weather forecast"
+#. 3.0->settings-schema.json->forecastDays->description
+#. 3.8->settings-schema.json->forecastDays->description
+msgid "Forecast length"
 msgstr ""
 
-#. cinnamon-weather->metadata.json->name
-msgid "Weather"
+#. 3.0->settings-schema.json->forecastHours->units
+#. 3.8->settings-schema.json->forecastHours->units
+msgid "hours"
 msgstr ""
 
-#~ msgid "Show 5-day forecast"
-#~ msgstr "Arată vremea pentru 5 zile"
+#. 3.0->settings-schema.json->forecastHours->description
+#. 3.8->settings-schema.json->forecastHours->description
+msgid "Hourly Forecast length"
+msgstr ""
 
-#~ msgid "Please wait"
-#~ msgstr "Așteptați"
+#. 3.0->settings-schema.json->unitSettings->description
+msgid "Units"
+msgstr ""
 
-#~ msgid "Today"
-#~ msgstr "Azi"
+#. 3.0->settings-schema.json->temperatureUnit->description
+#. 3.8->settings-schema.json->temperatureUnit->description
+#, fuzzy
+msgid "Temperature unit"
+msgstr "Temperatură:"
 
-#~ msgid "Tomorrow"
-#~ msgstr "Mâine"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Automatic"
+msgstr ""
 
-#~ msgid "http://edg3.co.uk/snippets/weather-location-codes/"
-#~ msgstr "http://edg3.co.uk/snippets/weather-location-codes/"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#, fuzzy
+msgid "Celsius"
+msgstr "celsius"
+
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#, fuzzy
+msgid "Fahrenheit"
+msgstr "fahrenheit"
+
+#. 3.0->settings-schema.json->temperatureUnit->tooltip
+#. 3.0->settings-schema.json->distanceUnit->tooltip
+#. 3.8->settings-schema.json->temperatureUnit->tooltip
+#. 3.8->settings-schema.json->distanceUnit->tooltip
+msgid ""
+"Automatic will try to guess your preference based your current display "
+"language."
+msgstr ""
+
+#. 3.0->settings-schema.json->windSpeedUnit->description
+#. 3.8->settings-schema.json->windSpeedUnit->description
+msgid "Wind speed unit"
+msgstr "Initatea de măsură pt. viteza vântului"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "kph"
+msgstr "km/oră"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "mph"
+msgstr "mile/oră"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "m/s"
+msgstr "m/s"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "knots"
+msgstr ""
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "Beaufort"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->description
+#. 3.8->settings-schema.json->pressureUnit->description
+msgid "Atmospheric pressure unit"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "hPa"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "in Hg"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "mm Hg"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "psi"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "at"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "atm"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "Pa"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->description
+#. 3.8->settings-schema.json->distanceUnit->description
+msgid "Distance unit"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Metric"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Imperial"
+msgstr ""
+
+#. 3.0->settings-schema.json->panelSettings->description
+msgid "Panel options"
+msgstr ""
+
+#. 3.0->settings-schema.json->showTextInPanel->description
+#. 3.8->settings-schema.json->showTextInPanel->description
+msgid "Display current temperature in panel"
+msgstr "Afișarea temperaturii curente în panou"
+
+#. 3.0->settings-schema.json->showCommentInPanel->description
+#. 3.8->settings-schema.json->showCommentInPanel->description
+msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
+msgstr "Arată condițiile vremii (de ex. \"Vânt\", \"Clar\") în panou"
+
+#. 3.0->settings-schema.json->showCommentInPanel->tooltip
+#. 3.8->settings-schema.json->showCommentInPanel->tooltip
+msgid "Only works with horizontal panels"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempTextOverride->description
+#. 3.8->settings-schema.json->tempTextOverride->description
+#, fuzzy
+msgid "Override label on panel"
+msgstr "Suprapunere locație"
+
+#. 3.0->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.0->settings-schema.json->useCustomMenuIcons->tooltip
+#. 3.8->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.8->settings-schema.json->useCustomMenuIcons->tooltip
+msgid "Iconset is weather-icons by Erik Flowers"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->description
+#. 3.8->settings-schema.json->useCustomAppletIcons->description
+msgid "Use custom icons on the panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->displaySettings->description
+#. 3.8->settings-schema.json->presentation-section->title
+msgid "Presentation"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->description
+#. 3.8->settings-schema.json->verticalOrientation->description
+#, fuzzy
+msgid "Show forecast vertically"
+msgstr "Arată vremea pentru 5 zile"
+
+#. 3.0->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->units
+#. 3.8->settings-schema.json->forecastColumns->units
+msgid "columns"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->description
+#. 3.8->settings-schema.json->forecastColumns->description
+msgid "Maximum number of columns for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->units
+#. 3.8->settings-schema.json->forecastRows->units
+msgid "rows"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->description
+#. 3.8->settings-schema.json->forecastRows->description
+msgid "Maximum number of rows for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->showSunrise->description
+#. 3.8->settings-schema.json->showSunrise->description
+msgid "Show sunrise / sunset times"
+msgstr "Arată timpul pentru răsărit/apus de soare"
+
+#. 3.0->settings-schema.json->show24Hours->description
+#. 3.8->settings-schema.json->show24Hours->description
+msgid "Display time in 24 hour format"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->description
+#. 3.8->settings-schema.json->shortHourlyTime->description
+msgid "Only display hours for hourly forecast time"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->tooltip
+#. 3.8->settings-schema.json->shortHourlyTime->tooltip
+msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->description
+#. 3.8->settings-schema.json->showForecastDates->description
+msgid "Display date for daily forecasts"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->tooltip
+#. 3.8->settings-schema.json->showForecastDates->tooltip
+msgid "Like \"Friday 15\""
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureHighFirst->description
+#. 3.8->settings-schema.json->temperatureHighFirst->description
+msgid "Show high temperature first in forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempRussianStyle->description
+#. 3.8->settings-schema.json->tempRussianStyle->description
+#, fuzzy
+msgid "Show temperature Russian style"
+msgstr "Temperatură:"
+
+#. 3.0->settings-schema.json->locationLabelOverride->description
+#. 3.8->settings-schema.json->locationLabelOverride->description
+msgid "Override location label"
+msgstr "Suprapunere locație"
+
+#. 3.0->settings-schema.json->conditionSettings->description
+#. 3.8->settings-schema.json->weather-conditions->title
+msgid "Weather conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->translateCondition->description
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Translate conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortConditions->description
+#. 3.8->settings-schema.json->shortConditions->description
+msgid "Less verbose conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->iconSettings->description
+#. 3.8->settings-schema.json->icons->title
+msgid "Icons"
+msgstr ""
+
+#. 3.0->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons in the applet"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomMenuIcons->description
+#. 3.8->settings-schema.json->useCustomMenuIcons->description
+msgid "Use custom icons in the popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->locations-page->title
+#. 3.8->settings-schema.json->location->description
+msgid "Location"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-page->title
+msgid "Other options"
+msgstr ""
+
+#. 3.8->settings-schema.json->info-section->title
+msgid "Help"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-section->title
+msgid "Location settings"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-store->title
+msgid "Saved Locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->panel-options->title
+msgid "Panel (Taskbar)"
+msgstr ""
+
+#. 3.8->settings-schema.json->presentation->title
+msgid "Popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-section->title
+msgid "Other Units"
+msgstr ""
+
+#. 3.8->settings-schema.json->temp-unit-section->title
+#, fuzzy
+msgid "Temperature Unit"
+msgstr "Temperatură:"
+
+#. 3.8->settings-schema.json->keybindings->title
+msgid "Keybindings"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info->title
+msgid "More about the Weather applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->submit-issue->title
+msgid "Report an issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->debug-options->title
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Debug"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->tooltip
+msgid ""
+"You can choose between several different weather forecast providers. Some "
+"providers require a API key to work, some have regional limits, differ in "
+"forecast length, and they all need a functional internet connection to work. "
+"The options are described in detail on the Cinnamon Spices Website which you "
+"can access with the button on the Help tab."
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Met Office UK (UK only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "US National Weather (US only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Pirate Weather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Visual Crossing (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Tomorrow.io (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "AccuWeather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weather Underground (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->location->tooltip
+msgid ""
+"You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use "
+"'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street} "
+"{City/Town} {Postcode} {Country}. The search algorithm is very flexible with "
+"the format. After 3 seconds without typing the address you entered is "
+"replaced automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->description
+#, fuzzy
+msgid "Save current location to storage"
+msgstr "Suprapunere locație"
+
+#. 3.8->settings-schema.json->saveLocation->tooltip
+msgid ""
+"Saves location information to file so you can switch between them with "
+"buttons in the applet, which will appear if you have more than one."
+msgstr ""
+
+#. 3.8->settings-schema.json->getLocation->description
+msgid "Weather Applet at Cinnamon Spices Website"
+msgstr ""
+
+#. 3.8->settings-schema.json->refreshInterval->tooltip
+msgid ""
+"If you are using a provider with API keys set it to an interval you won't "
+"run out of your quota with."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastDays->tooltip
+msgid ""
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->description
+msgid "Enable minutely precipitation forecast"
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->tooltip
+msgid ""
+"If you'd like to use this make sure you use your exact coordinates/address "
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
+msgstr ""
+
+#. 3.8->settings-schema.json->showBothTempUnits->description
+msgid "Show both temperature units at the same time"
+msgstr ""
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+#, fuzzy
+msgid "Override tooltip on panel"
+msgstr "Suprapunere locație"
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
+msgid "Always show Hourly Weather"
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->tooltip
+msgid ""
+"Hide/Show button will be hidden and Hourly weather will be permanently "
+"visible."
+msgstr ""
+
+#. 3.8->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->description
+msgid "Your saved locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->tooltip
+msgid ""
+"You have to make sure the Search entry field is unique and your Timezone is "
+"in the IANA time zone format (e.g. 'Europe/London')"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Latitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Longitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "City"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Country"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Timezone"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Search entry"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->description
+msgid "Display wind direction as text"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->tooltip
+msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->tooltip
+msgid "Does not apply to custom iconset, that is symbolic by default"
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons throughout the applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info-label->description
+msgid ""
+"For detailed information about the applet please go to the Spices Website to "
+"find info about known issues, troubleshooting, changelog and more by "
+"clicking the button below. Here you can ask questions etc in the comment "
+"section by logging in with your Github account."
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->description
+msgid "Submit an Issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->tooltip
+msgid ""
+"Opens webpage where you can fill out a new issue for the applet, needs a "
+"GitHub account.\n"
+" Please make sure that the issue is not already submitted."
+msgstr ""
+
+#. 3.8->settings-schema.json->maintainer->description
+msgid "Current maintainer: Gr3q"
+msgstr ""
+
+#. 3.8->settings-schema.json->issue-reporting-explanation->description
+msgid ""
+"If you find an issue with this applet please make a report by clicking on "
+"the button below and login in with your Github account.\n"
+"\n"
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
+msgstr ""
+
+#. 3.8->settings-schema.json->loc-info->description
+msgid ""
+"Your location in most cases work automatically but you can enter it manually "
+"by coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,"
+"Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/"
+"Town} {Postcode} {Country}. The search algorithm is very flexible with the "
+"format. After 3 seconds without typing the address you entered is replaced "
+"automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->description
+msgid "Log Level"
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->tooltip
+msgid ""
+"Info is the regular logging, Debug is debug, and Verbose also logs network "
+"request payloads. Changing this will only be effective on future logs. Only "
+"change it you are instructed or you know what you are doing."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Verbose"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->description
+msgid "Click Save to save debug information to a file"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->tooltip
+msgid ""
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
+msgstr ""
+
+#. 3.8->settings-schema.json->selectedLogPath->description
+msgid "Selected path to save Logs"
+msgstr ""

--- a/weather@mockturtl/files/weather@mockturtl/po/ru.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/ru.po
@@ -8,8 +8,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-15 22:54+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2021-07-20 14:32+0600\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,66 +19,69 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n"
-"%100<12 || n%100>14) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
-#: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131 3.8/main.js:31
+#: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Ошибка"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/main.js:32 3.8/main.js:34 3.8/main.js:36 3.8/main.js:39 3.8/main.js:42
-#: 3.8/main.js:43 3.8/main.js:44 3.8/main.js:45
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Ошибка сервиса"
 
-#: 3.0/applet.js:168 3.8/main.js:33
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Неверный ключа API"
 
-#: 3.0/applet.js:170 3.8/main.js:35
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Неверный формат местоположения"
 
-#: 3.0/applet.js:172 3.8/main.js:37
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Ключ заблокирован"
 
-#: 3.0/applet.js:173 3.8/main.js:38
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Невозможно найти местоположение"
 
-#: 3.0/applet.js:175 3.8/main.js:40
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Нет ключа API"
 
-#: 3.0/applet.js:176 3.8/main.js:41
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Нет местоположения"
 
-#: 3.0/applet.js:181 3.8/main.js:46
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Отсутствуют пакеты"
 
-#: 3.0/applet.js:182 3.8/main.js:47
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Местоположение не поддерживается"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/lib/notification_service.js:9
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Погода"
 
-#: 3.0/applet.js:217 3.8/main.js:261
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/main.js:262
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Нажмите дял открытия"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/main.js:273
-#: 3.8/ui_elements/uiCurrentWeather.js:134
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Обновить"
 
@@ -87,24 +91,27 @@ msgstr "API вернул код статуса между 400 и 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/location_services/locationstore.js:141
-#: 3.8/location_services/locationstore.js:145 3.8/location_services/locationstore.js:149
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Хранение местоположения"
 
 #: 3.0/applet.js:426
 msgid "You can't save a location obtained automatically, sorry"
-msgstr "Извините, невозможно сохранить местоположение, полученное автоматически"
+msgstr ""
+"Извините, невозможно сохранить местоположение, полученное автоматически"
 
 #: 3.0/applet.js:601
 msgid "Could not get weather information"
 msgstr "Невозможно получить информацию о погоде"
 
-#: 3.0/applet.js:624 3.8/main.js:135
-msgid "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
-msgstr "Неожиданная ошибка во время обновления погоды, см. логи в Looking Glass"
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
+msgid ""
+"Unexpected Error While Refreshing Weather, please see log in Looking Glass"
+msgstr ""
+"Неожиданная ошибка во время обновления погоды, см. логи в Looking Glass"
 
-#: 3.0/applet.js:670 3.8/main.js:393
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -120,7 +127,7 @@ msgstr "Ошибка сети, см. логи в Looking Glass"
 msgid "As of"
 msgstr "По состоянию на"
 
-#: 3.0/applet.js:1108 3.8/ui_elements/uiBar.js:37
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "При помощи"
 
@@ -128,89 +135,92 @@ msgstr "При помощи"
 msgid "from you"
 msgstr "от вас"
 
-#: 3.0/applet.js:1132 3.8/ui_elements/uiHourlyForecasts.js:214
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "мм"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/providers/darkSky.js:23
-#: 3.8/ui_elements/uiHourlyForecasts.js:214
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/providers/met_uk.js:296
-#: 3.8/ui_elements/uiBar.js:98
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "миль"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/providers/met_uk.js:297
-#: 3.8/ui_elements/uiBar.js:99
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "км"
 
-#: 3.0/applet.js:1227 3.8/ui.js:128
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Загрузка текущей погоды ..."
 
-#: 3.0/applet.js:1230 3.8/ui.js:131
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Загрузка прогноза погоды ..."
 
-#: 3.0/applet.js:1280 3.8/ui_elements/uiCurrentWeather.js:77
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Загрузка ..."
 
-#: 3.0/applet.js:1329 3.8/ui_elements/uiCurrentWeather.js:101
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Температура"
 
-#: 3.0/applet.js:1330 3.8/ui_elements/uiCurrentWeather.js:102
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Влажность"
 
-#: 3.0/applet.js:1331 3.8/ui_elements/uiCurrentWeather.js:103
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Давление"
 
-#: 3.0/applet.js:1332 3.8/providers/climacellV4.js:170 3.8/providers/climacellV4.js:177
-#: 3.8/providers/climacellV4.js:178 3.8/providers/climacellV4.js:184
-#: 3.8/ui_elements/uiCurrentWeather.js:104
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Ветер"
 
-#: 3.0/applet.js:1639 3.8/config.js:174
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
-"Убедитесь, что вы ввели местоположение или используйте автоматическое местоположение"
+"Убедитесь, что вы ввели местоположение или используйте автоматическое "
+"местоположение"
 
-#: 3.0/applet.js:1877 3.8/location_services/nominatim.js:30
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
-"Невозможно найти местоположение по адресу, пожалуйста убедитесь, что данные верны"
+"Невозможно найти местоположение по адресу, пожалуйста убедитесь, что данные "
+"верны"
 
-#: 3.0/applet.js:1901 3.8/location_services/nominatim.js:51
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "Не удалось вызвать Geolocation API, см. логи в Looking Glass."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/location_services/locationstore.js:141
-#: 3.8/location_services/locationstore.js:145
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Предупреждение"
 
-#: 3.0/applet.js:2032 3.8/location_services/locationstore.js:141
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
-"Вы можете сохранить правильное местопооложение только когда аплет не обновляется"
+"Вы можете сохранить правильное местопооложение только когда аплет не "
+"обновляется"
 
-#: 3.0/applet.js:2036 3.8/location_services/locationstore.js:145
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Вы не можете сохранить неверное местоположение"
 
+#. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/location_services/locationstore.js:149
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Инфомрация"
 
-#: 3.0/applet.js:2040 3.8/location_services/locationstore.js:149
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Местоположение уже сохранено"
 
@@ -240,21 +250,23 @@ msgstr "Местоположение удалено из библиотеки"
 
 #: 3.0/applet.js:2131
 msgid ""
-"Failed to load in data from location storage, please see the logs for more information"
+"Failed to load in data from location storage, please see the logs for more "
+"information"
 msgstr ""
-"Не удалось загрузить данные из хранилища местоположений, пожалуйста проверьте логи"
+"Не удалось загрузить данные из хранилища местоположений, пожалуйста "
+"проверьте логи"
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/providers/climacell.js:89 3.8/providers/climacellV4.js:71
-#: 3.8/providers/darkSky.js:82 3.8/providers/openWeatherMap.js:63
-#: 3.8/providers/us_weather.js:187 3.8/providers/visualcrossing.js:63
-#: 3.8/providers/weatherbit.js:98
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Ощущается как"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/providers/climacell.js:100 3.8/providers/darkSky.js:128
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Не удалось обработать информацию о погоде"
 
@@ -267,8 +279,7 @@ msgstr ""
 "или сначала получите его на https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/providers/climacell.js:152 3.8/providers/darkSky.js:156
-#: 3.8/providers/weatherbit.js:216
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -276,7 +287,7 @@ msgstr ""
 "Пожалуйста убедитесь, что\n"
 "введённый ключ API правильный и ваш аккаунт не заблокирован"
 
-#: 3.0/climacell.js:248 3.8/providers/climacell.js:162 3.8/providers/climacellV4.js:40
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -284,246 +295,253 @@ msgstr ""
 "Пожалуйста убедитесь, что\n"
 "введённый ключ API совпадает с ключем от Climacell"
 
-#: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308 3.0/met_norway.js:309
-#: 3.0/met_norway.js:315 3.0/met_norway.js:322 3.0/met_norway.js:329 3.0/met_uk.js:617
-#: 3.0/met_uk.js:624 3.0/met_uk.js:631 3.0/met_uk.js:632 3.8/providers/climacell.js:173
-#: 3.8/providers/climacell.js:174 3.8/providers/climacellV4.js:213
-#: 3.8/providers/met_norway.js:239 3.8/providers/met_norway.js:240
-#: 3.8/providers/met_norway.js:246 3.8/providers/met_norway.js:253
-#: 3.8/providers/met_norway.js:260 3.8/providers/met_uk.js:492
-#: 3.8/providers/met_uk.js:499 3.8/providers/met_uk.js:506 3.8/providers/met_uk.js:507
-#: 3.8/providers/visualcrossing.js:230
+#: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
+#: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
+#: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Сильный дождь"
 
-#: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483 3.0/met_norway.js:484
-#: 3.0/met_norway.js:490 3.0/us_weather.js:484 3.0/us_weather.js:533
-#: 3.0/us_weather.js:534 3.0/us_weather.js:541 3.0/yahoo.js:448
-#: 3.8/providers/climacell.js:180 3.8/providers/climacell.js:181
-#: 3.8/providers/climacellV4.js:198 3.8/providers/climacellV4.js:199
-#: 3.8/providers/climacellV4.js:205 3.8/providers/climacellV4.js:212
-#: 3.8/providers/climacellV4.js:254 3.8/providers/climacellV4.js:261
-#: 3.8/providers/climacellV4.js:268 3.8/providers/danishMI.js:186
-#: 3.8/providers/danishMI.js:187 3.8/providers/danishMI.js:228
-#: 3.8/providers/met_norway.js:414 3.8/providers/met_norway.js:415
-#: 3.8/providers/met_norway.js:421 3.8/providers/us_weather.js:378
-#: 3.8/providers/us_weather.js:427 3.8/providers/us_weather.js:428
-#: 3.8/providers/us_weather.js:435 3.8/providers/visualcrossing.js:222
+#: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
+#: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
+#: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Дождь"
 
-#: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392 3.0/met_norway.js:393
-#: 3.0/met_norway.js:399 3.0/met_norway.js:406 3.0/met_norway.js:413 3.0/met_uk.js:589
-#: 3.0/met_uk.js:596 3.0/met_uk.js:610 3.0/met_uk.js:611 3.0/openWeatherMap.js:381
-#: 3.8/providers/climacell.js:187 3.8/providers/climacell.js:188
-#: 3.8/providers/climacellV4.js:206 3.8/providers/met_norway.js:323
-#: 3.8/providers/met_norway.js:324 3.8/providers/met_norway.js:330
-#: 3.8/providers/met_norway.js:337 3.8/providers/met_norway.js:344
-#: 3.8/providers/met_uk.js:464 3.8/providers/met_uk.js:471 3.8/providers/met_uk.js:485
-#: 3.8/providers/met_uk.js:486 3.8/providers/openWeatherMap.js:344
-#: 3.8/providers/visualcrossing.js:232
+#: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
+#: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
+#: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Небольшой дождь"
 
-#: 3.0/climacell.js:280 3.8/providers/climacell.js:194 3.8/providers/climacellV4.js:269
-#: 3.8/providers/visualcrossing.js:206
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Сильный ледяной дождь"
 
-#: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288 3.0/climacell.js:295
-#: 3.0/openWeatherMap.js:386 3.0/us_weather.js:505 3.0/us_weather.js:506
-#: 3.0/us_weather.js:512 3.0/us_weather.js:513 3.0/us_weather.js:519
-#: 3.8/providers/climacell.js:195 3.8/providers/climacell.js:201
-#: 3.8/providers/climacell.js:202 3.8/providers/climacell.js:209
-#: 3.8/providers/climacellV4.js:255 3.8/providers/openWeatherMap.js:349
-#: 3.8/providers/us_weather.js:399 3.8/providers/us_weather.js:400
-#: 3.8/providers/us_weather.js:406 3.8/providers/us_weather.js:407
-#: 3.8/providers/us_weather.js:413
+#: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
+#: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
+#: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Ледяной дождь"
 
-#: 3.0/climacell.js:294 3.8/providers/climacell.js:208 3.8/providers/climacellV4.js:262
-#: 3.8/providers/visualcrossing.js:208
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Небольшой ледяной дождь"
 
-#: 3.0/climacell.js:301 3.8/providers/climacell.js:215
+#: 3.0/climacell.js:301
 msgid "Light freezing drizzle"
 msgstr "Лёгкая изморось"
 
-#: 3.0/climacell.js:302 3.8/providers/climacell.js:216 3.8/providers/climacellV4.js:248
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Изморось"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/providers/climacell.js:222
-#: 3.8/providers/climacell.js:223 3.8/providers/visualcrossing.js:188
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Лёгкая морось"
 
-#: 3.0/climacell.js:315 3.8/providers/climacell.js:229 3.8/providers/climacellV4.js:283
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Сильный град"
 
-#: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323 3.0/climacell.js:330
-#: 3.8/providers/climacell.js:230 3.8/providers/climacell.js:236
-#: 3.8/providers/climacell.js:237 3.8/providers/climacell.js:244
-#: 3.8/providers/climacellV4.js:275 3.8/providers/climacellV4.js:276
-#: 3.8/providers/climacellV4.js:282 3.8/providers/climacellV4.js:289
+#: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Град"
 
-#: 3.0/climacell.js:329 3.8/providers/climacell.js:243 3.8/providers/climacellV4.js:290
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Небольшой град"
 
-#: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364 3.0/met_norway.js:365
-#: 3.0/met_norway.js:371 3.0/met_norway.js:378 3.0/met_norway.js:385 3.0/met_uk.js:701
-#: 3.0/met_uk.js:708 3.0/met_uk.js:715 3.0/met_uk.js:716 3.0/openWeatherMap.js:393
-#: 3.8/providers/climacell.js:250 3.8/providers/climacell.js:251
-#: 3.8/providers/climacellV4.js:241 3.8/providers/danishMI.js:263
-#: 3.8/providers/met_norway.js:295 3.8/providers/met_norway.js:296
-#: 3.8/providers/met_norway.js:302 3.8/providers/met_norway.js:309
-#: 3.8/providers/met_norway.js:316 3.8/providers/met_uk.js:576
-#: 3.8/providers/met_uk.js:583 3.8/providers/met_uk.js:590 3.8/providers/met_uk.js:591
-#: 3.8/providers/openWeatherMap.js:356 3.8/providers/visualcrossing.js:248
+#: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
+#: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
+#: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Сильный снегопад"
 
-#: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539 3.0/met_norway.js:540
-#: 3.0/met_norway.js:546 3.0/openWeatherMap.js:392 3.0/us_weather.js:477
-#: 3.0/us_weather.js:478 3.0/yahoo.js:452 3.8/providers/climacell.js:257
-#: 3.8/providers/climacell.js:258 3.8/providers/climacellV4.js:219
-#: 3.8/providers/climacellV4.js:220 3.8/providers/climacellV4.js:233
-#: 3.8/providers/climacellV4.js:240 3.8/providers/danishMI.js:172
-#: 3.8/providers/danishMI.js:256 3.8/providers/met_norway.js:470
-#: 3.8/providers/met_norway.js:471 3.8/providers/met_norway.js:477
-#: 3.8/providers/openWeatherMap.js:355 3.8/providers/us_weather.js:371
-#: 3.8/providers/us_weather.js:372 3.8/providers/visualcrossing.js:242
+#: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
+#: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
+#: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Снегопад"
 
-#: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448 3.0/met_norway.js:449
-#: 3.0/met_norway.js:455 3.0/met_norway.js:462 3.0/met_norway.js:469 3.0/met_uk.js:680
-#: 3.0/met_uk.js:687 3.0/met_uk.js:694 3.0/met_uk.js:695 3.0/openWeatherMap.js:391
-#: 3.8/providers/climacellV4.js:234 3.8/providers/met_norway.js:379
-#: 3.8/providers/met_norway.js:380 3.8/providers/met_norway.js:386
-#: 3.8/providers/met_norway.js:393 3.8/providers/met_norway.js:400
-#: 3.8/providers/met_uk.js:555 3.8/providers/met_uk.js:562 3.8/providers/met_uk.js:569
-#: 3.8/providers/met_uk.js:570 3.8/providers/openWeatherMap.js:354
-#: 3.8/providers/visualcrossing.js:250
+#: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
+#: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
+#: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Лёгкий снегопад"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/providers/climacell.js:271
-#: 3.8/providers/climacell.js:272 3.8/providers/climacellV4.js:226
-#: 3.8/providers/climacellV4.js:227
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Кратковременные снегопады"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/providers/climacell.js:278
-#: 3.8/providers/climacell.js:279 3.8/providers/climacellV4.js:296
-#: 3.8/providers/climacellV4.js:297 3.8/providers/danishMI.js:270
-#: 3.8/providers/danishMI.js:271 3.8/providers/openWeatherMap.js:329
-#: 3.8/providers/us_weather.js:444 3.8/providers/us_weather.js:445
-#: 3.8/providers/visualcrossing.js:254
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Гроза"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/providers/climacell.js:285
-#: 3.8/providers/climacell.js:286 3.8/providers/climacellV4.js:164
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Лёгкий туман"
 
-#: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301 3.0/met_norway.js:302
-#: 3.0/met_uk.js:568 3.0/met_uk.js:569 3.0/openWeatherMap.js:405 3.0/us_weather.js:620
-#: 3.0/us_weather.js:621 3.8/providers/climacell.js:292 3.8/providers/climacell.js:293
-#: 3.8/providers/climacellV4.js:156 3.8/providers/climacellV4.js:157
-#: 3.8/providers/climacellV4.js:163 3.8/providers/met_norway.js:232
-#: 3.8/providers/met_norway.js:233 3.8/providers/met_uk.js:443
-#: 3.8/providers/met_uk.js:444 3.8/providers/openWeatherMap.js:368
-#: 3.8/providers/us_weather.js:514 3.8/providers/us_weather.js:515
-#: 3.8/providers/visualcrossing.js:196
+#: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
+#: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
+#: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Туман"
 
-#: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287 3.0/met_norway.js:288
-#: 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462 3.8/providers/climacell.js:299
-#: 3.8/providers/climacell.js:300 3.8/providers/climacellV4.js:128
-#: 3.8/providers/climacellV4.js:129 3.8/providers/danishMI.js:165
-#: 3.8/providers/danishMI.js:166 3.8/providers/met_norway.js:218
-#: 3.8/providers/met_norway.js:219 3.8/providers/met_uk.js:450
-#: 3.8/providers/met_uk.js:451
+#: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
+#: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Облачно"
 
-#: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428 3.0/us_weather.js:429
-#: 3.0/us_weather.js:463 3.8/providers/climacell.js:306 3.8/providers/climacell.js:307
-#: 3.8/providers/climacellV4.js:149 3.8/providers/climacellV4.js:150
-#: 3.8/providers/us_weather.js:322 3.8/providers/us_weather.js:323
-#: 3.8/providers/us_weather.js:357
+#: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Облачно с прояснениями"
 
-#: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476 3.0/met_norway.js:477
-#: 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547 3.0/met_uk.js:548
-#: 3.0/us_weather.js:421 3.0/us_weather.js:422 3.0/us_weather.js:456
-#: 3.8/providers/climacell.js:313 3.8/providers/climacell.js:314
-#: 3.8/providers/climacellV4.js:142 3.8/providers/climacellV4.js:143
-#: 3.8/providers/danishMI.js:158 3.8/providers/danishMI.js:159
-#: 3.8/providers/met_norway.js:407 3.8/providers/met_norway.js:408
-#: 3.8/providers/met_uk.js:415 3.8/providers/met_uk.js:416 3.8/providers/met_uk.js:422
-#: 3.8/providers/met_uk.js:423 3.8/providers/us_weather.js:315
-#: 3.8/providers/us_weather.js:316 3.8/providers/us_weather.js:350
+#: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
+#: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
+#: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Переменная облачность"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/providers/climacell.js:320
-#: 3.8/providers/climacell.js:321 3.8/providers/climacellV4.js:135
-#: 3.8/providers/climacellV4.js:136
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Преимущественно ясно"
 
-#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526 3.0/met_uk.js:527
-#: 3.0/openWeatherMap.js:411 3.0/us_weather.js:407 3.0/us_weather.js:408
-#: 3.0/us_weather.js:442 3.0/yahoo.js:465 3.8/providers/climacell.js:327
-#: 3.8/providers/climacell.js:328 3.8/providers/climacellV4.js:121
-#: 3.8/providers/climacellV4.js:122 3.8/providers/danishMI.js:151
-#: 3.8/providers/danishMI.js:152 3.8/providers/met_uk.js:401 3.8/providers/met_uk.js:402
-#: 3.8/providers/openWeatherMap.js:374 3.8/providers/us_weather.js:301
-#: 3.8/providers/us_weather.js:302 3.8/providers/us_weather.js:336
-#: 3.8/providers/visualcrossing.js:266
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
+#: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
+#: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Ясно"
 
-#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533 3.0/met_uk.js:534
-#: 3.0/yahoo.js:466 3.8/providers/climacell.js:327 3.8/providers/climacell.js:328
-#: 3.8/providers/climacellV4.js:121 3.8/providers/climacellV4.js:122
-#: 3.8/providers/met_uk.js:408 3.8/providers/met_uk.js:409
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Солнечно"
 
-#: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568 3.0/met_norway.js:569
-#: 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554 3.0/met_uk.js:555
-#: 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627 3.0/us_weather.js:628
-#: 3.8/providers/climacell.js:335 3.8/providers/climacell.js:336
-#: 3.8/providers/climacellV4.js:113 3.8/providers/climacellV4.js:114
-#: 3.8/providers/met_norway.js:499 3.8/providers/met_norway.js:500
-#: 3.8/providers/met_uk.js:394 3.8/providers/met_uk.js:395 3.8/providers/met_uk.js:429
-#: 3.8/providers/met_uk.js:430 3.8/providers/met_uk.js:618 3.8/providers/met_uk.js:619
-#: 3.8/providers/us_weather.js:521 3.8/providers/us_weather.js:522
+#: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
+#: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
+#: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: 3.0/darkSky.js:71 3.8/providers/darkSky.js:23
+#: 3.0/darkSky.js:71
 msgid "and"
 msgstr "and"
 
-#: 3.0/darkSky.js:71 3.8/providers/darkSky.js:23
+#: 3.0/darkSky.js:71
 msgid "until"
 msgstr "until"
 
-#: 3.0/darkSky.js:71 3.8/providers/darkSky.js:23
+#: 3.0/darkSky.js:71
 msgid "Possible"
 msgstr "Possible"
 
@@ -535,7 +553,7 @@ msgstr ""
 "Пожалуйста введите ключ API в настройках,\n"
 "или сначала получите на https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/providers/darkSky.js:166
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -543,171 +561,176 @@ msgstr ""
 "Пожалуйста убедитесь, что\n"
 "введённый ключ API совпадает с ключем от DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/location_services/ipApi.js:38
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Не удалось получить местоположение"
 
-#: 3.0/ipApi.js:95 3.8/location_services/ipApi.js:44
-msgid "Location Service responded with errors, please see the logs in Looking Glass"
+#: 3.0/ipApi.js:95
+msgid ""
+"Location Service responded with errors, please see the logs in Looking Glass"
 msgstr "Сервис местоположения ответил с ошибками, см. логи в Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/providers/met_norway.js:64
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Облачно"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/providers/met_norway.js:211 3.8/providers/met_norway.js:212
-#: 3.8/providers/openWeatherMap.js:375
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Ясно"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/providers/met_norway.js:225 3.8/providers/met_norway.js:226
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Ясно"
 
-#: 3.0/met_norway.js:316 3.8/providers/met_norway.js:247
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Сильный дождь с грозой"
 
-#: 3.0/met_norway.js:323 3.8/providers/met_norway.js:254
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Проливные дожди"
 
-#: 3.0/met_norway.js:330 3.8/providers/met_norway.js:261
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Проливные дожди с грозой"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/providers/met_norway.js:267
-#: 3.8/providers/met_norway.js:268 3.8/providers/met_norway.js:274
-#: 3.8/providers/met_norway.js:281 3.8/providers/met_norway.js:288
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Сильный мокрый снегопад"
 
-#: 3.0/met_norway.js:344 3.8/providers/met_norway.js:275
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Сильный мокрый снегопад с грозой"
 
-#: 3.0/met_norway.js:351 3.8/providers/met_norway.js:282
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Сильный дождь с мокрым снегом"
 
-#: 3.0/met_norway.js:358 3.8/providers/met_norway.js:289
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Сильный дождь с мокрым снегом и грозой"
 
-#: 3.0/met_norway.js:372 3.8/providers/met_norway.js:303
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Сильный снегопад с грозой"
 
-#: 3.0/met_norway.js:379 3.8/providers/danishMI.js:264 3.8/providers/met_norway.js:310
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Сильный снегопад"
 
-#: 3.0/met_norway.js:386 3.8/providers/met_norway.js:317
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Сильный снегопад с грозой"
 
-#: 3.0/met_norway.js:400 3.8/providers/met_norway.js:331
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Небольшой дожль с грозой"
 
-#: 3.0/met_norway.js:407 3.8/providers/met_norway.js:338
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Врменами небольшой дождь"
 
-#: 3.0/met_norway.js:414 3.8/providers/met_norway.js:345
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Небольшой дождь с грозой"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/providers/met_norway.js:351
-#: 3.8/providers/met_norway.js:352 3.8/providers/met_norway.js:358
-#: 3.8/providers/met_norway.js:365 3.8/providers/met_norway.js:372
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Небольшой мокрый снегопад"
 
-#: 3.0/met_norway.js:428 3.8/providers/met_norway.js:359
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Небольшой мокрый снегопад с грозой"
 
-#: 3.0/met_norway.js:435 3.8/providers/met_norway.js:366
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Небольшой мокрый снегопад"
 
-#: 3.0/met_norway.js:442 3.8/providers/met_norway.js:373
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Небольшой мокрый снегопад с грозой"
 
-#: 3.0/met_norway.js:456 3.8/providers/met_norway.js:387
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Небольшой снегопад с грозой"
 
-#: 3.0/met_norway.js:463 3.8/providers/met_norway.js:394
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Небольшой снегопад"
 
-#: 3.0/met_norway.js:470 3.8/providers/met_norway.js:401
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Небольшой снегопад с грозой"
 
-#: 3.0/met_norway.js:491 3.8/providers/met_norway.js:422
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Дождь с грозой"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/providers/danishMI.js:229 3.8/providers/danishMI.js:235
-#: 3.8/providers/met_norway.js:428 3.8/providers/met_norway.js:429
-#: 3.8/providers/met_norway.js:435 3.8/providers/us_weather.js:436
-#: 3.8/providers/visualcrossing.js:228
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Временами дожди"
 
-#: 3.0/met_norway.js:505 3.8/providers/met_norway.js:436
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Временами дожди с грозой"
 
 #: 3.0/met_norway.js:511 3.0/met_norway.js:512 3.0/met_norway.js:518
-#: 3.0/met_norway.js:525 3.0/met_norway.js:532 3.0/met_uk.js:638 3.0/met_uk.js:645
-#: 3.0/met_uk.js:652 3.0/met_uk.js:653 3.0/openWeatherMap.js:394 3.0/us_weather.js:491
-#: 3.0/us_weather.js:492 3.0/us_weather.js:498 3.0/us_weather.js:499
-#: 3.0/us_weather.js:526 3.0/us_weather.js:527 3.0/yahoo.js:454
-#: 3.8/providers/met_norway.js:442 3.8/providers/met_norway.js:443
-#: 3.8/providers/met_norway.js:449 3.8/providers/met_norway.js:456
-#: 3.8/providers/met_norway.js:463 3.8/providers/met_uk.js:513
-#: 3.8/providers/met_uk.js:520 3.8/providers/met_uk.js:527 3.8/providers/met_uk.js:528
-#: 3.8/providers/openWeatherMap.js:357 3.8/providers/us_weather.js:385
-#: 3.8/providers/us_weather.js:386 3.8/providers/us_weather.js:392
-#: 3.8/providers/us_weather.js:393 3.8/providers/us_weather.js:420
-#: 3.8/providers/us_weather.js:421
+#: 3.0/met_norway.js:525 3.0/met_norway.js:532 3.0/met_uk.js:638
+#: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
+#: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
+#: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Мокрый снег"
 
-#: 3.0/met_norway.js:519 3.8/providers/met_norway.js:450
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Мокрый снег с грозой"
 
-#: 3.0/met_norway.js:526 3.8/providers/met_norway.js:457
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Мокрый снегопад"
 
-#: 3.0/met_norway.js:533 3.8/providers/met_norway.js:464
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Мокрый снегопад с грозой"
 
-#: 3.0/met_norway.js:547 3.8/providers/met_norway.js:478
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Снег с грозой"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/providers/danishMI.js:257 3.8/providers/met_norway.js:484
-#: 3.8/providers/met_norway.js:485 3.8/providers/met_norway.js:491
-#: 3.8/providers/visualcrossing.js:246
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Снег"
 
-#: 3.0/met_norway.js:561 3.8/providers/met_norway.js:492
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Снег с грозой"
 
@@ -716,20 +739,21 @@ msgstr "Снег с грозой"
 msgid "Unexpected response from API"
 msgstr "Неожиданный ответ от API"
 
-#: 3.0/met_uk.js:316 3.8/providers/met_uk.js:171
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Видимость"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/providers/met_uk.js:195 3.8/providers/openWeatherMap.js:143
-#: 3.8/providers/us_weather.js:199 3.8/providers/weatherbit.js:108
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Не удалось обработать текущую информацию о погоде"
 
-#: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371 3.0/weatherbit.js:239
-#: 3.0/weatherbit.js:274 3.8/providers/met_uk.js:219 3.8/providers/met_uk.js:255
-#: 3.8/providers/us_weather.js:266 3.8/providers/weatherbit.js:135
-#: 3.8/providers/weatherbit.js:170
+#: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Не удалось обработать прогноз погоды"
 
@@ -758,288 +782,298 @@ msgid "Excellent - More than"
 msgstr "Отличная - более чем"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/providers/met_uk.js:436 3.8/providers/met_uk.js:437
-#: 3.8/providers/openWeatherMap.js:364 3.8/providers/visualcrossing.js:218
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Туман"
 
-#: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435 3.0/us_weather.js:436
-#: 3.0/us_weather.js:470 3.8/providers/met_uk.js:457 3.8/providers/met_uk.js:458
-#: 3.8/providers/us_weather.js:329 3.8/providers/us_weather.js:330
-#: 3.8/providers/us_weather.js:364 3.8/providers/visualcrossing.js:262
+#: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Пасмурно"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/providers/met_uk.js:465
-#: 3.8/providers/met_uk.js:472
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Небольшие дожди"
 
-#: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373 3.0/yahoo.js:445
-#: 3.8/providers/climacellV4.js:191 3.8/providers/climacellV4.js:192
-#: 3.8/providers/climacellV4.js:247 3.8/providers/met_uk.js:478
-#: 3.8/providers/met_uk.js:479 3.8/providers/openWeatherMap.js:336
-#: 3.8/providers/visualcrossing.js:184
+#: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Морось"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/providers/met_uk.js:493
-#: 3.8/providers/met_uk.js:500
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Сильные дожди"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/providers/met_uk.js:514
-#: 3.8/providers/met_uk.js:521
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Дождь со снегом"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/providers/met_uk.js:534 3.8/providers/met_uk.js:541
-#: 3.8/providers/met_uk.js:548 3.8/providers/met_uk.js:549
-#: 3.8/providers/visualcrossing.js:260
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Град"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/providers/met_uk.js:535
-#: 3.8/providers/met_uk.js:542
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Временами град"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/providers/met_uk.js:556
-#: 3.8/providers/met_uk.js:563
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Лёгкие снегопады"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/providers/met_uk.js:577
-#: 3.8/providers/met_uk.js:584
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Сильные снегопады"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/providers/met_uk.js:597 3.8/providers/met_uk.js:604 3.8/providers/met_uk.js:611
-#: 3.8/providers/met_uk.js:612
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Гроза"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/providers/met_uk.js:598
-#: 3.8/providers/met_uk.js:605
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Дождь с грозой"
 
-#: 3.0/openWeatherMap.js:238 3.8/providers/openWeatherMap.js:194
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Пожалуйста, убедитесь, что формат местоположения в настройках верный"
 
-#: 3.0/openWeatherMap.js:242 3.8/providers/openWeatherMap.js:198
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Убедитесь, что введённый в настройках ключ верный"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/providers/openWeatherMap.js:202 3.8/providers/openWeatherMap.js:227
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
-"Location not found, make sure location is available or it is in the correct format"
+"Location not found, make sure location is available or it is in the correct "
+"format"
 msgstr "Местоположение не найдено, убедитесь, что оно доступно и формат верный"
 
-#: 3.0/openWeatherMap.js:250 3.8/providers/openWeatherMap.js:206
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Если это проблема повторяетс, пожалуйста, обратитесь к автору апплета"
 
-#: 3.0/openWeatherMap.js:254 3.8/providers/openWeatherMap.js:210
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Неожиданная ошибка, см. логи в Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/providers/openWeatherMap.js:325
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Гроза, небольшой дождь"
 
-#: 3.0/openWeatherMap.js:363 3.8/providers/openWeatherMap.js:326
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Гроза, дождь"
 
-#: 3.0/openWeatherMap.js:364 3.8/providers/openWeatherMap.js:327
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Гроза, сильный дождь"
 
-#: 3.0/openWeatherMap.js:365 3.8/providers/openWeatherMap.js:328
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Лёгкая гроза"
 
-#: 3.0/openWeatherMap.js:367 3.8/providers/openWeatherMap.js:330
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Сильная гроза"
 
-#: 3.0/openWeatherMap.js:368 3.8/providers/openWeatherMap.js:331
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Рваная гроза"
 
-#: 3.0/openWeatherMap.js:369 3.8/providers/openWeatherMap.js:332
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Гроза с мелким дождём"
 
-#: 3.0/openWeatherMap.js:370 3.8/providers/openWeatherMap.js:333
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Гроза с моросью"
 
-#: 3.0/openWeatherMap.js:371 3.8/providers/openWeatherMap.js:334
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Гроза с сильным моросящим дождём"
 
-#: 3.0/openWeatherMap.js:372 3.8/providers/openWeatherMap.js:335
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Мороящий дождь"
 
-#: 3.0/openWeatherMap.js:374 3.8/providers/openWeatherMap.js:337
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Сильный дождь"
 
-#: 3.0/openWeatherMap.js:375 3.8/providers/openWeatherMap.js:338
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Лёгкий интетсивный моросящий дождь"
 
-#: 3.0/openWeatherMap.js:376 3.8/providers/openWeatherMap.js:339
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Моросящий дождь"
 
-#: 3.0/openWeatherMap.js:377 3.8/providers/openWeatherMap.js:340
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Сильный интетсивный моросящий дождь"
 
-#: 3.0/openWeatherMap.js:378 3.8/providers/openWeatherMap.js:341
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Ливень и морось"
 
-#: 3.0/openWeatherMap.js:379 3.8/providers/openWeatherMap.js:342
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Сильный ливень и морось"
 
-#: 3.0/openWeatherMap.js:380 3.8/providers/openWeatherMap.js:343
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Моросящий дождь"
 
-#: 3.0/openWeatherMap.js:382 3.8/providers/danishMI.js:193 3.8/providers/danishMI.js:194
-#: 3.8/providers/openWeatherMap.js:345
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Умеренный дождь"
 
-#: 3.0/openWeatherMap.js:383 3.8/providers/openWeatherMap.js:346
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Сильный дождь"
 
-#: 3.0/openWeatherMap.js:384 3.8/providers/openWeatherMap.js:347
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Сильный ливень"
 
-#: 3.0/openWeatherMap.js:385 3.8/providers/openWeatherMap.js:348
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Экстремальный ливень"
 
-#: 3.0/openWeatherMap.js:387 3.8/providers/openWeatherMap.js:350
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Лёгкий ливень"
 
-#: 3.0/openWeatherMap.js:388 3.8/providers/openWeatherMap.js:351
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Ливень"
 
-#: 3.0/openWeatherMap.js:389 3.8/providers/openWeatherMap.js:352
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Сильный ливень"
 
-#: 3.0/openWeatherMap.js:390 3.8/providers/openWeatherMap.js:353
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Местами дождь"
 
-#: 3.0/openWeatherMap.js:395 3.8/providers/openWeatherMap.js:358
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Мокрый снег"
 
-#: 3.0/openWeatherMap.js:396 3.8/providers/openWeatherMap.js:359
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Лёгкий снег с дождём"
 
-#: 3.0/openWeatherMap.js:397 3.8/providers/danishMI.js:200 3.8/providers/danishMI.js:201
-#: 3.8/providers/danishMI.js:207 3.8/providers/danishMI.js:242
-#: 3.8/providers/danishMI.js:249 3.8/providers/openWeatherMap.js:360
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Дождь со снегом"
 
-#: 3.0/openWeatherMap.js:398 3.8/providers/openWeatherMap.js:361
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Лёгкий снег"
 
-#: 3.0/openWeatherMap.js:399 3.8/providers/openWeatherMap.js:362
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Снег"
 
-#: 3.0/openWeatherMap.js:400 3.8/providers/openWeatherMap.js:363
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Сильный снегопад"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/providers/openWeatherMap.js:365 3.8/providers/us_weather.js:479
-#: 3.8/providers/us_weather.js:480
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Дым"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/providers/openWeatherMap.js:366 3.8/providers/us_weather.js:486
-#: 3.8/providers/us_weather.js:487
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Туман"
 
-#: 3.0/openWeatherMap.js:404 3.8/providers/openWeatherMap.js:367
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Песок, пыльные вихри"
 
-#: 3.0/openWeatherMap.js:406 3.8/providers/openWeatherMap.js:369
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Песок"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/providers/openWeatherMap.js:370 3.8/providers/us_weather.js:472
-#: 3.8/providers/us_weather.js:473
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Пыль"
 
-#: 3.0/openWeatherMap.js:408 3.8/providers/openWeatherMap.js:371
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Вулканический пепел"
 
-#: 3.0/openWeatherMap.js:409 3.8/providers/openWeatherMap.js:372
-#: 3.8/providers/visualcrossing.js:252
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Шквал"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/providers/openWeatherMap.js:373 3.8/providers/us_weather.js:451
-#: 3.8/providers/us_weather.js:452
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Смерч"
 
-#: 3.0/openWeatherMap.js:413 3.8/providers/openWeatherMap.js:376
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Ясное небо"
 
-#: 3.0/openWeatherMap.js:414 3.8/providers/openWeatherMap.js:377
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Облачно"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/providers/openWeatherMap.js:378
-#: 3.8/providers/us_weather.js:308 3.8/providers/us_weather.js:309
-#: 3.8/providers/us_weather.js:343
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Местами облачно"
 
-#: 3.0/openWeatherMap.js:416 3.8/providers/openWeatherMap.js:379
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Рассыпчатые обака"
 
-#: 3.0/openWeatherMap.js:417 3.8/providers/openWeatherMap.js:380
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Прерывистые облака"
 
-#: 3.0/openWeatherMap.js:418 3.8/providers/openWeatherMap.js:381
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Тучи"
 
@@ -1047,76 +1081,80 @@ msgstr "Тучи"
 msgid "Could not get forecast for your area"
 msgstr "Не удалось получить прогноз для вашей местности"
 
-#: 3.0/us_weather.js:231 3.8/providers/us_weather.js:95
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "Местоположение вне США, используйте другой сервис."
 
-#: 3.0/us_weather.js:394 3.8/providers/us_weather.js:289
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Не удалось обработать почасовой прогноз"
 
-#: 3.0/us_weather.js:443 3.8/providers/us_weather.js:337
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Ясно и ветренно"
 
-#: 3.0/us_weather.js:450 3.8/providers/us_weather.js:344
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Местами облака и ветренно"
 
-#: 3.0/us_weather.js:457 3.8/providers/us_weather.js:351
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Прерывистые облака и ветренно"
 
-#: 3.0/us_weather.js:464 3.8/providers/us_weather.js:358
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Преимущественно облачн о и ветренно"
 
-#: 3.0/us_weather.js:471 3.8/providers/us_weather.js:365
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Пасмурно и ветренно"
 
-#: 3.0/us_weather.js:485 3.8/providers/us_weather.js:379
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Снег с дождём"
 
-#: 3.0/us_weather.js:520 3.8/providers/us_weather.js:414
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Моросящий дождь со снегом"
 
-#: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336 3.0/yahoo.js:438
-#: 3.8/utils.js:212 3.8/providers/us_weather.js:458 3.8/providers/us_weather.js:459
+#: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Ураган"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/utils.js:207
-#: 3.8/providers/us_weather.js:465
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Шторм"
 
-#: 3.0/us_weather.js:572 3.8/providers/us_weather.js:466
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Тропический шторм"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/providers/us_weather.js:493 3.8/providers/us_weather.js:494
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Жарко"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/providers/us_weather.js:500 3.8/providers/us_weather.js:501
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Холодно"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/providers/us_weather.js:507 3.8/providers/us_weather.js:508
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Метель"
 
-#: 3.0/utils.js:146 3.8/utils.js:88
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Сегодня"
 
-#: 3.0/utils.js:148 3.8/utils.js:90
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Завтра"
 
@@ -1148,79 +1186,79 @@ msgstr "Пятница"
 msgid "Saturday"
 msgstr "Суббота"
 
-#: 3.0/utils.js:301 3.8/utils.js:177
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Штиль"
 
-#: 3.0/utils.js:304 3.8/utils.js:180
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Лёгкий ветерок"
 
-#: 3.0/utils.js:307 3.8/utils.js:183
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Лёгкий ветер"
 
-#: 3.0/utils.js:310 3.8/utils.js:186
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Слабый ветер"
 
-#: 3.0/utils.js:313 3.8/utils.js:189
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Умеренный ветер"
 
-#: 3.0/utils.js:316 3.8/utils.js:192
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Свежий ветер"
 
-#: 3.0/utils.js:319 3.8/utils.js:195
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Сильный ветер"
 
-#: 3.0/utils.js:322 3.8/utils.js:198
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Почти шторм"
 
-#: 3.0/utils.js:325 3.8/utils.js:201
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Шторм"
 
-#: 3.0/utils.js:328 3.8/utils.js:204
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Сильный шторм"
 
-#: 3.0/utils.js:334 3.8/utils.js:210
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Очень сильный шторм"
 
-#: 3.0/utils.js:429 3.8/utils.js:377
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "С"
 
-#: 3.0/utils.js:429 3.8/utils.js:377
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "СВ"
 
-#: 3.0/utils.js:429 3.8/utils.js:377
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "В"
 
-#: 3.0/utils.js:429 3.8/utils.js:377
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "ЮВ"
 
-#: 3.0/utils.js:429 3.8/utils.js:377
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "Ю"
 
-#: 3.0/utils.js:429 3.8/utils.js:377
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "ЮЗ"
 
-#: 3.0/utils.js:429 3.8/utils.js:377
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "З"
 
-#: 3.0/utils.js:429 3.8/utils.js:377
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "СЗ"
 
@@ -1266,11 +1304,12 @@ msgstr "Не удаётся подключиться к Yahoo API."
 
 #: 3.0/yahoo.js:186
 msgid ""
-"Unknown error happened while obtaining weather, see Looking Glass logs for more "
-"information"
-msgstr "Неожиданная ошибка во время обновления погоды, см. логи в Looking Glass"
+"Unknown error happened while obtaining weather, see Looking Glass logs for "
+"more information"
+msgstr ""
+"Неожиданная ошибка во время обновления погоды, см. логи в Looking Glass"
 
-#: 3.0/yahoo.js:437
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Тропический шторм"
 
@@ -1278,7 +1317,7 @@ msgstr "Тропический шторм"
 msgid "Severe Thunderstorms"
 msgstr "Сильный грозы"
 
-#: 3.0/yahoo.js:440
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Грозы"
 
@@ -1294,15 +1333,15 @@ msgstr "Дождь со снегом"
 msgid "Mixed Snow and Sleet"
 msgstr "Снег/мокрый снег"
 
-#: 3.0/yahoo.js:444
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Изморось"
 
-#: 3.0/yahoo.js:446
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Холодный дождь"
 
-#: 3.0/yahoo.js:447
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Ливень"
 
@@ -1314,11 +1353,11 @@ msgstr "Порывы снега"
 msgid "Light Snow Showers"
 msgstr "Небольшой снегопад"
 
-#: 3.0/yahoo.js:451
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Метель"
 
-#: 3.0/yahoo.js:456 3.8/providers/danishMI.js:179 3.8/providers/danishMI.js:180
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Туман"
 
@@ -1330,47 +1369,54 @@ msgstr "Дымно"
 msgid "Blustery"
 msgstr "Порывистый ветер"
 
-#: 3.0/yahoo.js:460
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Ветренно"
 
-#: 3.0/yahoo.js:463
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Преимущественная облачность"
 
-#: 3.0/yahoo.js:464
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Переменная облачность"
 
-#: 3.0/yahoo.js:467
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Преимущественно ясно"
 
-#: 3.0/yahoo.js:469
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Дождь с градом"
 
-#: 3.0/yahoo.js:471
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Отдельные грозы"
 
-#: 3.0/yahoo.js:472
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Местами грозы"
 
-#: 3.0/yahoo.js:473
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Местами дожди"
 
-#: 3.0/yahoo.js:474
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Сильный дождь"
 
-#: 3.0/yahoo.js:475
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Местами дожди со снегом"
 
-#: 3.0/yahoo.js:476
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Сильный снегопад"
 
@@ -1382,260 +1428,393 @@ msgstr "Не доступно"
 msgid "Scattered Thundershowers"
 msgstr "Местами грозовые ливни"
 
-#: 3.8/main.js:104
-msgid "This provider requires an API key to operate"
-msgstr "Этот сервис требует ключ API для работы"
+#: 3.8/weather-applet.js:9638
+msgid ""
+"Could not retrieve logs, log file was not found under path\n"
+" {logFilePath}"
+msgstr ""
 
-#: 3.8/main.js:143 3.8/ui_elements/uiBar.js:40
-msgid "As of {lastUpdatedTime}"
-msgstr "По состоянию на {lastUpdatedTime}"
-
-#: 3.8/providers/climacell.js:9 3.8/providers/climacellV4.js:8
-msgid "Climacell"
-msgstr "Climacell"
-
-#: 3.8/providers/climacell.js:39 3.8/providers/darkSky.js:33
-msgid "This API has ceased to function, please use another one."
-msgstr "Этот API перестал работать, воспользуйтесь другим. "
-
-#: 3.8/providers/climacell.js:264 3.8/providers/climacell.js:265
-msgid "Light Snow"
-msgstr "Небольшой снегопад"
-
-#: 3.8/providers/climacellV4.js:171
-msgid "Light wind"
-msgstr "Небольшой ветер"
-
-#: 3.8/providers/climacellV4.js:185
-msgid "Strong wind"
-msgstr "Сильный ветер"
-
-#. 3.8->settings-schema.json->dataService->options
-#: 3.8/providers/danishMI.js:8
-msgid "DMI Denmark"
-msgstr "DMI Denmark"
-
-#: 3.8/providers/danishMI.js:173
-msgid "Blowing snow"
-msgstr "Позёмки"
-
-#: 3.8/providers/danishMI.js:208 3.8/providers/visualcrossing.js:224
-msgid "Heavy rain and snow"
-msgstr "Сильный дождь со снегом"
-
-#: 3.8/providers/danishMI.js:214 3.8/providers/danishMI.js:215
-msgid "Slight snow"
-msgstr "Лёгкий снегопад"
-
-#: 3.8/providers/danishMI.js:221 3.8/providers/danishMI.js:222
-msgid "Moderate snow"
-msgstr "Умеренный снегопад"
-
-#: 3.8/providers/danishMI.js:236
-msgid "Moderate rain showers"
-msgstr "Умеренный дождь"
-
-#: 3.8/providers/danishMI.js:243
-msgid "Mixed rain and snow"
-msgstr "Дождь со снегом"
-
-#: 3.8/providers/danishMI.js:250
-msgid "Heavy mixed rain and snow"
-msgstr "Сильный дождь со снегом"
-
-#: 3.8/providers/danishMI.js:277 3.8/providers/danishMI.js:278
-msgid "NOT FOUND"
-msgstr "Не найдено"
-
-#: 3.8/providers/darkSky.js:9
-msgid "DarkSky"
-msgstr "DarkSky"
+#: 3.8/weather-applet.js:9642
+msgid ""
+"Could not get contents of log file under path\n"
+" {logFilePath}"
+msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
-#: 3.8/providers/met_norway.js:9
-msgid "MET Norway"
-msgstr "MET Norway"
-
-#. 3.0->settings-schema.json->dataService->options
-#: 3.8/providers/met_uk.js:9
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/providers/met_uk.js:137
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
+msgstr ""
+
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Данные для местоположения не найдены"
 
-#: 3.8/providers/met_uk.js:267
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Очень плохая"
 
-#: 3.8/providers/met_uk.js:267
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Менее чем {distance} {distanceUnit}"
 
-#: 3.8/providers/met_uk.js:271
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Отличная"
 
-#: 3.8/providers/met_uk.js:271
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Более чем {distance} {distanceUnit}"
 
-#: 3.8/providers/met_uk.js:276
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Плохая"
 
-#: 3.8/providers/met_uk.js:276 3.8/providers/met_uk.js:281 3.8/providers/met_uk.js:286
-#: 3.8/providers/met_uk.js:291
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Между {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/providers/met_uk.js:281
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Умереннная"
 
-#: 3.8/providers/met_uk.js:286
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Хорошая"
 
-#: 3.8/providers/met_uk.js:291
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Очень хорошая"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/providers/openWeatherMap.js:9
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
-#: 3.8/providers/us_weather.js:9
-msgid "US Weather"
-msgstr "US Weather"
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:11396
+msgid "MET Norway"
+msgstr "MET Norway"
 
-#: 3.8/providers/visualcrossing.js:7
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
-
-#: 3.8/providers/visualcrossing.js:182
-msgid "Blowing or drifting snow"
-msgstr "Метель"
-
-#: 3.8/providers/visualcrossing.js:186
-msgid "Heavy drizzle"
-msgstr "Сильный дождь"
-
-#: 3.8/providers/visualcrossing.js:190
-msgid "Heavy drizzle/rain"
-msgstr "Сильный моросящий дождь"
-
-#: 3.8/providers/visualcrossing.js:192
-msgid "Light drizzle/rain"
-msgstr "Лёгкая морось"
-
-#: 3.8/providers/visualcrossing.js:194
-msgid "Duststorm"
-msgstr "Пыльная буря"
-
-#: 3.8/providers/visualcrossing.js:198
-msgid "Freezing drizzle/freezing rain"
-msgstr "Изморось"
-
-#: 3.8/providers/visualcrossing.js:200
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Сильный ледяной дождь"
-
-#: 3.8/providers/visualcrossing.js:202
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Лёгкая изморось"
-
-#: 3.8/providers/visualcrossing.js:204
-msgid "Freezing fog"
-msgstr "Морозный туман"
-
-#: 3.8/providers/visualcrossing.js:210
-msgid "Funnel cloud/tornado"
-msgstr "Смерч"
-
-#: 3.8/providers/visualcrossing.js:212
-msgid "Hail showers"
-msgstr "Ливень с градом"
-
-#: 3.8/providers/visualcrossing.js:214
-msgid "Ice"
-msgstr "Лёд"
-
-#: 3.8/providers/visualcrossing.js:216
-msgid "Lightning without thunder"
-msgstr "Молнии без грома"
-
-#: 3.8/providers/visualcrossing.js:220
-msgid "Precipitation in vicinity"
-msgstr "Осадки поблизости"
-
-#: 3.8/providers/visualcrossing.js:226
-msgid "Light rain And snow"
-msgstr "Лёгкий снег с дождём"
-
-#: 3.8/providers/visualcrossing.js:234
-msgid "Sky coverage decreasing"
-msgstr "Небо проясняется"
-
-#: 3.8/providers/visualcrossing.js:236
-msgid "Sky coverage increasing"
-msgstr "Небо темнеет"
-
-#: 3.8/providers/visualcrossing.js:238
-msgid "Sky unchanged"
-msgstr "Небо без изменений"
-
-#: 3.8/providers/visualcrossing.js:240
-msgid "Smoke or haze"
-msgstr "Дым или дымка"
-
-#: 3.8/providers/visualcrossing.js:244
-msgid "Snow and rain showers"
-msgstr "Снегопад с ледяным дождём"
-
-#: 3.8/providers/visualcrossing.js:256
-msgid "Thunderstorm without precipitation"
-msgstr "Гроза без осадков"
-
-#: 3.8/providers/visualcrossing.js:258
-msgid "Diamond dust"
-msgstr "Алмазная пыль"
-
-#: 3.8/providers/visualcrossing.js:264
-msgid "Partially cloudy"
-msgstr "Переменная облачность"
-
-#: 3.8/providers/visualcrossing.js:287
-msgid "Please make sure you entered the API key correctly"
-msgstr "Пожалуйста убедитесь, что введённый ключ API верный"
-
-#: 3.8/providers/weatherbit.js:9
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/providers/weatherbit.js:230
-msgid "API key doesn't provide access to Hourly Weather, skipping"
-msgstr "Ключ API не предоставляет доступ к почасовому прогнозу. Пропущено."
+#: 3.8/weather-applet.js:12386
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Завтра"
 
-#: 3.8/ui_elements/uiBar.js:46
-msgid "{distance}{distanceUnit} from you"
-msgstr "{distance}{distanceUnit} от вас"
+#: 3.8/weather-applet.js:12561
+msgid "Light wind"
+msgstr "Небольшой ветер"
 
-#: 3.8/ui_elements/uiCurrentWeather.js:222
+#: 3.8/weather-applet.js:12575
+msgid "Strong wind"
+msgstr "Сильный ветер"
+
+#: 3.8/weather-applet.js:12723
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:13292
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:13474
+msgid "Blowing or drifting snow"
+msgstr "Метель"
+
+#: 3.8/weather-applet.js:13478
+msgid "Heavy drizzle"
+msgstr "Сильный дождь"
+
+#: 3.8/weather-applet.js:13482
+msgid "Heavy drizzle/rain"
+msgstr "Сильный моросящий дождь"
+
+#: 3.8/weather-applet.js:13484
+msgid "Light drizzle/rain"
+msgstr "Лёгкая морось"
+
+#: 3.8/weather-applet.js:13486
+#, fuzzy
+msgid "Dust Storm"
+msgstr "Пыльная буря"
+
+#: 3.8/weather-applet.js:13490
+msgid "Freezing drizzle/freezing rain"
+msgstr "Изморось"
+
+#: 3.8/weather-applet.js:13492
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Сильный ледяной дождь"
+
+#: 3.8/weather-applet.js:13494
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Лёгкая изморось"
+
+#: 3.8/weather-applet.js:13496
+msgid "Freezing fog"
+msgstr "Морозный туман"
+
+#: 3.8/weather-applet.js:13502
+msgid "Funnel cloud/tornado"
+msgstr "Смерч"
+
+#: 3.8/weather-applet.js:13504
+msgid "Hail showers"
+msgstr "Ливень с градом"
+
+#: 3.8/weather-applet.js:13506
+msgid "Ice"
+msgstr "Лёд"
+
+#: 3.8/weather-applet.js:13508
+msgid "Lightning without thunder"
+msgstr "Молнии без грома"
+
+#: 3.8/weather-applet.js:13512
+msgid "Precipitation in vicinity"
+msgstr "Осадки поблизости"
+
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
+msgid "Heavy rain and snow"
+msgstr "Сильный дождь со снегом"
+
+#: 3.8/weather-applet.js:13518
+msgid "Light rain And snow"
+msgstr "Лёгкий снег с дождём"
+
+#: 3.8/weather-applet.js:13526
+msgid "Sky coverage decreasing"
+msgstr "Небо проясняется"
+
+#: 3.8/weather-applet.js:13528
+msgid "Sky coverage increasing"
+msgstr "Небо темнеет"
+
+#: 3.8/weather-applet.js:13530
+msgid "Sky unchanged"
+msgstr "Небо без изменений"
+
+#: 3.8/weather-applet.js:13532
+msgid "Smoke or haze"
+msgstr "Дым или дымка"
+
+#: 3.8/weather-applet.js:13536
+msgid "Snow and rain showers"
+msgstr "Снегопад с ледяным дождём"
+
+#: 3.8/weather-applet.js:13548
+msgid "Thunderstorm without precipitation"
+msgstr "Гроза без осадков"
+
+#: 3.8/weather-applet.js:13550
+msgid "Diamond dust"
+msgstr "Алмазная пыль"
+
+#: 3.8/weather-applet.js:13556
+msgid "Partially cloudy"
+msgstr "Переменная облачность"
+
+#: 3.8/weather-applet.js:13578
+msgid "Please make sure you entered the API key correctly"
+msgstr "Пожалуйста убедитесь, что введённый ключ API верный"
+
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:13595
+msgid "DMI Denmark"
+msgstr "DMI Denmark"
+
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
+msgid "NOT FOUND"
+msgstr "Не найдено"
+
+#: 3.8/weather-applet.js:13779
+msgid "Blowing snow"
+msgstr "Позёмки"
+
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
+msgid "Slight snow"
+msgstr "Лёгкий снегопад"
+
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
+msgid "Moderate snow"
+msgstr "Умеренный снегопад"
+
+#: 3.8/weather-applet.js:13842
+msgid "Moderate rain showers"
+msgstr "Умеренный дождь"
+
+#: 3.8/weather-applet.js:13849
+msgid "Mixed rain and snow"
+msgstr "Дождь со снегом"
+
+#: 3.8/weather-applet.js:13856
+msgid "Heavy mixed rain and snow"
+msgstr "Сильный дождь со снегом"
+
+#: 3.8/weather-applet.js:14024
+#, fuzzy
+msgid "AccuWeather"
+msgstr "Погода"
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+#, fuzzy
+msgid "Weather Underground"
+msgstr "Погодные условия"
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+msgid "The location you provided was not found."
+msgstr ""
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+#, fuzzy
+msgid "Strong Storm"
+msgstr "Сильный ветер"
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "Дождь со снегом"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "Дождь со снегом"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "Снег"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "Преимущественно ясно"
+
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:15603
+#, fuzzy
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr "Сервис местоположения ответил с ошибками, см. логи в Looking Glass"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+"Убедитесь, что вы ввели местоположение или используйте автоматическое "
+"местоположение"
+
+#: 3.8/weather-applet.js:15968
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:15975
+msgid ""
+"Could not get contents of config file under path\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Этот сервис требует ключ API для работы"
+
+#: 3.8/weather-applet.js:16675
+msgid "Dew Point"
+msgstr ""
+
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Осадки закончатся в течение {precipEnd} минут"
 
-#: 3.8/ui_elements/uiCurrentWeather.js:224
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "Осадки не закончатся в течение часа"
 
-#: 3.8/ui_elements/uiCurrentWeather.js:227
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Осадки начнутся в течение {precipStart} минут"
+
+#: 3.8/weather-applet.js:16964
+msgid "Forecast parsing failed, see logs for more details."
+msgstr ""
+
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
+msgid "As of {lastUpdatedTime}"
+msgstr "По состоянию на {lastUpdatedTime}"
+
+#: 3.8/weather-applet.js:17502
+#, fuzzy
+msgid "{distance} {distanceUnit} from you"
+msgstr "{distance}{distanceUnit} от вас"
+
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
+msgid "Error Saving Debug Information"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Debug Information saved successfully"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Saved to {filePath}"
+msgstr ""
+
+#: 3.8/LogSaver.py:16
+msgid "Save to File"
+msgstr ""
+
+#: 3.8/LogSaver.py:29
+msgid "Select a destination"
+msgstr ""
 
 #. metadata.json->name
 #. 3.8->settings-schema.json->providers->title
@@ -1680,7 +1859,6 @@ msgid "Data service"
 msgstr "Сервис данных"
 
 #. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
 msgid "DarkSky (key needed)"
 msgstr "DarkSky (требуется ключ)"
 
@@ -1705,7 +1883,8 @@ msgstr "Ключ API"
 #. 3.0->settings-schema.json->apiKey->tooltip
 #. 3.8->settings-schema.json->apiKey->tooltip
 msgid "Copy this from your account of the used Data service and paste it here."
-msgstr "Скопируйте это из задействованного аккаунта сервиса данных и вставьте здесь."
+msgstr ""
+"Скопируйте это из задействованного аккаунта сервиса данных и вставьте здесь."
 
 #. 3.0->settings-schema.json->manualLocation->description
 #. 3.8->settings-schema.json->manualLocation->description
@@ -1723,7 +1902,8 @@ msgstr "Местоположение - Координаты"
 
 #. 3.0->settings-schema.json->location->tooltip
 msgid ""
-"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an address.\n"
+"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an "
+"address.\n"
 "Waits for 3 seconds after you stop typing before refreshes the weather."
 msgstr ""
 "Возможные значения: Ширтоа,Долгота, - напр.: 68.1932,17.1426, - либо адрес.\n"
@@ -1795,10 +1975,12 @@ msgstr "°F"
 #. 3.0->settings-schema.json->distanceUnit->tooltip
 #. 3.8->settings-schema.json->temperatureUnit->tooltip
 #. 3.8->settings-schema.json->distanceUnit->tooltip
-msgid "Automatic will try to guess your preference based your current display language."
+msgid ""
+"Automatic will try to guess your preference based your current display "
+"language."
 msgstr ""
-"Автоматический режим пытается использовать настройки на основе вашего текущего языка "
-"отображения."
+"Автоматический режим пытается использовать настройки на основе вашего "
+"текущего языка отображения."
 
 #. 3.0->settings-schema.json->windSpeedUnit->description
 #. 3.8->settings-schema.json->windSpeedUnit->description
@@ -1910,14 +2092,14 @@ msgid "Override label on panel"
 msgstr "Переопределить метку на панели"
 
 #. 3.0->settings-schema.json->tempTextOverride->tooltip
-#. 3.8->settings-schema.json->tempTextOverride->tooltip
 msgid ""
 "Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
-"Can be used if label does not fit on vertical panel, among other smart things."
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
 msgstr ""
 "Доступные значения: {c} условия, {t} температура и {u} единицы измерения.\n"
-"Может быть использовано если метка не входит в вертикальную панель с учётом других "
-"мелких деталей."
+"Может быть использовано если метка не входит в вертикальную панель с учётом "
+"других мелких деталей."
 
 #. 3.0->settings-schema.json->useCustomAppletIcons->tooltip
 #. 3.0->settings-schema.json->useCustomMenuIcons->tooltip
@@ -1981,8 +2163,9 @@ msgid "Only display hours for hourly forecast time"
 msgstr "Отображать только часы в почасовом прогнозе"
 
 #. 3.0->settings-schema.json->shortHourlyTime->tooltip
-msgid "Instead of 15:00 or 3 pm it will show up as 15 or 3 pm"
-msgstr "Вместо 15:00 или 3 pm дня будет отображаться 15 или 3 pm"
+#. 3.8->settings-schema.json->shortHourlyTime->tooltip
+msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
+msgstr "Вместо 15:00 или 3 pm будет отображаться 15 или 3 pm"
 
 #. 3.0->settings-schema.json->showForecastDates->description
 #. 3.8->settings-schema.json->showForecastDates->description
@@ -2087,19 +2270,28 @@ msgstr "Большое об апплете погоды"
 msgid "Report an issue"
 msgstr "Сообщить о проблеме"
 
+#. 3.8->settings-schema.json->debug-options->title
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Debug"
+msgstr ""
+
 #. 3.8->settings-schema.json->dataService->tooltip
 msgid ""
-"You can choose between several different weather forecast providers. Some providers "
-"require a API key to work, some have regional limits, differ in forecast length, and "
-"they all need a functional internet connection to work. The options are described in "
-"detail on the Cinnamon Spices Website which you can access with the button on the "
-"Help tab."
+"You can choose between several different weather forecast providers. Some "
+"providers require a API key to work, some have regional limits, differ in "
+"forecast length, and they all need a functional internet connection to work. "
+"The options are described in detail on the Cinnamon Spices Website which you "
+"can access with the button on the Help tab."
 msgstr ""
-"Вы можете выбрать между несколькими разными сервисами погодных данных. Некоторые "
-"сервисы требуют ключ API для работы, некоторые имеют ограничения по территории, "
-"отличаются по продолжительности прогноза, и все нуждаются в интернет соединении  для "
-"работы. Опции детально описаны на сайте Cinnamon Spices, который вы можете открыть по "
-"кнопке во вкладке Помощь."
+"Вы можете выбрать между несколькими разными сервисами погодных данных. "
+"Некоторые сервисы требуют ключ API для работы, некоторые имеют ограничения "
+"по территории, отличаются по продолжительности прогноза, и все нуждаются в "
+"интернет соединении  для работы. Опции детально описаны на сайте Cinnamon "
+"Spices, который вы можете открыть по кнопке во вкладке Помощь."
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
 
 #. 3.8->settings-schema.json->dataService->options
 msgid "Met Office UK (UK only)"
@@ -2110,29 +2302,48 @@ msgid "US National Weather (US only)"
 msgstr "US National Weather (только США)"
 
 #. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Pirate Weather (key needed)"
+msgstr "Weatherbit (требуется ключ)"
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Visual Crossing (key needed)"
 msgstr "Visual Crossing (требуется ключ)"
 
 #. 3.8->settings-schema.json->dataService->options
-msgid "ClimacellV4 (key needed)"
-msgstr "ClimacellV4 (требуется ключ)"
+#, fuzzy
+msgid "Tomorrow.io (key needed)"
+msgstr "Weatherbit (требуется ключ)"
 
 #. 3.8->settings-schema.json->dataService->options
-msgid "ClimacellV3 (key needed)"
-msgstr "ClimacellV3 (требуется ключ)"
+#, fuzzy
+msgid "AccuWeather (key needed)"
+msgstr "Weatherbit (требуется ключ)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Weather Underground (key needed)"
+msgstr "Weatherbit (требуется ключ)"
 
 #. 3.8->settings-schema.json->location->tooltip
 msgid ""
-"You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,"
-"Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/Town} "
-"{Postcode} {Country}. The search algorithm is very flexible with the format. After 3 "
-"seconds without typing the address you entered is replaced automatically for "
-"validating your choice."
+"You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use "
+"'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street} "
+"{City/Town} {Postcode} {Country}. The search algorithm is very flexible with "
+"the format. After 3 seconds without typing the address you entered is "
+"replaced automatically for validating your choice."
 msgstr ""
-"Вы можете ввести координаты 'Широта,Долгота' (напр. 51.5085,-0.1257) или использовать "
-"'Город,Код страны' (напр. London,UK) или попробовать {Номер дома} {Улица} {Город} "
-"{Почтовый индекс} {Страна}. Алгоритм поиска очень гибок. После 3 секунд без ввода, "
-"адрес автоматически заменяется для валидации."
+"Вы можете ввести координаты 'Широта,Долгота' (напр. 51.5085,-0.1257) или "
+"использовать 'Город,Код страны' (напр. London,UK) или попробовать {Номер "
+"дома} {Улица} {Город} {Почтовый индекс} {Страна}. Алгоритм поиска очень "
+"гибок. После 3 секунд без ввода, адрес автоматически заменяется для "
+"валидации."
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
 
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"
@@ -2140,11 +2351,12 @@ msgstr "Сохранить текущее местоположение в хра
 
 #. 3.8->settings-schema.json->saveLocation->tooltip
 msgid ""
-"Saves location information to file so you can switch between them with buttons in the "
-"applet, which will appear if you have more than one."
+"Saves location information to file so you can switch between them with "
+"buttons in the applet, which will appear if you have more than one."
 msgstr ""
-"Сохраняет инфомрацию о местоположении в файл, чтрбы вы могли переключаться между ними "
-"с помощью кнопок в апплете, которые появятся если введено более одного местоположения."
+"Сохраняет инфомрацию о местоположении в файл, чтрбы вы могли переключаться "
+"между ними с помощью кнопок в апплете, которые появятся если введено более "
+"одного местоположения."
 
 #. 3.8->settings-schema.json->getLocation->description
 msgid "Weather Applet at Cinnamon Spices Website"
@@ -2152,36 +2364,81 @@ msgstr "Апплет Погода на вебсайте Cinnamon Spices"
 
 #. 3.8->settings-schema.json->refreshInterval->tooltip
 msgid ""
-"If you are using a provider with API keys set it to an interval you won't run out of "
-"your quota with."
+"If you are using a provider with API keys set it to an interval you won't "
+"run out of your quota with."
 msgstr ""
-"Если вы используете сервис с ключами API, установите для него интервал, с которым у "
-"вас не закончится квота."
+"Если вы используете сервис с ключами API, установите для него интервал, с "
+"которым у вас не закончится квота."
 
 #. 3.8->settings-schema.json->forecastDays->tooltip
+#, fuzzy
 msgid ""
-"Maximum number of days that can be displayed, maximum rows and columns setting in the "
-"Presentation tab will affect the final number."
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
 msgstr ""
-"Наибольшее число дней для отображения, настройка наибольшего числа строк и колонок во "
-"вкладке Представление повлияет на конечный результат."
+"Наибольшее число дней для отображения, настройка наибольшего числа строк и "
+"колонок во вкладке Представление повлияет на конечный результат."
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+#, fuzzy
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
+msgstr ""
+"Наибольшее число дней для отображения, настройка наибольшего числа строк и "
+"колонок во вкладке Представление повлияет на конечный результат."
 
 #. 3.8->settings-schema.json->immediatePrecip->description
 msgid "Enable minutely precipitation forecast"
 msgstr "Включить поминутный прогноз осадков"
 
 #. 3.8->settings-schema.json->immediatePrecip->tooltip
+#, fuzzy
 msgid ""
-"If you'd like to use this make sure you use your exact coordinates/address as "
-"location to help its accuracy. Currently implemented with OpenWeatherMap only."
+"If you'd like to use this make sure you use your exact coordinates/address "
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
 msgstr ""
-"Если вы хотите это использовать, убедитесь, что вы используете точные координаты/"
-"адрес как местоположение, чтобы увеличить точность. Реализовано только для "
-"OpenWeatherMap."
+"Если вы хотите это использовать, убедитесь, что вы используете точные "
+"координаты/адрес как местоположение, чтобы увеличить точность. Реализовано "
+"только для OpenWeatherMap."
 
 #. 3.8->settings-schema.json->showBothTempUnits->description
 msgid "Show both temperature units at the same time"
 msgstr "Отображать обе единицы измерения температуры"
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+#, fuzzy
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+"Доступные значения: {c} условия, {t} температура и {u} единицы измерения.\n"
+"Может быть использовано если метка не входит в вертикальную панель с учётом "
+"других мелких деталей."
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+#, fuzzy
+msgid "Override tooltip on panel"
+msgstr "Переопределить метку на панели"
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
+msgid "Always show Hourly Weather"
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->tooltip
+msgid ""
+"Hide/Show button will be hidden and Hourly weather will be permanently "
+"visible."
+msgstr ""
 
 #. 3.8->settings-schema.json->verticalOrientation->tooltip
 msgid "Displaying forecasts from top to bottom instead from left to right."
@@ -2193,11 +2450,11 @@ msgstr "Ваши сохранённые местоположения"
 
 #. 3.8->settings-schema.json->locationList->tooltip
 msgid ""
-"You have to make sure the Search entry field is unique and your Timezone is in the "
-"IANA time zone format (e.g. 'Europe/London')"
+"You have to make sure the Search entry field is unique and your Timezone is "
+"in the IANA time zone format (e.g. 'Europe/London')"
 msgstr ""
-"Вы должны убедиться, что поисковая строка уникальна и ваш часовой пояс в формате "
-"IANA  (напр. 'Europe/London')"
+"Вы должны убедиться, что поисковая строка уникальна и ваш часовой пояс в "
+"формате IANA  (напр. 'Europe/London')"
 
 #. 3.8->settings-schema.json->locationList->columns->title
 msgid "Latitude"
@@ -2231,13 +2488,11 @@ msgstr "Отображать направление ветра как текст
 msgid "Like SE, N instead of direction icons."
 msgstr "Например ЮВ, С вместо иконок направления"
 
-#. 3.8->settings-schema.json->shortHourlyTime->tooltip
-msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
-msgstr "Вместо 15:00 или 3 pm будет отображаться 15 или 3 pm"
-
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"
-msgstr "Не применяется к альтернативному набору иконок, который символьный по умолчанию"
+msgstr ""
+"Не применяется к альтернативному набору иконок, который символьный по "
+"умолчанию"
 
 #. 3.8->settings-schema.json->useSymbolicIcons->description
 msgid "Use symbolic icons throughout the applet"
@@ -2245,14 +2500,15 @@ msgstr "Использовать символьные значки в аппле
 
 #. 3.8->settings-schema.json->more-info-label->description
 msgid ""
-"For detailed information about the applet please go to the Spices Website to find "
-"info about known issues, troubleshooting, changelog and more by clicking the button "
-"below. Here you can ask questions etc in the comment section by logging in with your "
-"Github account."
+"For detailed information about the applet please go to the Spices Website to "
+"find info about known issues, troubleshooting, changelog and more by "
+"clicking the button below. Here you can ask questions etc in the comment "
+"section by logging in with your Github account."
 msgstr ""
-"Для подробной иформации об апплете, пожалуйста, откройте сайт Cinnamon Spices, чтобы "
-"узнать об известных проблемах, логах изменений, нажав на кнопку снизу. Вы сможете "
-"задать вопросы в разделе комментариев, зайдя под вашим GitHub аккаунтом."
+"Для подробной иформации об апплете, пожалуйста, откройте сайт Cinnamon "
+"Spices, чтобы узнать об известных проблемах, логах изменений, нажав на "
+"кнопку снизу. Вы сможете задать вопросы в разделе комментариев, зайдя под "
+"вашим GitHub аккаунтом."
 
 #. 3.8->settings-schema.json->submitIssue->description
 msgid "Submit an Issue"
@@ -2260,12 +2516,12 @@ msgstr "Сообщить о проблеме"
 
 #. 3.8->settings-schema.json->submitIssue->tooltip
 msgid ""
-"Opens webpage where you can fill out a new issue for the applet, needs a GitHub "
-"account.\n"
+"Opens webpage where you can fill out a new issue for the applet, needs a "
+"GitHub account.\n"
 " Please make sure that the issue is not already submitted."
 msgstr ""
-"Открывает страницу, где вы можете сообщить о проблеме для апплета, нужен аккаунт "
-"GitHub.\n"
+"Открывает страницу, где вы можете сообщить о проблеме для апплета, нужен "
+"аккаунт GitHub.\n"
 " Пожалуйста, убедитесь, Что о проблеме уже не сообщалось."
 
 #. 3.8->settings-schema.json->maintainer->description
@@ -2273,30 +2529,66 @@ msgid "Current maintainer: Gr3q"
 msgstr "Текущий разработчик: Gr3q"
 
 #. 3.8->settings-schema.json->issue-reporting-explanation->description
+#, fuzzy
 msgid ""
-"If you find an issue with this applet please make a report by clicking on the button "
-"below and login in with your Github account. Before you start writing please make "
-"sure that the issue is not already submitted in the issues section. Don't forget to "
-"write weather@mockturtl in the top Title field to make it easier for everyone to know "
-"that the issue is about the weather applet (the form is for all Cinnamon applets)."
+"If you find an issue with this applet please make a report by clicking on "
+"the button below and login in with your Github account.\n"
+"\n"
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
 msgstr ""
-"Если вы нашли проблему с апплетом, пожалуйста сообщите о ней, нажав на кнопку ниже и "
-"войдя под вашим аккаунтом GitHub. До того как вы начнёте писать, убедитесь, что о "
-"проблеме уже не сообщалось в разделе \"issues\". Не забудьте написать "
-"weather@mockturtl в заголовке поля, чтобы всем было проще понять, что проблема "
-"касается погодного апплета (форма используется для всех апплетов Cinnamon)."
+"Если вы нашли проблему с апплетом, пожалуйста сообщите о ней, нажав на "
+"кнопку ниже и войдя под вашим аккаунтом GitHub. До того как вы начнёте "
+"писать, убедитесь, что о проблеме уже не сообщалось в разделе \"issues\". Не "
+"забудьте написать weather@mockturtl в заголовке поля, чтобы всем было проще "
+"понять, что проблема касается погодного апплета (форма используется для всех "
+"апплетов Cinnamon)."
 
 #. 3.8->settings-schema.json->loc-info->description
 msgid ""
-"Your location in most cases work automatically but you can enter it manually by "
-"coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,Country-code' (e."
-"g. London,UK) or try to enter {House number} {Street} {City/Town} {Postcode} "
-"{Country}. The search algorithm is very flexible with the format. After 3 seconds "
-"without typing the address you entered is replaced automatically for validating your "
-"choice."
+"Your location in most cases work automatically but you can enter it manually "
+"by coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,"
+"Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/"
+"Town} {Postcode} {Country}. The search algorithm is very flexible with the "
+"format. After 3 seconds without typing the address you entered is replaced "
+"automatically for validating your choice."
 msgstr ""
-"В большинстве случаев местоположение работает автоматически, но вы можете ввести "
-"координатывручную 'Широта,Долгота' (напр. 51.5085,-0.1257) или использовать 'Город,"
-"Код страны' (например. London,UK) или попробуйте ввести {Номер дома} {Улица} {Город} "
-"{Почтовый индекс} {Страна}. Алгоритм поиска очень гибок. После 3 секунд без ввода, "
-"адрес автоматически заменяется для валидации."
+"В большинстве случаев местоположение работает автоматически, но вы можете "
+"ввести координатывручную 'Широта,Долгота' (напр. 51.5085,-0.1257) или "
+"использовать 'Город,Код страны' (например. London,UK) или попробуйте ввести "
+"{Номер дома} {Улица} {Город} {Почтовый индекс} {Страна}. Алгоритм поиска "
+"очень гибок. После 3 секунд без ввода, адрес автоматически заменяется для "
+"валидации."
+
+#. 3.8->settings-schema.json->logLevel->description
+msgid "Log Level"
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->tooltip
+msgid ""
+"Info is the regular logging, Debug is debug, and Verbose also logs network "
+"request payloads. Changing this will only be effective on future logs. Only "
+"change it you are instructed or you know what you are doing."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Verbose"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->description
+msgid "Click Save to save debug information to a file"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->tooltip
+msgid ""
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
+msgstr ""
+
+#. 3.8->settings-schema.json->selectedLogPath->description
+msgid "Selected path to save Logs"
+msgstr ""

--- a/weather@mockturtl/files/weather@mockturtl/po/sk.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/sk.po
@@ -7,8 +7,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 3.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-19 07:23+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2021-08-08 22:01+0200\n"
 "Last-Translator: Dušan Kazik <prescott66@gmail.com>\n"
 "Language-Team: slovenčina <>\n"
@@ -20,65 +21,65 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 1 : (n>=2 && n<=4) ? 2 : 0;\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:14911
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Chyba"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:14912 3.8/weather-applet.js:14914
-#: 3.8/weather-applet.js:14916 3.8/weather-applet.js:14919
-#: 3.8/weather-applet.js:14922 3.8/weather-applet.js:14923
-#: 3.8/weather-applet.js:14924 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Chyba služby"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:14913
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Nesprávny kľúč rozhrania API"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:14915
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Nesprávny formát umiestnenia"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:14917
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Kľúč je zablokovaný"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:14918
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Nie je možné nájsť polohu"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:14920
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Žiadny kľúč API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:14921
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Žiadna lokácia"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:14926
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Chýbajúce balíky"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:14927
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Oblať nie je pokrytá"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9111
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Applet Počasie"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:15144
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:15145
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Kliknite pre otvorenie"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:10673
-#: 3.8/weather-applet.js:15156
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Obnoviť"
 
@@ -88,8 +89,8 @@ msgstr "Rozhranie API vrátilo stavový kód medzi 400 a 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9278
-#: 3.8/weather-applet.js:9282 3.8/weather-applet.js:9286
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Ukladací priestor polohy"
 
@@ -101,13 +102,13 @@ msgstr "Polohu získanú automaticky nie je možné uložiť, ľutujeme"
 msgid "Could not get weather information"
 msgstr "Nepodarilo sa získať informácie o počasí"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:15017
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Neočakávaná chyba pri aktualizácii počasia, pozrite sa do logu Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:15273
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -123,7 +124,7 @@ msgstr "Chyba siete, skontrolujte denníky v programe Looking Glass"
 msgid "As of"
 msgstr "Aktualizácia z"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:11332
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Údaje z"
 
@@ -131,90 +132,90 @@ msgstr "Údaje z"
 msgid "from you"
 msgstr "od Vás"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:11266
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:11266
-#: 3.8/weather-applet.js:11596
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10104
-#: 3.8/weather-applet.js:11393
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10105
-#: 3.8/weather-applet.js:11394
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:11545
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Načítava sa aktuálne počasie ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:11548
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Načítava sa predpoveď počasia ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:10616
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Načítava sa ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:10640
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Teplota"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:10641
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Vlhkosť"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:10642
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Tlak"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:10643 3.8/weather-applet.js:14385
-#: 3.8/weather-applet.js:14392 3.8/weather-applet.js:14393
-#: 3.8/weather-applet.js:14399
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Vietor"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:9573
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Uistite sa, že ste zadali miesto, alebo použite namiesto toho automatické "
 "určovanie polohy"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9358
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Na základe adresy sa nepodarilo nájsť polohu. Skontrolujte, či je správna"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9379
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Nepodarilo sa zavolať Geolocation API, chyby nájdete v časti Looking Glass."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9278
-#: 3.8/weather-applet.js:9282
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Varovanie"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9278
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "Správne umiestnenia môžete uložiť iba vtedy, ak sa aplet neobnovuje"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9282
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Nemôžete uložiť nesprávnu polohu"
 
+#. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9286
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Info"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9286
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Poloha už je uložená"
 
@@ -251,14 +252,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11655 3.8/weather-applet.js:11973
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:12884
-#: 3.8/weather-applet.js:13980 3.8/weather-applet.js:14286
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Pocitovo"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:11701
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Informácie o počasí sa nepodarilo spracovať"
 
@@ -271,7 +273,7 @@ msgstr ""
 "alebo si kľúč najskôr zaobstarajte na https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11731 3.8/weather-applet.js:13050
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -279,7 +281,7 @@ msgstr ""
 "Uistite sa prosím\n"
 "že ste zadali správny kľúč API a že Váš účet nie je uzamknutý"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:14253
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -290,58 +292,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10303 3.8/weather-applet.js:10310
-#: 3.8/weather-applet.js:10317 3.8/weather-applet.js:10318
-#: 3.8/weather-applet.js:13494 3.8/weather-applet.js:13495
-#: 3.8/weather-applet.js:13501 3.8/weather-applet.js:13508
-#: 3.8/weather-applet.js:13515 3.8/weather-applet.js:14150
-#: 3.8/weather-applet.js:14428
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Silný dážď"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12674 3.8/weather-applet.js:12723
-#: 3.8/weather-applet.js:12724 3.8/weather-applet.js:12731
-#: 3.8/weather-applet.js:13669 3.8/weather-applet.js:13670
-#: 3.8/weather-applet.js:13676 3.8/weather-applet.js:14142
-#: 3.8/weather-applet.js:14413 3.8/weather-applet.js:14414
-#: 3.8/weather-applet.js:14420 3.8/weather-applet.js:14427
-#: 3.8/weather-applet.js:14469 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14730
-#: 3.8/weather-applet.js:14731 3.8/weather-applet.js:14772
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Dážď"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10275
-#: 3.8/weather-applet.js:10282 3.8/weather-applet.js:10296
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:13578 3.8/weather-applet.js:13579
-#: 3.8/weather-applet.js:13585 3.8/weather-applet.js:13592
-#: 3.8/weather-applet.js:13599 3.8/weather-applet.js:14152
-#: 3.8/weather-applet.js:14421
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Slabý dážď"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:14126 3.8/weather-applet.js:14484
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Silný mrznúci dážď"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:12248
-#: 3.8/weather-applet.js:12695 3.8/weather-applet.js:12696
-#: 3.8/weather-applet.js:12702 3.8/weather-applet.js:12703
-#: 3.8/weather-applet.js:12709 3.8/weather-applet.js:14470
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Mrznúci dážď"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:14128 3.8/weather-applet.js:14477
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Slabý mrznúci dážď"
 
@@ -349,174 +353,189 @@ msgstr "Slabý mrznúci dážď"
 msgid "Light freezing drizzle"
 msgstr "Slabé mrznúce mrholenie"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:14463
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Mráz a mrholenie"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14108
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Mierne mrholenie"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:14498
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Silný ľadovec"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:14497 3.8/weather-applet.js:14504
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Ľadovec"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:14505
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Mierny ľadovec"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10387
-#: 3.8/weather-applet.js:10394 3.8/weather-applet.js:10401
-#: 3.8/weather-applet.js:10402 3.8/weather-applet.js:12255
-#: 3.8/weather-applet.js:13550 3.8/weather-applet.js:13551
-#: 3.8/weather-applet.js:13557 3.8/weather-applet.js:13564
-#: 3.8/weather-applet.js:13571 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14456 3.8/weather-applet.js:14807
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Husté sneženie"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:12254 3.8/weather-applet.js:12667
-#: 3.8/weather-applet.js:12668 3.8/weather-applet.js:13725
-#: 3.8/weather-applet.js:13726 3.8/weather-applet.js:13732
-#: 3.8/weather-applet.js:14162 3.8/weather-applet.js:14434
-#: 3.8/weather-applet.js:14435 3.8/weather-applet.js:14448
-#: 3.8/weather-applet.js:14455 3.8/weather-applet.js:14716
-#: 3.8/weather-applet.js:14800
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Sneženie"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10366
-#: 3.8/weather-applet.js:10373 3.8/weather-applet.js:10380
-#: 3.8/weather-applet.js:10381 3.8/weather-applet.js:12253
-#: 3.8/weather-applet.js:13634 3.8/weather-applet.js:13635
-#: 3.8/weather-applet.js:13641 3.8/weather-applet.js:13648
-#: 3.8/weather-applet.js:13655 3.8/weather-applet.js:14170
-#: 3.8/weather-applet.js:14449
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Slabé sneženie"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:14441
-#: 3.8/weather-applet.js:14442
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Príval dažďa"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:12228
-#: 3.8/weather-applet.js:12740 3.8/weather-applet.js:12741
-#: 3.8/weather-applet.js:14174 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14814
-#: 3.8/weather-applet.js:14815
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Búrka"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:14379
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Mierna hmla"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10254 3.8/weather-applet.js:10255
-#: 3.8/weather-applet.js:12267 3.8/weather-applet.js:12810
-#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:13487
-#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14116
-#: 3.8/weather-applet.js:14371 3.8/weather-applet.js:14372
-#: 3.8/weather-applet.js:14378
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Hmlisto"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10261 3.8/weather-applet.js:10262
-#: 3.8/weather-applet.js:13473 3.8/weather-applet.js:13474
-#: 3.8/weather-applet.js:14343 3.8/weather-applet.js:14344
-#: 3.8/weather-applet.js:14709 3.8/weather-applet.js:14710
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Oblačno"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12618
-#: 3.8/weather-applet.js:12619 3.8/weather-applet.js:12653
-#: 3.8/weather-applet.js:14364 3.8/weather-applet.js:14365
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Zamračené"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10226
-#: 3.8/weather-applet.js:10227 3.8/weather-applet.js:10233
-#: 3.8/weather-applet.js:10234 3.8/weather-applet.js:12611
-#: 3.8/weather-applet.js:12612 3.8/weather-applet.js:12646
-#: 3.8/weather-applet.js:13662 3.8/weather-applet.js:13663
-#: 3.8/weather-applet.js:14357 3.8/weather-applet.js:14358
-#: 3.8/weather-applet.js:14702 3.8/weather-applet.js:14703
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Polojasno"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:14350
-#: 3.8/weather-applet.js:14351
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Takmer jadno"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10212 3.8/weather-applet.js:10213
-#: 3.8/weather-applet.js:12273 3.8/weather-applet.js:12597
-#: 3.8/weather-applet.js:12598 3.8/weather-applet.js:12632
-#: 3.8/weather-applet.js:14186 3.8/weather-applet.js:14336
-#: 3.8/weather-applet.js:14337 3.8/weather-applet.js:14695
-#: 3.8/weather-applet.js:14696
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Jasno"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10219
-#: 3.8/weather-applet.js:10220 3.8/weather-applet.js:14336
-#: 3.8/weather-applet.js:14337
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Slnečno"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10205
-#: 3.8/weather-applet.js:10206 3.8/weather-applet.js:10240
-#: 3.8/weather-applet.js:10241 3.8/weather-applet.js:10429
-#: 3.8/weather-applet.js:10430 3.8/weather-applet.js:12588
-#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12817
-#: 3.8/weather-applet.js:12818 3.8/weather-applet.js:13456
-#: 3.8/weather-applet.js:13457 3.8/weather-applet.js:13754
-#: 3.8/weather-applet.js:13755 3.8/weather-applet.js:14328
-#: 3.8/weather-applet.js:14329
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Neznáme"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:11596
+#: 3.0/darkSky.js:71
 msgid "and"
 msgstr "a"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:11596
+#: 3.0/darkSky.js:71
 msgid "until"
 msgstr "do"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:11596
+#: 3.0/darkSky.js:71
 msgid "Possible"
 msgstr "Možné"
 
@@ -528,7 +547,7 @@ msgstr ""
 "V nastaveniach zadajte kľúč API,\n"
 "alebo si ho najskôr zaobstarajte na https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:11741
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -536,132 +555,132 @@ msgstr ""
 "Uistite sa prosím,\n"
 "že ste zadali kľúč API, ktorý máte od DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:9062
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Lokalitu nie je možné nájsť"
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:9068
+#: 3.0/ipApi.js:95
 msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 "Služba určovania polohy odpovedala chybami. Pozrite si denníky v službe "
 "Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:13310
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Oblačno"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:13466
-#: 3.8/weather-applet.js:13467
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Jasno"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:13480 3.8/weather-applet.js:13481
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Pekne"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:13502
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Búrka so silným dažďom"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:13509
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Silné dažďové prehánky"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:13516
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Silné dažďové prehánky s búrkou"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:13522
-#: 3.8/weather-applet.js:13523 3.8/weather-applet.js:13529
-#: 3.8/weather-applet.js:13536 3.8/weather-applet.js:13543
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Silný dážď"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:13530
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Silný dážď a búrka"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:13537
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Silné dažďové prehánky"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:13544
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Silné dažďové prehánky s búrkou"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:13558
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Husté sneženie a búrka"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:13565
-#: 3.8/weather-applet.js:14808
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Silné snehové prehánky"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:13572
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Silné snehové prehánky a búrka"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:13586
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Slabý dážď a búrka"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:13593
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Slabé dažďové prehánky"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:13600
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Slabé dažďové prehánky s búrkou"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:13606
-#: 3.8/weather-applet.js:13607 3.8/weather-applet.js:13613
-#: 3.8/weather-applet.js:13620 3.8/weather-applet.js:13627
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Ľahký dážď so snehom"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:13614
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Ľahký dážď so snehom a búrka"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:13621
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Ľahký dážď so snehom"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:13628
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Ľahký dážď so snehom a búrka"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:13642
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Slabé sneženie a búrka"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:13649
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Mierne snehové prehánky"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:13656
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Slabé snehové prehánky a búrka"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:13677
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Dážď a hrmavica"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12732
-#: 3.8/weather-applet.js:13683 3.8/weather-applet.js:13684
-#: 3.8/weather-applet.js:13690 3.8/weather-applet.js:14148
-#: 3.8/weather-applet.js:14773 3.8/weather-applet.js:14779
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Snehové prehánky"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:13691
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Dažďové prehánky a hrmavica"
 
@@ -670,42 +689,44 @@ msgstr "Dažďové prehánky a hrmavica"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10324
-#: 3.8/weather-applet.js:10331 3.8/weather-applet.js:10338
-#: 3.8/weather-applet.js:10339 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12681 3.8/weather-applet.js:12682
-#: 3.8/weather-applet.js:12688 3.8/weather-applet.js:12689
-#: 3.8/weather-applet.js:12716 3.8/weather-applet.js:12717
-#: 3.8/weather-applet.js:13697 3.8/weather-applet.js:13698
-#: 3.8/weather-applet.js:13704 3.8/weather-applet.js:13711
-#: 3.8/weather-applet.js:13718
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Poľadovica"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:13705
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Búrka a poľadovica"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:13712
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Mrznúce prehánky"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:13719
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Mrznúce prehánky a hrmavica"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:13733
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Sneženie a hrmavica"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:13739 3.8/weather-applet.js:13740
-#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:14166
-#: 3.8/weather-applet.js:14801
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Snehové prehánky"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:13747
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Snehové prehánky a hrmavica"
 
@@ -714,21 +735,21 @@ msgstr "Snehové prehánky a hrmavica"
 msgid "Unexpected response from API"
 msgstr "Neočakávaná odpoveď z API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10033
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Dohľadnosť"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10057
-#: 3.8/weather-applet.js:12053 3.8/weather-applet.js:12543
-#: 3.8/weather-applet.js:12894
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Informácie o aktuálnom počasí sa nepodarilo spracovať"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:9853
-#: 3.8/weather-applet.js:9888 3.8/weather-applet.js:12351
-#: 3.8/weather-applet.js:12920 3.8/weather-applet.js:12954
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Informácie o predpovedi sa nepodarilo spracovať"
 
@@ -757,85 +778,88 @@ msgid "Excellent - More than"
 msgstr "Vynikajúce - viac ako"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10247 3.8/weather-applet.js:10248
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:14138
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Hmla"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10268
-#: 3.8/weather-applet.js:10269 3.8/weather-applet.js:12625
-#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:12660
-#: 3.8/weather-applet.js:14182
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Zatiahnuté"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10276
-#: 3.8/weather-applet.js:10283
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Slabé dažďové prehánky"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10289 3.8/weather-applet.js:10290
-#: 3.8/weather-applet.js:12235 3.8/weather-applet.js:14104
-#: 3.8/weather-applet.js:14406 3.8/weather-applet.js:14407
-#: 3.8/weather-applet.js:14462
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Mrholenie"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10304
-#: 3.8/weather-applet.js:10311
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Silná prehánka"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10325
-#: 3.8/weather-applet.js:10332
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Mrznúca prehánka"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10345 3.8/weather-applet.js:10352
-#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:10360
-#: 3.8/weather-applet.js:14180
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Krúpy"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10346
-#: 3.8/weather-applet.js:10353
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Prehánky s krúpami"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10367
-#: 3.8/weather-applet.js:10374
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Mierne snehové prehánky"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10388
-#: 3.8/weather-applet.js:10395
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Silné snehové prehánky"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10408 3.8/weather-applet.js:10415
-#: 3.8/weather-applet.js:10422 3.8/weather-applet.js:10423
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Búrky"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10409
-#: 3.8/weather-applet.js:10416
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Búrky s prehánkami"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:12106
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "V nastaveniach prosím skontrolujte, či je Poloha v správnom formáte"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:12110
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Uistite sa, že ste v nastaveniach zadali správny kľúč"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11922 3.8/weather-applet.js:12114
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -843,207 +867,211 @@ msgstr ""
 "Poloha sa nenašla, uistite sa, že je k dispozícii, resp. že je v správnom "
 "formáte"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:12118
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Ak tento problém pretrváva, kontaktujte autora tohto apletu"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:12122
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Neznáma chyba, pozrite si denníky v programe Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:12224
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Slabý dážď a búrka"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:12225
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Búrka s dažďom"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:12226
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Búrka so silným dažďom"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:12227
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Slabá búrka"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:12229
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Silná búrka"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:12230
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Ojedinelé búrky"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:12231
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Búrka a mierne mrznúce mrholenie"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:12232
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Búrka a mrznúce mrholenie"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:12233
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Búrka a silné mrznúce mrholenie"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:12234
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Slabé mrznúce mrholenie"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:12236
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Silné mrznúce mrholenie"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:12237
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Slabé mrznúce mrholenie/dážď"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:12238
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Mrholenie"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:12239
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Silné mrznúce mrholenie"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:12240
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Mrznúce dažďové prehánky"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:12241
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Výdatné mrznúce dažďové prehánky"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:12242
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Mrznúce preánky"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:12244
-#: 3.8/weather-applet.js:14737 3.8/weather-applet.js:14738
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Stredne silný dážď"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:12245
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Silný dážď"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:12246
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Veľmi silný dážď"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:12247
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Extrémny dážď"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:12249
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Slabé dažďové prehánky"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:12250
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Prehánky"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:12251
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Silné dažďové prehánky"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:12252
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Ojedinelé prehánky"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:12257
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Prehánky so snehom"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:12258
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Slabý dážď so snehom"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:12259
-#: 3.8/weather-applet.js:14744 3.8/weather-applet.js:14745
-#: 3.8/weather-applet.js:14751 3.8/weather-applet.js:14786
-#: 3.8/weather-applet.js:14793
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Dážď so snehom"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:12260
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Mierne snehové prehánky"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:12261
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Prehánky"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:12262
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Silné snehové prehánky"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:12264 3.8/weather-applet.js:12775
-#: 3.8/weather-applet.js:12776
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Dymno"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:12265 3.8/weather-applet.js:12782
-#: 3.8/weather-applet.js:12783
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Hmla"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:12266
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Prašno"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:12268
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Prašno"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:12269 3.8/weather-applet.js:12768
-#: 3.8/weather-applet.js:12769
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Prašno"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:12270
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Vulkanický prach"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:12271
-#: 3.8/weather-applet.js:14172
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Víchor"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:12272 3.8/weather-applet.js:12747
-#: 3.8/weather-applet.js:12748
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Tornádo"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:12275
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Jasno"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:12276
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Oblačno"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:12277
-#: 3.8/weather-applet.js:12604 3.8/weather-applet.js:12605
-#: 3.8/weather-applet.js:12639
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Miestami oblačno"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:12278
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Miestami oblačno"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:12279
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Miestami oblačno"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:12280
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Zatiahnuté"
 
@@ -1051,77 +1079,80 @@ msgstr "Zatiahnuté"
 msgid "Could not get forecast for your area"
 msgstr "Predpoveď pre vašu oblasť sa nepodarilo získať"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12309
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "Poloha sa nachádza mimo USA, použite iného poskytovateľa."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12373
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Informácie o hodinovej predpovedi sa nepodarilo spracovať"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12633
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Jasno a veterno"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12640
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Miestami oblačno a veterno"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12647
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Polojasno a veterno"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12654
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Takmer zamračené a veterno"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12661
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Zatiahnuté a veterno"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12675
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Dážď so snehom"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12710
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Mrznúci dážď a sneh"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:8750 3.8/weather-applet.js:12754
-#: 3.8/weather-applet.js:12755
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Hurikán"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:8745
-#: 3.8/weather-applet.js:12761
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Búrka"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12762
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Tropická búrka"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12789 3.8/weather-applet.js:12790
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Horúco"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12797
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Chladno"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12804
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Metelica"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:8634
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Dnes"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:8636
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Zajtra"
 
@@ -1153,79 +1184,79 @@ msgstr "Piatok"
 msgid "Saturday"
 msgstr "Sobota"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:8715
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Bezvetrie"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:8718
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Svieži vzduch"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:8721
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Slabý vánok"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:8724
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Jemný vánok"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:8727
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Mierny vánok"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:8730
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Čerstvý vánok"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:8733
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Silný vánok"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:8736
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Takmer víchrica"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:8739
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Víchrica"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:8742
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Silná víchrica"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:8748
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Prudká búrka"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "SV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "V"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "JV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "J"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "JZ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "Z"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "SZ"
 
@@ -1277,7 +1308,7 @@ msgstr ""
 "Pri získavaní počasia sa vyskytla neznáma chyba, ďalšie informácie nájdete v "
 "denníkoch programu Looking Glass"
 
-#: 3.0/yahoo.js:437
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Tropická búrka"
 
@@ -1285,7 +1316,7 @@ msgstr "Tropická búrka"
 msgid "Severe Thunderstorms"
 msgstr "Časté búrky"
 
-#: 3.0/yahoo.js:440
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Búrky"
 
@@ -1301,15 +1332,15 @@ msgstr "Dážď a poľadovica"
 msgid "Mixed Snow and Sleet"
 msgstr "Sneh a poľadovica"
 
-#: 3.0/yahoo.js:444
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Mráz a mrholenie"
 
-#: 3.0/yahoo.js:446
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Mrznúci dážď"
 
-#: 3.0/yahoo.js:447
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Prehánky"
 
@@ -1321,11 +1352,11 @@ msgstr "Snehové záveje"
 msgid "Light Snow Showers"
 msgstr "Mierne snehové prehánky"
 
-#: 3.0/yahoo.js:451
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Fujavica"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14723 3.8/weather-applet.js:14724
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Hmlisto"
 
@@ -1337,47 +1368,54 @@ msgstr "Dymno"
 msgid "Blustery"
 msgstr "Búrlivo"
 
-#: 3.0/yahoo.js:460
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Veterno"
 
-#: 3.0/yahoo.js:463
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Prevažne zamračené"
 
-#: 3.0/yahoo.js:464
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Miestami oblačno"
 
-#: 3.0/yahoo.js:467
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Prevažne slnečno"
 
-#: 3.0/yahoo.js:469
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Dážď s krúpami"
 
-#: 3.0/yahoo.js:471
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Ojedinelé búrky"
 
-#: 3.0/yahoo.js:472
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Občasné búrky"
 
-#: 3.0/yahoo.js:473
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Občasné prehánky"
 
-#: 3.0/yahoo.js:474
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Hustý dážď"
 
-#: 3.0/yahoo.js:475
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Občasné snehové prehánky"
 
-#: 3.0/yahoo.js:476
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Husté sneženie"
 
@@ -1389,254 +1427,395 @@ msgstr "Nedostupné"
 msgid "Scattered Thundershowers"
 msgstr "Občasné búrky"
 
+#: 3.8/weather-applet.js:9638
+msgid ""
+"Could not retrieve logs, log file was not found under path\n"
+" {logFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:9642
+msgid ""
+"Could not get contents of log file under path\n"
+" {logFilePath}"
+msgstr ""
+
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:9815
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "MET Office UK"
 
-#: 3.8/weather-applet.js:9999
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
+msgstr ""
+
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Údaje o polohe sa nenašli"
 
-#: 3.8/weather-applet.js:10070
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Veľmi zlé"
 
-#: 3.8/weather-applet.js:10070
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Menej ako {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10074
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Vynikajúce"
 
-#: 3.8/weather-applet.js:10074
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Viac ako {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10079
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Slabé"
 
-#: 3.8/weather-applet.js:10079 3.8/weather-applet.js:10084
-#: 3.8/weather-applet.js:10089 3.8/weather-applet.js:10094
-#: 3.8/weather-applet.js:10099
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Medzi {lessDistance}-{greaterDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10084
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Uspokojivé"
 
-#: 3.8/weather-applet.js:10089
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Dobré"
 
-#: 3.8/weather-applet.js:10094 3.8/weather-applet.js:10099
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Veľmi dobré"
 
-#: 3.8/weather-applet.js:10761
-msgid "Precipitation will end in {precipEnd} minutes"
-msgstr "Zrážky sa skončia o {precipEnd} minúty"
-
-#: 3.8/weather-applet.js:10763
-msgid "Precipitation won't end in within an hour"
-msgstr "Zrážky sa do hodiny neskončia"
-
-#: 3.8/weather-applet.js:10766
-msgid "Precipitation will start within {precipStart} minutes"
-msgstr "Zrážky začnú do {precipStart} minút"
-
-#: 3.8/weather-applet.js:11335 3.8/weather-applet.js:15025
-msgid "As of {lastUpdatedTime}"
-msgstr "Aktualizácia z {lastUpdatedTime}"
-
-#: 3.8/weather-applet.js:11341
-msgid "{distance}{distanceUnit} from you"
-msgstr "{distance} {distanceUnit} od vás"
-
-#: 3.8/weather-applet.js:11582
-msgid "DarkSky"
-msgstr "DarkSky"
-
-#: 3.8/weather-applet.js:11606
-msgid "This API has ceased to function, please use another one."
-msgstr "Toto API prestalo fungovať, použite prosím iné."
-
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11907
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
-#: 3.8/weather-applet.js:12290
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:12834
-msgid "WeatherBit"
-msgstr "WeatherBit"
-
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13251
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:13924
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
+#: 3.8/weather-applet.js:11955
+msgid "WeatherBit"
+msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:14102
-msgid "Blowing or drifting snow"
-msgstr "Fujavica a snehové víry"
+#: 3.8/weather-applet.js:12386
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Zajtra"
 
-#: 3.8/weather-applet.js:14106
-msgid "Heavy drizzle"
-msgstr "Silné mrznúce mrholenie"
-
-#: 3.8/weather-applet.js:14110
-msgid "Heavy drizzle/rain"
-msgstr "Silné mrznúce mrholenie/dážď"
-
-#: 3.8/weather-applet.js:14112
-msgid "Light drizzle/rain"
-msgstr "Slabé mrznúce mrholenie/dážď"
-
-#: 3.8/weather-applet.js:14114
-msgid "Duststorm"
-msgstr "Prachová búrka"
-
-#: 3.8/weather-applet.js:14118
-msgid "Freezing drizzle/freezing rain"
-msgstr "Mráz a mrholenie/dážď"
-
-#: 3.8/weather-applet.js:14120
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Silné mrznúce mrholenie/dážď"
-
-#: 3.8/weather-applet.js:14122
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Slabé mrznúce mrholenie/dážď"
-
-#: 3.8/weather-applet.js:14124
-msgid "Freezing fog"
-msgstr "Mrznúca hmla"
-
-#: 3.8/weather-applet.js:14130
-msgid "Funnel cloud/tornado"
-msgstr "Tromba/tornádo"
-
-#: 3.8/weather-applet.js:14132
-msgid "Hail showers"
-msgstr "Krúpové prehánky"
-
-#: 3.8/weather-applet.js:14134
-msgid "Ice"
-msgstr "Ľad"
-
-#: 3.8/weather-applet.js:14136
-msgid "Lightning without thunder"
-msgstr "Blýskavica"
-
-#: 3.8/weather-applet.js:14140
-msgid "Precipitation in vicinity"
-msgstr "Zrážky v okolí"
-
-#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14752
-msgid "Heavy rain and snow"
-msgstr "Výdatný dážď so snehom"
-
-#: 3.8/weather-applet.js:14146
-msgid "Light rain And snow"
-msgstr "Slabý dážď so snehom"
-
-#: 3.8/weather-applet.js:14154
-msgid "Sky coverage decreasing"
-msgstr "Ubúdajúca oblačnosť"
-
-#: 3.8/weather-applet.js:14156
-msgid "Sky coverage increasing"
-msgstr "Pribúdajúca oblačnosť"
-
-#: 3.8/weather-applet.js:14158
-msgid "Sky unchanged"
-msgstr "Oblačnosť bez zmeny"
-
-#: 3.8/weather-applet.js:14160
-msgid "Smoke or haze"
-msgstr "Dymno alebo opar"
-
-#: 3.8/weather-applet.js:14164
-msgid "Snow and rain showers"
-msgstr "Snehové prehánky s dažďom"
-
-#: 3.8/weather-applet.js:14176
-msgid "Thunderstorm without precipitation"
-msgstr "Hrmavica"
-
-#: 3.8/weather-applet.js:14178
-msgid "Diamond dust"
-msgstr "Diamantový prach"
-
-#: 3.8/weather-applet.js:14184
-msgid "Partially cloudy"
-msgstr "Miestami oblačno"
-
-#: 3.8/weather-applet.js:14207
-msgid "Please make sure you entered the API key correctly"
-msgstr "Uistite sa, že ste kľúč API zadali správne"
-
-#: 3.8/weather-applet.js:14221
-msgid "Climacell"
-msgstr "Climacell"
-
-#: 3.8/weather-applet.js:14386
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Slabý vietor"
 
-#: 3.8/weather-applet.js:14400
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Silný vietor"
 
+#: 3.8/weather-applet.js:12723
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:13292
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:13474
+msgid "Blowing or drifting snow"
+msgstr "Fujavica a snehové víry"
+
+#: 3.8/weather-applet.js:13478
+msgid "Heavy drizzle"
+msgstr "Silné mrznúce mrholenie"
+
+#: 3.8/weather-applet.js:13482
+msgid "Heavy drizzle/rain"
+msgstr "Silné mrznúce mrholenie/dážď"
+
+#: 3.8/weather-applet.js:13484
+msgid "Light drizzle/rain"
+msgstr "Slabé mrznúce mrholenie/dážď"
+
+#: 3.8/weather-applet.js:13486
+#, fuzzy
+msgid "Dust Storm"
+msgstr "Prachová búrka"
+
+#: 3.8/weather-applet.js:13490
+msgid "Freezing drizzle/freezing rain"
+msgstr "Mráz a mrholenie/dážď"
+
+#: 3.8/weather-applet.js:13492
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Silné mrznúce mrholenie/dážď"
+
+#: 3.8/weather-applet.js:13494
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Slabé mrznúce mrholenie/dážď"
+
+#: 3.8/weather-applet.js:13496
+msgid "Freezing fog"
+msgstr "Mrznúca hmla"
+
+#: 3.8/weather-applet.js:13502
+msgid "Funnel cloud/tornado"
+msgstr "Tromba/tornádo"
+
+#: 3.8/weather-applet.js:13504
+msgid "Hail showers"
+msgstr "Krúpové prehánky"
+
+#: 3.8/weather-applet.js:13506
+msgid "Ice"
+msgstr "Ľad"
+
+#: 3.8/weather-applet.js:13508
+msgid "Lightning without thunder"
+msgstr "Blýskavica"
+
+#: 3.8/weather-applet.js:13512
+msgid "Precipitation in vicinity"
+msgstr "Zrážky v okolí"
+
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
+msgid "Heavy rain and snow"
+msgstr "Výdatný dážď so snehom"
+
+#: 3.8/weather-applet.js:13518
+msgid "Light rain And snow"
+msgstr "Slabý dážď so snehom"
+
+#: 3.8/weather-applet.js:13526
+msgid "Sky coverage decreasing"
+msgstr "Ubúdajúca oblačnosť"
+
+#: 3.8/weather-applet.js:13528
+msgid "Sky coverage increasing"
+msgstr "Pribúdajúca oblačnosť"
+
+#: 3.8/weather-applet.js:13530
+msgid "Sky unchanged"
+msgstr "Oblačnosť bez zmeny"
+
+#: 3.8/weather-applet.js:13532
+msgid "Smoke or haze"
+msgstr "Dymno alebo opar"
+
+#: 3.8/weather-applet.js:13536
+msgid "Snow and rain showers"
+msgstr "Snehové prehánky s dažďom"
+
+#: 3.8/weather-applet.js:13548
+msgid "Thunderstorm without precipitation"
+msgstr "Hrmavica"
+
+#: 3.8/weather-applet.js:13550
+msgid "Diamond dust"
+msgstr "Diamantový prach"
+
+#: 3.8/weather-applet.js:13556
+msgid "Partially cloudy"
+msgstr "Miestami oblačno"
+
+#: 3.8/weather-applet.js:13578
+msgid "Please make sure you entered the API key correctly"
+msgstr "Uistite sa, že ste kľúč API zadali správne"
+
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14544
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14684 3.8/weather-applet.js:14685
-#: 3.8/weather-applet.js:14821 3.8/weather-applet.js:14822
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "NENÁJDENÉ"
 
-#: 3.8/weather-applet.js:14717
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Fujavica"
 
-#: 3.8/weather-applet.js:14758 3.8/weather-applet.js:14759
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Slabé sneženie"
 
-#: 3.8/weather-applet.js:14765 3.8/weather-applet.js:14766
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Stredne silné sneženie"
 
-#: 3.8/weather-applet.js:14780
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Stredne silné prehánky"
 
-#: 3.8/weather-applet.js:14787
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Dážď so snehom"
 
-#: 3.8/weather-applet.js:14794
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Výdatný dážď so snehom"
 
-#: 3.8/weather-applet.js:14986
+#: 3.8/weather-applet.js:14024
+#, fuzzy
+msgid "AccuWeather"
+msgstr "Počasie"
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+#, fuzzy
+msgid "Weather Underground"
+msgstr "Poveternostné podmienky"
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+msgid "The location you provided was not found."
+msgstr ""
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+#, fuzzy
+msgid "Strong Storm"
+msgstr "Silný vánok"
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "Dážď so snehom"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "Dážď a poľadovica"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "Snehové prehánky"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "Takmer jadno"
+
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:15603
+#, fuzzy
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+"Služba určovania polohy odpovedala chybami. Pozrite si denníky v službe "
+"Looking Glass"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+"Uistite sa, že ste zadali miesto, alebo použite namiesto toho automatické "
+"určovanie polohy"
+
+#: 3.8/weather-applet.js:15968
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:15975
+msgid ""
+"Could not get contents of config file under path\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:16233
 msgid "This provider requires an API key to operate"
 msgstr "Tento poskytovateľ vyžaduje na svoju činnosť kľúč API"
+
+#: 3.8/weather-applet.js:16675
+msgid "Dew Point"
+msgstr ""
+
+#: 3.8/weather-applet.js:16747
+msgid "Precipitation will end in {precipEnd} minutes"
+msgstr "Zrážky sa skončia o {precipEnd} minúty"
+
+#: 3.8/weather-applet.js:16749
+msgid "Precipitation won't end in within an hour"
+msgstr "Zrážky sa do hodiny neskončia"
+
+#: 3.8/weather-applet.js:16752
+msgid "Precipitation will start within {precipStart} minutes"
+msgstr "Zrážky začnú do {precipStart} minút"
+
+#: 3.8/weather-applet.js:16964
+msgid "Forecast parsing failed, see logs for more details."
+msgstr ""
+
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
+msgid "As of {lastUpdatedTime}"
+msgstr "Aktualizácia z {lastUpdatedTime}"
+
+#: 3.8/weather-applet.js:17502
+#, fuzzy
+msgid "{distance} {distanceUnit} from you"
+msgstr "{distance} {distanceUnit} od vás"
+
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
+msgid "Error Saving Debug Information"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Debug Information saved successfully"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Saved to {filePath}"
+msgstr ""
+
+#: 3.8/LogSaver.py:16
+msgid "Save to File"
+msgstr ""
+
+#: 3.8/LogSaver.py:29
+msgid "Select a destination"
+msgstr ""
 
 #. metadata.json->name
 #. 3.8->settings-schema.json->providers->title
@@ -1681,7 +1860,6 @@ msgid "Data service"
 msgstr "Dátová služba"
 
 #. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
 msgid "DarkSky (key needed)"
 msgstr "DarkSky (potrebný kľúč)"
 
@@ -1916,7 +2094,6 @@ msgid "Override label on panel"
 msgstr "Prepísať štítok panelu"
 
 #. 3.0->settings-schema.json->tempTextOverride->tooltip
-#. 3.8->settings-schema.json->tempTextOverride->tooltip
 msgid ""
 "Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
 "Can be used if label does not fit on vertical panel, among other smart "
@@ -1987,7 +2164,8 @@ msgid "Only display hours for hourly forecast time"
 msgstr "Zobraziť hodiny iba pre hodinovú predpoveď"
 
 #. 3.0->settings-schema.json->shortHourlyTime->tooltip
-msgid "Instead of 15:00 or 3 pm it will show up as 15 or 3 pm"
+#. 3.8->settings-schema.json->shortHourlyTime->tooltip
+msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
 msgstr "Namiesto 15:00 alebo 3 pm sa zobrazí ako 15 alebo 3 pm"
 
 #. 3.0->settings-schema.json->showForecastDates->description
@@ -2093,6 +2271,11 @@ msgstr "Viac o aplete Počasie"
 msgid "Report an issue"
 msgstr "Nahlásiť problém"
 
+#. 3.8->settings-schema.json->debug-options->title
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Debug"
+msgstr ""
+
 #. 3.8->settings-schema.json->dataService->tooltip
 msgid ""
 "You can choose between several different weather forecast providers. Some "
@@ -2109,6 +2292,10 @@ msgstr ""
 "Pomocník."
 
 #. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Met Office UK (UK only)"
 msgstr "MET Office UK (iba pre UK)"
 
@@ -2117,12 +2304,28 @@ msgid "US National Weather (US only)"
 msgstr "US National Weather (len pre USA)"
 
 #. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Pirate Weather (key needed)"
+msgstr "Weatherbit (potrebný kľúč)"
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Visual Crossing (key needed)"
 msgstr "Visual Crossing (potrebný kľúč)"
 
 #. 3.8->settings-schema.json->dataService->options
-msgid "ClimacellV4 (key needed)"
-msgstr "ClimacellV4 (potrebný kľúč)"
+#, fuzzy
+msgid "Tomorrow.io (key needed)"
+msgstr "Weatherbit (potrebný kľúč)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "AccuWeather (key needed)"
+msgstr "Weatherbit (potrebný kľúč)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Weather Underground (key needed)"
+msgstr "Weatherbit (potrebný kľúč)"
 
 #. 3.8->settings-schema.json->location->tooltip
 msgid ""
@@ -2138,6 +2341,12 @@ msgstr ""
 "{Krajina}. Algoritmus vyhľadávania je s formátom veľmi flexibilný. Po 3 "
 "sekundách bez písania sa adresa, ktorú ste zadali, automaticky nahradí pre "
 "overenie vášho výberu."
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
 
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"
@@ -2165,9 +2374,20 @@ msgstr ""
 "sa vám kvóta neminie."
 
 #. 3.8->settings-schema.json->forecastDays->tooltip
+#, fuzzy
 msgid ""
-"Maximum number of days that can be displayed, maximum rows and columns "
-"setting in the Presentation tab will affect the final number."
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+"Konečný počet ovplyvní maximálny počet dní, ktoré je možné zobraziť, "
+"nastavenie maximálnych riadkov a stĺpcov na karte Prezentácia."
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+#, fuzzy
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
 msgstr ""
 "Konečný počet ovplyvní maximálny počet dní, ktoré je možné zobraziť, "
 "nastavenie maximálnych riadkov a stĺpcov na karte Prezentácia."
@@ -2177,10 +2397,11 @@ msgid "Enable minutely precipitation forecast"
 msgstr "Povoliť minútovú predpoveď zrážok"
 
 #. 3.8->settings-schema.json->immediatePrecip->tooltip
+#, fuzzy
 msgid ""
 "If you'd like to use this make sure you use your exact coordinates/address "
-"as location to help its accuracy. Currently implemented with OpenWeatherMap "
-"only."
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
 msgstr ""
 "Ak to chcete použiť, uistite sa, že ako presnú polohu uvádzate presné "
 "súradnice/adresu. V súčasnosti sa dá použiť iba s OpenWeatherMap."
@@ -2188,6 +2409,37 @@ msgstr ""
 #. 3.8->settings-schema.json->showBothTempUnits->description
 msgid "Show both temperature units at the same time"
 msgstr "Zobraziť obe jednotky teploty súčasne"
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+#, fuzzy
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+"Dostupné hodnoty sú: {c} je stav, {t} je teplota a {u} je jednotka.\n"
+"Použiteľné, aj ak sa štítok nezmestí na zvislý panel."
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+#, fuzzy
+msgid "Override tooltip on panel"
+msgstr "Prepísať štítok panelu"
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
+msgid "Always show Hourly Weather"
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->tooltip
+msgid ""
+"Hide/Show button will be hidden and Hourly weather will be permanently "
+"visible."
+msgstr ""
 
 #. 3.8->settings-schema.json->verticalOrientation->tooltip
 msgid "Displaying forecasts from top to bottom instead from left to right."
@@ -2237,10 +2489,6 @@ msgstr "Zobraziť smer vetra ako text"
 msgid "Like SE, N instead of direction icons."
 msgstr "Napríklad ako JV, S, namiesto ikonky smeru."
 
-#. 3.8->settings-schema.json->shortHourlyTime->tooltip
-msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
-msgstr "Namiesto 15:00 alebo 3 pm sa zobrazí ako 15 alebo 3 pm"
-
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"
 msgstr "Netýka sa vlastnej sady ikon, ktorá je predvolene symbolická"
@@ -2280,13 +2528,17 @@ msgid "Current maintainer: Gr3q"
 msgstr "Aktuálny správca: Gr3q"
 
 #. 3.8->settings-schema.json->issue-reporting-explanation->description
+#, fuzzy
 msgid ""
 "If you find an issue with this applet please make a report by clicking on "
-"the button below and login in with your Github account. Before you start "
-"writing please make sure that the issue is not already submitted in the "
-"issues section. Don't forget to write weather@mockturtl in the top Title "
-"field to make it easier for everyone to know that the issue is about the "
-"weather applet (the form is for all Cinnamon applets)."
+"the button below and login in with your Github account.\n"
+"\n"
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
 msgstr ""
 "Ak narazíte na problém s týmto apletom, nahláste to prosím kliknutím na "
 "tlačidlo nižšie a prihláste sa pomocou svojho účtu Github. Predtým, ako "
@@ -2312,36 +2564,31 @@ msgstr ""
 "sekundách bez zadania sa adresa, ktorú ste zadali, automaticky nahradí na "
 "overenie vášho výberu."
 
-#~ msgid "Settings"
-#~ msgstr "Nastavenia"
+#. 3.8->settings-schema.json->logLevel->description
+msgid "Log Level"
+msgstr ""
 
-#~ msgid "Sunrise"
-#~ msgstr "Východ slnka"
+#. 3.8->settings-schema.json->logLevel->tooltip
+msgid ""
+"Info is the regular logging, Debug is debug, and Verbose also logs network "
+"request payloads. Changing this will only be effective on future logs. Only "
+"change it you are instructed or you know what you are doing."
+msgstr ""
 
-#~ msgid "Sunset"
-#~ msgstr "Západ slnka"
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Verbose"
+msgstr ""
 
-#~ msgid "Wind Chill:"
-#~ msgstr "Pocitová teplota:"
+#. 3.8->settings-schema.json->fileSelect->description
+msgid "Click Save to save debug information to a file"
+msgstr ""
 
-#~ msgid "Isolated thundershowers"
-#~ msgstr "Ojedinelé búrky s prehánkami"
+#. 3.8->settings-schema.json->fileSelect->tooltip
+msgid ""
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
+msgstr ""
 
-#~ msgid "Get WOEID"
-#~ msgstr "Získať WOEID"
-
-#~ msgid "WOEID"
-#~ msgstr "WOEID"
-
-#~ msgid "Where On Earth ID"
-#~ msgstr "Where On Earth ID"
-
-#, fuzzy
-#~ msgid "kPa"
-#~ msgstr "Pa"
-
-#~ msgid "mbar"
-#~ msgstr "mbar"
-
-#~ msgid "Symbolic icons"
-#~ msgstr "Symbolické ikony"
+#. 3.8->settings-schema.json->selectedLogPath->description
+msgid "Selected path to save Logs"
+msgstr ""

--- a/weather@mockturtl/files/weather@mockturtl/po/sl.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/sl.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: weather@mockturtl 3.1.2\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-19 07:23+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2021-08-04 14:34+0200\n"
 "Last-Translator: dkrat7 <dkrat7 @github.com>\n"
 "Language-Team: \n"
@@ -18,65 +19,65 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:14911
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Napaka"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:14912 3.8/weather-applet.js:14914
-#: 3.8/weather-applet.js:14916 3.8/weather-applet.js:14919
-#: 3.8/weather-applet.js:14922 3.8/weather-applet.js:14923
-#: 3.8/weather-applet.js:14924 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Napaka storitve"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:14913
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Napačen ključ za API"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:14915
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Napačna oblika lokacije"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:14917
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Ključ blokiran"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:14918
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Ne najdem lokacije"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:14920
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Manjka ključ za API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:14921
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Manjka lokacija"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:14926
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Manjkajo paketi"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:14927
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Lokacija ni pokrita"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9111
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Aplikacija Vreme"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:15144
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:15145
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Odpri s klikom"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:10673
-#: 3.8/weather-applet.js:15156
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Osveži"
 
@@ -86,8 +87,8 @@ msgstr "API je vrnil kodo statusa med 400 in 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9278
-#: 3.8/weather-applet.js:9282 3.8/weather-applet.js:9286
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Shramba lokacij"
 
@@ -99,14 +100,14 @@ msgstr "Samodejno pridobljene lokacije ne morete shraniti"
 msgid "Could not get weather information"
 msgstr "Vremenske informacije ni mogoče pridobiti"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:15017
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Nepričakovana napaka pri osveževanju Vremena, preverite dnevniški zapis v "
 "Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:15273
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -122,7 +123,7 @@ msgstr "Napaka mreže, preverite dnevniške zapise (Looking Glass)"
 msgid "As of"
 msgstr "Ob"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:11332
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Vir podatkov"
 
@@ -130,89 +131,89 @@ msgstr "Vir podatkov"
 msgid "from you"
 msgstr "od vas"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:11266
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:11266
-#: 3.8/weather-applet.js:11596
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10104
-#: 3.8/weather-applet.js:11393
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10105
-#: 3.8/weather-applet.js:11394
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:11545
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Pridobivam trenutno vreme..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:11548
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Pridobivam vremensko napoved ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:10616
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Pridobivam ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:10640
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:10641
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Vlažnost"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:10642
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Zračni tlak"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:10643 3.8/weather-applet.js:14385
-#: 3.8/weather-applet.js:14392 3.8/weather-applet.js:14393
-#: 3.8/weather-applet.js:14399
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Veter"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:9573
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr "Preverite, da ste vnesli lokacijo ali pa uporabite samodejno lokacijo"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9358
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Ni bilo mogoče pridobiti lokacije na podlagi naslova, preverite, če je "
 "pravilen"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9379
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 "Neuspešno klicanje geolokacijskega API-ja, preverite Looking Glass za napake."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9278
-#: 3.8/weather-applet.js:9282
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Opozorilo"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9278
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "Lokacijo lahko shranite samo, ko se aplikacija ne osvežuje"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9282
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Nepravilne lokacije ne morete shraniti"
 
+#. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9286
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Informacije"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9286
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Lokacija je že shranjena"
 
@@ -250,14 +251,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:11655 3.8/weather-applet.js:11973
-#: 3.8/weather-applet.js:12531 3.8/weather-applet.js:12884
-#: 3.8/weather-applet.js:13980 3.8/weather-applet.js:14286
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Občuti se kot"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:11701
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Neuspešna obdelava vremenskih informacij"
 
@@ -270,7 +272,7 @@ msgstr ""
 "ali pa ga pridobite na https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11731 3.8/weather-applet.js:13050
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -278,7 +280,7 @@ msgstr ""
 "Preverite, da ste vnesli\n"
 "pravilen ključ za API in vaš račun ni zaklenjen"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:14253
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -289,58 +291,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10303 3.8/weather-applet.js:10310
-#: 3.8/weather-applet.js:10317 3.8/weather-applet.js:10318
-#: 3.8/weather-applet.js:13494 3.8/weather-applet.js:13495
-#: 3.8/weather-applet.js:13501 3.8/weather-applet.js:13508
-#: 3.8/weather-applet.js:13515 3.8/weather-applet.js:14150
-#: 3.8/weather-applet.js:14428
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Močan dež"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:12674 3.8/weather-applet.js:12723
-#: 3.8/weather-applet.js:12724 3.8/weather-applet.js:12731
-#: 3.8/weather-applet.js:13669 3.8/weather-applet.js:13670
-#: 3.8/weather-applet.js:13676 3.8/weather-applet.js:14142
-#: 3.8/weather-applet.js:14413 3.8/weather-applet.js:14414
-#: 3.8/weather-applet.js:14420 3.8/weather-applet.js:14427
-#: 3.8/weather-applet.js:14469 3.8/weather-applet.js:14476
-#: 3.8/weather-applet.js:14483 3.8/weather-applet.js:14730
-#: 3.8/weather-applet.js:14731 3.8/weather-applet.js:14772
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Dež"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10275
-#: 3.8/weather-applet.js:10282 3.8/weather-applet.js:10296
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:12243
-#: 3.8/weather-applet.js:13578 3.8/weather-applet.js:13579
-#: 3.8/weather-applet.js:13585 3.8/weather-applet.js:13592
-#: 3.8/weather-applet.js:13599 3.8/weather-applet.js:14152
-#: 3.8/weather-applet.js:14421
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Rahel dež"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:14126 3.8/weather-applet.js:14484
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Močan zmrznjen dež"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:12248
-#: 3.8/weather-applet.js:12695 3.8/weather-applet.js:12696
-#: 3.8/weather-applet.js:12702 3.8/weather-applet.js:12703
-#: 3.8/weather-applet.js:12709 3.8/weather-applet.js:14470
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Zmrznjen dež"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:14128 3.8/weather-applet.js:14477
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Rahel zmrznjen dež"
 
@@ -348,174 +352,189 @@ msgstr "Rahel zmrznjen dež"
 msgid "Light freezing drizzle"
 msgstr "Rahlo zmrznjeno pršenje"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:14463
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Zmrznjeno pršenje"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:14108
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Rahlo pršenje"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:14498
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Močna sodra"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:14490 3.8/weather-applet.js:14491
-#: 3.8/weather-applet.js:14497 3.8/weather-applet.js:14504
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Sodra"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:14505
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Rahla sodra"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10387
-#: 3.8/weather-applet.js:10394 3.8/weather-applet.js:10401
-#: 3.8/weather-applet.js:10402 3.8/weather-applet.js:12255
-#: 3.8/weather-applet.js:13550 3.8/weather-applet.js:13551
-#: 3.8/weather-applet.js:13557 3.8/weather-applet.js:13564
-#: 3.8/weather-applet.js:13571 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14456 3.8/weather-applet.js:14807
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Močno sneženje"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:12254 3.8/weather-applet.js:12667
-#: 3.8/weather-applet.js:12668 3.8/weather-applet.js:13725
-#: 3.8/weather-applet.js:13726 3.8/weather-applet.js:13732
-#: 3.8/weather-applet.js:14162 3.8/weather-applet.js:14434
-#: 3.8/weather-applet.js:14435 3.8/weather-applet.js:14448
-#: 3.8/weather-applet.js:14455 3.8/weather-applet.js:14716
-#: 3.8/weather-applet.js:14800
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Sneg"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10366
-#: 3.8/weather-applet.js:10373 3.8/weather-applet.js:10380
-#: 3.8/weather-applet.js:10381 3.8/weather-applet.js:12253
-#: 3.8/weather-applet.js:13634 3.8/weather-applet.js:13635
-#: 3.8/weather-applet.js:13641 3.8/weather-applet.js:13648
-#: 3.8/weather-applet.js:13655 3.8/weather-applet.js:14170
-#: 3.8/weather-applet.js:14449
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Rahlo sneženje"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:14441
-#: 3.8/weather-applet.js:14442
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Pršenje"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:12228
-#: 3.8/weather-applet.js:12740 3.8/weather-applet.js:12741
-#: 3.8/weather-applet.js:14174 3.8/weather-applet.js:14511
-#: 3.8/weather-applet.js:14512 3.8/weather-applet.js:14814
-#: 3.8/weather-applet.js:14815
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Nevihta"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:14379
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Rahla megla"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10254 3.8/weather-applet.js:10255
-#: 3.8/weather-applet.js:12267 3.8/weather-applet.js:12810
-#: 3.8/weather-applet.js:12811 3.8/weather-applet.js:13487
-#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14116
-#: 3.8/weather-applet.js:14371 3.8/weather-applet.js:14372
-#: 3.8/weather-applet.js:14378
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Megla"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10261 3.8/weather-applet.js:10262
-#: 3.8/weather-applet.js:13473 3.8/weather-applet.js:13474
-#: 3.8/weather-applet.js:14343 3.8/weather-applet.js:14344
-#: 3.8/weather-applet.js:14709 3.8/weather-applet.js:14710
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Oblačno"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12618
-#: 3.8/weather-applet.js:12619 3.8/weather-applet.js:12653
-#: 3.8/weather-applet.js:14364 3.8/weather-applet.js:14365
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Pretežno oblačno"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10226
-#: 3.8/weather-applet.js:10227 3.8/weather-applet.js:10233
-#: 3.8/weather-applet.js:10234 3.8/weather-applet.js:12611
-#: 3.8/weather-applet.js:12612 3.8/weather-applet.js:12646
-#: 3.8/weather-applet.js:13662 3.8/weather-applet.js:13663
-#: 3.8/weather-applet.js:14357 3.8/weather-applet.js:14358
-#: 3.8/weather-applet.js:14702 3.8/weather-applet.js:14703
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Delno oblačno"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:14350
-#: 3.8/weather-applet.js:14351
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Pretežno jasno"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10212 3.8/weather-applet.js:10213
-#: 3.8/weather-applet.js:12273 3.8/weather-applet.js:12597
-#: 3.8/weather-applet.js:12598 3.8/weather-applet.js:12632
-#: 3.8/weather-applet.js:14186 3.8/weather-applet.js:14336
-#: 3.8/weather-applet.js:14337 3.8/weather-applet.js:14695
-#: 3.8/weather-applet.js:14696
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Jasno"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10219
-#: 3.8/weather-applet.js:10220 3.8/weather-applet.js:14336
-#: 3.8/weather-applet.js:14337
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Sončno"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10205
-#: 3.8/weather-applet.js:10206 3.8/weather-applet.js:10240
-#: 3.8/weather-applet.js:10241 3.8/weather-applet.js:10429
-#: 3.8/weather-applet.js:10430 3.8/weather-applet.js:12588
-#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12817
-#: 3.8/weather-applet.js:12818 3.8/weather-applet.js:13456
-#: 3.8/weather-applet.js:13457 3.8/weather-applet.js:13754
-#: 3.8/weather-applet.js:13755 3.8/weather-applet.js:14328
-#: 3.8/weather-applet.js:14329
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Neznano"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:11596
+#: 3.0/darkSky.js:71
 msgid "and"
 msgstr "in"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:11596
+#: 3.0/darkSky.js:71
 msgid "until"
 msgstr "do"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:11596
+#: 3.0/darkSky.js:71
 msgid "Possible"
 msgstr "Možnost"
 
@@ -527,7 +546,7 @@ msgstr ""
 "Vnesite ključ za API v nastavitve,\n"
 "ali pa ga pridobite na https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:11741
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -535,132 +554,132 @@ msgstr ""
 "Preverite, da ste vnesli\n"
 "ključ za API, ki ste ga dobili od DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:9062
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Lokacije ni mogoče pridobiti"
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:9068
+#: 3.0/ipApi.js:95
 msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 "Lokacijska storitev je sporočila napako, preverite dnevniški zapis v Looking "
 "Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:13310
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Oblačnost"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:12274 3.8/weather-applet.js:13466
-#: 3.8/weather-applet.js:13467
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Jasno nebo"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:13480 3.8/weather-applet.js:13481
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Pretežno jasno"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:13502
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Močan dež in grmenje"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:13509
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Močne dežne plohe"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:13516
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Močne dežne plohe in grmenje"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:13522
-#: 3.8/weather-applet.js:13523 3.8/weather-applet.js:13529
-#: 3.8/weather-applet.js:13536 3.8/weather-applet.js:13543
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Močna sodra"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:13530
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Močna sodra in grmenje"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:13537
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Močne plohe s sodro"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:13544
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Močne plohe s sodro in grmenjem"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:13558
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Močno sneženje in grmenje"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:13565
-#: 3.8/weather-applet.js:14808
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Močne snežne plohe"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:13572
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Močne snežne plohe in grmenje"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:13586
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Rahel dež in grmenje"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:13593
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Rahle dežne plohe"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:13600
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Rahle dežne plohe in grmenje"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:13606
-#: 3.8/weather-applet.js:13607 3.8/weather-applet.js:13613
-#: 3.8/weather-applet.js:13620 3.8/weather-applet.js:13627
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Rahla sodra"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:13614
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Rahla sodra in grmenje"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:13621
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Manjše plohe s sodro"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:13628
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Manjše plohe s sodro in grmenje"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:13642
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Rahlo sneženje in grmenje"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:13649
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Manjše snežne plohe"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:13656
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Manjše snežne plohe in grmenje"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:13677
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Dež in grmenje"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:12732
-#: 3.8/weather-applet.js:13683 3.8/weather-applet.js:13684
-#: 3.8/weather-applet.js:13690 3.8/weather-applet.js:14148
-#: 3.8/weather-applet.js:14773 3.8/weather-applet.js:14779
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Dežne plohe"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:13691
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Dežne plohe in grmenje"
 
@@ -669,42 +688,44 @@ msgstr "Dežne plohe in grmenje"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10324
-#: 3.8/weather-applet.js:10331 3.8/weather-applet.js:10338
-#: 3.8/weather-applet.js:10339 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12681 3.8/weather-applet.js:12682
-#: 3.8/weather-applet.js:12688 3.8/weather-applet.js:12689
-#: 3.8/weather-applet.js:12716 3.8/weather-applet.js:12717
-#: 3.8/weather-applet.js:13697 3.8/weather-applet.js:13698
-#: 3.8/weather-applet.js:13704 3.8/weather-applet.js:13711
-#: 3.8/weather-applet.js:13718
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Sodra"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:13705
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Sodra in grmenje"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:13712
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Plohe s sodro"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:13719
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Plohe s sodro in grmenje"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:13733
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Sneženje in grmenje"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:13739 3.8/weather-applet.js:13740
-#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:14166
-#: 3.8/weather-applet.js:14801
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Snežne plohe"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:13747
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Snežne plohe in grmenje"
 
@@ -713,21 +734,21 @@ msgstr "Snežne plohe in grmenje"
 msgid "Unexpected response from API"
 msgstr "Nepričakovan odziv s strani API-ja"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10033
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Vidnost"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10057
-#: 3.8/weather-applet.js:12053 3.8/weather-applet.js:12543
-#: 3.8/weather-applet.js:12894
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Neuspešna obdelava trenutnih vremenskih informacij"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:9853
-#: 3.8/weather-applet.js:9888 3.8/weather-applet.js:12351
-#: 3.8/weather-applet.js:12920 3.8/weather-applet.js:12954
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Neuspešna obdelava vremenske napovedi"
 
@@ -756,294 +777,300 @@ msgid "Excellent - More than"
 msgstr "Odlično - Več kot"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10247 3.8/weather-applet.js:10248
-#: 3.8/weather-applet.js:12263 3.8/weather-applet.js:14138
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Meglica"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10268
-#: 3.8/weather-applet.js:10269 3.8/weather-applet.js:12625
-#: 3.8/weather-applet.js:12626 3.8/weather-applet.js:12660
-#: 3.8/weather-applet.js:14182
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Pretežno oblačno"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10276
-#: 3.8/weather-applet.js:10283
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Manjše dežne plohe"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10289 3.8/weather-applet.js:10290
-#: 3.8/weather-applet.js:12235 3.8/weather-applet.js:14104
-#: 3.8/weather-applet.js:14406 3.8/weather-applet.js:14407
-#: 3.8/weather-applet.js:14462
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Pršenje"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10304
-#: 3.8/weather-applet.js:10311
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Močne dežne plohe"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10325
-#: 3.8/weather-applet.js:10332
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Plohe s sodro"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10345 3.8/weather-applet.js:10352
-#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:10360
-#: 3.8/weather-applet.js:14180
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Toča"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10346
-#: 3.8/weather-applet.js:10353
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Ploha s točo"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10367
-#: 3.8/weather-applet.js:10374
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Manjša snežna ploha"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10388
-#: 3.8/weather-applet.js:10395
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Močna snežna ploha"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10408 3.8/weather-applet.js:10415
-#: 3.8/weather-applet.js:10422 3.8/weather-applet.js:10423
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Grmenje"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10409
-#: 3.8/weather-applet.js:10416
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Nevihta s ploho"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:12106
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Preverite, da ima v nastavitvah lokacija pravilno obliko"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:12110
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Preverite, da ste v nastavitvah vnesli pravilen ključ"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11922 3.8/weather-applet.js:12114
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 "Lokacija ni najdena, preverite, da lokacija obstaja in da ima pravilno obliko"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:12118
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Če težava ostane, kontaktirajte avtorja aplikacije"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:12122
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Neznana napaka, preverite dnevniške zapise v Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:12224
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Nevihta z rahlim dežjem"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:12225
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Nevihta z dežjem"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:12226
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Nevihta z močnim dežjem"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:12227
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Manjša nevihta"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:12229
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Močna nevihta"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:12230
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Nevihta s prekinitvami"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:12231
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Nevihta z rahlim pršenjem"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:12232
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Nevihta s pršenjem"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:12233
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Nevihta z močnim pršenjem"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:12234
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Rahlo pršenje"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:12236
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Močno pršenje"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:12237
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Rahlo pršenje"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:12238
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Pršenje"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:12239
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Močno pršenje"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:12240
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Dežna ploha in pršenje"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:12241
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Močna dežna ploha in pršenje"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:12242
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Ploha s pršenjem"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:12244
-#: 3.8/weather-applet.js:14737 3.8/weather-applet.js:14738
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Zmeren dež"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:12245
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Močan dež"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:12246
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Zelo močan dež"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:12247
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Ekstremen dež"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:12249
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Rahla dežna ploha"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:12250
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Dežna ploha"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:12251
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Močna dežna ploha"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:12252
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Dežna ploha s prekinitvami"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:12257
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Plohe s sodro"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:12258
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Rahel dež s snegom"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:12259
-#: 3.8/weather-applet.js:14744 3.8/weather-applet.js:14745
-#: 3.8/weather-applet.js:14751 3.8/weather-applet.js:14786
-#: 3.8/weather-applet.js:14793
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 #, fuzzy
-#| msgid "Mixed rain and snow"
 msgid "Rain and snow"
 msgstr "Dež s snegom"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:12260
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Manjša snežna ploha"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:12261
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Snežna ploha"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:12262
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Močno snežna ploha"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:12264 3.8/weather-applet.js:12775
-#: 3.8/weather-applet.js:12776
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Dim"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:12265 3.8/weather-applet.js:12782
-#: 3.8/weather-applet.js:12783
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Meglica"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:12266
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Peščeni, prašni vrtinci"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:12268
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Pesek"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:12269 3.8/weather-applet.js:12768
-#: 3.8/weather-applet.js:12769
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Prah"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:12270
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Vulkanski pepel"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:12271
-#: 3.8/weather-applet.js:14172
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Sunki vetra"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:12272 3.8/weather-applet.js:12747
-#: 3.8/weather-applet.js:12748
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Tornado"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:12275
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Jasno nebo"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:12276
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Oblaki"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:12277
-#: 3.8/weather-applet.js:12604 3.8/weather-applet.js:12605
-#: 3.8/weather-applet.js:12639
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Nekaj oblakov"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:12278
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Raztreseni oblaki"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:12279
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Razpršeni oblaki"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:12280
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Pretežno oblačno"
 
@@ -1051,77 +1078,80 @@ msgstr "Pretežno oblačno"
 msgid "Could not get forecast for your area"
 msgstr "Za vaše področje ni mogoče pridobiti napovedi"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12309
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "Lokacija je zunaj ZDA, uporabite drugo storitev."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12373
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Neuspešna obdelava urne napovedi"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12633
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Jasno in vetrovno"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12640
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Nekaj oblakov in vetrovno"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12647
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Delno oblačno in vetrovno"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12654
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Pretežno oblačno in vetrovno"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12661
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Pretežno oblačno in vetrovno"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12675
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Dež s snegom"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12710
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Zmrznjen dež in sneg"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:8750 3.8/weather-applet.js:12754
-#: 3.8/weather-applet.js:12755
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Orkan"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:8745
-#: 3.8/weather-applet.js:12761
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Nevihta"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12762
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Tropska nevihta"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12789 3.8/weather-applet.js:12790
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Vroče"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12796 3.8/weather-applet.js:12797
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Mrzlo"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12803 3.8/weather-applet.js:12804
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Snežni metež"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:8634
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Danes"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:8636
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Jutri"
 
@@ -1153,79 +1183,79 @@ msgstr "Petek"
 msgid "Saturday"
 msgstr "Sobota"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:8715
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Mirno"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:8718
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Rahel piš"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:8721
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Rahla sapa"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:8724
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Nežen vetrič"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:8727
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Zmeren vetrič"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:8730
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Svež vetrič"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:8733
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Močan vetrič"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:8736
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Manjši sunki vetra"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:8739
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Sunki vetra"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:8742
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Močni sunki vetra"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:8748
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Silovito neurje"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "SV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "V"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "JV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "J"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "JZ"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "Z"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:8900
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "SZ"
 
@@ -1277,9 +1307,8 @@ msgstr ""
 "Pri pridobivanju vremena se je zgodila neznana napaka, preverite Looking "
 "Glass za več informacij"
 
-#: 3.0/yahoo.js:437
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 #, fuzzy
-#| msgid "Tropical storm"
 msgid "Tropical Storm"
 msgstr "Tropska nevihta"
 
@@ -1287,7 +1316,7 @@ msgstr "Tropska nevihta"
 msgid "Severe Thunderstorms"
 msgstr "Hude nevihte"
 
-#: 3.0/yahoo.js:440
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Nevihte"
 
@@ -1297,29 +1326,25 @@ msgstr "Dež s snegom"
 
 #: 3.0/yahoo.js:442
 #, fuzzy
-#| msgid "Mixed rain and sleet"
 msgid "Mixed Rain and Sleet"
 msgstr "Dež s sodro"
 
 #: 3.0/yahoo.js:443
 #, fuzzy
-#| msgid "Mixed snow and sleet"
 msgid "Mixed Snow and Sleet"
 msgstr "Sneg s sodro"
 
-#: 3.0/yahoo.js:444
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 #, fuzzy
-#| msgid "Freezing drizzle"
 msgid "Freezing Drizzle"
 msgstr "Zmrznjeno pršenje"
 
-#: 3.0/yahoo.js:446
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 #, fuzzy
-#| msgid "Freezing rain"
 msgid "Freezing Rain"
 msgstr "Zmrznjen dež"
 
-#: 3.0/yahoo.js:447
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Plohe"
 
@@ -1329,15 +1354,14 @@ msgstr "Naletavanje snega"
 
 #: 3.0/yahoo.js:450
 #, fuzzy
-#| msgid "Light snow showers"
 msgid "Light Snow Showers"
 msgstr "Manjše snežne plohe"
 
-#: 3.0/yahoo.js:451
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Snežni vihar"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:14723 3.8/weather-applet.js:14724
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Megleno"
 
@@ -1349,330 +1373,464 @@ msgstr "Zadimljeno"
 msgid "Blustery"
 msgstr "Viharno"
 
-#: 3.0/yahoo.js:460
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Vetrovno"
 
-#: 3.0/yahoo.js:463
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 #, fuzzy
-#| msgid "Mostly cloudy"
 msgid "Mostly Cloudy"
 msgstr "Pretežno oblačno"
 
-#: 3.0/yahoo.js:464
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 #, fuzzy
-#| msgid "Partly cloudy"
 msgid "Partly Cloudy"
 msgstr "Delno oblačno"
 
-#: 3.0/yahoo.js:467
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Pretežno jasno"
 
-#: 3.0/yahoo.js:469
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 #, fuzzy
-#| msgid "Mixed rain and hail"
 msgid "Mixed Rain and Hail"
 msgstr "Dež s točo"
 
-#: 3.0/yahoo.js:471
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 #, fuzzy
-#| msgid "Isolated thunderstorms"
 msgid "Isolated Thunderstorms"
 msgstr "Posamezne nevihte"
 
-#: 3.0/yahoo.js:472
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 #, fuzzy
-#| msgid "Scattered thunderstorms"
 msgid "Scattered Thunderstorms"
 msgstr "Razpršene nevihte"
 
-#: 3.0/yahoo.js:473
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 #, fuzzy
-#| msgid "Scattered showers"
 msgid "Scattered Showers"
 msgstr "Razpršene plohe"
 
-#: 3.0/yahoo.js:474
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Močan dež"
 
-#: 3.0/yahoo.js:475
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 #, fuzzy
-#| msgid "Scattered snow showers"
 msgid "Scattered Snow Showers"
 msgstr "Razpršene snežne plohe"
 
-#: 3.0/yahoo.js:476
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 #, fuzzy
-#| msgid "Heavy snow"
 msgid "Heavy Snow"
 msgstr "Močno sneženje"
 
 #: 3.0/yahoo.js:478
 #, fuzzy
-#| msgid "Not available"
 msgid "Not Available"
 msgstr "Ni na razpolago"
 
 #: 3.0/yahoo.js:479
 #, fuzzy
-#| msgid "Scattered thunderstorms"
 msgid "Scattered Thundershowers"
 msgstr "Razpršene nevihte"
 
+#: 3.8/weather-applet.js:9638
+msgid ""
+"Could not retrieve logs, log file was not found under path\n"
+" {logFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:9642
+msgid ""
+"Could not get contents of log file under path\n"
+" {logFilePath}"
+msgstr ""
+
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:9815
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:9999
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
+msgstr ""
+
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Za lokacijo ni najdenih podatkov"
 
-#: 3.8/weather-applet.js:10070
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Zelo slabo"
 
-#: 3.8/weather-applet.js:10070
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Manj kot {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10074
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Odlično"
 
-#: 3.8/weather-applet.js:10074
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Več kot {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10079
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Slabo"
 
-#: 3.8/weather-applet.js:10079 3.8/weather-applet.js:10084
-#: 3.8/weather-applet.js:10089 3.8/weather-applet.js:10094
-#: 3.8/weather-applet.js:10099
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Med {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10084
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Srednje"
 
-#: 3.8/weather-applet.js:10089
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Dobro"
 
-#: 3.8/weather-applet.js:10094 3.8/weather-applet.js:10099
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Zelo dobro"
 
-#: 3.8/weather-applet.js:10761
-msgid "Precipitation will end in {precipEnd} minutes"
-msgstr "Padavine bodo ponehale v {precipEnd} minutah"
-
-#: 3.8/weather-applet.js:10763
-msgid "Precipitation won't end in within an hour"
-msgstr "Padavine ne bodo ponehale v eni uri"
-
-#: 3.8/weather-applet.js:10766
-msgid "Precipitation will start within {precipStart} minutes"
-msgstr "Padavine bodo pričele v {precipStart} minutah"
-
-#: 3.8/weather-applet.js:11335 3.8/weather-applet.js:15025
-msgid "As of {lastUpdatedTime}"
-msgstr "Ob {lastUpdatedTime}"
-
-#: 3.8/weather-applet.js:11341
-msgid "{distance}{distanceUnit} from you"
-msgstr "{distance}{distanceUnit} od vas"
-
-#: 3.8/weather-applet.js:11582
-msgid "DarkSky"
-msgstr "DarkSky"
-
-#: 3.8/weather-applet.js:11606
-msgid "This API has ceased to function, please use another one."
-msgstr "API je prenehal delovati, uporabite drugega."
-
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11907
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
-#: 3.8/weather-applet.js:12290
-msgid "US Weather"
-msgstr "US Weather"
-
-#: 3.8/weather-applet.js:12834
-msgid "WeatherBit"
-msgstr "WeatherBit"
-
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13251
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:13924
-msgid "Visual Crossing"
-msgstr "Visual Crossing"
+#: 3.8/weather-applet.js:11955
+msgid "WeatherBit"
+msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:14102
+#: 3.8/weather-applet.js:12386
 #, fuzzy
-#| msgid "Blowing snow"
-msgid "Blowing or drifting snow"
-msgstr "Snežni vihar"
+msgid "Tomorrow.io"
+msgstr "Jutri"
 
-#: 3.8/weather-applet.js:14106
-msgid "Heavy drizzle"
-msgstr "Močno pršenje"
-
-#: 3.8/weather-applet.js:14110
-msgid "Heavy drizzle/rain"
-msgstr "Močno pršenje/dež"
-
-#: 3.8/weather-applet.js:14112
-msgid "Light drizzle/rain"
-msgstr "Rahlo pršenje/dež"
-
-#: 3.8/weather-applet.js:14114
-msgid "Duststorm"
-msgstr "Prašna nevihta"
-
-#: 3.8/weather-applet.js:14118
-msgid "Freezing drizzle/freezing rain"
-msgstr "Zmrznjeno pršenje/dež"
-
-#: 3.8/weather-applet.js:14120
-msgid "Heavy freezing drizzle/freezing rain"
-msgstr "Močno zmrznjeno pršenje/dež"
-
-#: 3.8/weather-applet.js:14122
-msgid "Light freezing drizzle/freezing rain"
-msgstr "Rahlo zmrznjeno pršenje/dež"
-
-#: 3.8/weather-applet.js:14124
-msgid "Freezing fog"
-msgstr "Zmrznjena megla"
-
-#: 3.8/weather-applet.js:14130
-msgid "Funnel cloud/tornado"
-msgstr "Lijakasti oblak/tornado"
-
-#: 3.8/weather-applet.js:14132
-msgid "Hail showers"
-msgstr "Plohe s točo"
-
-#: 3.8/weather-applet.js:14134
-msgid "Ice"
-msgstr "Led"
-
-#: 3.8/weather-applet.js:14136
-msgid "Lightning without thunder"
-msgstr "Bliskanje brez grmenja"
-
-#: 3.8/weather-applet.js:14140
-msgid "Precipitation in vicinity"
-msgstr "Padavine v bližini"
-
-#: 3.8/weather-applet.js:14144 3.8/weather-applet.js:14752
-msgid "Heavy rain and snow"
-msgstr "Močan dež in sneg"
-
-#: 3.8/weather-applet.js:14146
-msgid "Light rain And snow"
-msgstr "Rahel dež in sneg"
-
-#: 3.8/weather-applet.js:14154
-msgid "Sky coverage decreasing"
-msgstr "Pokritost neba se zmanjšuje"
-
-#: 3.8/weather-applet.js:14156
-msgid "Sky coverage increasing"
-msgstr "Pokritost neba se povečuje"
-
-#: 3.8/weather-applet.js:14158
-msgid "Sky unchanged"
-msgstr "Nebo je nespremenjeno"
-
-#: 3.8/weather-applet.js:14160
-msgid "Smoke or haze"
-msgstr "Dim ali meglica"
-
-#: 3.8/weather-applet.js:14164
-msgid "Snow and rain showers"
-msgstr "Snežne in dežne plohe"
-
-#: 3.8/weather-applet.js:14176
-msgid "Thunderstorm without precipitation"
-msgstr "Nevihta brez padavin"
-
-#: 3.8/weather-applet.js:14178
-msgid "Diamond dust"
-msgstr "Ledene iglice"
-
-#: 3.8/weather-applet.js:14184
-#, fuzzy
-#| msgid "Partly cloudy"
-msgid "Partially cloudy"
-msgstr "Delno oblačno"
-
-#: 3.8/weather-applet.js:14207
-msgid "Please make sure you entered the API key correctly"
-msgstr "Preverite, da ste vnesli pravilen ključ za API"
-
-#: 3.8/weather-applet.js:14221
-msgid "Climacell"
-msgstr "Climacell"
-
-#: 3.8/weather-applet.js:14386
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Šibek veter"
 
-#: 3.8/weather-applet.js:14400
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Močan veter"
 
+#: 3.8/weather-applet.js:12723
+msgid "US Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:13292
+msgid "Visual Crossing"
+msgstr "Visual Crossing"
+
+#: 3.8/weather-applet.js:13474
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "Snežni vihar"
+
+#: 3.8/weather-applet.js:13478
+msgid "Heavy drizzle"
+msgstr "Močno pršenje"
+
+#: 3.8/weather-applet.js:13482
+msgid "Heavy drizzle/rain"
+msgstr "Močno pršenje/dež"
+
+#: 3.8/weather-applet.js:13484
+msgid "Light drizzle/rain"
+msgstr "Rahlo pršenje/dež"
+
+#: 3.8/weather-applet.js:13486
+#, fuzzy
+msgid "Dust Storm"
+msgstr "Prašna nevihta"
+
+#: 3.8/weather-applet.js:13490
+msgid "Freezing drizzle/freezing rain"
+msgstr "Zmrznjeno pršenje/dež"
+
+#: 3.8/weather-applet.js:13492
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Močno zmrznjeno pršenje/dež"
+
+#: 3.8/weather-applet.js:13494
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Rahlo zmrznjeno pršenje/dež"
+
+#: 3.8/weather-applet.js:13496
+msgid "Freezing fog"
+msgstr "Zmrznjena megla"
+
+#: 3.8/weather-applet.js:13502
+msgid "Funnel cloud/tornado"
+msgstr "Lijakasti oblak/tornado"
+
+#: 3.8/weather-applet.js:13504
+msgid "Hail showers"
+msgstr "Plohe s točo"
+
+#: 3.8/weather-applet.js:13506
+msgid "Ice"
+msgstr "Led"
+
+#: 3.8/weather-applet.js:13508
+msgid "Lightning without thunder"
+msgstr "Bliskanje brez grmenja"
+
+#: 3.8/weather-applet.js:13512
+msgid "Precipitation in vicinity"
+msgstr "Padavine v bližini"
+
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
+msgid "Heavy rain and snow"
+msgstr "Močan dež in sneg"
+
+#: 3.8/weather-applet.js:13518
+msgid "Light rain And snow"
+msgstr "Rahel dež in sneg"
+
+#: 3.8/weather-applet.js:13526
+msgid "Sky coverage decreasing"
+msgstr "Pokritost neba se zmanjšuje"
+
+#: 3.8/weather-applet.js:13528
+msgid "Sky coverage increasing"
+msgstr "Pokritost neba se povečuje"
+
+#: 3.8/weather-applet.js:13530
+msgid "Sky unchanged"
+msgstr "Nebo je nespremenjeno"
+
+#: 3.8/weather-applet.js:13532
+msgid "Smoke or haze"
+msgstr "Dim ali meglica"
+
+#: 3.8/weather-applet.js:13536
+msgid "Snow and rain showers"
+msgstr "Snežne in dežne plohe"
+
+#: 3.8/weather-applet.js:13548
+msgid "Thunderstorm without precipitation"
+msgstr "Nevihta brez padavin"
+
+#: 3.8/weather-applet.js:13550
+msgid "Diamond dust"
+msgstr "Ledene iglice"
+
+#: 3.8/weather-applet.js:13556
+#, fuzzy
+msgid "Partially cloudy"
+msgstr "Delno oblačno"
+
+#: 3.8/weather-applet.js:13578
+msgid "Please make sure you entered the API key correctly"
+msgstr "Preverite, da ste vnesli pravilen ključ za API"
+
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:14544
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:14684 3.8/weather-applet.js:14685
-#: 3.8/weather-applet.js:14821 3.8/weather-applet.js:14822
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "NI NAJDENO"
 
-#: 3.8/weather-applet.js:14717
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Snežni vihar"
 
-#: 3.8/weather-applet.js:14758 3.8/weather-applet.js:14759
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Rahlo sneženje"
 
-#: 3.8/weather-applet.js:14765 3.8/weather-applet.js:14766
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Zmerno sneženje"
 
-#: 3.8/weather-applet.js:14780
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Zmerne snežne plohe"
 
-#: 3.8/weather-applet.js:14787
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Dež s snegom"
 
-#: 3.8/weather-applet.js:14794
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Močan dež s snegom"
 
-#: 3.8/weather-applet.js:14986
+#: 3.8/weather-applet.js:14024
+#, fuzzy
+msgid "AccuWeather"
+msgstr "Vreme"
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+#, fuzzy
+msgid "Weather Underground"
+msgstr "Vremenske razmere"
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+msgid "The location you provided was not found."
+msgstr ""
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+#, fuzzy
+msgid "Strong Storm"
+msgstr "Močan vetrič"
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "Dež s snegom"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "Dež s sodro"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "Snežne plohe"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "Pretežno jasno"
+
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:15603
+#, fuzzy
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+"Lokacijska storitev je sporočila napako, preverite dnevniški zapis v Looking "
+"Glass"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr "Preverite, da ste vnesli lokacijo ali pa uporabite samodejno lokacijo"
+
+#: 3.8/weather-applet.js:15968
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:15975
+msgid ""
+"Could not get contents of config file under path\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:16233
 msgid "This provider requires an API key to operate"
 msgstr "Storitev za delovanje zahteva ključ za API"
+
+#: 3.8/weather-applet.js:16675
+msgid "Dew Point"
+msgstr ""
+
+#: 3.8/weather-applet.js:16747
+msgid "Precipitation will end in {precipEnd} minutes"
+msgstr "Padavine bodo ponehale v {precipEnd} minutah"
+
+#: 3.8/weather-applet.js:16749
+msgid "Precipitation won't end in within an hour"
+msgstr "Padavine ne bodo ponehale v eni uri"
+
+#: 3.8/weather-applet.js:16752
+msgid "Precipitation will start within {precipStart} minutes"
+msgstr "Padavine bodo pričele v {precipStart} minutah"
+
+#: 3.8/weather-applet.js:16964
+msgid "Forecast parsing failed, see logs for more details."
+msgstr ""
+
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
+msgid "As of {lastUpdatedTime}"
+msgstr "Ob {lastUpdatedTime}"
+
+#: 3.8/weather-applet.js:17502
+#, fuzzy
+msgid "{distance} {distanceUnit} from you"
+msgstr "{distance}{distanceUnit} od vas"
+
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
+msgid "Error Saving Debug Information"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Debug Information saved successfully"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Saved to {filePath}"
+msgstr ""
+
+#: 3.8/LogSaver.py:16
+msgid "Save to File"
+msgstr ""
+
+#: 3.8/LogSaver.py:29
+msgid "Select a destination"
+msgstr ""
 
 #. metadata.json->name
 #. 3.8->settings-schema.json->providers->title
@@ -1717,7 +1875,6 @@ msgid "Data service"
 msgstr "Podatkovna storitev"
 
 #. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
 msgid "DarkSky (key needed)"
 msgstr "DarkSky (potreben ključ)"
 
@@ -1952,7 +2109,6 @@ msgid "Override label on panel"
 msgstr "Prednostna oznaka v opravilni vrstici"
 
 #. 3.0->settings-schema.json->tempTextOverride->tooltip
-#. 3.8->settings-schema.json->tempTextOverride->tooltip
 msgid ""
 "Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
 "Can be used if label does not fit on vertical panel, among other smart "
@@ -2024,7 +2180,8 @@ msgid "Only display hours for hourly forecast time"
 msgstr "Za čas urne napovedi prikaži samo ure"
 
 #. 3.0->settings-schema.json->shortHourlyTime->tooltip
-msgid "Instead of 15:00 or 3 pm it will show up as 15 or 3 pm"
+#. 3.8->settings-schema.json->shortHourlyTime->tooltip
+msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
 msgstr "Namesto 15:00 ali 3:00 pm bo prikazano kot 15 ali 3 pm"
 
 #. 3.0->settings-schema.json->showForecastDates->description
@@ -2116,7 +2273,6 @@ msgstr "Ostale enote"
 
 #. 3.8->settings-schema.json->temp-unit-section->title
 #, fuzzy
-#| msgid "Temperature unit"
 msgid "Temperature Unit"
 msgstr "Enota za temperaturo"
 
@@ -2131,6 +2287,11 @@ msgstr "Več o aplikaciji Vreme"
 #. 3.8->settings-schema.json->submit-issue->title
 msgid "Report an issue"
 msgstr "Prijavite napako"
+
+#. 3.8->settings-schema.json->debug-options->title
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Debug"
+msgstr ""
 
 #. 3.8->settings-schema.json->dataService->tooltip
 msgid ""
@@ -2147,6 +2308,10 @@ msgstr ""
 "lahko dosežete preko zavihka Pomoč."
 
 #. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Met Office UK (UK only)"
 msgstr "Met Office UK (samo za Združeno kraljestvo)"
 
@@ -2155,12 +2320,28 @@ msgid "US National Weather (US only)"
 msgstr "US National Weather (samo za ZDA)"
 
 #. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Pirate Weather (key needed)"
+msgstr "Weatherbit (potreben ključ)"
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Visual Crossing (key needed)"
 msgstr "Visual Crossing (potreben ključ)"
 
 #. 3.8->settings-schema.json->dataService->options
-msgid "ClimacellV4 (key needed)"
-msgstr "ClimacellV4 (potreben ključ)"
+#, fuzzy
+msgid "Tomorrow.io (key needed)"
+msgstr "Weatherbit (potreben ključ)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "AccuWeather (key needed)"
+msgstr "Weatherbit (potreben ključ)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Weather Underground (key needed)"
+msgstr "Weatherbit (potreben ključ)"
 
 #. 3.8->settings-schema.json->location->tooltip
 msgid ""
@@ -2174,6 +2355,12 @@ msgstr ""
 "Država (npr. London,UK) ali pa poskusite vnest {House number} {Street} {City/"
 "Town} {Postcode} {Country}. Iskalni algoritem je fleksibilen glede oblike. "
 "Po 3 sekundah po vnosu se vnos samodejno preveri."
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
 
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"
@@ -2200,9 +2387,20 @@ msgstr ""
 "presegel kvote."
 
 #. 3.8->settings-schema.json->forecastDays->tooltip
+#, fuzzy
 msgid ""
-"Maximum number of days that can be displayed, maximum rows and columns "
-"setting in the Presentation tab will affect the final number."
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+"Največje število dni, ki bo prikazano Največje število vrstic in stolpcev v "
+"predstavitvenem zavihku bo vplivalo na končno vrednost."
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+#, fuzzy
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
 msgstr ""
 "Največje število dni, ki bo prikazano Največje število vrstic in stolpcev v "
 "predstavitvenem zavihku bo vplivalo na končno vrednost."
@@ -2212,10 +2410,11 @@ msgid "Enable minutely precipitation forecast"
 msgstr "Omogoči minutno napoved padavin"
 
 #. 3.8->settings-schema.json->immediatePrecip->tooltip
+#, fuzzy
 msgid ""
 "If you'd like to use this make sure you use your exact coordinates/address "
-"as location to help its accuracy. Currently implemented with OpenWeatherMap "
-"only."
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
 msgstr ""
 "Če želite uporabiti, uporabite čim bolj točne koordinate. Trenutno omogočeno "
 "le pri OpenWeatherMap."
@@ -2223,6 +2422,38 @@ msgstr ""
 #. 3.8->settings-schema.json->showBothTempUnits->description
 msgid "Show both temperature units at the same time"
 msgstr "Hkrati prikaži obe enoti za temperaturo"
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+#, fuzzy
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+"Možne vrednosti: {c} so razmere, {t} je temperatura in {u} je enota.\n"
+"Lahko uporabite, če oznaka ne ustreza vertikalni vrstici ali pa za kaj "
+"drugega."
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+#, fuzzy
+msgid "Override tooltip on panel"
+msgstr "Prednostna oznaka v opravilni vrstici"
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
+msgid "Always show Hourly Weather"
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->tooltip
+msgid ""
+"Hide/Show button will be hidden and Hourly weather will be permanently "
+"visible."
+msgstr ""
 
 #. 3.8->settings-schema.json->verticalOrientation->tooltip
 msgid "Displaying forecasts from top to bottom instead from left to right."
@@ -2272,10 +2503,6 @@ msgstr "Prikaži smer vetra kot besedilo"
 msgid "Like SE, N instead of direction icons."
 msgstr "Kot npr. SV, S namesto ikon za smer."
 
-#. 3.8->settings-schema.json->shortHourlyTime->tooltip
-msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
-msgstr "Namesto 15:00 ali 3:00 pm bo prikazano kot 15 ali 3 pm"
-
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"
 msgstr "Ne nanaša se na nabor ikon po meri, ki je privzeto simboličen"
@@ -2312,13 +2539,17 @@ msgid "Current maintainer: Gr3q"
 msgstr "Trenutni vzdrževalec: Gr3q"
 
 #. 3.8->settings-schema.json->issue-reporting-explanation->description
+#, fuzzy
 msgid ""
 "If you find an issue with this applet please make a report by clicking on "
-"the button below and login in with your Github account. Before you start "
-"writing please make sure that the issue is not already submitted in the "
-"issues section. Don't forget to write weather@mockturtl in the top Title "
-"field to make it easier for everyone to know that the issue is about the "
-"weather applet (the form is for all Cinnamon applets)."
+"the button below and login in with your Github account.\n"
+"\n"
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
 msgstr ""
 "Če najdete težavo s to aplikacijo, sporočite to s klikom na spodnji gumb."
 
@@ -2335,41 +2566,31 @@ msgstr ""
 "ročno z vnosom koordinat ali pa kode mesta,države. Lahko poskusite z{House "
 "number} {Street} {City/Town} {Postcode} {Country}."
 
-#~ msgid "Settings"
-#~ msgstr "Nastavitve"
+#. 3.8->settings-schema.json->logLevel->description
+msgid "Log Level"
+msgstr ""
 
-#~ msgid "Sunrise"
-#~ msgstr "Sončni vzhod"
+#. 3.8->settings-schema.json->logLevel->tooltip
+msgid ""
+"Info is the regular logging, Debug is debug, and Verbose also logs network "
+"request payloads. Changing this will only be effective on future logs. Only "
+"change it you are instructed or you know what you are doing."
+msgstr ""
 
-#~ msgid "Sunset"
-#~ msgstr "Sončni zahod"
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Verbose"
+msgstr ""
 
-#~ msgid "Wind Chill:"
-#~ msgstr "Občutek mraza:"
+#. 3.8->settings-schema.json->fileSelect->description
+msgid "Click Save to save debug information to a file"
+msgstr ""
 
-#~ msgid "Isolated thundershowers"
-#~ msgstr "Posamezne nevihte s plohami"
+#. 3.8->settings-schema.json->fileSelect->tooltip
+msgid ""
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
+msgstr ""
 
-#~ msgid "Get WOEID"
-#~ msgstr "Pridobi WOEID"
-
-#~ msgid "http://woeid.rosselliot.co.nz/"
-#~ msgstr "http://woeid.rosselliot.co.nz/"
-
-#~ msgid "Vertical orientation"
-#~ msgstr "Navpična postavitev"
-
-#~ msgid "WOEID"
-#~ msgstr "WOEID"
-
-#~ msgid "Where On Earth ID"
-#~ msgstr "Identifikacijska številka kraja na zemlji"
-
-#~ msgid "kPa"
-#~ msgstr "kPa"
-
-#~ msgid "mbar"
-#~ msgstr "mbar"
-
-#~ msgid "Symbolic icons"
-#~ msgstr "Simbolične ikone"
+#. 3.8->settings-schema.json->selectedLogPath->description
+msgid "Selected path to save Logs"
+msgstr ""

--- a/weather@mockturtl/files/weather@mockturtl/po/sr.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/sr.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-07 14:19+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2021-02-16 11:25+0100\n"
 "Last-Translator: Knez <vladimirknezev@gmail.com>\n"
 "Language-Team: Serbia <LL@li.org>\n"
@@ -17,495 +18,100 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
 
-#: applet.js:337 3.0/applet.js:234 3.8/applet.js:184
-msgid "..."
-msgstr "..."
-
-#: applet.js:338 3.0/applet.js:235 3.8/applet.js:185
-msgid "Click to open"
-msgstr "Кликни за отварање"
-
-#: applet.js:389
-msgid "Settings"
-msgstr "Поставке"
-
-#: applet.js:511
-msgid "No location provided"
-msgstr "Нема постављене локације"
-
-#: applet.js:610 3.0/applet.js:563 3.8/applet.js:472
-msgid "Cloudiness"
-msgstr "Облачност"
-
-#: applet.js:634 3.0/applet.js:593 3.8/applet.js:502
-msgid "Sunrise"
-msgstr "Излазак сунца"
-
-#: applet.js:635 3.0/applet.js:594 3.8/applet.js:503
-msgid "Sunset"
-msgstr "Залазак сунца"
-
-#: applet.js:708 3.0/applet.js:686 3.8/applet.js:595
-msgid "Loading current weather ..."
-msgstr "Учитавање тренутне прогнозе..."
-
-#: applet.js:709 3.0/applet.js:689 3.8/applet.js:598
-msgid "Loading future weather ..."
-msgstr "Учитавање будуће прогнозе..."
-
-#: applet.js:731 3.0/applet.js:718 3.8/applet.js:627
-msgid "Loading ..."
-msgstr "Учитавање..."
-
-#: applet.js:737 3.0/applet.js:268 3.0/applet.js:708 3.8/applet.js:218 3.8/applet.js:617
-msgid "Refresh"
-msgstr "Освежи"
-
-#: applet.js:802 3.0/applet.js:740 3.8/applet.js:649
-msgid "Temperature:"
-msgstr "Температура"
-
-#: applet.js:804 3.0/applet.js:741 3.8/applet.js:650
-msgid "Humidity:"
-msgstr "Влажност:"
-
-#: applet.js:806 3.0/applet.js:742 3.8/applet.js:651
-msgid "Pressure:"
-msgstr "Притисак:"
-
-#: applet.js:808 3.0/applet.js:743 3.8/applet.js:652
-msgid "Wind:"
-msgstr "Ветар:"
-
-#: applet.js:1026 3.0/utils.js:73 3.8/utils.js:73
-msgid "Sunday"
-msgstr "Недеља"
-
-#: applet.js:1026 3.0/utils.js:73 3.8/utils.js:73
-msgid "Monday"
-msgstr "Понедељак"
-
-#: applet.js:1026 3.0/utils.js:73 3.8/utils.js:73
-msgid "Tuesday"
-msgstr "Уторак"
-
-#: applet.js:1026 3.0/utils.js:73 3.8/utils.js:73
-msgid "Wednesday"
-msgstr "Среда"
-
-#: applet.js:1026 3.0/utils.js:73 3.8/utils.js:73
-msgid "Thursday"
-msgstr "Четвртак"
-
-#: applet.js:1026 3.0/utils.js:73 3.8/utils.js:73
-msgid "Friday"
-msgstr "Петак"
-
-#: applet.js:1026 3.0/utils.js:73 3.8/utils.js:73
-msgid "Saturday"
-msgstr "Субота"
-
-#: applet.js:1030 3.0/utils.js:178 3.8/utils.js:178
-msgid "N"
-msgstr "С"
-
-#: applet.js:1030 3.0/utils.js:178 3.8/utils.js:178
-msgid "NE"
-msgstr "СИ"
-
-#: applet.js:1030 3.0/utils.js:178 3.8/utils.js:178
-msgid "E"
-msgstr "И"
-
-#: applet.js:1030 3.0/utils.js:178 3.8/utils.js:178
-msgid "SE"
-msgstr "ЈИ"
-
-#: applet.js:1030 3.0/utils.js:178 3.8/utils.js:178
-msgid "S"
-msgstr "Ј"
-
-#: applet.js:1030 3.0/utils.js:178 3.8/utils.js:178
-msgid "SW"
-msgstr "ЈЗ"
-
-#: applet.js:1030 3.0/utils.js:178 3.8/utils.js:178
-msgid "W"
-msgstr "З"
-
-#: applet.js:1030 3.0/utils.js:178 3.8/utils.js:178
-msgid "NW"
-msgstr "СЗ"
-
-#: applet.js:1080
-msgid "Service Unavailable"
-msgstr "Услуга недоступна"
-
-#: applet.js:1084 3.0/applet.js:195 3.0/applet.js:197 3.0/applet.js:199 3.0/applet.js:202
-#: 3.0/applet.js:205 3.0/applet.js:206 3.0/applet.js:207 3.0/applet.js:208 3.8/applet.js:146
-#: 3.8/applet.js:148 3.8/applet.js:150 3.8/applet.js:153 3.8/applet.js:156 3.8/applet.js:157
-#: 3.8/applet.js:158 3.8/applet.js:159
-msgid "Service Error"
-msgstr "Грешка услуге"
-
-#: applet.js:1086
-msgid "Wrong API Key"
-msgstr "Неисправан АПИ кључ"
-
-#: applet.js:1089
-msgid "City Not found"
-msgstr "Град није пронађен"
-
-#: applet.js:1092
-msgid "Key Temp. Blocked"
-msgstr "Кључ темп. блокиран"
-
-#: 3.0/darkSky.js:64 3.8/darkSky.js:29
-msgid "and"
-msgstr "и"
-
-#: 3.0/darkSky.js:64 3.8/darkSky.js:29
-msgid "until"
-msgstr "до"
-
-#: 3.0/darkSky.js:64 3.8/darkSky.js:29
-msgid "in"
-msgstr "у"
-
-#: 3.0/darkSky.js:165 3.8/darkSky.js:118
-msgid "Failed to Process Weather Info"
-msgstr "Обрада информација о времену није успела"
-
-#: 3.0/darkSky.js:181 3.8/darkSky.js:134
-msgid ""
-"Please enter API key in settings,\n"
-"or get one first on https://darksky.net/dev/register"
-msgstr ""
-"Молимо вас да унесете АПИ кључ у подешавањима,\n"
-"или узмите прво један са https://darksky.net/dev/register"
-
-#: 3.0/darkSky.js:218 3.8/darkSky.js:171
-msgid ""
-"Please Make sure you\n"
-"entered the API key correctly"
-msgstr ""
-"Проверите да ли сте\n"
-"правилно унели АПИ кључ"
-
-#: 3.0/ipApi.js:85 3.8/ipApi.js:40
-msgid "Could not obtain location"
-msgstr "Није могуће добити локацију"
-
-#: 3.0/ipApi.js:91 3.8/ipApi.js:46
-msgid "Location Service responded with errors, please see the logs in Looking Glass"
-msgstr "Локацијска служба одговорила је на грешке, погледајте записнике у прозорче огледала"
-
-#: 3.0/openWeatherMap.js:153 3.8/openWeatherMap.js:96
-msgid "Failed to Process Current Weather Info"
-msgstr "Обрада тренутних информација о времену није успела"
-
-#: 3.0/openWeatherMap.js:202 3.8/openWeatherMap.js:145
-msgid "Failed to Process Forecast Info"
-msgstr "Информације о прогнози нису успеле"
-
-#: 3.0/openWeatherMap.js:218 3.8/openWeatherMap.js:161
-msgid "Please enter a Location in settings"
-msgstr "Унесите локацију у подешавањима"
-
-#: 3.0/openWeatherMap.js:245 3.8/openWeatherMap.js:188
-msgid "Please make sure Location is in the correct format in the Settings"
-msgstr "Проверите да ли је локација у исправном формату у подешавањима"
-
-#: 3.0/openWeatherMap.js:249 3.8/openWeatherMap.js:192
-msgid "Make sure you entered the correct key in settings"
-msgstr "Проверите да ли сте унели исправан кључ у подешавању"
-
-#: 3.0/openWeatherMap.js:253 3.0/openWeatherMap.js:273 3.8/openWeatherMap.js:196
-#: 3.8/openWeatherMap.js:216
-msgid "Location not found, make sure location is available or it is in the correct format"
-msgstr "Локација није пронађена, проверите да ли је локација доступна или је исправнаформат"
-
-#: 3.0/openWeatherMap.js:257 3.8/openWeatherMap.js:200
-msgid "If this problem persists, please contact the Author of this applet"
-msgstr "Ако овај проблем и даље постоји, обратите се аутору овог програмчета"
-
-#: 3.0/openWeatherMap.js:261 3.8/openWeatherMap.js:204
-msgid "Unknown Error, please see the logs in Looking Glass"
-msgstr "Непозната грешка, погледајте записнике у прозорче огледала"
-
-#: 3.0/openWeatherMap.js:326 3.8/openWeatherMap.js:268
-msgid "Thunderstorm with light rain"
-msgstr "Грмљавина са слабом кишом"
-
-#: 3.0/openWeatherMap.js:327 3.8/openWeatherMap.js:269
-msgid "Thunderstorm with rain"
-msgstr "Грмљавина са кишом"
-
-#: 3.0/openWeatherMap.js:328 3.8/openWeatherMap.js:270
-msgid "Thunderstorm with heavy rain"
-msgstr "Грмљавина са јаком кишом"
-
-#: 3.0/openWeatherMap.js:329 3.8/openWeatherMap.js:271
-msgid "Light thunderstorm"
-msgstr "Слаба олуја с грмљавином"
-
-#: 3.0/openWeatherMap.js:330 3.8/openWeatherMap.js:272
-msgid "Thunderstorm"
-msgstr "Олуја с грмљавином"
-
-#: 3.0/openWeatherMap.js:331 3.8/openWeatherMap.js:273
-msgid "Heavy thunderstorm"
-msgstr "Јака олуја с грмљавином"
-
-#: 3.0/openWeatherMap.js:332 3.8/openWeatherMap.js:274
-msgid "Ragged thunderstorm"
-msgstr "Изузетно јака грмљавина"
-
-#: 3.0/openWeatherMap.js:333 3.8/openWeatherMap.js:275
-msgid "Thunderstorm with light drizzle"
-msgstr "Грмљавина са слабим ромињањем кише"
-
-#: 3.0/openWeatherMap.js:334 3.8/openWeatherMap.js:276
-msgid "Thunderstorm with drizzle"
-msgstr "Грмљавина са ромињањем"
-
-#: 3.0/openWeatherMap.js:335 3.8/openWeatherMap.js:277
-msgid "Thunderstorm with heavy drizzle"
-msgstr "Грмљавина са јаким ромињањем"
-
-#: 3.0/openWeatherMap.js:336 3.8/openWeatherMap.js:278
-msgid "Light intensity drizzle"
-msgstr "Слабо ромињање"
-
-#: 3.0/openWeatherMap.js:337 3.8/openWeatherMap.js:279
-msgid "Drizzle"
-msgstr "Ромињање"
-
-#: 3.0/openWeatherMap.js:338 3.8/openWeatherMap.js:280
-msgid "Heavy intensity drizzle"
-msgstr "Јако ромињање"
-
-#: 3.0/openWeatherMap.js:339 3.8/openWeatherMap.js:281
-msgid "Light intensity drizzle rain"
-msgstr "Слабо ромињање кише"
-
-#: 3.0/openWeatherMap.js:340 3.8/openWeatherMap.js:282
-msgid "Drizzle rain"
-msgstr "Ромињање кише"
-
-#: 3.0/openWeatherMap.js:341 3.8/openWeatherMap.js:283
-msgid "Heavy intensity drizzle rain"
-msgstr "Јако ромињање кише"
-
-#: 3.0/openWeatherMap.js:342 3.8/openWeatherMap.js:284
-msgid "Shower rain and drizzle"
-msgstr "Пљускови и ромињање"
-
-#: 3.0/openWeatherMap.js:343 3.8/openWeatherMap.js:285
-msgid "Heavy shower rain and drizzle"
-msgstr "Јаки пљускови и ромињање"
-
-#: 3.0/openWeatherMap.js:344 3.8/openWeatherMap.js:286
-msgid "Shower drizzle"
-msgstr "Ромињање"
-
-#: 3.0/openWeatherMap.js:345 3.8/openWeatherMap.js:287
-msgid "Light rain"
-msgstr "Слаба киша"
-
-#: 3.0/openWeatherMap.js:346 3.8/openWeatherMap.js:288
-msgid "Moderate rain"
-msgstr "Умерена киша"
-
-#: 3.0/openWeatherMap.js:347 3.8/openWeatherMap.js:289
-msgid "Heavy intensity rain"
-msgstr "Јака киша"
-
-#: 3.0/openWeatherMap.js:348 3.8/openWeatherMap.js:290
-msgid "Very heavy rain"
-msgstr "Веома јака киша"
-
-#: 3.0/openWeatherMap.js:349 3.8/openWeatherMap.js:291
-msgid "Extreme rain"
-msgstr "Екстремна киша"
-
-#: 3.0/openWeatherMap.js:350 3.8/openWeatherMap.js:292
-msgid "Freezing rain"
-msgstr "Ледена киша"
-
-#: 3.0/openWeatherMap.js:351 3.8/openWeatherMap.js:293
-msgid "Light intensity shower rain"
-msgstr "Слаби краткотрајни пљусак"
-
-#: 3.0/openWeatherMap.js:352 3.8/openWeatherMap.js:294
-msgid "Shower rain"
-msgstr "Пљусак"
-
-#: 3.0/openWeatherMap.js:353 3.8/openWeatherMap.js:295
-msgid "Heavy intensity shower rain"
-msgstr "Јак краткотрајни пљусак"
-
-#: 3.0/openWeatherMap.js:354 3.8/openWeatherMap.js:296
-msgid "Ragged shower rain"
-msgstr "Изузетно јак пљусак"
-
-#: 3.0/openWeatherMap.js:355 3.8/openWeatherMap.js:297
-msgid "Light snow"
-msgstr "Слаб снег"
-
-#: 3.0/openWeatherMap.js:356 3.8/openWeatherMap.js:298
-msgid "Snow"
-msgstr "Снег"
-
-#: 3.0/openWeatherMap.js:357 3.8/openWeatherMap.js:299
-msgid "Heavy snow"
-msgstr "Јак снег"
-
-#: 3.0/openWeatherMap.js:358 3.8/openWeatherMap.js:300
-msgid "Sleet"
-msgstr "Суснежица"
-
-#: 3.0/openWeatherMap.js:359 3.8/openWeatherMap.js:301
-msgid "Shower sleet"
-msgstr "Јака суснежица"
-
-#: 3.0/openWeatherMap.js:360 3.8/openWeatherMap.js:302
-msgid "Light rain and snow"
-msgstr "Слба киша и снег"
-
-#: 3.0/openWeatherMap.js:361 3.8/openWeatherMap.js:303
-msgid "Rain and snow"
-msgstr "Киша и снег"
-
-#: 3.0/openWeatherMap.js:362 3.8/openWeatherMap.js:304
-msgid "Light shower snow"
-msgstr "Блага падавина снега"
-
-#: 3.0/openWeatherMap.js:363 3.8/openWeatherMap.js:305
-msgid "Shower snow"
-msgstr "Мећава"
-
-#: 3.0/openWeatherMap.js:364 3.8/openWeatherMap.js:306
-msgid "Heavy shower snow"
-msgstr "Јак мећаве"
-
-#: 3.0/openWeatherMap.js:365 3.8/openWeatherMap.js:307
-msgid "Mist"
-msgstr "Сумаглица"
-
-#: 3.0/openWeatherMap.js:366 3.8/openWeatherMap.js:308
-msgid "Smoke"
-msgstr "Дим"
-
-#: 3.0/openWeatherMap.js:367 3.8/openWeatherMap.js:309
-msgid "Haze"
-msgstr "Измаглица"
-
-#: 3.0/openWeatherMap.js:368 3.8/openWeatherMap.js:310
-msgid "Sand, dust whirls"
-msgstr "Песак, ковитлаци прашине"
-
-#: 3.0/openWeatherMap.js:369 3.8/openWeatherMap.js:311
-msgid "Fog"
-msgstr "Магла"
-
-#: 3.0/openWeatherMap.js:370 3.8/openWeatherMap.js:312
-msgid "Sand"
-msgstr "Песак"
-
-#: 3.0/openWeatherMap.js:371 3.8/openWeatherMap.js:313
-msgid "Dust"
-msgstr "Прашина"
-
-#: 3.0/openWeatherMap.js:372 3.8/openWeatherMap.js:314
-msgid "Volcanic ash"
-msgstr "Вулкански пепео"
-
-#: 3.0/openWeatherMap.js:373 3.8/openWeatherMap.js:315
-msgid "Squalls"
-msgstr "Бура"
-
-#: 3.0/openWeatherMap.js:374 3.8/openWeatherMap.js:316
-msgid "Tornado"
-msgstr "Торнадо"
-
-#: 3.0/openWeatherMap.js:375 3.8/openWeatherMap.js:317
-msgid "Clear"
-msgstr "Ведро"
-
-#: 3.0/openWeatherMap.js:376 3.8/openWeatherMap.js:318
-msgid "Clear sky"
-msgstr "Ведро"
-
-#: 3.0/openWeatherMap.js:377 3.8/openWeatherMap.js:319
-msgid "Sky is clear"
-msgstr "Ведро"
-
-#: 3.0/openWeatherMap.js:378 3.8/openWeatherMap.js:320
-msgid "Few clouds"
-msgstr "Мало облака"
-
-#: 3.0/openWeatherMap.js:379 3.8/openWeatherMap.js:321
-msgid "Scattered clouds"
-msgstr "Распирени облаци"
-
-#: 3.0/openWeatherMap.js:380 3.8/openWeatherMap.js:322
-msgid "Broken clouds"
-msgstr "Испрекидани облаци"
-
-#: 3.0/openWeatherMap.js:381 3.8/openWeatherMap.js:323
-msgid "Overcast clouds"
-msgstr "Тмурно"
-
-#: 3.0/applet.js:194 3.8/applet.js:145
+#: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Грешка"
 
-#: 3.0/applet.js:196 3.8/applet.js:147
+#: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
+#: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
+msgid "Service Error"
+msgstr "Грешка услуге"
+
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Нетачан АПИ кључ"
 
-#: 3.0/applet.js:198 3.8/applet.js:149
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Нетачан формат локације"
 
-#: 3.0/applet.js:200 3.8/applet.js:151
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Кључ је блокиран"
 
-#: 3.0/applet.js:201 3.8/applet.js:152
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Није могуће пронаћи локацију"
 
-#: 3.0/applet.js:203 3.8/applet.js:154
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Нема Апи кључа"
 
-#: 3.0/applet.js:204 3.8/applet.js:155
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Нема локације"
 
-#: 3.0/applet.js:442 3.8/applet.js:367
-msgid "Make sure you entered a location or use Automatic location instead"
-msgstr "Проверите да ли сте унели локацију или уместо ње користите Аутоматску локацију"
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
+msgid "Missing Packages"
+msgstr ""
 
-#: 3.0/applet.js:487 3.8/applet.js:399
-msgid "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
-msgstr "Неочекивана грешка током освежавања времена, погледајте записнике у прозорче огледала"
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
+#, fuzzy
+msgid "Location not covered"
+msgstr "Нема постављене локације"
 
-#: 3.0/applet.js:569 3.8/applet.js:478
-msgid "Feels like"
-msgstr "Као да је"
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
+#, fuzzy
+msgid "Weather Applet"
+msgstr "Време"
 
-#: 3.0/applet.js:628 3.8/applet.js:537
-msgid "Today"
-msgstr "Данас"
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
+msgid "..."
+msgstr "..."
 
-#: 3.0/applet.js:630 3.8/applet.js:539
-msgid "Tomorrow"
-msgstr "Сутра"
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
+msgid "Click to open"
+msgstr "Кликни за отварање"
 
-#: 3.0/applet.js:828 3.8/applet.js:737
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
+msgid "Refresh"
+msgstr "Освежи"
+
+#: 3.0/applet.js:272
+msgid "API returned status code between 400 and 500"
+msgstr ""
+
+#: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
+#: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
+#, fuzzy
+msgid "Location Store"
+msgstr "Локација"
+
+#: 3.0/applet.js:426
+msgid "You can't save a location obtained automatically, sorry"
+msgstr ""
+
+#: 3.0/applet.js:601
+#, fuzzy
+msgid "Could not get weather information"
+msgstr "Није могуће добити локацију"
+
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
+msgid ""
+"Unexpected Error While Refreshing Weather, please see log in Looking Glass"
+msgstr ""
+"Неочекивана грешка током освежавања времена, погледајте записнике у прозорче "
+"огледала"
+
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -513,238 +119,1798 @@ msgstr ""
 "Није могуће ажурирати време...\n"
 "да ли сте повезани на интернет"
 
-#: 3.0/applet.js:841 3.8/applet.js:750
+#: 3.0/applet.js:684
 msgid "Network Error, please check logs in Looking Glass"
 msgstr "Мрежна грешка, погледајте записнике у прозорче огледала"
 
-#. settings-schema.json->head->description
-msgid "Settings for weather@mockturtl 1.8+"
-msgstr "Подешавања за weather@mockturtl 1.8+"
+#: 3.0/applet.js:969 3.0/applet.js:1110
+msgid "As of"
+msgstr ""
 
-#. settings-schema.json->keybinding->description
-#. 3.0->settings-schema.json->keybinding->description
-#. 3.8->settings-schema.json->keybinding->description
-msgid "Set the keybinding to call the menu"
-msgstr "Подесите тастера да бисте сте позвали изборник"
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
+msgid "Powered by"
+msgstr ""
 
-#. settings-schema.json->providerSettings->description
-#. 3.0->settings-schema.json->providerSettings->description
-#. 3.8->settings-schema.json->providerSettings->description
-msgid "Weather Provider Settings"
-msgstr "Подешавања временског провајдера"
+#: 3.0/applet.js:1113
+msgid "from you"
+msgstr ""
 
-#. settings-schema.json->dataService->description
-#. 3.0->settings-schema.json->dataService->description
-#. 3.8->settings-schema.json->dataService->description
-msgid "Data service"
-msgstr "Услуга преноса података"
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
+msgid "mm"
+msgstr ""
 
-#. settings-schema.json->dataService->options
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
+msgid "in"
+msgstr "у"
+
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
+msgid "mi"
+msgstr ""
+
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
+msgid "km"
+msgstr ""
+
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
+msgid "Loading current weather ..."
+msgstr "Учитавање тренутне прогнозе..."
+
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
+msgid "Loading future weather ..."
+msgstr "Учитавање будуће прогнозе..."
+
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
+msgid "Loading ..."
+msgstr "Учитавање..."
+
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
+#, fuzzy
+msgid "Temperature"
+msgstr "Температура"
+
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
+#, fuzzy
+msgid "Humidity"
+msgstr "Влажност:"
+
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
+#, fuzzy
+msgid "Pressure"
+msgstr "Притисак:"
+
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
+#, fuzzy
+msgid "Wind"
+msgstr "Ветар:"
+
+#: 3.0/applet.js:1639
+msgid "Make sure you entered a location or use Automatic location instead"
+msgstr ""
+"Проверите да ли сте унели локацију или уместо ње користите Аутоматску "
+"локацију"
+
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
+msgid "Could not find location based on address, please check if it's right"
+msgstr ""
+
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
+msgid "Failed to call Geolocation API, see Looking Glass for errors."
+msgstr ""
+
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "Warning"
+msgstr ""
+
+#: 3.0/applet.js:2032
+msgid "You can only save correct locations when the applet is not refreshing"
+msgstr ""
+
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "You can't save an incorrect location"
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->options
+#: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.8/weather-applet.js:9875
+msgid "Info"
+msgstr ""
+
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
+msgid "Location is already saved"
+msgstr ""
+
+#: 3.0/applet.js:2049 3.0/applet.js:2083
+msgid "Success"
+msgstr ""
+
+#: 3.0/applet.js:2049
+msgid "Location is saved to library"
+msgstr ""
+
+#: 3.0/applet.js:2062
+msgid "You can't remove a location while the applet is refreshing"
+msgstr ""
+
+#: 3.0/applet.js:2066
+#, fuzzy
+msgid "You can't remove an incorrect location"
+msgstr "Није могуће добити локацију"
+
+#: 3.0/applet.js:2070
+msgid "Location is not in storage, can't delete"
+msgstr ""
+
+#: 3.0/applet.js:2083
+msgid "Location is deleted from library"
+msgstr ""
+
+#: 3.0/applet.js:2131
+msgid ""
+"Failed to load in data from location storage, please see the logs for more "
+"information"
+msgstr ""
+
+#: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
+#: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
+#, fuzzy
+msgid "Feels Like"
+msgstr "Као да је"
+
+#: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
+#: 3.8/weather-applet.js:15387
+msgid "Failed to Process Weather Info"
+msgstr "Обрада информација о времену није успела"
+
+#: 3.0/climacell.js:224
+#, fuzzy
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://developer.climacell.co/sign-up"
+msgstr ""
+"Молимо вас да унесете АПИ кључ у подешавањима,\n"
+"или узмите прво један са https://darksky.net/dev/register"
+
+#: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key correctly and your account is not locked"
+msgstr ""
+"Проверите да ли сте\n"
+"правилно унели АПИ кључ"
+
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Climacell"
+msgstr ""
+"Проверите да ли сте\n"
+"правилно унели АПИ кључ"
+
+#: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
+#: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
+#: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
+#, fuzzy
+msgid "Heavy rain"
+msgstr "Веома јака киша"
+
+#: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
+#: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
+#: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
+msgid "Rain"
+msgstr ""
+
+#: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
+#: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
+#: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
+msgid "Light rain"
+msgstr "Слаба киша"
+
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
+#, fuzzy
+msgid "Heavy freezing rain"
+msgstr "Ледена киша"
+
+#: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
+#: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
+#: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
+msgid "Freezing rain"
+msgstr "Ледена киша"
+
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
+#, fuzzy
+msgid "Light freezing rain"
+msgstr "Ледена киша"
+
+#: 3.0/climacell.js:301
+#, fuzzy
+msgid "Light freezing drizzle"
+msgstr "Слабо ромињање"
+
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
+#, fuzzy
+msgid "Freezing drizzle"
+msgstr "Ледена киша"
+
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
+#, fuzzy
+msgid "Light drizzle"
+msgstr "Слабо ромињање"
+
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
+msgid "Heavy ice pellets"
+msgstr ""
+
+#: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
+msgid "Ice pellets"
+msgstr ""
+
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
+msgid "Light ice pellets"
+msgstr ""
+
+#: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
+#: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
+#: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
+msgid "Heavy snow"
+msgstr "Јак снег"
+
+#: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
+#: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
+#: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
+msgid "Snow"
+msgstr "Снег"
+
+#: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
+#: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
+#: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
+msgid "Light snow"
+msgstr "Слаб снег"
+
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
+msgid "Flurries"
+msgstr ""
+
+#: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
+msgid "Thunderstorm"
+msgstr "Олуја с грмљавином"
+
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
+#, fuzzy
+msgid "Light fog"
+msgstr "Слаб снег"
+
+#: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
+#: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
+#: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
+msgid "Fog"
+msgstr "Магла"
+
+#: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
+#: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
+#, fuzzy
+msgid "Cloudy"
+msgstr "Облачност"
+
+#: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
+msgid "Mostly cloudy"
+msgstr ""
+
+#: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
+#: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
+#: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
+msgid "Partly cloudy"
+msgstr ""
+
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
+msgid "Mostly clear"
+msgstr ""
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
+#: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
+#: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
+msgid "Clear"
+msgstr "Ведро"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
+msgid "Sunny"
+msgstr ""
+
+#: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
+#: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
+#: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
+msgid "Unknown"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "and"
+msgstr "и"
+
+#: 3.0/darkSky.js:71
+msgid "until"
+msgstr "до"
+
+#: 3.0/darkSky.js:71
+msgid "Possible"
+msgstr ""
+
+#: 3.0/darkSky.js:211
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://darksky.net/dev/register"
+msgstr ""
+"Молимо вас да унесете АПИ кључ у подешавањима,\n"
+"или узмите прво један са https://darksky.net/dev/register"
+
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
+#, fuzzy
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from DarkSky"
+msgstr ""
+"Проверите да ли сте\n"
+"правилно унели АПИ кључ"
+
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
+msgid "Could not obtain location"
+msgstr "Није могуће добити локацију"
+
+#: 3.0/ipApi.js:95
+msgid ""
+"Location Service responded with errors, please see the logs in Looking Glass"
+msgstr ""
+"Локацијска служба одговорила је на грешке, погледајте записнике у прозорче "
+"огледала"
+
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
+msgid "Cloudiness"
+msgstr "Облачност"
+
+#: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
+msgid "Clear sky"
+msgstr "Ведро"
+
+#: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
+msgid "Fair"
+msgstr ""
+
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
+#, fuzzy
+msgid "Heavy rain and thunder"
+msgstr "Јаки пљускови и ромињање"
+
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
+#, fuzzy
+msgid "Heavy rain showers"
+msgstr "Јак мећаве"
+
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
+#, fuzzy
+msgid "Heavy rain showers and thunder"
+msgstr "Јаки пљускови и ромињање"
+
+#: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
+#, fuzzy
+msgid "Heavy sleet"
+msgstr "Јак снег"
+
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
+#, fuzzy
+msgid "Heavy sleet and thunder"
+msgstr "Јака олуја с грмљавином"
+
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
+#, fuzzy
+msgid "Heavy sleet showers"
+msgstr "Јак мећаве"
+
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
+#, fuzzy
+msgid "Heavy sleet showers and thunder"
+msgstr "Јаки пљускови и ромињање"
+
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
+#, fuzzy
+msgid "Heavy snow and thunder"
+msgstr "Јака олуја с грмљавином"
+
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
+#, fuzzy
+msgid "Heavy snow showers"
+msgstr "Јак мећаве"
+
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
+#, fuzzy
+msgid "Heavy snow showers and thunder"
+msgstr "Јаки пљускови и ромињање"
+
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
+#, fuzzy
+msgid "Light rain and thunder"
+msgstr "Слба киша и снег"
+
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
+#, fuzzy
+msgid "Light rain showers"
+msgstr "Слба киша и снег"
+
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
+#, fuzzy
+msgid "Light rain showers and thunder"
+msgstr "Слба киша и снег"
+
+#: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
+#, fuzzy
+msgid "Light sleet"
+msgstr "Слаб снег"
+
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
+#, fuzzy
+msgid "Light sleet and thunder"
+msgstr "Слаба олуја с грмљавином"
+
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
+#, fuzzy
+msgid "Light sleet showers"
+msgstr "Блага падавина снега"
+
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
+#, fuzzy
+msgid "Light sleet showers and thunder"
+msgstr "Слаби краткотрајни пљусак"
+
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
+#, fuzzy
+msgid "Light snow and thunder"
+msgstr "Слаба олуја с грмљавином"
+
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
+#, fuzzy
+msgid "Light snow showers"
+msgstr "Блага падавина снега"
+
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
+msgid "Light snow showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
+#, fuzzy
+msgid "Rain and thunder"
+msgstr "Киша и снег"
+
+#: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
+#, fuzzy
+msgid "Rain showers"
+msgstr "Киша и снег"
+
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
+msgid "Rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:511 3.0/met_norway.js:512 3.0/met_norway.js:518
+#: 3.0/met_norway.js:525 3.0/met_norway.js:532 3.0/met_uk.js:638
+#: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
+#: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
+#: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
+msgid "Sleet"
+msgstr "Суснежица"
+
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
+msgid "Sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
+#, fuzzy
+msgid "Sleet showers"
+msgstr "Блага падавина снега"
+
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
+msgid "Sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
+msgid "Snow and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
+#, fuzzy
+msgid "Snow showers"
+msgstr "Мећава"
+
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
+msgid "Snow showers and thunder"
+msgstr ""
+
+#: 3.0/met_uk.js:162 3.0/met_uk.js:192 3.0/met_uk.js:239 3.0/us_weather.js:151
+#: 3.0/us_weather.js:179
+msgid "Unexpected response from API"
+msgstr ""
+
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
+msgid "Visibility"
+msgstr ""
+
+#: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
+msgid "Failed to Process Current Weather Info"
+msgstr "Обрада тренутних информација о времену није успела"
+
+#: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
+msgid "Failed to Process Forecast Info"
+msgstr "Информације о прогнози нису успеле"
+
+#: 3.0/met_uk.js:408
+msgid "Very poor - Less than"
+msgstr ""
+
+#: 3.0/met_uk.js:410
+msgid "Poor - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:412
+#, fuzzy
+msgid "Moderate - Between"
+msgstr "Умерена киша"
+
+#: 3.0/met_uk.js:414
+msgid "Good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:416
+msgid "Very good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:417
+msgid "Excellent - More than"
+msgstr ""
+
+#: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
+msgid "Mist"
+msgstr "Сумаглица"
+
+#: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
+#, fuzzy
+msgid "Overcast"
+msgstr "Тмурно"
+
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
+#, fuzzy
+msgid "Light rain shower"
+msgstr "Слба киша и снег"
+
+#: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
+msgid "Drizzle"
+msgstr "Ромињање"
+
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
+#, fuzzy
+msgid "Heavy rain shower"
+msgstr "Јак мећаве"
+
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
+msgid "Sleet shower"
+msgstr ""
+
+#: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
+msgid "Hail"
+msgstr ""
+
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
+#, fuzzy
+msgid "Hail shower"
+msgstr "Јак мећаве"
+
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
+#, fuzzy
+msgid "Light snow shower"
+msgstr "Блага падавина снега"
+
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
+#, fuzzy
+msgid "Heavy snow shower"
+msgstr "Јак мећаве"
+
+#: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
+#, fuzzy
+msgid "Thunder"
+msgstr "Олуја с грмљавином"
+
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
+#, fuzzy
+msgid "Thunder shower"
+msgstr "Олуја с грмљавином"
+
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
+msgid "Please make sure Location is in the correct format in the Settings"
+msgstr "Проверите да ли је локација у исправном формату у подешавањима"
+
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
+msgid "Make sure you entered the correct key in settings"
+msgstr "Проверите да ли сте унели исправан кључ у подешавању"
+
+#: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
+msgid ""
+"Location not found, make sure location is available or it is in the correct "
+"format"
+msgstr ""
+"Локација није пронађена, проверите да ли је локација доступна или је "
+"исправнаформат"
+
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
+msgid "If this problem persists, please contact the Author of this applet"
+msgstr "Ако овај проблем и даље постоји, обратите се аутору овог програмчета"
+
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
+msgid "Unknown Error, please see the logs in Looking Glass"
+msgstr "Непозната грешка, погледајте записнике у прозорче огледала"
+
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
+msgid "Thunderstorm with light rain"
+msgstr "Грмљавина са слабом кишом"
+
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
+msgid "Thunderstorm with rain"
+msgstr "Грмљавина са кишом"
+
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
+msgid "Thunderstorm with heavy rain"
+msgstr "Грмљавина са јаком кишом"
+
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
+msgid "Light thunderstorm"
+msgstr "Слаба олуја с грмљавином"
+
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
+msgid "Heavy thunderstorm"
+msgstr "Јака олуја с грмљавином"
+
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
+msgid "Ragged thunderstorm"
+msgstr "Изузетно јака грмљавина"
+
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
+msgid "Thunderstorm with light drizzle"
+msgstr "Грмљавина са слабим ромињањем кише"
+
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
+msgid "Thunderstorm with drizzle"
+msgstr "Грмљавина са ромињањем"
+
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
+msgid "Thunderstorm with heavy drizzle"
+msgstr "Грмљавина са јаким ромињањем"
+
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
+msgid "Light intensity drizzle"
+msgstr "Слабо ромињање"
+
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
+msgid "Heavy intensity drizzle"
+msgstr "Јако ромињање"
+
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
+msgid "Light intensity drizzle rain"
+msgstr "Слабо ромињање кише"
+
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
+msgid "Drizzle rain"
+msgstr "Ромињање кише"
+
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
+msgid "Heavy intensity drizzle rain"
+msgstr "Јако ромињање кише"
+
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
+msgid "Shower rain and drizzle"
+msgstr "Пљускови и ромињање"
+
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
+msgid "Heavy shower rain and drizzle"
+msgstr "Јаки пљускови и ромињање"
+
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
+msgid "Shower drizzle"
+msgstr "Ромињање"
+
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
+msgid "Moderate rain"
+msgstr "Умерена киша"
+
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
+msgid "Heavy intensity rain"
+msgstr "Јака киша"
+
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
+msgid "Very heavy rain"
+msgstr "Веома јака киша"
+
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
+msgid "Extreme rain"
+msgstr "Екстремна киша"
+
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
+msgid "Light intensity shower rain"
+msgstr "Слаби краткотрајни пљусак"
+
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
+msgid "Shower rain"
+msgstr "Пљусак"
+
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
+msgid "Heavy intensity shower rain"
+msgstr "Јак краткотрајни пљусак"
+
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
+msgid "Ragged shower rain"
+msgstr "Изузетно јак пљусак"
+
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
+msgid "Shower sleet"
+msgstr "Јака суснежица"
+
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
+msgid "Light rain and snow"
+msgstr "Слба киша и снег"
+
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
+msgid "Rain and snow"
+msgstr "Киша и снег"
+
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
+msgid "Light shower snow"
+msgstr "Блага падавина снега"
+
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
+msgid "Shower snow"
+msgstr "Мећава"
+
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
+msgid "Heavy shower snow"
+msgstr "Јак мећаве"
+
+#: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
+msgid "Smoke"
+msgstr "Дим"
+
+#: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
+msgid "Haze"
+msgstr "Измаглица"
+
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
+msgid "Sand, dust whirls"
+msgstr "Песак, ковитлаци прашине"
+
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
+msgid "Sand"
+msgstr "Песак"
+
+#: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
+msgid "Dust"
+msgstr "Прашина"
+
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
+msgid "Volcanic ash"
+msgstr "Вулкански пепео"
+
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
+msgid "Squalls"
+msgstr "Бура"
+
+#: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
+msgid "Tornado"
+msgstr "Торнадо"
+
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
+msgid "Sky is clear"
+msgstr "Ведро"
+
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
+#, fuzzy
+msgid "Clouds"
+msgstr "Облачност"
+
+#: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
+msgid "Few clouds"
+msgstr "Мало облака"
+
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
+msgid "Scattered clouds"
+msgstr "Распирени облаци"
+
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
+msgid "Broken clouds"
+msgstr "Испрекидани облаци"
+
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
+msgid "Overcast clouds"
+msgstr "Тмурно"
+
+#: 3.0/us_weather.js:120
+msgid "Could not get forecast for your area"
+msgstr ""
+
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
+msgid "Location is outside US, please use a different provider."
+msgstr ""
+
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
+#, fuzzy
+msgid "Failed to Process Hourly Forecast Info"
+msgstr "Информације о прогнози нису успеле"
+
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
+msgid "Clear and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
+#, fuzzy
+msgid "Few clouds and windy"
+msgstr "Мало облака"
+
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
+msgid "Partly cloudy and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
+msgid "Mostly cloudy and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
+#, fuzzy
+msgid "Overcast and windy"
+msgstr "Тмурно"
+
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
+#, fuzzy
+msgid "Snowy rain"
+msgstr "Пљусак"
+
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
+#, fuzzy
+msgid "Freezing rain and snow"
+msgstr "Слба киша и снег"
+
+#: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
+msgid "Hurricane"
+msgstr ""
+
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
+msgid "Storm"
+msgstr ""
+
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
+msgid "Tropical storm"
+msgstr ""
+
+#: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
+msgid "Hot"
+msgstr ""
+
+#: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
+msgid "Cold"
+msgstr ""
+
+#: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
+msgid "Blizzard"
+msgstr ""
+
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
+msgid "Today"
+msgstr "Данас"
+
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
+msgid "Tomorrow"
+msgstr "Сутра"
+
+#: 3.0/utils.js:204
+msgid "Sunday"
+msgstr "Недеља"
+
+#: 3.0/utils.js:204
+msgid "Monday"
+msgstr "Понедељак"
+
+#: 3.0/utils.js:204
+msgid "Tuesday"
+msgstr "Уторак"
+
+#: 3.0/utils.js:204
+msgid "Wednesday"
+msgstr "Среда"
+
+#: 3.0/utils.js:204
+msgid "Thursday"
+msgstr "Четвртак"
+
+#: 3.0/utils.js:204
+msgid "Friday"
+msgstr "Петак"
+
+#: 3.0/utils.js:204
+msgid "Saturday"
+msgstr "Субота"
+
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
+msgid "Calm"
+msgstr ""
+
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
+#, fuzzy
+msgid "Light air"
+msgstr "Слаба киша"
+
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
+#, fuzzy
+msgid "Light breeze"
+msgstr "Слаба киша"
+
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
+msgid "Gentle breeze"
+msgstr ""
+
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
+#, fuzzy
+msgid "Moderate breeze"
+msgstr "Умерена киша"
+
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
+msgid "Fresh breeze"
+msgstr ""
+
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
+msgid "Strong breeze"
+msgstr ""
+
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
+msgid "Near gale"
+msgstr ""
+
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
+msgid "Gale"
+msgstr ""
+
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
+msgid "Strong gale"
+msgstr ""
+
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
+msgid "Violent storm"
+msgstr ""
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
+msgid "N"
+msgstr "С"
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
+msgid "NE"
+msgstr "СИ"
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
+msgid "E"
+msgstr "И"
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
+msgid "SE"
+msgstr "ЈИ"
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
+msgid "S"
+msgstr "Ј"
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
+msgid "SW"
+msgstr "ЈЗ"
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
+msgid "W"
+msgstr "З"
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
+msgid "NW"
+msgstr "СЗ"
+
+#: 3.0/weatherbit.js:312
+#, fuzzy
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://www.weatherbit.io/account/create"
+msgstr ""
+"Молимо вас да унесете АПИ кључ у подешавањима,\n"
+"или узмите прво један са https://darksky.net/dev/register"
+
+#: 3.0/yahoo.js:78
+msgid ""
+"Unknown Error happened while calling Yahoo bridge,\n"
+" see Looking Glass log for errors"
+msgstr ""
+
+#: 3.0/yahoo.js:91
+msgid ""
+"Yahoo bridge responded in bad format,\n"
+" see Looking Glass log for errors"
+msgstr ""
+
+#: 3.0/yahoo.js:177
+msgid "Missing package"
+msgstr ""
+
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+msgid "Please install '"
+msgstr ""
+
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+msgid "', then refresh manually."
+msgstr ""
+
+#: 3.0/yahoo.js:182
+msgid "Could not connect to Yahoo API."
+msgstr ""
+
+#: 3.0/yahoo.js:186
+msgid ""
+"Unknown error happened while obtaining weather, see Looking Glass logs for "
+"more information"
+msgstr ""
+
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
+msgid "Tropical Storm"
+msgstr ""
+
+#: 3.0/yahoo.js:439
+#, fuzzy
+msgid "Severe Thunderstorms"
+msgstr "Олуја с грмљавином"
+
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
+#, fuzzy
+msgid "Thunderstorms"
+msgstr "Олуја с грмљавином"
+
+#: 3.0/yahoo.js:441
+#, fuzzy
+msgid "Mixed Rain and Snow"
+msgstr "Киша и снег"
+
+#: 3.0/yahoo.js:442
+msgid "Mixed Rain and Sleet"
+msgstr ""
+
+#: 3.0/yahoo.js:443
+msgid "Mixed Snow and Sleet"
+msgstr ""
+
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
+#, fuzzy
+msgid "Freezing Drizzle"
+msgstr "Ледена киша"
+
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
+#, fuzzy
+msgid "Freezing Rain"
+msgstr "Ледена киша"
+
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
+#, fuzzy
+msgid "Showers"
+msgstr "Мећава"
+
+#: 3.0/yahoo.js:449
+msgid "Snow Flurries"
+msgstr ""
+
+#: 3.0/yahoo.js:450
+#, fuzzy
+msgid "Light Snow Showers"
+msgstr "Блага падавина снега"
+
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
+msgid "Blowing Snow"
+msgstr ""
+
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
+msgid "Foggy"
+msgstr ""
+
+#: 3.0/yahoo.js:458
+#, fuzzy
+msgid "Smoky"
+msgstr "Дим"
+
+#: 3.0/yahoo.js:459
+msgid "Blustery"
+msgstr ""
+
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
+#, fuzzy
+msgid "Windy"
+msgstr "Ветар:"
+
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
+msgid "Mostly Cloudy"
+msgstr ""
+
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
+msgid "Partly Cloudy"
+msgstr ""
+
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
+msgid "Mostly Sunny"
+msgstr ""
+
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
+msgid "Mixed Rain and Hail"
+msgstr ""
+
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
+#, fuzzy
+msgid "Isolated Thunderstorms"
+msgstr "Изузетно јака грмљавина"
+
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
+#, fuzzy
+msgid "Scattered Thunderstorms"
+msgstr "Изузетно јака грмљавина"
+
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
+#, fuzzy
+msgid "Scattered Showers"
+msgstr "Распирени облаци"
+
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
+#, fuzzy
+msgid "Heavy Rain"
+msgstr "Јак снег"
+
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
+#, fuzzy
+msgid "Scattered Snow Showers"
+msgstr "Распирени облаци"
+
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
+#, fuzzy
+msgid "Heavy Snow"
+msgstr "Јак снег"
+
+#: 3.0/yahoo.js:478
+msgid "Not Available"
+msgstr ""
+
+#: 3.0/yahoo.js:479
+#, fuzzy
+msgid "Scattered Thundershowers"
+msgstr "Распирени облаци"
+
+#: 3.8/weather-applet.js:9638
+msgid ""
+"Could not retrieve logs, log file was not found under path\n"
+" {logFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:9642
+msgid ""
+"Could not get contents of log file under path\n"
+" {logFilePath}"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10283
+msgid "Met Office UK"
+msgstr ""
+
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
+msgstr ""
+
+#: 3.8/weather-applet.js:10476
+#, fuzzy
+msgid "Data was not found for location"
+msgstr "Није могуће пронаћи локацију"
+
+#: 3.8/weather-applet.js:10557
+msgid "Very poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10557
+msgid "Less than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "Excellent"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "More than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566
+msgid "Poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
+msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10571
+#, fuzzy
+msgid "Moderate"
+msgstr "Умерена киша"
+
+#: 3.8/weather-applet.js:10576
+msgid "Good"
+msgstr ""
+
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
+msgid "Very good"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
-#. settings-schema.json->location->description
-#. 3.0->settings-schema.json->location->description
-#. 3.8->settings-schema.json->location->description
-msgid "Location"
-msgstr "Локација"
-
-#. settings-schema.json->location->tooltip
-#. 3.0->settings-schema.json->location->tooltip
-#. 3.8->settings-schema.json->location->tooltip
-msgid "Acceptable inputs: City,CountryCode or Zipcode,CountryCode or Latitude,Longtitude"
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:11396
+msgid "MET Norway"
 msgstr ""
-"Прихватљиви уноси: Град, позивни број земље или поштански број, код земље илиШирина, дужина"
 
-#. settings-schema.json->getLocation->description
-msgid "Setup Location"
-msgstr "Подесите локацију"
+#: 3.8/weather-applet.js:11955
+#, fuzzy
+msgid "WeatherBit"
+msgstr "Време"
 
-#. settings-schema.json->getLocation->tooltip
-#. 3.0->settings-schema.json->getLocation->tooltip
-#. 3.8->settings-schema.json->getLocation->tooltip
-msgid "Opens webpage guide"
-msgstr "Отвара водич за веб странице"
+#: 3.8/weather-applet.js:12386
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Сутра"
 
-#. settings-schema.json->personalSettings->description
-#. 3.0->settings-schema.json->personalSettings->description
-#. 3.8->settings-schema.json->personalSettings->description
-msgid "Personal Settings"
-msgstr "Лична подешавања"
+#: 3.8/weather-applet.js:12561
+#, fuzzy
+msgid "Light wind"
+msgstr "Слаба киша"
 
-#. settings-schema.json->temperatureUnit->description
-#. 3.0->settings-schema.json->temperatureUnit->description
-#. 3.8->settings-schema.json->temperatureUnit->description
-msgid "Temperature unit"
-msgstr "Јединица температуре"
+#: 3.8/weather-applet.js:12575
+msgid "Strong wind"
+msgstr ""
 
-#. settings-schema.json->temperatureUnit->options
-#. 3.0->settings-schema.json->temperatureUnit->options
-#. 3.8->settings-schema.json->temperatureUnit->options
-msgid "celsius"
-msgstr "целзијус"
+#: 3.8/weather-applet.js:12723
+#, fuzzy
+msgid "US Weather"
+msgstr "Време"
 
-#. settings-schema.json->temperatureUnit->options
-#. 3.0->settings-schema.json->temperatureUnit->options
-#. 3.8->settings-schema.json->temperatureUnit->options
-msgid "fahrenheit"
-msgstr "фаренхајт"
+#: 3.8/weather-applet.js:13292
+msgid "Visual Crossing"
+msgstr ""
 
-#. settings-schema.json->temperatureHighFirst->description
-#. 3.0->settings-schema.json->temperatureHighFirst->description
-#. 3.8->settings-schema.json->temperatureHighFirst->description
-msgid "Show high temperature first in forecast"
-msgstr "Прво покажи високу температуру у прогнози"
+#: 3.8/weather-applet.js:13474
+msgid "Blowing or drifting snow"
+msgstr ""
 
-#. settings-schema.json->windSpeedUnit->description
-#. 3.0->settings-schema.json->windSpeedUnit->description
-#. 3.8->settings-schema.json->windSpeedUnit->description
-msgid "Wind speed unit"
-msgstr "Јединица за брзину ветра"
+#: 3.8/weather-applet.js:13478
+#, fuzzy
+msgid "Heavy drizzle"
+msgstr "Јако ромињање"
 
-#. settings-schema.json->windSpeedUnit->options
-#. 3.0->settings-schema.json->windSpeedUnit->options
-#. 3.8->settings-schema.json->windSpeedUnit->options
-msgid "kph"
-msgstr "kph"
+#: 3.8/weather-applet.js:13482
+#, fuzzy
+msgid "Heavy drizzle/rain"
+msgstr "Јако ромињање кише"
 
-#. settings-schema.json->windSpeedUnit->options
-#. 3.0->settings-schema.json->windSpeedUnit->options
-#. 3.8->settings-schema.json->windSpeedUnit->options
-msgid "mph"
-msgstr "mph"
+#: 3.8/weather-applet.js:13484
+#, fuzzy
+msgid "Light drizzle/rain"
+msgstr "Слабо ромињање кише"
 
-#. settings-schema.json->windSpeedUnit->options
-#. 3.0->settings-schema.json->windSpeedUnit->options
-#. 3.8->settings-schema.json->windSpeedUnit->options
-msgid "m/s"
-msgstr "m/s"
+#: 3.8/weather-applet.js:13486
+msgid "Dust Storm"
+msgstr ""
 
-#. settings-schema.json->windSpeedUnit->options
-#. 3.0->settings-schema.json->windSpeedUnit->options
-#. 3.8->settings-schema.json->windSpeedUnit->options
-msgid "knots"
-msgstr "чворова"
+#: 3.8/weather-applet.js:13490
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "Ледена киша"
 
-#. settings-schema.json->pressureUnit->description
-#. 3.0->settings-schema.json->pressureUnit->description
-#. 3.8->settings-schema.json->pressureUnit->description
-msgid "Atmospheric pressure unit"
-msgstr "Јединица атмосферског притиска"
+#: 3.8/weather-applet.js:13492
+#, fuzzy
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr "Јако ромињање кише"
 
-#. settings-schema.json->pressureUnit->options
-#. 3.0->settings-schema.json->pressureUnit->options
-#. 3.8->settings-schema.json->pressureUnit->options
-msgid "hPa"
-msgstr "hPa"
+#: 3.8/weather-applet.js:13494
+#, fuzzy
+msgid "Light freezing drizzle/freezing rain"
+msgstr "Слабо ромињање кише"
 
-#. settings-schema.json->pressureUnit->options
-#. 3.0->settings-schema.json->pressureUnit->options
-#. 3.8->settings-schema.json->pressureUnit->options
-msgid "in Hg"
-msgstr "in Hg"
+#: 3.8/weather-applet.js:13496
+#, fuzzy
+msgid "Freezing fog"
+msgstr "Ледена киша"
 
-#. settings-schema.json->pressureUnit->options
-#. 3.0->settings-schema.json->pressureUnit->options
-#. 3.8->settings-schema.json->pressureUnit->options
-msgid "mm Hg"
-msgstr "mm Hg"
+#: 3.8/weather-applet.js:13502
+msgid "Funnel cloud/tornado"
+msgstr ""
 
-#. settings-schema.json->pressureUnit->options
-#. 3.0->settings-schema.json->pressureUnit->options
-#. 3.8->settings-schema.json->pressureUnit->options
-msgid "psi"
-msgstr "psi"
+#: 3.8/weather-applet.js:13504
+#, fuzzy
+msgid "Hail showers"
+msgstr "Јак мећаве"
 
-#. settings-schema.json->pressureUnit->options
-#. 3.0->settings-schema.json->pressureUnit->options
-#. 3.8->settings-schema.json->pressureUnit->options
-msgid "at"
-msgstr "at"
+#: 3.8/weather-applet.js:13506
+msgid "Ice"
+msgstr ""
 
-#. settings-schema.json->pressureUnit->options
-#. 3.0->settings-schema.json->pressureUnit->options
-#. 3.8->settings-schema.json->pressureUnit->options
-msgid "atm"
-msgstr "atm"
+#: 3.8/weather-applet.js:13508
+#, fuzzy
+msgid "Lightning without thunder"
+msgstr "Слаба олуја с грмљавином"
 
-#. settings-schema.json->pressureUnit->options
-#. 3.0->settings-schema.json->pressureUnit->options
-#. 3.8->settings-schema.json->pressureUnit->options
-msgid "Pa"
-msgstr "Pa"
+#: 3.8/weather-applet.js:13512
+msgid "Precipitation in vicinity"
+msgstr ""
 
-#. settings-schema.json->verticalOrientation->description
-#. 3.0->settings-schema.json->verticalOrientation->description
-#. 3.8->settings-schema.json->verticalOrientation->description
-msgid "Vertical orientation"
-msgstr "Вертикална оријентација"
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
+#, fuzzy
+msgid "Heavy rain and snow"
+msgstr "Киша и снег"
 
-#. settings-schema.json->showSunrise->description
-#. 3.0->settings-schema.json->showSunrise->description
-#. 3.8->settings-schema.json->showSunrise->description
-msgid "Show sunrise / sunset times"
-msgstr "Прикажи времена изласка / заласка сунца"
+#: 3.8/weather-applet.js:13518
+#, fuzzy
+msgid "Light rain And snow"
+msgstr "Слба киша и снег"
 
-#. settings-schema.json->show24Hours->description
-#. 3.0->settings-schema.json->show24Hours->description
-#. 3.8->settings-schema.json->show24Hours->description
-msgid "Display time in 24 hour format"
-msgstr "Прикажи време у 24-сатном формату"
+#: 3.8/weather-applet.js:13526
+msgid "Sky coverage decreasing"
+msgstr ""
 
-#. settings-schema.json->forecastDays->units
-#. 3.0->settings-schema.json->forecastDays->units
-#. 3.8->settings-schema.json->forecastDays->units
-msgid "days"
-msgstr "дани"
+#: 3.8/weather-applet.js:13528
+msgid "Sky coverage increasing"
+msgstr ""
 
-#. settings-schema.json->forecastDays->description
-#. 3.0->settings-schema.json->forecastDays->description
-#. 3.8->settings-schema.json->forecastDays->description
-msgid "Forecast length"
-msgstr "Предвиђена прогноза"
+#: 3.8/weather-applet.js:13530
+msgid "Sky unchanged"
+msgstr ""
 
-#. settings-schema.json->translateCondition->description
-msgid "Translate condition"
-msgstr "Преведи временска стања"
+#: 3.8/weather-applet.js:13532
+msgid "Smoke or haze"
+msgstr ""
 
-#. settings-schema.json->useSymbolicIcons->description
-#. 3.0->settings-schema.json->useSymbolicIcons->description
-#. 3.8->settings-schema.json->useSymbolicIcons->description
-msgid "Symbolic icons"
-msgstr "Прикажи симболичке иконе"
+#: 3.8/weather-applet.js:13536
+msgid "Snow and rain showers"
+msgstr ""
 
-#. settings-schema.json->showTextInPanel->description
-#. 3.0->settings-schema.json->showTextInPanel->description
-#. 3.8->settings-schema.json->showTextInPanel->description
-msgid "Display current temperature in panel"
-msgstr "Прикажи тренутну температуру на панелу"
+#: 3.8/weather-applet.js:13548
+#, fuzzy
+msgid "Thunderstorm without precipitation"
+msgstr "Грмљавина са кишом"
 
-#. settings-schema.json->showCommentInPanel->description
-#. 3.0->settings-schema.json->showCommentInPanel->description
-#. 3.8->settings-schema.json->showCommentInPanel->description
-msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
-msgstr "Прикажи стање времена (нпр., \"Ветровито\", \"Ведро\") на панелу"
+#: 3.8/weather-applet.js:13550
+msgid "Diamond dust"
+msgstr ""
 
-#. settings-schema.json->locationLabelOverride->description
-#. 3.0->settings-schema.json->locationLabelOverride->description
-#. 3.8->settings-schema.json->locationLabelOverride->description
-msgid "Override location label"
-msgstr "Ручно упишите локацију"
+#: 3.8/weather-applet.js:13556
+msgid "Partially cloudy"
+msgstr ""
 
-#. settings-schema.json->refreshInterval->units
-#. 3.0->settings-schema.json->refreshInterval->units
-#. 3.8->settings-schema.json->refreshInterval->units
-msgid "minutes"
-msgstr "минуте"
+#: 3.8/weather-applet.js:13578
+#, fuzzy
+msgid "Please make sure you entered the API key correctly"
+msgstr ""
+"Проверите да ли сте\n"
+"правилно унели АПИ кључ"
 
-#. settings-schema.json->refreshInterval->description
-#. 3.0->settings-schema.json->refreshInterval->description
-#. 3.8->settings-schema.json->refreshInterval->description
-msgid "Update interval"
-msgstr "Интервал ажурирања"
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:13595
+msgid "DMI Denmark"
+msgstr ""
+
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
+msgid "NOT FOUND"
+msgstr ""
+
+#: 3.8/weather-applet.js:13779
+#, fuzzy
+msgid "Blowing snow"
+msgstr "Слаб снег"
+
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
+#, fuzzy
+msgid "Slight snow"
+msgstr "Слаб снег"
+
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
+#, fuzzy
+msgid "Moderate snow"
+msgstr "Умерена киша"
+
+#: 3.8/weather-applet.js:13842
+#, fuzzy
+msgid "Moderate rain showers"
+msgstr "Умерена киша"
+
+#: 3.8/weather-applet.js:13849
+#, fuzzy
+msgid "Mixed rain and snow"
+msgstr "Слба киша и снег"
+
+#: 3.8/weather-applet.js:13856
+#, fuzzy
+msgid "Heavy mixed rain and snow"
+msgstr "Слба киша и снег"
+
+#: 3.8/weather-applet.js:14024
+#, fuzzy
+msgid "AccuWeather"
+msgstr "Време"
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+msgid "Weather Underground"
+msgstr ""
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+#, fuzzy
+msgid "The location you provided was not found."
+msgstr "Нема постављене локације"
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+msgid "Strong Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "Киша и снег"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "Киша и снег"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "Мећава"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+msgid "Mostly Clear"
+msgstr ""
+
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "Време"
+
+#: 3.8/weather-applet.js:15603
+#, fuzzy
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+"Локацијска служба одговорила је на грешке, погледајте записнике у прозорче "
+"огледала"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+"Проверите да ли сте унели локацију или уместо ње користите Аутоматску "
+"локацију"
+
+#: 3.8/weather-applet.js:15968
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:15975
+msgid ""
+"Could not get contents of config file under path\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr ""
+
+#: 3.8/weather-applet.js:16675
+msgid "Dew Point"
+msgstr ""
+
+#: 3.8/weather-applet.js:16747
+msgid "Precipitation will end in {precipEnd} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16749
+msgid "Precipitation won't end in within an hour"
+msgstr ""
+
+#: 3.8/weather-applet.js:16752
+msgid "Precipitation will start within {precipStart} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16964
+msgid "Forecast parsing failed, see logs for more details."
+msgstr ""
+
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
+msgid "As of {lastUpdatedTime}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17502
+msgid "{distance} {distanceUnit} from you"
+msgstr ""
+
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
+msgid "Error Saving Debug Information"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Debug Information saved successfully"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Saved to {filePath}"
+msgstr ""
+
+#: 3.8/LogSaver.py:16
+msgid "Save to File"
+msgstr ""
+
+#: 3.8/LogSaver.py:29
+msgid "Select a destination"
+msgstr ""
 
 #. metadata.json->name
+#. 3.8->settings-schema.json->providers->title
 msgid "Weather"
 msgstr "Време"
 
@@ -756,15 +1922,55 @@ msgstr "Погледајте вашу локалну временску прог
 msgid "Settings for weather@mockturtl 3.0+"
 msgstr "Подешавања за weather@mockturtl 3.0+"
 
+#. 3.0->settings-schema.json->keybinding->description
+#. 3.8->settings-schema.json->keybinding->description
+msgid "Set the keybinding to call the menu"
+msgstr "Подесите тастера да бисте сте позвали изборник"
+
+#. 3.0->settings-schema.json->descriptions->description
+#, fuzzy
+msgid "Weather service information"
+msgstr "Подешавања временског провајдера"
+
+#. 3.0->settings-schema.json->moreInfo->description
+msgid "Click here for detailed description"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->tooltip
+#. 3.0->settings-schema.json->getLocation->tooltip
+#. 3.8->settings-schema.json->getLocation->tooltip
+msgid "Opens webpage guide"
+msgstr "Отвара водич за веб странице"
+
+#. 3.0->settings-schema.json->providerSettings->description
+#. 3.8->settings-schema.json->provider-options->title
+#, fuzzy
+msgid "Weather Provider Options"
+msgstr "Подешавања временског провајдера"
+
+#. 3.0->settings-schema.json->dataService->description
+#. 3.8->settings-schema.json->dataService->description
+msgid "Data service"
+msgstr "Услуга преноса података"
+
 #. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
-msgid "OpenWeatherMap (no key needed)"
+#, fuzzy
+msgid "DarkSky (key needed)"
 msgstr "OpenWeatherMap (није потребан кључ)"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-msgid "DarkSky"
-msgstr "DarkSky"
+#, fuzzy
+msgid "Weatherbit (key needed)"
+msgstr "OpenWeatherMap (није потребан кључ)"
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Yahoo"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Climacell (key needed)"
+msgstr ""
 
 #. 3.0->settings-schema.json->apiKey->description
 #. 3.8->settings-schema.json->apiKey->description
@@ -774,7 +1980,8 @@ msgstr "АПИ кључ"
 #. 3.0->settings-schema.json->apiKey->tooltip
 #. 3.8->settings-schema.json->apiKey->tooltip
 msgid "Copy this from your account of the used Data service and paste it here."
-msgstr "Копирајте ово са свог налога коришћене услуге података и убаците га овде."
+msgstr ""
+"Копирајте ово са свог налога коришћене услуге података и убаците га овде."
 
 #. 3.0->settings-schema.json->manualLocation->description
 #. 3.8->settings-schema.json->manualLocation->description
@@ -786,10 +1993,307 @@ msgstr "Ручна локација"
 msgid "Enable this if your location is not accurate"
 msgstr "Омогућите то ако ваша локација није тачна"
 
+#. 3.0->settings-schema.json->location->description
+msgid "Location - Coordinates"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->tooltip
+msgid ""
+"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an "
+"address.\n"
+"Waits for 3 seconds after you stop typing before refreshes the weather."
+msgstr ""
+
 #. 3.0->settings-schema.json->getLocation->description
-#. 3.8->settings-schema.json->getLocation->description
 msgid "Setup API Key and Location"
 msgstr "Подешавање АПИ кључа и локације"
+
+#. 3.0->settings-schema.json->refreshInterval->units
+#. 3.8->settings-schema.json->refreshInterval->units
+msgid "minutes"
+msgstr "минуте"
+
+#. 3.0->settings-schema.json->refreshInterval->description
+#. 3.8->settings-schema.json->refreshInterval->description
+msgid "Update interval"
+msgstr "Интервал ажурирања"
+
+#. 3.0->settings-schema.json->forecastDays->units
+#. 3.8->settings-schema.json->forecastDays->units
+msgid "days"
+msgstr "дани"
+
+#. 3.0->settings-schema.json->forecastDays->description
+#. 3.8->settings-schema.json->forecastDays->description
+msgid "Forecast length"
+msgstr "Предвиђена прогноза"
+
+#. 3.0->settings-schema.json->forecastHours->units
+#. 3.8->settings-schema.json->forecastHours->units
+msgid "hours"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastHours->description
+#. 3.8->settings-schema.json->forecastHours->description
+#, fuzzy
+msgid "Hourly Forecast length"
+msgstr "Предвиђена прогноза"
+
+#. 3.0->settings-schema.json->unitSettings->description
+msgid "Units"
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureUnit->description
+#. 3.8->settings-schema.json->temperatureUnit->description
+msgid "Temperature unit"
+msgstr "Јединица температуре"
+
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Automatic"
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#, fuzzy
+msgid "Celsius"
+msgstr "целзијус"
+
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#, fuzzy
+msgid "Fahrenheit"
+msgstr "фаренхајт"
+
+#. 3.0->settings-schema.json->temperatureUnit->tooltip
+#. 3.0->settings-schema.json->distanceUnit->tooltip
+#. 3.8->settings-schema.json->temperatureUnit->tooltip
+#. 3.8->settings-schema.json->distanceUnit->tooltip
+msgid ""
+"Automatic will try to guess your preference based your current display "
+"language."
+msgstr ""
+
+#. 3.0->settings-schema.json->windSpeedUnit->description
+#. 3.8->settings-schema.json->windSpeedUnit->description
+msgid "Wind speed unit"
+msgstr "Јединица за брзину ветра"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "kph"
+msgstr "kph"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "mph"
+msgstr "mph"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "m/s"
+msgstr "m/s"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "knots"
+msgstr "чворова"
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "Beaufort"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->description
+#. 3.8->settings-schema.json->pressureUnit->description
+msgid "Atmospheric pressure unit"
+msgstr "Јединица атмосферског притиска"
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "hPa"
+msgstr "hPa"
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "in Hg"
+msgstr "in Hg"
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "mm Hg"
+msgstr "mm Hg"
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "psi"
+msgstr "psi"
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "at"
+msgstr "at"
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "atm"
+msgstr "atm"
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "Pa"
+msgstr "Pa"
+
+#. 3.0->settings-schema.json->distanceUnit->description
+#. 3.8->settings-schema.json->distanceUnit->description
+msgid "Distance unit"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Metric"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Imperial"
+msgstr ""
+
+#. 3.0->settings-schema.json->panelSettings->description
+#, fuzzy
+msgid "Panel options"
+msgstr "Ручна локација"
+
+#. 3.0->settings-schema.json->showTextInPanel->description
+#. 3.8->settings-schema.json->showTextInPanel->description
+msgid "Display current temperature in panel"
+msgstr "Прикажи тренутну температуру на панелу"
+
+#. 3.0->settings-schema.json->showCommentInPanel->description
+#. 3.8->settings-schema.json->showCommentInPanel->description
+msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
+msgstr "Прикажи стање времена (нпр., \"Ветровито\", \"Ведро\") на панелу"
+
+#. 3.0->settings-schema.json->showCommentInPanel->tooltip
+#. 3.8->settings-schema.json->showCommentInPanel->tooltip
+msgid "Only works with horizontal panels"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempTextOverride->description
+#. 3.8->settings-schema.json->tempTextOverride->description
+#, fuzzy
+msgid "Override label on panel"
+msgstr "Ручно упишите локацију"
+
+#. 3.0->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.0->settings-schema.json->useCustomMenuIcons->tooltip
+#. 3.8->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.8->settings-schema.json->useCustomMenuIcons->tooltip
+msgid "Iconset is weather-icons by Erik Flowers"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->description
+#. 3.8->settings-schema.json->useCustomAppletIcons->description
+msgid "Use custom icons on the panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->displaySettings->description
+#. 3.8->settings-schema.json->presentation-section->title
+msgid "Presentation"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->description
+#. 3.8->settings-schema.json->verticalOrientation->description
+msgid "Show forecast vertically"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->units
+#. 3.8->settings-schema.json->forecastColumns->units
+msgid "columns"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->description
+#. 3.8->settings-schema.json->forecastColumns->description
+msgid "Maximum number of columns for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->units
+#. 3.8->settings-schema.json->forecastRows->units
+msgid "rows"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->description
+#. 3.8->settings-schema.json->forecastRows->description
+msgid "Maximum number of rows for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->showSunrise->description
+#. 3.8->settings-schema.json->showSunrise->description
+msgid "Show sunrise / sunset times"
+msgstr "Прикажи времена изласка / заласка сунца"
+
+#. 3.0->settings-schema.json->show24Hours->description
+#. 3.8->settings-schema.json->show24Hours->description
+msgid "Display time in 24 hour format"
+msgstr "Прикажи време у 24-сатном формату"
+
+#. 3.0->settings-schema.json->shortHourlyTime->description
+#. 3.8->settings-schema.json->shortHourlyTime->description
+msgid "Only display hours for hourly forecast time"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->tooltip
+#. 3.8->settings-schema.json->shortHourlyTime->tooltip
+msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->description
+#. 3.8->settings-schema.json->showForecastDates->description
+#, fuzzy
+msgid "Display date for daily forecasts"
+msgstr "Прикажи време у 24-сатном формату"
+
+#. 3.0->settings-schema.json->showForecastDates->tooltip
+#. 3.8->settings-schema.json->showForecastDates->tooltip
+msgid "Like \"Friday 15\""
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureHighFirst->description
+#. 3.8->settings-schema.json->temperatureHighFirst->description
+msgid "Show high temperature first in forecast"
+msgstr "Прво покажи високу температуру у прогнози"
+
+#. 3.0->settings-schema.json->tempRussianStyle->description
+#. 3.8->settings-schema.json->tempRussianStyle->description
+#, fuzzy
+msgid "Show temperature Russian style"
+msgstr "Прво покажи високу температуру у прогнози"
+
+#. 3.0->settings-schema.json->locationLabelOverride->description
+#. 3.8->settings-schema.json->locationLabelOverride->description
+msgid "Override location label"
+msgstr "Ручно упишите локацију"
+
+#. 3.0->settings-schema.json->conditionSettings->description
+#. 3.8->settings-schema.json->weather-conditions->title
+#, fuzzy
+msgid "Weather conditions"
+msgstr "Преведи временска стања"
 
 #. 3.0->settings-schema.json->translateCondition->description
 #. 3.8->settings-schema.json->translateCondition->description
@@ -801,13 +2305,339 @@ msgstr "Преведи временска стања"
 msgid "Less verbose conditions"
 msgstr "Manje opširna vremenska stanja"
 
-#. 3.0->settings-schema.json->credits->description
-#. 3.8->settings-schema.json->credits->description
-msgid ""
-"powered by: OpenWeatherMap, DarkSky, ipapi. Big Thanks to OpenWeatherMap for their support!"
+#. 3.0->settings-schema.json->iconSettings->description
+#. 3.8->settings-schema.json->icons->title
+msgid "Icons"
 msgstr ""
-"покреће га: OpenWeatherMap, DarkSky, ipapi. Велико хвала OpenWeatherMap зањихову подршку!"
 
-#. 3.8->settings-schema.json->head->description
-msgid "Settings for weather@mockturtl 3.8+"
-msgstr "Подешавања за weather@mockturtl 3.8+"
+#. 3.0->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons in the applet"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomMenuIcons->description
+#. 3.8->settings-schema.json->useCustomMenuIcons->description
+msgid "Use custom icons in the popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->locations-page->title
+#. 3.8->settings-schema.json->location->description
+msgid "Location"
+msgstr "Локација"
+
+#. 3.8->settings-schema.json->units-page->title
+msgid "Other options"
+msgstr ""
+
+#. 3.8->settings-schema.json->info-section->title
+msgid "Help"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-section->title
+#, fuzzy
+msgid "Location settings"
+msgstr "Унесите локацију у подешавањима"
+
+#. 3.8->settings-schema.json->location-store->title
+#, fuzzy
+msgid "Saved Locations"
+msgstr "Подесите локацију"
+
+#. 3.8->settings-schema.json->panel-options->title
+msgid "Panel (Taskbar)"
+msgstr ""
+
+#. 3.8->settings-schema.json->presentation->title
+msgid "Popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-section->title
+msgid "Other Units"
+msgstr ""
+
+#. 3.8->settings-schema.json->temp-unit-section->title
+#, fuzzy
+msgid "Temperature Unit"
+msgstr "Јединица температуре"
+
+#. 3.8->settings-schema.json->keybindings->title
+msgid "Keybindings"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info->title
+msgid "More about the Weather applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->submit-issue->title
+msgid "Report an issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->debug-options->title
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Debug"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->tooltip
+msgid ""
+"You can choose between several different weather forecast providers. Some "
+"providers require a API key to work, some have regional limits, differ in "
+"forecast length, and they all need a functional internet connection to work. "
+"The options are described in detail on the Cinnamon Spices Website which you "
+"can access with the button on the Help tab."
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Met Office UK (UK only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "US National Weather (US only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Pirate Weather (key needed)"
+msgstr "OpenWeatherMap (није потребан кључ)"
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Visual Crossing (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Tomorrow.io (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "AccuWeather (key needed)"
+msgstr "OpenWeatherMap (није потребан кључ)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Weather Underground (key needed)"
+msgstr "OpenWeatherMap (није потребан кључ)"
+
+#. 3.8->settings-schema.json->location->tooltip
+msgid ""
+"You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use "
+"'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street} "
+"{City/Town} {Postcode} {Country}. The search algorithm is very flexible with "
+"the format. After 3 seconds without typing the address you entered is "
+"replaced automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->description
+#, fuzzy
+msgid "Save current location to storage"
+msgstr "Ручно упишите локацију"
+
+#. 3.8->settings-schema.json->saveLocation->tooltip
+msgid ""
+"Saves location information to file so you can switch between them with "
+"buttons in the applet, which will appear if you have more than one."
+msgstr ""
+
+#. 3.8->settings-schema.json->getLocation->description
+msgid "Weather Applet at Cinnamon Spices Website"
+msgstr ""
+
+#. 3.8->settings-schema.json->refreshInterval->tooltip
+msgid ""
+"If you are using a provider with API keys set it to an interval you won't "
+"run out of your quota with."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastDays->tooltip
+msgid ""
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->description
+msgid "Enable minutely precipitation forecast"
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->tooltip
+msgid ""
+"If you'd like to use this make sure you use your exact coordinates/address "
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
+msgstr ""
+
+#. 3.8->settings-schema.json->showBothTempUnits->description
+#, fuzzy
+msgid "Show both temperature units at the same time"
+msgstr "Прво покажи високу температуру у прогнози"
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+#, fuzzy
+msgid "Override tooltip on panel"
+msgstr "Ручно упишите локацију"
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
+msgid "Always show Hourly Weather"
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->tooltip
+msgid ""
+"Hide/Show button will be hidden and Hourly weather will be permanently "
+"visible."
+msgstr ""
+
+#. 3.8->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->description
+msgid "Your saved locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->tooltip
+msgid ""
+"You have to make sure the Search entry field is unique and your Timezone is "
+"in the IANA time zone format (e.g. 'Europe/London')"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Latitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Longitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "City"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Country"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Timezone"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Search entry"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->description
+msgid "Display wind direction as text"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->tooltip
+msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->tooltip
+msgid "Does not apply to custom iconset, that is symbolic by default"
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons throughout the applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info-label->description
+msgid ""
+"For detailed information about the applet please go to the Spices Website to "
+"find info about known issues, troubleshooting, changelog and more by "
+"clicking the button below. Here you can ask questions etc in the comment "
+"section by logging in with your Github account."
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->description
+msgid "Submit an Issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->tooltip
+msgid ""
+"Opens webpage where you can fill out a new issue for the applet, needs a "
+"GitHub account.\n"
+" Please make sure that the issue is not already submitted."
+msgstr ""
+
+#. 3.8->settings-schema.json->maintainer->description
+msgid "Current maintainer: Gr3q"
+msgstr ""
+
+#. 3.8->settings-schema.json->issue-reporting-explanation->description
+msgid ""
+"If you find an issue with this applet please make a report by clicking on "
+"the button below and login in with your Github account.\n"
+"\n"
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
+msgstr ""
+
+#. 3.8->settings-schema.json->loc-info->description
+msgid ""
+"Your location in most cases work automatically but you can enter it manually "
+"by coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,"
+"Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/"
+"Town} {Postcode} {Country}. The search algorithm is very flexible with the "
+"format. After 3 seconds without typing the address you entered is replaced "
+"automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->description
+msgid "Log Level"
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->tooltip
+msgid ""
+"Info is the regular logging, Debug is debug, and Verbose also logs network "
+"request payloads. Changing this will only be effective on future logs. Only "
+"change it you are instructed or you know what you are doing."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Verbose"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->description
+msgid "Click Save to save debug information to a file"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->tooltip
+msgid ""
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
+msgstr ""
+
+#. 3.8->settings-schema.json->selectedLogPath->description
+msgid "Selected path to save Logs"
+msgstr ""

--- a/weather@mockturtl/files/weather@mockturtl/po/sv.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/sv.po
@@ -7,8 +7,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: weather@mockturtl 3.4.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-30 08:55+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2024-02-01 22:38+0100\n"
 "Last-Translator: jorgenqv <jorgenqv@yahoo.com>\n"
 "Language-Team: \n"
@@ -19,65 +20,65 @@ msgstr ""
 "X-Generator: Poedit 3.4.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17607
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Fel"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17608 3.8/weather-applet.js:17610
-#: 3.8/weather-applet.js:17612 3.8/weather-applet.js:17615
-#: 3.8/weather-applet.js:17618 3.8/weather-applet.js:17619
-#: 3.8/weather-applet.js:17620 3.8/weather-applet.js:17621
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Tjänst-fel"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17609
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Felaktig API nyckel"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17611
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Felaktigt Plats format"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17613
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Nyckel blockerad"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17614
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Kan inte hitta plats"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17616
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Ingen Api-nyckel"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17617
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Ingen plats"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17622
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Saknar paket"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17623
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Platsen täcks inte"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9711
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Väder-panelprogram"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17921
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17922
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Klicka för att öppna"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16215
-#: 3.8/weather-applet.js:17925
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Uppdatera"
 
@@ -87,8 +88,8 @@ msgstr "API returnerade statuskod mellan 400 och 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Spara plats"
 
@@ -100,13 +101,13 @@ msgstr "Du kan inte spara en plats som hämtats automatiskt, tyvärr"
 msgid "Could not get weather information"
 msgstr "Kunde inte hämta väderinformation"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17760
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Oväntat fel medan uppdatering av väder, vänligen se logg i Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:18003
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -122,7 +123,7 @@ msgstr "Nätverksfel, vänligen checka loggar i Looking Glass"
 msgid "As of"
 msgstr "Fr.o.m"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:17006
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Drivs av"
 
@@ -130,52 +131,52 @@ msgstr "Drivs av"
 msgid "from you"
 msgstr "från dig"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16919
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:16919
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "i"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10312
-#: 3.8/weather-applet.js:17084
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10313
-#: 3.8/weather-applet.js:17085
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17262
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Läser in aktuellt väder..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17265
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Läser in kommande väder..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16168
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Läser in..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16189
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Temperatur"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16190
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Luftfuktighet"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16191
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Lufttryck"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12257 3.8/weather-applet.js:12263
-#: 3.8/weather-applet.js:14217 3.8/weather-applet.js:14218
-#: 3.8/weather-applet.js:16037
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Vind"
 
@@ -184,35 +185,34 @@ msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Kontrollera att du angett en plats eller använd Automatisk plats istället"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9952
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Kunde inte hitta plats baserad på adress, vänligen kontrollera om det är rätt"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9973
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "Misslyckades att anropa Geolocation API, se Looking Glass för fel."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Varning"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9872
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "Du kan bara spara korrekt plats när panelprogrammet inte uppdateras"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Du kan inte spara en inkorrekt plats"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9880
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Info"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Plats är redan sparad"
 
@@ -250,15 +250,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10740 3.8/weather-applet.js:11711
-#: 3.8/weather-applet.js:12150 3.8/weather-applet.js:12659
-#: 3.8/weather-applet.js:13021 3.8/weather-applet.js:14388
-#: 3.8/weather-applet.js:14929
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Känns som"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:14991
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Misslyckades att behandla väderinformation"
 
@@ -271,7 +271,7 @@ msgstr ""
 "eller hämta en först på https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:14871
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -279,7 +279,7 @@ msgstr ""
 "Vänligen var säker på att du\n"
 "angett API-nyckeln korrekt och att ditt konto inte är låst"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12113
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -290,60 +290,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10516 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10530 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:11379 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:11386 3.8/weather-applet.js:11393
-#: 3.8/weather-applet.js:11400 3.8/weather-applet.js:12292
-#: 3.8/weather-applet.js:13187
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Kraftigt regn"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11554 3.8/weather-applet.js:11555
-#: 3.8/weather-applet.js:11561 3.8/weather-applet.js:12277
-#: 3.8/weather-applet.js:12278 3.8/weather-applet.js:12284
-#: 3.8/weather-applet.js:12291 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12340 3.8/weather-applet.js:12347
-#: 3.8/weather-applet.js:12801 3.8/weather-applet.js:12850
-#: 3.8/weather-applet.js:12851 3.8/weather-applet.js:12858
-#: 3.8/weather-applet.js:13179 3.8/weather-applet.js:13448
-#: 3.8/weather-applet.js:13449 3.8/weather-applet.js:13490
-#: 3.8/weather-applet.js:14189 3.8/weather-applet.js:14190
-#: 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Regn"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10495 3.8/weather-applet.js:10509
-#: 3.8/weather-applet.js:10510 3.8/weather-applet.js:11009
-#: 3.8/weather-applet.js:11463 3.8/weather-applet.js:11464
-#: 3.8/weather-applet.js:11470 3.8/weather-applet.js:11477
-#: 3.8/weather-applet.js:11484 3.8/weather-applet.js:12285
-#: 3.8/weather-applet.js:13189
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Lättare regn"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12348 3.8/weather-applet.js:13163
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Kraftigt underkylt regn"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11014
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12822
-#: 3.8/weather-applet.js:12823 3.8/weather-applet.js:12829
-#: 3.8/weather-applet.js:12830 3.8/weather-applet.js:12836
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Underkylt regn"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12341 3.8/weather-applet.js:13165
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Lätt underkylt regn"
 
@@ -351,177 +351,177 @@ msgstr "Lätt underkylt regn"
 msgid "Light freezing drizzle"
 msgstr "Lätt underkylt duggregn"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12327
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Underkylt dyggregn"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13145
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Lätt duggregn"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12362
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Kraftigt hagel"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12354 3.8/weather-applet.js:12355
-#: 3.8/weather-applet.js:12361 3.8/weather-applet.js:12368
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Småhagel"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12369
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Lätt småhagel"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10600
-#: 3.8/weather-applet.js:10607 3.8/weather-applet.js:10614
-#: 3.8/weather-applet.js:10615 3.8/weather-applet.js:11021
-#: 3.8/weather-applet.js:11435 3.8/weather-applet.js:11436
-#: 3.8/weather-applet.js:11442 3.8/weather-applet.js:11449
-#: 3.8/weather-applet.js:11456 3.8/weather-applet.js:12320
-#: 3.8/weather-applet.js:13205 3.8/weather-applet.js:13525
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Tung snö"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:11610
-#: 3.8/weather-applet.js:11611 3.8/weather-applet.js:11617
-#: 3.8/weather-applet.js:12298 3.8/weather-applet.js:12299
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12795
-#: 3.8/weather-applet.js:13199 3.8/weather-applet.js:13434
-#: 3.8/weather-applet.js:13518 3.8/weather-applet.js:14203
-#: 3.8/weather-applet.js:14204 3.8/weather-applet.js:14581
-#: 3.8/weather-applet.js:14582
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Snö"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11019
-#: 3.8/weather-applet.js:11519 3.8/weather-applet.js:11520
-#: 3.8/weather-applet.js:11526 3.8/weather-applet.js:11533
-#: 3.8/weather-applet.js:11540 3.8/weather-applet.js:12313
-#: 3.8/weather-applet.js:13207
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Lätt snöfall"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12305
-#: 3.8/weather-applet.js:12306 3.8/weather-applet.js:14560
-#: 3.8/weather-applet.js:14561
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Kastbyar"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:12375 3.8/weather-applet.js:12376
-#: 3.8/weather-applet.js:12867 3.8/weather-applet.js:12868
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13532
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:14210
-#: 3.8/weather-applet.js:14211
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Åska"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12243
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Lätt dimma"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11372
-#: 3.8/weather-applet.js:11373 3.8/weather-applet.js:12235
-#: 3.8/weather-applet.js:12236 3.8/weather-applet.js:12242
-#: 3.8/weather-applet.js:12937 3.8/weather-applet.js:12938
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:14161
-#: 3.8/weather-applet.js:14162 3.8/weather-applet.js:14609
-#: 3.8/weather-applet.js:14610
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Dimma"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10474 3.8/weather-applet.js:10475
-#: 3.8/weather-applet.js:11358 3.8/weather-applet.js:11359
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:12208
-#: 3.8/weather-applet.js:13427 3.8/weather-applet.js:13428
-#: 3.8/weather-applet.js:14154 3.8/weather-applet.js:14155
-#: 3.8/weather-applet.js:14651 3.8/weather-applet.js:14652
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Molnigt"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12228
-#: 3.8/weather-applet.js:12229 3.8/weather-applet.js:12745
-#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:12780
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Mestadels molnigt"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10439
-#: 3.8/weather-applet.js:10440 3.8/weather-applet.js:10446
-#: 3.8/weather-applet.js:10447 3.8/weather-applet.js:11547
-#: 3.8/weather-applet.js:11548 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12222 3.8/weather-applet.js:12738
-#: 3.8/weather-applet.js:12739 3.8/weather-applet.js:12773
-#: 3.8/weather-applet.js:13420 3.8/weather-applet.js:13421
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Delvis molnigt"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Mestadels klart"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10425 3.8/weather-applet.js:10426
-#: 3.8/weather-applet.js:11039 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:12724
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12759
-#: 3.8/weather-applet.js:13223 3.8/weather-applet.js:13413
-#: 3.8/weather-applet.js:13414 3.8/weather-applet.js:14140
-#: 3.8/weather-applet.js:14141 3.8/weather-applet.js:14147
-#: 3.8/weather-applet.js:14148 3.8/weather-applet.js:14686
-#: 3.8/weather-applet.js:14687
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Klart"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10432
-#: 3.8/weather-applet.js:10433 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:14693
-#: 3.8/weather-applet.js:14694
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Soligt"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10418
-#: 3.8/weather-applet.js:10419 3.8/weather-applet.js:10453
-#: 3.8/weather-applet.js:10454 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10643 3.8/weather-applet.js:11341
-#: 3.8/weather-applet.js:11342 3.8/weather-applet.js:11639
-#: 3.8/weather-applet.js:11640 3.8/weather-applet.js:12192
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12715
-#: 3.8/weather-applet.js:12716 3.8/weather-applet.js:12944
-#: 3.8/weather-applet.js:12945 3.8/weather-applet.js:14073
-#: 3.8/weather-applet.js:14074 3.8/weather-applet.js:14224
-#: 3.8/weather-applet.js:14225 3.8/weather-applet.js:14797
-#: 3.8/weather-applet.js:14799
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Okänt"
 
@@ -545,7 +545,7 @@ msgstr ""
 "Vänligen ange API nyckel i inställningar,\n"
 "eller hämta en först https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:14881
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -553,7 +553,7 @@ msgstr ""
 "Vänligen var säker på att du\n"
 "angett den API-nyckeln du har hos DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:15197
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Kunde inte hämta plats"
 
@@ -563,121 +563,121 @@ msgid ""
 msgstr ""
 "Plats-tjänsten svarade med felmeddelanden, vänligen se logg i Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11203
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Molnighet"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11351
-#: 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Klar himmel"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11365 3.8/weather-applet.js:11366
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Klart"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11387
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Kraftigt regn med åska"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11394
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Kraftiga regnskurar"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11401
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Kraftiga regnskurar med åska"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11407
-#: 3.8/weather-applet.js:11408 3.8/weather-applet.js:11414
-#: 3.8/weather-applet.js:11421 3.8/weather-applet.js:11428
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Kraftigt slask"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11415
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Kraftigt slask med åska"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11422
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Kraftiga slaskskurar"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11429
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Kraftiga slaskskurar och åska"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11443
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Kraftigt snöfall och åska"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11450
-#: 3.8/weather-applet.js:13526
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Kraftiga snöbyar"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11457
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Kraftiga snöbyar och åska"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11471
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Lätt regn med åska"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11478
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Lätta regnskurar"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11485
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Lätta regnskurar och åska"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11491
-#: 3.8/weather-applet.js:11492 3.8/weather-applet.js:11498
-#: 3.8/weather-applet.js:11505 3.8/weather-applet.js:11512
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Lätt slask"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11499
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Lätt slask med åska"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11506
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Lätta slaskskurar"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11513
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Lätta slaskskurar och åska"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11527
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Lätt snöfall och åska"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11534
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Lätta snöbyar"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11541
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Lätta snöbyar och åska"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11562
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Regn och åska"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11568
-#: 3.8/weather-applet.js:11569 3.8/weather-applet.js:11575
-#: 3.8/weather-applet.js:12859 3.8/weather-applet.js:13185
-#: 3.8/weather-applet.js:13491 3.8/weather-applet.js:13497
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Regnskurar"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11576
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Regnskurar och åska"
 
@@ -686,44 +686,44 @@ msgstr "Regnskurar och åska"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10537
-#: 3.8/weather-applet.js:10544 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11582 3.8/weather-applet.js:11583
-#: 3.8/weather-applet.js:11589 3.8/weather-applet.js:11596
-#: 3.8/weather-applet.js:11603 3.8/weather-applet.js:12808
-#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12815
-#: 3.8/weather-applet.js:12816 3.8/weather-applet.js:12843
-#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14196
-#: 3.8/weather-applet.js:14197 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Slask"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11590
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Slask och åska"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11597
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Slaskskurar"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11604
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Slaskskurar och åska"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11618
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Snö och åska"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11624 3.8/weather-applet.js:11625
-#: 3.8/weather-applet.js:11631 3.8/weather-applet.js:13203
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Snöbyar"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11632
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Snöbyar och åska"
 
@@ -732,21 +732,21 @@ msgstr "Snöbyar och åska"
 msgid "Unexpected response from API"
 msgstr "Oväntad respons från API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10237
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Sikt"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10265
-#: 3.8/weather-applet.js:10817 3.8/weather-applet.js:11722
-#: 3.8/weather-applet.js:12672
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Misslyckades med att behandla aktuell Väder-info"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10055
-#: 3.8/weather-applet.js:10089 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11782 3.8/weather-applet.js:12474
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Misslyckades att behandla prognos-info"
 
@@ -775,300 +775,300 @@ msgid "Excellent - More than"
 msgstr "Utmärkt - Mer än"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10460 3.8/weather-applet.js:10461
-#: 3.8/weather-applet.js:11029 3.8/weather-applet.js:13175
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Disigt"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:12752
-#: 3.8/weather-applet.js:12753 3.8/weather-applet.js:12787
-#: 3.8/weather-applet.js:13219
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Mulet"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10489
-#: 3.8/weather-applet.js:10496
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Lätta regnskurar"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:12326
-#: 3.8/weather-applet.js:13141 3.8/weather-applet.js:14532
-#: 3.8/weather-applet.js:14533
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Smådugg"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:10524
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Tunga regnskurar"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10538
-#: 3.8/weather-applet.js:10545
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Slaskskurar"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:13217 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14169 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:14589
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Hagel"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Hagelbyar"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Lätta snöbyar"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Tunga snöbyar"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10621 3.8/weather-applet.js:10628
-#: 3.8/weather-applet.js:10635 3.8/weather-applet.js:10636
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Åska"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Åskskurar"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10872
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Vänligen var noga med plats är i korrekt format i inställningarna"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10876
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Se till att du angett korrekt nyckel i inställningarna"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10681 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 "Plats hittades inte, var säker på att den är tillgänglig och är i rätt format"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10884
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 "Om detta problem fortsätter, vänligen kontakta detta panelprograms utvecklare"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10888
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Okänt fel, vänligen se loggar i Looking Glass"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10990
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Åska med lättare regn"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10991
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Åska med regn"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10992
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Åska med kraftigt regn"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10993
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Lättare Åska"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10995
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Kraftig åska"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10996
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Ojämna åskbyar"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10997
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Åska med lättare duggregn"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10998
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Åska med duggregn"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10999
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Åska med kraftigt duggregn"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11000
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Lättare smådugg"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11002
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Kraftigt smådugg"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11003
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Lättare duggregn"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11004
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Duggregn"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11005
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Kraftigt duggregn"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11006
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Regnskurar och duggregn"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11007
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Kraftiga skurar och duggregn"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11008
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Duschregn"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11010
-#: 3.8/weather-applet.js:13455 3.8/weather-applet.js:13456
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Måttligt regn"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11011
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Kraftigt intensivt regn"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11012
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Mycket kraftigt regn"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11013
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Extremt regn"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11015
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Lätta intensiva regnskurar"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11016
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Regnskurar"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11017
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Kraftiga intensiva regnskurar"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11018
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Störtskurar"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11023
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Slaskskurar"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11024
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Lätt regn och snö"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11025
-#: 3.8/weather-applet.js:13462 3.8/weather-applet.js:13463
-#: 3.8/weather-applet.js:13469 3.8/weather-applet.js:13504
-#: 3.8/weather-applet.js:13511
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Regn och snö"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11026
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Lätta snöbyar"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11027
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Snöbyar"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11028
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Kraftiga snöbyar"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:12902
-#: 3.8/weather-applet.js:12903 3.8/weather-applet.js:14623
-#: 3.8/weather-applet.js:14624
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Rök"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11031 3.8/weather-applet.js:12909
-#: 3.8/weather-applet.js:12910 3.8/weather-applet.js:14616
-#: 3.8/weather-applet.js:14617
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Disigt"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11032
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Sand, dammvirvlar"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11034
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Sand"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11035 3.8/weather-applet.js:12895
-#: 3.8/weather-applet.js:12896 3.8/weather-applet.js:14602
-#: 3.8/weather-applet.js:14603
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Damm"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11036
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Vulkanisk aska"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:13209
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Vindbyar"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11038 3.8/weather-applet.js:12874
-#: 3.8/weather-applet.js:12875 3.8/weather-applet.js:14475
-#: 3.8/weather-applet.js:14476
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Tromb"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11041
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Himmelen är klar"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11042
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Moln"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11043
-#: 3.8/weather-applet.js:12731 3.8/weather-applet.js:12732
-#: 3.8/weather-applet.js:12766
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Enstaka moln"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11044
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Spridda moln"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11045
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Växlande molnighet"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11046
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Mulet"
 
@@ -1076,80 +1076,80 @@ msgstr "Mulet"
 msgid "Could not get forecast for your area"
 msgstr "Kunde inte hämta prognos för ditt område"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12431
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "Platsen är utanför USA, vänligen använd en annan väderlekstjänst."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12495
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Det gick inte att behandla prognosinformation per timme"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12760
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Klart och blåsigt"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12767
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Få moln och blåsigt"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12774
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Delvis molnigt och blåsigt"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Mest molnigt och blåsigt"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12788
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Mulet och blåsigt"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12802
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Snöigt regn"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12837
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Frysande regn och snö"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9153 3.8/weather-applet.js:12881
-#: 3.8/weather-applet.js:12882 3.8/weather-applet.js:14489
-#: 3.8/weather-applet.js:14490
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Orkan"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9148
-#: 3.8/weather-applet.js:12888
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Storm"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12889
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Tropisk storm"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12916 3.8/weather-applet.js:12917
-#: 3.8/weather-applet.js:14721 3.8/weather-applet.js:14722
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Hett"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12923 3.8/weather-applet.js:12924
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Kallt"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12930 3.8/weather-applet.js:12931
-#: 3.8/weather-applet.js:14770 3.8/weather-applet.js:14771
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Häftig snöstorm"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9025
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Idag"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9027
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Imorgon"
 
@@ -1181,79 +1181,79 @@ msgstr "Fredag"
 msgid "Saturday"
 msgstr "Lördag"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9118
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Stiljte"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9121
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Nästan stiltje"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9124
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Lätt bris"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9127
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "God bris"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9130
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Måttlig bris"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9133
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Frisk bris"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9136
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Styv bris"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9139
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Styv kuling"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9142
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Hård kuling"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9145
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Halv storm"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9151
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Svår storm"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "N"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "NO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "Ö"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "SO"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "S"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "SV"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "V"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "NV"
 
@@ -1305,7 +1305,7 @@ msgstr ""
 "Okänt fel hände medan hämtning av väder, se Looking Glass loggar för mer "
 "infromation"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14482 3.8/weather-applet.js:14483
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Tropisk storm"
 
@@ -1313,7 +1313,7 @@ msgstr "Tropisk storm"
 msgid "Severe Thunderstorms"
 msgstr "Kraftigt åskväder"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14503 3.8/weather-applet.js:14504
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Åskväder"
 
@@ -1329,15 +1329,15 @@ msgstr "Blandat regnslask"
 msgid "Mixed Snow and Sleet"
 msgstr "Blandat snö och slask"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Fryst duggregn"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Frysande regn"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Skurar"
 
@@ -1349,11 +1349,11 @@ msgstr "Snöbyar"
 msgid "Light Snow Showers"
 msgstr "Lätta snöbyar"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14574 3.8/weather-applet.js:14575
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Snöblåst"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13441 3.8/weather-applet.js:13442
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Dimmigt"
 
@@ -1365,54 +1365,54 @@ msgstr "Rökigt"
 msgid "Blustery"
 msgstr "Häftig blåst"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14637 3.8/weather-applet.js:14638
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Blåsigt"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:14658 3.8/weather-applet.js:14659
-#: 3.8/weather-applet.js:14665 3.8/weather-applet.js:14666
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Mestadels molnigt"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14175 3.8/weather-applet.js:14176
-#: 3.8/weather-applet.js:14182 3.8/weather-applet.js:14183
-#: 3.8/weather-applet.js:14672 3.8/weather-applet.js:14673
-#: 3.8/weather-applet.js:14679 3.8/weather-applet.js:14680
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Delvis molnigt"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Mestadels soligt"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:14714 3.8/weather-applet.js:14715
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Blandat regn och hagel"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:14728 3.8/weather-applet.js:14729
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Enstaka åskaväder"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:14735 3.8/weather-applet.js:14736
-#: 3.8/weather-applet.js:14791 3.8/weather-applet.js:14792
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Utbrett åskväder"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:14742 3.8/weather-applet.js:14743
-#: 3.8/weather-applet.js:14777 3.8/weather-applet.js:14778
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Spridda skurar"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:14749 3.8/weather-applet.js:14750
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Kraftigt regn"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:14756 3.8/weather-applet.js:14757
-#: 3.8/weather-applet.js:14784 3.8/weather-applet.js:14785
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Spridda snöbyar"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:14763 3.8/weather-applet.js:14764
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Blötsnö"
 
@@ -1424,7 +1424,7 @@ msgstr "Inte tillgängligt"
 msgid "Scattered Thundershowers"
 msgstr "Spridda åskbyar"
 
-#: 3.8/weather-applet.js:9637
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1432,7 +1432,7 @@ msgstr ""
 "Kunde inte hämta loggar, loggfil hittades inte i sökväg\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9641
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1441,298 +1441,298 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10013
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10118
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 "MET Office UK täcker endast UK, vänligen säkerställ att din plats är i landet"
 
-#: 3.8/weather-applet.js:10197
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Ingen data hittades för plats"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Mycket dåligt"
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Mindre än {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Utmärkt"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Mer än {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10287
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Dåligt"
 
-#: 3.8/weather-applet.js:10287 3.8/weather-applet.js:10292
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:10302
-#: 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Mellan {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10292
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Måttligt"
 
-#: 3.8/weather-applet.js:10297
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "God"
 
-#: 3.8/weather-applet.js:10302 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Mycket god"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10662
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norge"
 
-#: 3.8/weather-applet.js:11659
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12080
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12250
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Lätt vind"
 
-#: 3.8/weather-applet.js:12264
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Stark vind"
 
-#: 3.8/weather-applet.js:12411
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:12962
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:13139
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Blåsande eller drivande snö"
 
-#: 3.8/weather-applet.js:13143
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Kraftigt smådugg"
 
-#: 3.8/weather-applet.js:13147
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Kraftigt dugg/regn"
 
-#: 3.8/weather-applet.js:13149
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Lätt dugg/regn"
 
-#: 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Sandstorm"
 
-#: 3.8/weather-applet.js:13155
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Underkylt dugg/underkylt regn"
 
-#: 3.8/weather-applet.js:13157
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Kraftigt underkylt dugg/underkylt regn"
 
-#: 3.8/weather-applet.js:13159
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Lätt underkylt dugg/underkylt regn"
 
-#: 3.8/weather-applet.js:13161
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Frysande dimma"
 
-#: 3.8/weather-applet.js:13167
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Trattmoln/tromb"
 
-#: 3.8/weather-applet.js:13169
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Hagelskurar"
 
-#: 3.8/weather-applet.js:13171
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Is"
 
-#: 3.8/weather-applet.js:13173
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Blixtar utan åska"
 
-#: 3.8/weather-applet.js:13177
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Nederbörd i närheten"
 
-#: 3.8/weather-applet.js:13181 3.8/weather-applet.js:13470
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Kraftigt regn och snö"
 
-#: 3.8/weather-applet.js:13183
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Lätt regn och snö"
 
-#: 3.8/weather-applet.js:13191
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Minskande himmelstäckning"
 
-#: 3.8/weather-applet.js:13193
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Ökande himmelstäckning"
 
-#: 3.8/weather-applet.js:13195
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Oförändrad himmel"
 
-#: 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Rök eller dis"
 
-#: 3.8/weather-applet.js:13201
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Snö och regnskurar"
 
-#: 3.8/weather-applet.js:13213
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Åska utan nederbörd"
 
-#: 3.8/weather-applet.js:13215
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Isnål-snö"
 
-#: 3.8/weather-applet.js:13221
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Delvis molnigt"
 
-#: 3.8/weather-applet.js:13243
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Vänligen kolla att du angett API-nyckel korrekt"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13259
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Danmark"
 
-#: 3.8/weather-applet.js:13402 3.8/weather-applet.js:13403
-#: 3.8/weather-applet.js:13539 3.8/weather-applet.js:13540
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "HITTADES INTE"
 
-#: 3.8/weather-applet.js:13435
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Snöblåst"
 
-#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:13477
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Lätt snöfall"
 
-#: 3.8/weather-applet.js:13483 3.8/weather-applet.js:13484
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Måttligt snöfall"
 
-#: 3.8/weather-applet.js:13498
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Måttliga regnskurar"
 
-#: 3.8/weather-applet.js:13505
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Snöblandat regn"
 
-#: 3.8/weather-applet.js:13512
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Kraftigt snöblandat regn"
 
-#: 3.8/weather-applet.js:13657
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:13953
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:13966
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "Vänligen välj en annan tjänst eller plats"
 
-#: 3.8/weather-applet.js:14263
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14453
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "API-nyckeln du angav är ogiltig."
 
-#: 3.8/weather-applet.js:14460
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "Platsen du angav hittades inte."
 
-#: 3.8/weather-applet.js:14496 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Kraftig storm"
 
-#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:14512
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Regn och snö"
 
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Blandat regnslask"
 
-#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Snöbyar"
 
-#: 3.8/weather-applet.js:14630 3.8/weather-applet.js:14631
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "Blåsigt"
 
-#: 3.8/weather-applet.js:14644 3.8/weather-applet.js:14645
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr "Kylig"
 
-#: 3.8/weather-applet.js:14700 3.8/weather-applet.js:14701
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Mestadels klart"
 
-#: 3.8/weather-applet.js:14853
+#: 3.8/weather-applet.js:15247
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:15206
+#: 3.8/weather-applet.js:15603
 msgid ""
 "Location Service couldn't find your location, please see the logs in Looking "
 "Glass"
 msgstr ""
 "Plats-tjänsten kunde inte hitta din plats, vänligen se logg i Looking Glass"
 
-#: 3.8/weather-applet.js:15428
+#: 3.8/weather-applet.js:15831
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 "Kontrollera att du angett en plats eller använd Automatisk plats istället."
 
-#: 3.8/weather-applet.js:15565
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1740,7 +1740,7 @@ msgstr ""
 "Kunde inte hämta inställningar, fil hittades inte i sökväg\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15572
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1748,57 +1748,57 @@ msgstr ""
 "Kunde inte hämta innehåll för inställningsfil i sökväg\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:16192
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Denna väderlekstjänst kräver en API-nyckel för att fungera"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Daggpunkt"
 
-#: 3.8/weather-applet.js:16264
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Nederbörd kommer att upphöra inom {precipEnd} minuter"
 
-#: 3.8/weather-applet.js:16266
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "Nederbörd kommer inte att upphöra inom en timme"
 
-#: 3.8/weather-applet.js:16269
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Nederbörd kommer att börja inom {precipStart} minuter"
 
-#: 3.8/weather-applet.js:16481
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Prognos tolkning misslyckades, se loggar för mer information."
 
-#: 3.8/weather-applet.js:17013 3.8/weather-applet.js:17802
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "Fr.o.m. {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:17019
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} från dig"
 
-#: 3.8/weather-applet.js:17023
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "Stationsnamn: {stationName}"
 
-#: 3.8/weather-applet.js:17026
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "Område: {stationArea}"
 
-#: 3.8/weather-applet.js:17573 3.8/weather-applet.js:17583
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Fel vid sparande av felsökningsinformation"
 
-#: 3.8/weather-applet.js:17595
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Felsökningsinformationen har sparats"
 
-#: 3.8/weather-applet.js:17595
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Sparad i {filePath}"
-
-#: 3.8/weather-applet.js:17726
-msgid "This provider requires an API key to operate"
-msgstr "Denna väderlekstjänst kräver en API-nyckel för att fungera"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -2592,47 +2592,3 @@ msgstr ""
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr "Vald sökväg för att spara loggar"
-
-#~ msgid "DarkSky"
-#~ msgstr "DarkSky"
-
-#~ msgid "This API has ceased to function, please use another one."
-#~ msgstr ""
-#~ "Denna API har upphört att fungera, vänligen använd en annan istället."
-
-#~ msgid "Instead of 15:00 or 3 pm it will show up as 15 or 3 pm"
-#~ msgstr "Istället för 15:00 eller 3 pm så visas det som 15 eller 3 pm"
-
-#~ msgid "Climacell"
-#~ msgstr "Climacell"
-
-#~ msgid "ClimacellV4 (key needed)"
-#~ msgstr "ClimacellV4 (nyckel behövs)"
-
-#~ msgid "Light Snow"
-#~ msgstr "Lätt snö"
-
-#~ msgid "API key doesn't provide access to Hourly Weather, skipping"
-#~ msgstr "API-nyckel tillåter inte tillgång till väder per timme, hoppar över"
-
-#~ msgid "ClimacellV3 (key needed)"
-#~ msgstr "ClimacellV3 (nyckel behövs)"
-
-#~ msgid "Please install '{missingPackage}', then refresh manually."
-#~ msgstr ""
-#~ "Vänligen installera '{missingPackage}', därefter uppdatera manuellt."
-
-#~ msgid "Currently only used with DarkSky."
-#~ msgstr "Används för tillfället bara med DarkSky."
-
-#~ msgid "Units, Icons and Keys"
-#~ msgstr "Enheter, Ikoner och Tangenter"
-
-#~ msgid "How to choose a weather provider"
-#~ msgstr "Hur man väljer en väderlekstjänst"
-
-#~ msgid "Allowed location formats"
-#~ msgstr "Tillåtna platsformat"
-
-#~ msgid "View additional information"
-#~ msgstr "Se ytterligare information"

--- a/weather@mockturtl/files/weather@mockturtl/po/tr.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/tr.po
@@ -13,8 +13,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 3.2.8\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-24 09:42+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2023-02-03 09:59+0300\n"
 "Last-Translator: Serkan ÖNDER <serkanonder@outlook.com>\n"
 "Language-Team: \n"
@@ -26,65 +27,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17472
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Hata"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17473 3.8/weather-applet.js:17475
-#: 3.8/weather-applet.js:17477 3.8/weather-applet.js:17480
-#: 3.8/weather-applet.js:17483 3.8/weather-applet.js:17484
-#: 3.8/weather-applet.js:17485 3.8/weather-applet.js:17486
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Servis Hatası"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17474
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Hatalı API Anahtarı"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17476
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Yanlış Konum Biçimi"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17478
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Anahtar Engellendi"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17479
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Konum bulunamadı"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17481
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Api Anahtarı Yok"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17482
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Konum Yok"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17487
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Eksik Paketler"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17488
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Konum kapsanmamış"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9748
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Hava Durumu Uygulaması"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17797
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17798
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Açmak için tıklayın"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16181
-#: 3.8/weather-applet.js:17801
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Yenile"
 
@@ -94,8 +95,8 @@ msgstr "API, 400 ile 500 arasında durum kodu döndürdü"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9914
-#: 3.8/weather-applet.js:9918 3.8/weather-applet.js:9922
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Konum Deposu"
 
@@ -107,13 +108,13 @@ msgstr "Otomatik olarak elde edilen bir konumu kaydedemezsiniz, üzgünüm"
 msgid "Could not get weather information"
 msgstr "Hava durumu bilgisi alınamadı"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17636
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 "Hava Yenileme Sırasında Beklenmeyen Hata, lütfen Hata günlüklerine bakın"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:17879
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -129,7 +130,7 @@ msgstr "Ağ Hatası, lütfen Hata günlüklerini kontrol edin"
 msgid "As of"
 msgstr "İtibarıyla"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:16885
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "Veri sağlayıcı"
 
@@ -137,90 +138,88 @@ msgstr "Veri sağlayıcı"
 msgid "from you"
 msgstr "sizden"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16798
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "mm"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:10721
-#: 3.8/weather-applet.js:16798
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "in"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10354
-#: 3.8/weather-applet.js:16963
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "mi"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10355
-#: 3.8/weather-applet.js:16964
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "km"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17143
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Mevcut hava durumu yükleniyor ..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17146
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Gelecekteki hava durumu yükleniyor ..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16134
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Yükleniyor ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16155
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Sıcaklık"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16156
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Nem"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16157
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Basınç"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12599 3.8/weather-applet.js:12606
-#: 3.8/weather-applet.js:12607 3.8/weather-applet.js:12613
-#: 3.8/weather-applet.js:14569 3.8/weather-applet.js:14570
-#: 3.8/weather-applet.js:16006
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Rüzgar"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:15403
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 "Bir konum girdiğinizden emin olun veya bunun yerine Otomatik konum kullanın"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9994
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 "Adrese göre konum bulunamadı, lütfen doğru olup olmadığını kontrol edin"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10015
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "Geolocation API çağrılamadı, hatalar için Hata Günlüklerine bakın."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9914
-#: 3.8/weather-applet.js:9918
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "Uyarı"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9914
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "Doğru konumları yalnızca uygulama yenilenmediğinde kaydedebilirsiniz"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9918
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Yanlış bir konumu kaydedemezsiniz"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9922
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Bilgi"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9922
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Konum zaten kaydedildi"
 
@@ -258,15 +257,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10801 3.8/weather-applet.js:11095
-#: 3.8/weather-applet.js:12062 3.8/weather-applet.js:12502
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13373
-#: 3.8/weather-applet.js:14740
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Hissedilen"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:10846
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Hava Durumu Bilgisi İşlenemedi"
 
@@ -279,7 +278,7 @@ msgstr ""
 "veya https://developer.climacell.co/sign-up adresinden bir tane edinin"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:10730 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -287,7 +286,7 @@ msgstr ""
 "Lütfen API anahtarını doğru girdiğinizden emin olun\n"
 "hesabınız kilitli değil"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12468
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -298,60 +297,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:11734 3.8/weather-applet.js:11735
-#: 3.8/weather-applet.js:11741 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11755 3.8/weather-applet.js:12642
-#: 3.8/weather-applet.js:13539
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Şiddetli yağmur"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11909 3.8/weather-applet.js:11910
-#: 3.8/weather-applet.js:11916 3.8/weather-applet.js:12627
-#: 3.8/weather-applet.js:12628 3.8/weather-applet.js:12634
-#: 3.8/weather-applet.js:12641 3.8/weather-applet.js:12683
-#: 3.8/weather-applet.js:12690 3.8/weather-applet.js:12697
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:13202
-#: 3.8/weather-applet.js:13203 3.8/weather-applet.js:13210
-#: 3.8/weather-applet.js:13531 3.8/weather-applet.js:13800
-#: 3.8/weather-applet.js:13801 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:14541 3.8/weather-applet.js:14542
-#: 3.8/weather-applet.js:14906 3.8/weather-applet.js:14907
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Yağmur"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10530
-#: 3.8/weather-applet.js:10537 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11364
-#: 3.8/weather-applet.js:11818 3.8/weather-applet.js:11819
-#: 3.8/weather-applet.js:11825 3.8/weather-applet.js:11832
-#: 3.8/weather-applet.js:11839 3.8/weather-applet.js:12635
-#: 3.8/weather-applet.js:13541
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Hafif yağmur"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12698 3.8/weather-applet.js:13515
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Şiddetli dondurucu yağmur"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11369
-#: 3.8/weather-applet.js:12684 3.8/weather-applet.js:13174
-#: 3.8/weather-applet.js:13175 3.8/weather-applet.js:13181
-#: 3.8/weather-applet.js:13182 3.8/weather-applet.js:13188
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Dolu yağışlı"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12691 3.8/weather-applet.js:13517
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Hafif donan yağmur"
 
@@ -359,189 +358,189 @@ msgstr "Hafif donan yağmur"
 msgid "Light freezing drizzle"
 msgstr "Hafif dondurucu çiseleme"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12677
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Dondurucu çiseleme"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13497
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Hafif çiseleme"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12712
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Yoğun buz topakları"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12704 3.8/weather-applet.js:12705
-#: 3.8/weather-applet.js:12711 3.8/weather-applet.js:12718
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Buz topakları"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12719
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Hafif buz topakları"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10649 3.8/weather-applet.js:10656
-#: 3.8/weather-applet.js:10657 3.8/weather-applet.js:11376
-#: 3.8/weather-applet.js:11790 3.8/weather-applet.js:11791
-#: 3.8/weather-applet.js:11797 3.8/weather-applet.js:11804
-#: 3.8/weather-applet.js:11811 3.8/weather-applet.js:12670
-#: 3.8/weather-applet.js:13557 3.8/weather-applet.js:13877
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Ağır kar yağışı"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11375 3.8/weather-applet.js:11965
-#: 3.8/weather-applet.js:11966 3.8/weather-applet.js:11972
-#: 3.8/weather-applet.js:12648 3.8/weather-applet.js:12649
-#: 3.8/weather-applet.js:12662 3.8/weather-applet.js:12669
-#: 3.8/weather-applet.js:13146 3.8/weather-applet.js:13147
-#: 3.8/weather-applet.js:13551 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13870 3.8/weather-applet.js:14555
-#: 3.8/weather-applet.js:14556 3.8/weather-applet.js:14934
-#: 3.8/weather-applet.js:14935
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Kar"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10621
-#: 3.8/weather-applet.js:10628 3.8/weather-applet.js:10635
-#: 3.8/weather-applet.js:10636 3.8/weather-applet.js:11374
-#: 3.8/weather-applet.js:11874 3.8/weather-applet.js:11875
-#: 3.8/weather-applet.js:11881 3.8/weather-applet.js:11888
-#: 3.8/weather-applet.js:11895 3.8/weather-applet.js:12663
-#: 3.8/weather-applet.js:13559
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Hafif kar"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12655
-#: 3.8/weather-applet.js:12656 3.8/weather-applet.js:14913
-#: 3.8/weather-applet.js:14914
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Sağanak yağış"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11349
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12726
-#: 3.8/weather-applet.js:13219 3.8/weather-applet.js:13220
-#: 3.8/weather-applet.js:13563 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:14562
-#: 3.8/weather-applet.js:14563
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Gökgürültülü Fırtınalı"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12593
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Hafif Sis"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10509 3.8/weather-applet.js:10510
-#: 3.8/weather-applet.js:11388 3.8/weather-applet.js:11727
-#: 3.8/weather-applet.js:11728 3.8/weather-applet.js:12585
-#: 3.8/weather-applet.js:12586 3.8/weather-applet.js:12592
-#: 3.8/weather-applet.js:13289 3.8/weather-applet.js:13290
-#: 3.8/weather-applet.js:13505 3.8/weather-applet.js:14513
-#: 3.8/weather-applet.js:14514 3.8/weather-applet.js:14962
-#: 3.8/weather-applet.js:14963
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Sisli"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10516 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:11713 3.8/weather-applet.js:11714
-#: 3.8/weather-applet.js:12557 3.8/weather-applet.js:12558
-#: 3.8/weather-applet.js:13779 3.8/weather-applet.js:13780
-#: 3.8/weather-applet.js:14506 3.8/weather-applet.js:14507
-#: 3.8/weather-applet.js:15004 3.8/weather-applet.js:15005
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Bulutlu"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12578
-#: 3.8/weather-applet.js:12579 3.8/weather-applet.js:13097
-#: 3.8/weather-applet.js:13098 3.8/weather-applet.js:13132
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Çok Bulutlu"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10489 3.8/weather-applet.js:11902
-#: 3.8/weather-applet.js:11903 3.8/weather-applet.js:12571
-#: 3.8/weather-applet.js:12572 3.8/weather-applet.js:13090
-#: 3.8/weather-applet.js:13091 3.8/weather-applet.js:13125
-#: 3.8/weather-applet.js:13772 3.8/weather-applet.js:13773
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Parçalı Bulutlu"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12564
-#: 3.8/weather-applet.js:12565
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Çoğunlukla Açık"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11394 3.8/weather-applet.js:12550
-#: 3.8/weather-applet.js:12551 3.8/weather-applet.js:13076
-#: 3.8/weather-applet.js:13077 3.8/weather-applet.js:13111
-#: 3.8/weather-applet.js:13575 3.8/weather-applet.js:13765
-#: 3.8/weather-applet.js:13766 3.8/weather-applet.js:14492
-#: 3.8/weather-applet.js:14493 3.8/weather-applet.js:14499
-#: 3.8/weather-applet.js:14500 3.8/weather-applet.js:15039
-#: 3.8/weather-applet.js:15040
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Açık"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10474
-#: 3.8/weather-applet.js:10475 3.8/weather-applet.js:12550
-#: 3.8/weather-applet.js:12551 3.8/weather-applet.js:15046
-#: 3.8/weather-applet.js:15047
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Güneşli"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10460
-#: 3.8/weather-applet.js:10461 3.8/weather-applet.js:10495
-#: 3.8/weather-applet.js:10496 3.8/weather-applet.js:10684
-#: 3.8/weather-applet.js:10685 3.8/weather-applet.js:11696
-#: 3.8/weather-applet.js:11697 3.8/weather-applet.js:11994
-#: 3.8/weather-applet.js:11995 3.8/weather-applet.js:12542
-#: 3.8/weather-applet.js:12543 3.8/weather-applet.js:13067
-#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13296
-#: 3.8/weather-applet.js:13297 3.8/weather-applet.js:14425
-#: 3.8/weather-applet.js:14426 3.8/weather-applet.js:14576
-#: 3.8/weather-applet.js:14577 3.8/weather-applet.js:15150
-#: 3.8/weather-applet.js:15152
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Bilinmeyen"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10721
+#: 3.0/darkSky.js:71
 msgid "and"
 msgstr "ve"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10721
+#: 3.0/darkSky.js:71
 msgid "until"
 msgstr "a kadar"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10721
+#: 3.0/darkSky.js:71
 msgid "Possible"
 msgstr "Mümkün"
 
@@ -553,7 +552,7 @@ msgstr ""
 "Lütfen ayarlara API anahtarını girin,\n"
 "veya https://darksky.net/dev/register adresinden bir tane edinin"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:10740
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -561,130 +560,130 @@ msgstr ""
 "Lütfen emin ol\n"
 "DarkSky'den sahip olduğunuz API anahtarını girdiniz"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:9693
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Konum alınamadı"
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:9699
+#: 3.0/ipApi.js:95
 msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr "Konum Hizmeti hatalarla yanıt verdi, lütfen hata günlüklerine bakın"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11558
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Bulanıklık"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11395 3.8/weather-applet.js:11706
-#: 3.8/weather-applet.js:11707
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Hava açık"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11720 3.8/weather-applet.js:11721
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Açık"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11742
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Şiddetli yağmur ve gök gürültüsü"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11749
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Şiddetli sağnak yağmur"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11756
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Şiddetli sağnak yağmur ve gök gürültüsü"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11762
-#: 3.8/weather-applet.js:11763 3.8/weather-applet.js:11769
-#: 3.8/weather-applet.js:11776 3.8/weather-applet.js:11783
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Yoğun sulu kar"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11770
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Yoğun sulu kar ve gök gürültüsü"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11777
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Şiddetl isağnak sulu kar"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11784
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Şiddetli sağnak sulu kar ve gök gürültüsü"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11798
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Yoğun kar ve gök gürültüsü"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11805
-#: 3.8/weather-applet.js:13878
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Şiddetli sağnak kar yağışı"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11812
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Şiddetli sağnak kar yağışı ve gök gürültüsü"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11826
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Hafif yağmur ve gök gürültüsü"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11833
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Hafif sağanak yağmur"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11840
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Hafif sağanak yağmur ve gök gürültüsü"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11846
-#: 3.8/weather-applet.js:11847 3.8/weather-applet.js:11853
-#: 3.8/weather-applet.js:11860 3.8/weather-applet.js:11867
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Hafif Sulu kar"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11854
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Hafif karla karışık yağmur ve gök gürültüsü"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11861
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Hafif sağnak karla karışık yağmur"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11868
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Hafif sağnak karla karışık yağmur ve gök gürültüsü"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11882
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Hafif kar yağışı ve gök gürültüsü"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11889
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Hafif sağanak kar yağışı"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11896
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Hafif sağnak kar yağışı ve gök gürültüsü"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11917
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Yağmur ve gök gürültüsü"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11923
-#: 3.8/weather-applet.js:11924 3.8/weather-applet.js:11930
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13537
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Sağanak yağmur"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11931
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Sağanak yağmur ve gök gürültüsü"
 
@@ -693,44 +692,44 @@ msgstr "Sağanak yağmur ve gök gürültüsü"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11377
-#: 3.8/weather-applet.js:11937 3.8/weather-applet.js:11938
-#: 3.8/weather-applet.js:11944 3.8/weather-applet.js:11951
-#: 3.8/weather-applet.js:11958 3.8/weather-applet.js:13160
-#: 3.8/weather-applet.js:13161 3.8/weather-applet.js:13167
-#: 3.8/weather-applet.js:13168 3.8/weather-applet.js:13195
-#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:14548
-#: 3.8/weather-applet.js:14549 3.8/weather-applet.js:14948
-#: 3.8/weather-applet.js:14949
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Karla karışık yağmur"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11945
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Karla karışık yağmur ve gök gürültüsü"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11952
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Karla karışık yağmur"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11959
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Karla karışık sağanak yağmur ve gök gürültüsü"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11973
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Kar ve gök gürültüsü"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11979 3.8/weather-applet.js:11980
-#: 3.8/weather-applet.js:11986 3.8/weather-applet.js:13555
-#: 3.8/weather-applet.js:13871
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Sağanak kar"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11987
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Sağanak kar ve gök gürültüsü"
 
@@ -739,21 +738,21 @@ msgstr "Sağanak kar ve gök gürültüsü"
 msgid "Unexpected response from API"
 msgstr "API'den beklenmeyen yanıt"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10279
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Görüş mesafesi"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10307
-#: 3.8/weather-applet.js:11172 3.8/weather-applet.js:12073
-#: 3.8/weather-applet.js:13022
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Mevcut Hava Durumu Bilgisi İşlenemedi"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10097
-#: 3.8/weather-applet.js:10131 3.8/weather-applet.js:12099
-#: 3.8/weather-applet.js:12133 3.8/weather-applet.js:12824
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Tahmin Bilgileri İşlenemedi"
 
@@ -782,88 +781,88 @@ msgid "Excellent - More than"
 msgstr "Mükemmel - Şundan fazla"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11384 3.8/weather-applet.js:13527
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Buğulu"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10524 3.8/weather-applet.js:13104
-#: 3.8/weather-applet.js:13105 3.8/weather-applet.js:13139
-#: 3.8/weather-applet.js:13571
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Bulutlu"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:10538
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Hafif sağanak yağmur"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10544 3.8/weather-applet.js:10545
-#: 3.8/weather-applet.js:11356 3.8/weather-applet.js:12620
-#: 3.8/weather-applet.js:12621 3.8/weather-applet.js:12676
-#: 3.8/weather-applet.js:13493 3.8/weather-applet.js:14885
-#: 3.8/weather-applet.js:14886
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Çiseleme"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Şiddetli sağnak yağmur"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Karla karışık yağmur"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10600 3.8/weather-applet.js:10607
-#: 3.8/weather-applet.js:10614 3.8/weather-applet.js:10615
-#: 3.8/weather-applet.js:13569 3.8/weather-applet.js:14520
-#: 3.8/weather-applet.js:14521 3.8/weather-applet.js:14941
-#: 3.8/weather-applet.js:14942
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Dolu"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Sağanak dolu"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Hafif sağanak kar yağışı"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10643
-#: 3.8/weather-applet.js:10650
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Şiddetli sağnak kar yağışı"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10663 3.8/weather-applet.js:10670
-#: 3.8/weather-applet.js:10677 3.8/weather-applet.js:10678
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Gökgürültülü"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10664
-#: 3.8/weather-applet.js:10671
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Gökgürültülü sağnak"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11227
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "Lütfen Ayarda Konumun doğru biçimde olduğundan emin olun"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11231
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Ayarlara doğru anahtarı girdiğinizden emin olun"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11235
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
@@ -871,211 +870,211 @@ msgstr ""
 "Konum bulunamadı, konumun kullanılabilir olduğundan veya doğru biçimde "
 "olduğundan emin olun"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11239
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Bu sorun devam ederse, lütfen bu uygulamanın Yazarına başvurun"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11243
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Bilinmeyen Hata, lütfen Hata günlüklere bakın"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11345
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Hafif yağmur ve gök gürültülü sağanak yağış"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11346
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Fırtına ve yağmur"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11347
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Fırtına şiddetli yağmur"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11348
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Hafif gök gürültülü fırtına"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11350
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Yoğun gök gürültülü fırtına"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11351
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Düzensiz fırtına"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11352
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Gök gürültülü hafif çiseleme"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11353
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Çiseleyen yağmur fırtınası"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11354
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Fırtına ağır çiseleyen yağmur ile"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11355
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Hafif yoğun çiseleme"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11357
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Ağır yoğun çiseleme"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11358
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Hafif yoğun yağmurlu"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11359
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Çiseleyen yağmur"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11360
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Şiddetli yoğun yağmur"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11361
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Çiseleme ve ahmak ıslatan"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11362
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Şiddetli çiseleme ve ahmak ıslatan"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11363
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Çiseleme ahmak ıslatan"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11365
-#: 3.8/weather-applet.js:13807 3.8/weather-applet.js:13808
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Ilımlı yağmur"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11366
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Yüksek yoğun yağmur"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11367
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Çok şiddetli yağmur"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11368
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Aşırı yağmur"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11370
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Hafif şiddetli yağmur"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11371
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Şiddetli yağmur"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11372
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Sağanak yağmur"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11373
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Düzensiz sağanak yağmur"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11378
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Ahmak ıslatan"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11379
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Hafif kar ve yağmur"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:13814 3.8/weather-applet.js:13815
-#: 3.8/weather-applet.js:13821 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13863
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Yağmur ve kar"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11381
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Hafif şiddetli kar yağışı"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11382
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Şiddetli kar"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11383
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Ağır şiddetli kar"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11385 3.8/weather-applet.js:13254
-#: 3.8/weather-applet.js:13255 3.8/weather-applet.js:14976
-#: 3.8/weather-applet.js:14977
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Dumanlı"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11386 3.8/weather-applet.js:13261
-#: 3.8/weather-applet.js:13262 3.8/weather-applet.js:14969
-#: 3.8/weather-applet.js:14970
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Puslu"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11387
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Kum, toz fırtınası"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11389
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Kum"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11390 3.8/weather-applet.js:13247
-#: 3.8/weather-applet.js:13248 3.8/weather-applet.js:14955
-#: 3.8/weather-applet.js:14956
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Tozlu"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11391
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Volkanik kül"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11392
-#: 3.8/weather-applet.js:13561
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Bağrışma"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11393 3.8/weather-applet.js:13226
-#: 3.8/weather-applet.js:13227 3.8/weather-applet.js:14828
-#: 3.8/weather-applet.js:14829
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Bora"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11396
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Gökyüzü açık"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11397
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Bulutlu"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11398
-#: 3.8/weather-applet.js:13083 3.8/weather-applet.js:13084
-#: 3.8/weather-applet.js:13118
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Az bulutlu"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11399
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Dağınık bulutlu"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11400
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Parçalı bulutlu"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11401
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Kapalı bulanık"
 
@@ -1083,80 +1082,80 @@ msgstr "Kapalı bulanık"
 msgid "Could not get forecast for your area"
 msgstr "Bölgeniz için hava tahmini alınamadı"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "Konum ABD dışında, lütfen farklı bir sağlayıcı kullanın."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12845
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Saatlik Tahmin Bilgileri İşlenemedi"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13112
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Açık ve rüzgarlı"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13119
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Az bulutluAz bulutlu ve rüzgarlı"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13126
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Parçalı ve rüzgarlı"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13133
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Çoğunlukla bulutlu ve rüzgarlı"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13140
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Bulutlu ve rüzgarlı"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13154
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Karlı yağmur"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13189
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Dondurucu Yağmur ve kar"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9148 3.8/weather-applet.js:13233
-#: 3.8/weather-applet.js:13234 3.8/weather-applet.js:14842
-#: 3.8/weather-applet.js:14843
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Kasırga"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9143
-#: 3.8/weather-applet.js:13240
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Fırtına"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13241
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Tropik Fırtına"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13268 3.8/weather-applet.js:13269
-#: 3.8/weather-applet.js:15074 3.8/weather-applet.js:15075
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Sıcak"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13275 3.8/weather-applet.js:13276
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Soğuk"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13282 3.8/weather-applet.js:13283
-#: 3.8/weather-applet.js:15123 3.8/weather-applet.js:15124
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Kar fırtınası"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9021
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Bugün"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9023
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Yarın"
 
@@ -1188,79 +1187,79 @@ msgstr "Cuma"
 msgid "Saturday"
 msgstr "Cumartesi"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9113
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Sakin"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9116
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Hafif hava"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9119
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Hafif bir esinti"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9122
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Hafif esinti"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9125
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Ilıman esinti"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9128
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Taze esinti"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9131
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Güçlü esinti"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9134
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Yakın bora"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9137
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Bora"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9140
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Şiddetli bora"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9146
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Şiddetli fırtına"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "K"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "KD"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "D"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "GD"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "G"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "GB"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "B"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "KB"
 
@@ -1312,7 +1311,7 @@ msgstr ""
 "Hava durumu alınırken bilinmeyen bir hata oluştu, daha fazla bilgi için Hata "
 "günlüklerine bakın"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14835 3.8/weather-applet.js:14836
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Tropikal Fırtına"
 
@@ -1320,7 +1319,7 @@ msgstr "Tropikal Fırtına"
 msgid "Severe Thunderstorms"
 msgstr "Şiddetli Fırtınalar"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14856 3.8/weather-applet.js:14857
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Gök gürültülü"
 
@@ -1336,15 +1335,15 @@ msgstr "Sulu Kar"
 msgid "Mixed Snow and Sleet"
 msgstr "Sulu Kar"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14878 3.8/weather-applet.js:14879
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Dondurucu Çiseleme"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14892 3.8/weather-applet.js:14893
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Dondurucu yağmur"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14899 3.8/weather-applet.js:14900
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Sağanak"
 
@@ -1356,11 +1355,11 @@ msgstr "Kar Fırtınası"
 msgid "Light Snow Showers"
 msgstr "Hafif Kar Yağışı"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14927 3.8/weather-applet.js:14928
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Tipi"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13793 3.8/weather-applet.js:13794
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Sisli"
 
@@ -1372,54 +1371,54 @@ msgstr "Dumanlı"
 msgid "Blustery"
 msgstr "Fırtınalı"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14990 3.8/weather-applet.js:14991
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Rüzgarlı"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15011 3.8/weather-applet.js:15012
-#: 3.8/weather-applet.js:15018 3.8/weather-applet.js:15019
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Çok Bulutlu"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14527 3.8/weather-applet.js:14528
-#: 3.8/weather-applet.js:14534 3.8/weather-applet.js:14535
-#: 3.8/weather-applet.js:15025 3.8/weather-applet.js:15026
-#: 3.8/weather-applet.js:15032 3.8/weather-applet.js:15033
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Parçalı Bulutlu"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15060 3.8/weather-applet.js:15061
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Çoğunlukla Güneşli"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15067 3.8/weather-applet.js:15068
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Karışık Yağmur ve Dolu"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15081 3.8/weather-applet.js:15082
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "İzole Fırtınalar"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15088 3.8/weather-applet.js:15089
-#: 3.8/weather-applet.js:15144 3.8/weather-applet.js:15145
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Aralıklı sağanak"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15095 3.8/weather-applet.js:15096
-#: 3.8/weather-applet.js:15130 3.8/weather-applet.js:15131
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Sağanak Yağış"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15102 3.8/weather-applet.js:15103
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Şiddetli Yağmur"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15109 3.8/weather-applet.js:15110
-#: 3.8/weather-applet.js:15137 3.8/weather-applet.js:15138
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Dağınık Kar Yağışı"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15116 3.8/weather-applet.js:15117
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Şiddetli Kar"
 
@@ -1431,7 +1430,7 @@ msgstr "Müsait değil"
 msgid "Scattered Thundershowers"
 msgstr "Fırtına Bulutlu"
 
-#: 3.8/weather-applet.js:9632
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1439,7 +1438,7 @@ msgstr ""
 "Günlükler alınamadı, günlük dosyası yol altında bulunamadı\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9636
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1448,11 +1447,11 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10055
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10160
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
@@ -1460,279 +1459,289 @@ msgstr ""
 "MET Office UK yalnızca Birleşik Krallık'ı kapsar, lütfen konumunuzun ülke "
 "içinde olduğundan emin olun"
 
-#: 3.8/weather-applet.js:10239
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Konum için veri bulunamadı"
 
-#: 3.8/weather-applet.js:10320
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Çok zayıf"
 
-#: 3.8/weather-applet.js:10320
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "{distance} {distanceUnit} 'den az"
 
-#: 3.8/weather-applet.js:10324
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Mükemmel"
 
-#: 3.8/weather-applet.js:10324
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "{distance} {distanceUnit} 'den fazla"
 
-#: 3.8/weather-applet.js:10329
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Zayıf"
 
-#: 3.8/weather-applet.js:10329 3.8/weather-applet.js:10334
-#: 3.8/weather-applet.js:10339 3.8/weather-applet.js:10344
-#: 3.8/weather-applet.js:10349
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "{smallerDistance}-{biggerDistance} {distanceUnit} arasında"
 
-#: 3.8/weather-applet.js:10334
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Ilımlı"
 
-#: 3.8/weather-applet.js:10339
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "İyi"
 
-#: 3.8/weather-applet.js:10344 3.8/weather-applet.js:10349
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Çok iyi"
 
-#: 3.8/weather-applet.js:10704
-msgid "DarkSky"
-msgstr "DarkSky"
-
-#: 3.8/weather-applet.js:10756
-msgid "This API has ceased to function, please use another one."
-msgstr "Bu API çalışmayı durdurdu, lütfen başka bir tane kullanın."
-
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11017
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11465
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norveç"
 
-#: 3.8/weather-applet.js:12010
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12435
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12600
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Hafif Rüzgar"
 
-#: 3.8/weather-applet.js:12614
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Şiddetli Rüzgar"
 
-#: 3.8/weather-applet.js:12761
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "ABD Hava Durumu"
 
-#: 3.8/weather-applet.js:13314
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Görsel Geçiş"
 
-#: 3.8/weather-applet.js:13491
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Üfleyen veya sürüklenen kar"
 
-#: 3.8/weather-applet.js:13495
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Yoğun çiseleme"
 
-#: 3.8/weather-applet.js:13499
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Şiddetli çiseleme/yağmur"
 
-#: 3.8/weather-applet.js:13501
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Hafif çiseleme/yağmur"
 
-#: 3.8/weather-applet.js:13503
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Toz Fırtınası"
 
-#: 3.8/weather-applet.js:13507
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Dondurucu çiseleme/dondurucu yağmur"
 
-#: 3.8/weather-applet.js:13509
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Şiddetli donan çiseleme/dondurucu yağmur"
 
-#: 3.8/weather-applet.js:13511
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Hafif donan çiseleme/dondurucu yağmur"
 
-#: 3.8/weather-applet.js:13513
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Dondurucu sis"
 
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Huni bulutu/kasırga"
 
-#: 3.8/weather-applet.js:13521
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Dolu sağanakları"
 
-#: 3.8/weather-applet.js:13523
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Buz"
 
-#: 3.8/weather-applet.js:13525
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Gök gürültüsü olmayan şimşek"
 
-#: 3.8/weather-applet.js:13529
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Yakın çevrede yağış"
 
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:13822
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Şiddetli yağmur ve kar"
 
-#: 3.8/weather-applet.js:13535
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Hafif yağmur ve kar"
 
-#: 3.8/weather-applet.js:13543
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Gökyüzü kapsama alanı azalıyor"
 
-#: 3.8/weather-applet.js:13545
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Gökyüzü kapsama alanı artıyor"
 
-#: 3.8/weather-applet.js:13547
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Gökyüzü değişmedi"
 
-#: 3.8/weather-applet.js:13549
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Duman veya pus"
 
-#: 3.8/weather-applet.js:13553
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Kar ve yağmur sağanakları"
 
-#: 3.8/weather-applet.js:13565
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Yağışsız fırtına"
 
-#: 3.8/weather-applet.js:13567
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Elmas tozu"
 
-#: 3.8/weather-applet.js:13573
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Parçalı bulutlu"
 
-#: 3.8/weather-applet.js:13595
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Lütfen API anahtarını doğru girdiğinizden emin olun"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13611
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Danimarka"
 
-#: 3.8/weather-applet.js:13754 3.8/weather-applet.js:13755
-#: 3.8/weather-applet.js:13891 3.8/weather-applet.js:13892
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "BULUNAMADI"
 
-#: 3.8/weather-applet.js:13787
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Tipi"
 
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Hafif kar"
 
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13836
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Orta şiddette kar"
 
-#: 3.8/weather-applet.js:13850
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Orta şiddetli sağanak yağmur"
 
-#: 3.8/weather-applet.js:13857
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Karla karışık yağmur"
 
-#: 3.8/weather-applet.js:13864
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Şiddetli karla karışık yağmur"
 
-#: 3.8/weather-applet.js:13961
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:14305
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "Alman Hava Servisi"
 
-#: 3.8/weather-applet.js:14318
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "Lütfen farklı bir sağlayıcı veya konum seçin"
 
-#: 3.8/weather-applet.js:14615
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14806
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "Sağladığınız API anahtarı geçersiz."
 
-#: 3.8/weather-applet.js:14813
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "Sağladığınız konum bulunamadı."
 
-#: 3.8/weather-applet.js:14849 3.8/weather-applet.js:14850
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Güçlü Fırtına"
 
-#: 3.8/weather-applet.js:14864 3.8/weather-applet.js:14865
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Yağmur ve Kar"
 
-#: 3.8/weather-applet.js:14871 3.8/weather-applet.js:14872
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Yağmur ve Sulu Kar"
 
-#: 3.8/weather-applet.js:14920 3.8/weather-applet.js:14921
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Sağanak Kar"
 
-#: 3.8/weather-applet.js:14983 3.8/weather-applet.js:14984
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "Esintili"
 
-#: 3.8/weather-applet.js:14997 3.8/weather-applet.js:14998
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr "Soğuk"
 
-#: 3.8/weather-applet.js:15053 3.8/weather-applet.js:15054
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Çoğunlukla Açık"
 
-#: 3.8/weather-applet.js:15541
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "ABD Hava Durumu"
+
+#: 3.8/weather-applet.js:15603
+#, fuzzy
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr "Konum Hizmeti hatalarla yanıt verdi, lütfen hata günlüklerine bakın"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+"Bir konum girdiğinizden emin olun veya bunun yerine Otomatik konum kullanın"
+
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1740,7 +1749,7 @@ msgstr ""
 "Yapılandırma alınamadı, dosya yol altında bulunamadı\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15546
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1748,58 +1757,58 @@ msgstr ""
 "Yol altında yapılandırma dosyasının içeriği alınamadı\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:16158
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Bu sağlayıcının çalışması için bir API anahtarı gerekiyor"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Çiy Noktası"
 
-#: 3.8/weather-applet.js:16230
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Yağış {precipEnd} dakika içinde sona erecek"
 
-#: 3.8/weather-applet.js:16232
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "Yağış bir saat içinde bitmeyecek"
 
-#: 3.8/weather-applet.js:16235
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Yağış {precipStart} dakika içinde başlayacak"
 
-#: 3.8/weather-applet.js:16443
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 "Tahmin ayrıştırma başarısız oldu, daha fazla ayrıntı için günlüklere bakın."
 
-#: 3.8/weather-applet.js:16892 3.8/weather-applet.js:17678
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "{lastUpdatedTime} itibarıyla"
 
-#: 3.8/weather-applet.js:16898
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "Sizden {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:16902
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "İstasyon Adı: {stationName}"
 
-#: 3.8/weather-applet.js:16905
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "Alan: {stationArea}"
 
-#: 3.8/weather-applet.js:17438 3.8/weather-applet.js:17448
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Hata Ayıklama Bilgileri Kaydedilirken Hata"
 
-#: 3.8/weather-applet.js:17460
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Hata Ayıklama Bilgileri başarıyla kaydedildi"
 
-#: 3.8/weather-applet.js:17460
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "{filePath} klasörüne kaydedildi"
-
-#: 3.8/weather-applet.js:17603
-msgid "This provider requires an API key to operate"
-msgstr "Bu sağlayıcının çalışması için bir API anahtarı gerekiyor"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -1852,7 +1861,6 @@ msgid "Data service"
 msgstr "Veri servisi"
 
 #. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
 msgid "DarkSky (key needed)"
 msgstr "DarkSky (anahtar gerekli)"
 
@@ -2297,6 +2305,11 @@ msgid "US National Weather (US only)"
 msgstr "ABD Ulusal Hava Durumu (yalnızca ABD)"
 
 #. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Pirate Weather (key needed)"
+msgstr "Weatherbit (anahtar gerekli)"
+
+#. 3.8->settings-schema.json->dataService->options
 msgid "Visual Crossing (key needed)"
 msgstr "Visual Crossing (anahtar gerekli)"
 
@@ -2325,6 +2338,12 @@ msgstr ""
 "{Şehir/Kasaba} {Postakodu} {Ulke} girmeyi deneyebilirsiniz. Arama "
 "algoritması, format ile çok esnektir. Girdiğiniz adresi yazdıktan 3 saniye "
 "sonra, seçiminizi doğrulamak için otomatik olarak kaydedilir."
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
 
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"
@@ -2372,10 +2391,11 @@ msgid "Enable minutely precipitation forecast"
 msgstr "Dakikalık yağış tahminini etkinleştirin"
 
 #. 3.8->settings-schema.json->immediatePrecip->tooltip
+#, fuzzy
 msgid ""
 "If you'd like to use this make sure you use your exact coordinates/address "
-"as location to help its accuracy. Currently implemented with OpenWeatherMap "
-"and MET Norway only."
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
 msgstr ""
 "Bunu kullanmak isterseniz, doğruluğuna yardımcı olmak için konum olarak tam "
 "koordinatlarınızı/adresinizi kullandığınızdan emin olun. Şu anda yalnızca "
@@ -2577,154 +2597,3 @@ msgstr ""
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr "Günlükleri kaydetmek için seçilen yol"
-
-#~ msgid "Instead of 15:00 or 3 pm it will show up as 15 or 3 pm"
-#~ msgstr "15:00 veya 3 ös yerine 15 veya 3 ös olarak görünecektir"
-
-#~ msgid "Climacell"
-#~ msgstr "Climacell"
-
-#~ msgid "Light Snow"
-#~ msgstr "Hafif Kar yağışı"
-
-#~ msgid "API key doesn't provide access to Hourly Weather, skipping"
-#~ msgstr "API anahtarı, Saatlik Hava Durumuna erişim sağlamıyor, atlanıyor"
-
-#~ msgid "ClimacellV4 (key needed)"
-#~ msgstr "ClimacellV4 (anahtar gerekli)"
-
-#~ msgid "ClimacellV3 (key needed)"
-#~ msgstr "ClimacellV3 (anahtar gerekli)"
-
-#~ msgid "Please install '{missingPackage}', then refresh manually."
-#~ msgstr ""
-#~ "Lütfen '{missingPackage}' dosyasını yükleyin, ardından manuel olarak "
-#~ "yenileyin."
-
-#~ msgid "Currently only used with DarkSky."
-#~ msgstr "Şu anda yalnızca DarkSky ile kullanılıyor."
-
-#~ msgid "Units, Icons and Keys"
-#~ msgstr "Birimler, Simgeler ve Tuşlar"
-
-#~ msgid "How to choose a weather provider"
-#~ msgstr "Hava durumu sağlayıcısı nasıl seçilir"
-
-#~ msgid "Allowed location formats"
-#~ msgstr "İzin verilen konum biçimleri"
-
-#~ msgid "View additional information"
-#~ msgstr "Ek bilgileri görüntüleyin"
-
-#~ msgid "Clear Sky"
-#~ msgstr "Gökyüzü Açık"
-
-#~ msgid "Light Rain"
-#~ msgstr "Hafif Yağmur"
-
-#~ msgid "Rain Showers"
-#~ msgstr "Sağanak Yağmur"
-
-#~ msgid "Few Clouds"
-#~ msgstr "Az bulutlu"
-
-#~ msgid "Substantial Rain"
-#~ msgstr "Önemli Yağmurlu"
-
-#~ msgid "Substantial Freezing Rain"
-#~ msgstr "Önemli Dondurucu Yağmur"
-
-#~ msgid "Substantial Ice Pellets"
-#~ msgstr "Önemli Buz Parçaları"
-
-#~ msgid "Substantial Snow"
-#~ msgstr "Önemli Kar yağışı"
-
-#~ msgid "Delete current location from storage"
-#~ msgstr "Mevcut konumu depodan sil"
-
-#~ msgid "Removes location information from storage file."
-#~ msgstr "Konum bilgilerini depolama dosyasından kaldırır."
-
-#~ msgid "Wind:"
-#~ msgstr "Rüzgar:"
-
-#~ msgid "Acceptable inputs is Latitude,Longitude"
-#~ msgstr "Kabul edilebilir girdiler Enlem, Boylam"
-
-#~ msgid "Settings"
-#~ msgstr "Ayarlar"
-
-#~ msgid "Cloudiness:"
-#~ msgstr "Bulanıklık:"
-
-#~ msgid "Sunrise"
-#~ msgstr "Gün doğumu"
-
-#~ msgid "Sunset"
-#~ msgstr "Gün batımı"
-
-#~ msgid "Service Unavailable"
-#~ msgstr "Hizmet Kullanılamıyor"
-
-#~ msgid "Wrong API Key"
-#~ msgstr "Yanlış API Anahtarı"
-
-#~ msgid "City Not found"
-#~ msgstr "Şehir Bulunamadı"
-
-#~ msgid "Key Temp. Blocked"
-#~ msgstr "Anahtar Sıcaklığı . Tıkalı"
-
-#~ msgid "Weather Provider Settings"
-#~ msgstr "Hava Durumu Sağlayıcı Ayarları"
-
-#~ msgid ""
-#~ "Acceptable inputs: City,CountryCode or Zipcode,CountryCode or Latitude,"
-#~ "Longitude"
-#~ msgstr ""
-#~ "Kabul edilebilir girişler: Şehir, Ülke Kodu veya Posta Kodu, Ülke Kodu "
-#~ "veya Enlem, Boylam"
-
-#~ msgid "Personal Settings"
-#~ msgstr "Kişisel ayarlar"
-
-#~ msgid "Vertical orientation"
-#~ msgstr "Dikey yönlendirme"
-
-#~ msgid "Translate condition"
-#~ msgstr "Dİlinize çeviri"
-
-#~ msgid "Symbolic icons"
-#~ msgstr "Sembolik simgeler"
-
-#~ msgid "Settings for weather@mockturtl 1.8+"
-#~ msgstr "Weather@mockturtl 1.8+ için ayarlar"
-
-#~ msgid "Ligth Rain"
-#~ msgstr "Hafif Yağmur"
-
-#~ msgid "Please enter location in the correct format (coordinates)"
-#~ msgstr "Lütfen konumu doğru biçimde girin (koordinatlar)"
-
-#~ msgid ""
-#~ "powered by: OpenWeatherMap, DarkSky, MET Norway, Weatherbit,\n"
-#~ "Yahoo and ip-api. Big Thanks to OpenWeatherMap for their FOSS support!"
-#~ msgstr ""
-#~ "tarafından desteklenmektedir: OpenWeatherMap, DarkSky, MET Norveç, "
-#~ "Weatherbit,\n"
-#~ "Yahoo ve ip-api. FOSS desteği için OpenWeatherMap'e çok teşekkürler!"
-
-#~ msgid "Settings for weather@mockturtl 3.8+"
-#~ msgstr "Weather@mockturtl 3.8+ için ayarlar"
-
-#~ msgid "Weather provider information"
-#~ msgstr "Hava durumu sağlayıcısı bilgileri"
-
-#~ msgid ""
-#~ "powered by: OpenWeatherMap, DarkSky, MET Norway, Weatherbit, Yahoo and ip-"
-#~ "api. Big Thanks to OpenWeatherMap for their FOSS support!"
-#~ msgstr ""
-#~ "tarafından desteklenmektedir: OpenWeatherMap, DarkSky, MET Norveç, "
-#~ "Weatherbit, Yahoo ve ip-api. FOSS desteği için OpenWeatherMap'e çok "
-#~ "teşekkürler!"

--- a/weather@mockturtl/files/weather@mockturtl/po/uk.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/uk.po
@@ -1,7 +1,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1\n"
-"POT-Creation-Date: \n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Denys Komar <id52@pm.me>\n"
 "Language-Team: \n"
@@ -12,65 +14,65 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17472
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "Помилка"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17473 3.8/weather-applet.js:17475
-#: 3.8/weather-applet.js:17477 3.8/weather-applet.js:17480
-#: 3.8/weather-applet.js:17483 3.8/weather-applet.js:17484
-#: 3.8/weather-applet.js:17485 3.8/weather-applet.js:17486
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "Помилка сервісу"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17474
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "Невірний ключ API"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17476
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "Невірний формат місцеположення"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17478
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "Ключ заблоковано"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17479
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "Неможливо виявити місцеположення"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17481
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "Немає ключа API"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17482
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "Немає місцеположення"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17487
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "Відсутні пакети"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17488
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "Місцеположення не обслуговується"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9748
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "Weather Applet"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17797
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17798
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "Натисніть, щоб відкрити"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16181
-#: 3.8/weather-applet.js:17801
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "Оновити"
 
@@ -80,8 +82,8 @@ msgstr "API повернув код статусу між 400 і 500"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9914
-#: 3.8/weather-applet.js:9918 3.8/weather-applet.js:9922
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "Постачальник місцерозташування"
 
@@ -93,11 +95,14 @@ msgstr "На жаль, ви не можете зберегти місцезна�
 msgid "Could not get weather information"
 msgstr "Не вдалося отримати інформацію про погоду"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17636
-msgid "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
-msgstr "Неочікувана помилка під час оновлення прогнозу погоди, перегляньте вхід у Looking Glass"
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
+msgid ""
+"Unexpected Error While Refreshing Weather, please see log in Looking Glass"
+msgstr ""
+"Неочікувана помилка під час оновлення прогнозу погоди, перегляньте вхід у "
+"Looking Glass"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:17879
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -109,12 +114,11 @@ msgstr ""
 msgid "Network Error, please check logs in Looking Glass"
 msgstr "Помилка мережі, перевірте журнали в Looking Glass"
 
-#. Більше підходить
 #: 3.0/applet.js:969 3.0/applet.js:1110
 msgid "As of"
 msgstr "Станом на"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:16885
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "На основі"
 
@@ -122,88 +126,92 @@ msgstr "На основі"
 msgid "from you"
 msgstr "від вас"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16798
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "мм"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:10721
-#: 3.8/weather-applet.js:16798
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "в"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10354
-#: 3.8/weather-applet.js:16963
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "миль"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10355
-#: 3.8/weather-applet.js:16964
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "км"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17143
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "Завантаження поточної погоди..."
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17146
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "Завантаження прогнозу погоди..."
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16134
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "Завантаження ..."
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16155
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "Температура"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16156
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "Вологість"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16157
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "Тиск"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12599 3.8/weather-applet.js:12606
-#: 3.8/weather-applet.js:12607 3.8/weather-applet.js:12613
-#: 3.8/weather-applet.js:14569 3.8/weather-applet.js:14570
-#: 3.8/weather-applet.js:16006
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "Вітер"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:15403
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
-msgstr "Переконайтеся, що ви ввели місцезнаходження, або замість цього скористайтеся автоматичним визначенням місцезнаходження"
+msgstr ""
+"Переконайтеся, що ви ввели місцезнаходження, або замість цього скористайтеся "
+"автоматичним визначенням місцезнаходження"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9994
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
-msgstr "Не вдалося знайти місцезнаходження за адресою, будь ласка, перевірте, чи це правильно"
+msgstr ""
+"Не вдалося знайти місцезнаходження за адресою, будь ласка, перевірте, чи це "
+"правильно"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:10015
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
-msgstr "Не вдалося викликати Geolocation API. Перегляньте помилки в Looking Glass."
+msgstr ""
+"Не вдалося викликати Geolocation API. Перегляньте помилки в Looking Glass."
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9914
-#: 3.8/weather-applet.js:9918
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "УВАГА"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9914
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
-msgstr "Правильні розташування можна зберегти лише тоді, коли аплет не оновлюється"
+msgstr ""
+"Правильні розташування можна зберегти лише тоді, коли аплет не оновлюється"
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9918
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr "Ви не можете зберегти неправильне розташування"
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9922
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr "Інформація"
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9922
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr "Розташування вже збережено"
 
@@ -232,20 +240,24 @@ msgid "Location is deleted from library"
 msgstr "Розташування видалено з бібліотеки"
 
 #: 3.0/applet.js:2131
-msgid "Failed to load in data from location storage, please see the logs for more information"
-msgstr "Не вдалося завантажити дані зі сховища місцезнаходження, будь ласка, перегляньте журнали для отримання додаткової інформації"
+msgid ""
+"Failed to load in data from location storage, please see the logs for more "
+"information"
+msgstr ""
+"Не вдалося завантажити дані зі сховища місцезнаходження, будь ласка, "
+"перегляньте журнали для отримання додаткової інформації"
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10801 3.8/weather-applet.js:11095
-#: 3.8/weather-applet.js:12062 3.8/weather-applet.js:12502
-#: 3.8/weather-applet.js:13009 3.8/weather-applet.js:13373
-#: 3.8/weather-applet.js:14740
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "Відчувається як"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:10846
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "Помилка отримання інформації про погоду"
 
@@ -258,7 +270,7 @@ msgstr ""
 "або спочатку отримайте його на https://developer.climacell.co/sign-up"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:10730 3.8/weather-applet.js:12232
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -266,7 +278,7 @@ msgstr ""
 "Будь ласка, переконайтеся, що ви\n"
 "ввели ключ API правильно, і ваш обліковий запис не заблоковано"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12468
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -277,60 +289,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:11734 3.8/weather-applet.js:11735
-#: 3.8/weather-applet.js:11741 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11755 3.8/weather-applet.js:12642
-#: 3.8/weather-applet.js:13539
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "Сильний дощ"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11909 3.8/weather-applet.js:11910
-#: 3.8/weather-applet.js:11916 3.8/weather-applet.js:12627
-#: 3.8/weather-applet.js:12628 3.8/weather-applet.js:12634
-#: 3.8/weather-applet.js:12641 3.8/weather-applet.js:12683
-#: 3.8/weather-applet.js:12690 3.8/weather-applet.js:12697
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:13202
-#: 3.8/weather-applet.js:13203 3.8/weather-applet.js:13210
-#: 3.8/weather-applet.js:13531 3.8/weather-applet.js:13800
-#: 3.8/weather-applet.js:13801 3.8/weather-applet.js:13842
-#: 3.8/weather-applet.js:14541 3.8/weather-applet.js:14542
-#: 3.8/weather-applet.js:14906 3.8/weather-applet.js:14907
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "Дощ"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10530
-#: 3.8/weather-applet.js:10537 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11364
-#: 3.8/weather-applet.js:11818 3.8/weather-applet.js:11819
-#: 3.8/weather-applet.js:11825 3.8/weather-applet.js:11832
-#: 3.8/weather-applet.js:11839 3.8/weather-applet.js:12635
-#: 3.8/weather-applet.js:13541
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "Легкий дощ"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12698 3.8/weather-applet.js:13515
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "Сильний крижаний дощ"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11369
-#: 3.8/weather-applet.js:12684 3.8/weather-applet.js:13174
-#: 3.8/weather-applet.js:13175 3.8/weather-applet.js:13181
-#: 3.8/weather-applet.js:13182 3.8/weather-applet.js:13188
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Крижаний дощ"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12691 3.8/weather-applet.js:13517
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "Легкий крижаний дощ"
 
@@ -338,189 +350,189 @@ msgstr "Легкий крижаний дощ"
 msgid "Light freezing drizzle"
 msgstr "Легка крижана мряка"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12677
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "Крижана мряка"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13497
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "Легка мряка"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12712
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "Сильний мокрий сніг"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12704 3.8/weather-applet.js:12705
-#: 3.8/weather-applet.js:12711 3.8/weather-applet.js:12718
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "Мокрий сніг"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12719
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "Легкий мокрий сніг"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10649 3.8/weather-applet.js:10656
-#: 3.8/weather-applet.js:10657 3.8/weather-applet.js:11376
-#: 3.8/weather-applet.js:11790 3.8/weather-applet.js:11791
-#: 3.8/weather-applet.js:11797 3.8/weather-applet.js:11804
-#: 3.8/weather-applet.js:11811 3.8/weather-applet.js:12670
-#: 3.8/weather-applet.js:13557 3.8/weather-applet.js:13877
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Сильний сніг"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11375 3.8/weather-applet.js:11965
-#: 3.8/weather-applet.js:11966 3.8/weather-applet.js:11972
-#: 3.8/weather-applet.js:12648 3.8/weather-applet.js:12649
-#: 3.8/weather-applet.js:12662 3.8/weather-applet.js:12669
-#: 3.8/weather-applet.js:13146 3.8/weather-applet.js:13147
-#: 3.8/weather-applet.js:13551 3.8/weather-applet.js:13786
-#: 3.8/weather-applet.js:13870 3.8/weather-applet.js:14555
-#: 3.8/weather-applet.js:14556 3.8/weather-applet.js:14934
-#: 3.8/weather-applet.js:14935
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "Сніг"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10621
-#: 3.8/weather-applet.js:10628 3.8/weather-applet.js:10635
-#: 3.8/weather-applet.js:10636 3.8/weather-applet.js:11374
-#: 3.8/weather-applet.js:11874 3.8/weather-applet.js:11875
-#: 3.8/weather-applet.js:11881 3.8/weather-applet.js:11888
-#: 3.8/weather-applet.js:11895 3.8/weather-applet.js:12663
-#: 3.8/weather-applet.js:13559
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "Легкий сніг"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12655
-#: 3.8/weather-applet.js:12656 3.8/weather-applet.js:14913
-#: 3.8/weather-applet.js:14914
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "Шквали"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11349
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12726
-#: 3.8/weather-applet.js:13219 3.8/weather-applet.js:13220
-#: 3.8/weather-applet.js:13563 3.8/weather-applet.js:13884
-#: 3.8/weather-applet.js:13885 3.8/weather-applet.js:14562
-#: 3.8/weather-applet.js:14563
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "Гроза"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12593
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "Легкий туман"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10509 3.8/weather-applet.js:10510
-#: 3.8/weather-applet.js:11388 3.8/weather-applet.js:11727
-#: 3.8/weather-applet.js:11728 3.8/weather-applet.js:12585
-#: 3.8/weather-applet.js:12586 3.8/weather-applet.js:12592
-#: 3.8/weather-applet.js:13289 3.8/weather-applet.js:13290
-#: 3.8/weather-applet.js:13505 3.8/weather-applet.js:14513
-#: 3.8/weather-applet.js:14514 3.8/weather-applet.js:14962
-#: 3.8/weather-applet.js:14963
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "Туман"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10516 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:11713 3.8/weather-applet.js:11714
-#: 3.8/weather-applet.js:12557 3.8/weather-applet.js:12558
-#: 3.8/weather-applet.js:13779 3.8/weather-applet.js:13780
-#: 3.8/weather-applet.js:14506 3.8/weather-applet.js:14507
-#: 3.8/weather-applet.js:15004 3.8/weather-applet.js:15005
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "Хмарно"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12578
-#: 3.8/weather-applet.js:12579 3.8/weather-applet.js:13097
-#: 3.8/weather-applet.js:13098 3.8/weather-applet.js:13132
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "Переважно хмарно"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10489 3.8/weather-applet.js:11902
-#: 3.8/weather-applet.js:11903 3.8/weather-applet.js:12571
-#: 3.8/weather-applet.js:12572 3.8/weather-applet.js:13090
-#: 3.8/weather-applet.js:13091 3.8/weather-applet.js:13125
-#: 3.8/weather-applet.js:13772 3.8/weather-applet.js:13773
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "Мінлива хмарність"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12564
-#: 3.8/weather-applet.js:12565
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "Переважно ясно"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11394 3.8/weather-applet.js:12550
-#: 3.8/weather-applet.js:12551 3.8/weather-applet.js:13076
-#: 3.8/weather-applet.js:13077 3.8/weather-applet.js:13111
-#: 3.8/weather-applet.js:13575 3.8/weather-applet.js:13765
-#: 3.8/weather-applet.js:13766 3.8/weather-applet.js:14492
-#: 3.8/weather-applet.js:14493 3.8/weather-applet.js:14499
-#: 3.8/weather-applet.js:14500 3.8/weather-applet.js:15039
-#: 3.8/weather-applet.js:15040
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "Ясно"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10474
-#: 3.8/weather-applet.js:10475 3.8/weather-applet.js:12550
-#: 3.8/weather-applet.js:12551 3.8/weather-applet.js:15046
-#: 3.8/weather-applet.js:15047
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "Сонячно"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10460
-#: 3.8/weather-applet.js:10461 3.8/weather-applet.js:10495
-#: 3.8/weather-applet.js:10496 3.8/weather-applet.js:10684
-#: 3.8/weather-applet.js:10685 3.8/weather-applet.js:11696
-#: 3.8/weather-applet.js:11697 3.8/weather-applet.js:11994
-#: 3.8/weather-applet.js:11995 3.8/weather-applet.js:12542
-#: 3.8/weather-applet.js:12543 3.8/weather-applet.js:13067
-#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13296
-#: 3.8/weather-applet.js:13297 3.8/weather-applet.js:14425
-#: 3.8/weather-applet.js:14426 3.8/weather-applet.js:14576
-#: 3.8/weather-applet.js:14577 3.8/weather-applet.js:15150
-#: 3.8/weather-applet.js:15152
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "Невідомо"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10721
+#: 3.0/darkSky.js:71
 msgid "and"
 msgstr "і"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10721
+#: 3.0/darkSky.js:71
 msgid "until"
 msgstr "поки"
 
-#: 3.0/darkSky.js:71 3.8/weather-applet.js:10721
+#: 3.0/darkSky.js:71
 msgid "Possible"
 msgstr "Можливо"
 
@@ -532,7 +544,7 @@ msgstr ""
 "Будь ласка, введіть ключ API в налаштуваннях,\n"
 "або спочатку отримайте його на https://darksky.net/dev/register"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:10740
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -540,129 +552,131 @@ msgstr ""
 "Будь ласка, переконайтеся, що ви\n"
 "ввів ключ API, який ви маєте від DarkSky"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:9693
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "Не вдалося отримати місцезнаходження"
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:9699
-msgid "Location Service responded with errors, please see the logs in Looking Glass"
-msgstr "Служба локації відповіла помилками, перегляньте журнали в Looking Glass"
+#: 3.0/ipApi.js:95
+msgid ""
+"Location Service responded with errors, please see the logs in Looking Glass"
+msgstr ""
+"Служба локації відповіла помилками, перегляньте журнали в Looking Glass"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11558
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "Хмарність"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11395 3.8/weather-applet.js:11706
-#: 3.8/weather-applet.js:11707
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "Чисте небо"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11720 3.8/weather-applet.js:11721
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "Ясно"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11742
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "Сильний дощ з громом"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11749
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "Сильний дощ"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11756
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "Сильний дощ з громом"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11762
-#: 3.8/weather-applet.js:11763 3.8/weather-applet.js:11769
-#: 3.8/weather-applet.js:11776 3.8/weather-applet.js:11783
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "Сильний мокрий сніг"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11770
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "Сильний мокрий сніг з громом"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11777
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "Сильний мокрий сніг"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11784
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "Сильний мокрий сніг з громом"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11798
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "Сильний сніг"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11805
-#: 3.8/weather-applet.js:13878
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "Сильні снігопади"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11812
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "Сильні снігопади з громом"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11826
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "Легкий дощ з громом"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11833
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "Невеликий дощ"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11840
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "Невеликий дощ з громом"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11846
-#: 3.8/weather-applet.js:11847 3.8/weather-applet.js:11853
-#: 3.8/weather-applet.js:11860 3.8/weather-applet.js:11867
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "Невеликий мокрий сніг"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11854
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "Невеликий мокрий сніг з громом"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11861
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "Невеликий дощ з мокрим снігом"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11868
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "Невеликий дощ з мокрим снігом, гром"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11882
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "Невеликий сніг з громом"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11889
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "Невеликий сніг"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11896
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "Невеликий сніг з громом"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11917
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "Дощ з громом"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11923
-#: 3.8/weather-applet.js:11924 3.8/weather-applet.js:11930
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13537
-#: 3.8/weather-applet.js:13843 3.8/weather-applet.js:13849
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "Дощ"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11931
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "Дощ з громом"
 
@@ -671,44 +685,44 @@ msgstr "Дощ з громом"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11377
-#: 3.8/weather-applet.js:11937 3.8/weather-applet.js:11938
-#: 3.8/weather-applet.js:11944 3.8/weather-applet.js:11951
-#: 3.8/weather-applet.js:11958 3.8/weather-applet.js:13160
-#: 3.8/weather-applet.js:13161 3.8/weather-applet.js:13167
-#: 3.8/weather-applet.js:13168 3.8/weather-applet.js:13195
-#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:14548
-#: 3.8/weather-applet.js:14549 3.8/weather-applet.js:14948
-#: 3.8/weather-applet.js:14949
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "Мокрий сніг"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11945
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "Мокрий сніг з громом"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11952
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "Мокрий сніг"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11959
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "Мокрий сніг з громом"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11973
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "Сніг та грім"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11979 3.8/weather-applet.js:11980
-#: 3.8/weather-applet.js:11986 3.8/weather-applet.js:13555
-#: 3.8/weather-applet.js:13871
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Сніг"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11987
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "Сніг та грім"
 
@@ -717,21 +731,21 @@ msgstr "Сніг та грім"
 msgid "Unexpected response from API"
 msgstr "Неочікувана відповідь від API"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10279
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "Видимі"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10307
-#: 3.8/weather-applet.js:11172 3.8/weather-applet.js:12073
-#: 3.8/weather-applet.js:13022
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "Помилка отримання поточної погоди"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10097
-#: 3.8/weather-applet.js:10131 3.8/weather-applet.js:12099
-#: 3.8/weather-applet.js:12133 3.8/weather-applet.js:12824
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "Помилка отримання прогнозу на майбутнє"
 
@@ -760,296 +774,302 @@ msgid "Excellent - More than"
 msgstr "Чудово"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11384 3.8/weather-applet.js:13527
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "Димка"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10524 3.8/weather-applet.js:13104
-#: 3.8/weather-applet.js:13105 3.8/weather-applet.js:13139
-#: 3.8/weather-applet.js:13571
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "Похмуро"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:10538
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "Легкий дощ"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10544 3.8/weather-applet.js:10545
-#: 3.8/weather-applet.js:11356 3.8/weather-applet.js:12620
-#: 3.8/weather-applet.js:12621 3.8/weather-applet.js:12676
-#: 3.8/weather-applet.js:13493 3.8/weather-applet.js:14885
-#: 3.8/weather-applet.js:14886
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "Мряка"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "Сильний дощ"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "Мокрий сніг"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10600 3.8/weather-applet.js:10607
-#: 3.8/weather-applet.js:10614 3.8/weather-applet.js:10615
-#: 3.8/weather-applet.js:13569 3.8/weather-applet.js:14520
-#: 3.8/weather-applet.js:14521 3.8/weather-applet.js:14941
-#: 3.8/weather-applet.js:14942
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "Град"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "Злива з градом"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "Невеликий сніг"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10643
-#: 3.8/weather-applet.js:10650
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "Сильний сніг"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10663 3.8/weather-applet.js:10670
-#: 3.8/weather-applet.js:10677 3.8/weather-applet.js:10678
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "Грім"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10664
-#: 3.8/weather-applet.js:10671
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "Гроза"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11227
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
-msgstr "Переконайтеся, що місцеположення вказано у правильному форматі в налаштуваннях"
+msgstr ""
+"Переконайтеся, що місцеположення вказано у правильному форматі в "
+"налаштуваннях"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11231
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "Переконайтеся, що ви ввели правильний ключ у налаштуваннях"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:11036 3.8/weather-applet.js:11235
-msgid "Location not found, make sure location is available or it is in the correct format"
-msgstr "Розташування не знайдено. Переконайтеся, що місцеположення доступне або має правильний формат"
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
+msgid ""
+"Location not found, make sure location is available or it is in the correct "
+"format"
+msgstr ""
+"Розташування не знайдено. Переконайтеся, що місцеположення доступне або має "
+"правильний формат"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11239
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "Якщо проблема не зникає, зверніться до автора цього аплету"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11243
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "Невідома помилка, дивіться в логах"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11345
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "Гроза, невеликий дощ"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11346
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "Гроза, дощ"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11347
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "Гроза, сильний дощ"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11348
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "Невелика гроза"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11350
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "Сильна гроза"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11351
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "Можливі грози"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11352
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "Гроза з мрякою"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11353
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "Гроза з мрякою"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11354
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "Гроза з сильною мрякою"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11355
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "Мряка"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11357
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "Сильна мряка"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11358
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "Легка мряка"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11359
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "Дощ, мряка"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11360
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "Сильний дощ, мряка"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11361
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "Дощ, мряка"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11362
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "Сильний дощ з мрякою"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11363
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "Мряка"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11365
-#: 3.8/weather-applet.js:13807 3.8/weather-applet.js:13808
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "Помірний дощ"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11366
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "Сильний дощ"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11367
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "Злива"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11368
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "Злива"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11370
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "Дощ"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11371
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "Дощ"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11372
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "Рясний дощ"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11373
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "Можливий дощ"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11378
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "Мокрий сніг"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11379
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "Легкий сніг з дощем"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:13814 3.8/weather-applet.js:13815
-#: 3.8/weather-applet.js:13821 3.8/weather-applet.js:13856
-#: 3.8/weather-applet.js:13863
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "Сніг з дощем"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11381
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "Легкий сніг"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11382
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "Сніг"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11383
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "Силний сніг"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11385 3.8/weather-applet.js:13254
-#: 3.8/weather-applet.js:13255 3.8/weather-applet.js:14976
-#: 3.8/weather-applet.js:14977
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "Смог"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11386 3.8/weather-applet.js:13261
-#: 3.8/weather-applet.js:13262 3.8/weather-applet.js:14969
-#: 3.8/weather-applet.js:14970
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "Мгла"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11387
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "Пісок, пил"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11389
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "Пісок"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11390 3.8/weather-applet.js:13247
-#: 3.8/weather-applet.js:13248 3.8/weather-applet.js:14955
-#: 3.8/weather-applet.js:14956
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "Пил"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11391
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "Вулканічний попіл"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11392
-#: 3.8/weather-applet.js:13561
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "Шквали"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11393 3.8/weather-applet.js:13226
-#: 3.8/weather-applet.js:13227 3.8/weather-applet.js:14828
-#: 3.8/weather-applet.js:14829
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "Торнадо"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11396
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "Чисте небо"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11397
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "Хмарно"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11398
-#: 3.8/weather-applet.js:13083 3.8/weather-applet.js:13084
-#: 3.8/weather-applet.js:13118
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "Невелика хмарність"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11399
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "Розсіяна хмарність"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11400
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "Розірвані хмари"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11401
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "Похмурі хмари"
 
@@ -1057,80 +1077,82 @@ msgstr "Похмурі хмари"
 msgid "Could not get forecast for your area"
 msgstr "Не вдалося отримати прогноз для вашої області"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
-msgstr "Місцезнаходження знаходиться за межами США, використовуйте іншого постачальника."
+msgstr ""
+"Місцезнаходження знаходиться за межами США, використовуйте іншого "
+"постачальника."
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12845
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "Не вдалося обробити інформацію про погодинний прогноз"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:13112
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "Ясно та вітряно"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:13119
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "Малохмарно та вітряно"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:13126
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "Мінлива хмарність та вітер"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:13133
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "Переважно хмарно та вітряно"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:13140
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "Похмуро і вітряно"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:13154
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "Сніг з дожщем"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:13189
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "Крижаний дощ і сніг"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9148 3.8/weather-applet.js:13233
-#: 3.8/weather-applet.js:13234 3.8/weather-applet.js:14842
-#: 3.8/weather-applet.js:14843
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "Ураган"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9143
-#: 3.8/weather-applet.js:13240
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "Шторм"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:13241
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "Тропічний шторм"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:13268 3.8/weather-applet.js:13269
-#: 3.8/weather-applet.js:15074 3.8/weather-applet.js:15075
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "Спека"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:13275 3.8/weather-applet.js:13276
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "Холодно"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:13282 3.8/weather-applet.js:13283
-#: 3.8/weather-applet.js:15123 3.8/weather-applet.js:15124
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "Завірюха"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9021
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "Сьогодні"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9023
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "Завтра"
 
@@ -1162,79 +1184,79 @@ msgstr "П'ятниця"
 msgid "Saturday"
 msgstr "Сублта"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9113
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "Штиль"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9116
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "Легке повітря"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9119
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "Легкий вітерець"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9122
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "Легкий бриз"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9125
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "Помірний вітер"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9128
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "Свіжий вітерець"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9131
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "Сильний вітер"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9134
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "Майже шторм"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9137
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "Шторм"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9140
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "Сильний шторм"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9146
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "Сильний шторм"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "П"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "Пн-Сх"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "Сх"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "Пд-Сх"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "Пд"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "Пд-Зх"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "Зх"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "Пн-Зх"
 
@@ -1279,10 +1301,14 @@ msgid "Could not connect to Yahoo API."
 msgstr "Не вдалося підключитися до Yahoo API."
 
 #: 3.0/yahoo.js:186
-msgid "Unknown error happened while obtaining weather, see Looking Glass logs for more information"
-msgstr "Під час отримання погоди сталася невідома помилка. Для отримання додаткової інформації перегляньте журнали логів"
+msgid ""
+"Unknown error happened while obtaining weather, see Looking Glass logs for "
+"more information"
+msgstr ""
+"Під час отримання погоди сталася невідома помилка. Для отримання додаткової "
+"інформації перегляньте журнали логів"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14835 3.8/weather-applet.js:14836
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "Тропічний шторм"
 
@@ -1290,7 +1316,7 @@ msgstr "Тропічний шторм"
 msgid "Severe Thunderstorms"
 msgstr "Сильні грози"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14856 3.8/weather-applet.js:14857
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "Грози"
 
@@ -1306,15 +1332,15 @@ msgstr "Дощ із мокрим снігом"
 msgid "Mixed Snow and Sleet"
 msgstr "Сніг та мокрий сніг"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14878 3.8/weather-applet.js:14879
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "Крижана мряка"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14892 3.8/weather-applet.js:14893
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "Крижаний дощ"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14899 3.8/weather-applet.js:14900
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "Дощик"
 
@@ -1326,11 +1352,11 @@ msgstr "Снігові шквали"
 msgid "Light Snow Showers"
 msgstr "Невеликий сніг"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14927 3.8/weather-applet.js:14928
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "Заметіль"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13793 3.8/weather-applet.js:13794
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "Туманно"
 
@@ -1342,54 +1368,54 @@ msgstr "Димчасто"
 msgid "Blustery"
 msgstr "Вітряно"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14990 3.8/weather-applet.js:14991
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "Вітряно"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:15011 3.8/weather-applet.js:15012
-#: 3.8/weather-applet.js:15018 3.8/weather-applet.js:15019
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "Переважно хмарно"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14527 3.8/weather-applet.js:14528
-#: 3.8/weather-applet.js:14534 3.8/weather-applet.js:14535
-#: 3.8/weather-applet.js:15025 3.8/weather-applet.js:15026
-#: 3.8/weather-applet.js:15032 3.8/weather-applet.js:15033
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "Мінлива хмарність"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:15060 3.8/weather-applet.js:15061
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "Переважно сонячно"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:15067 3.8/weather-applet.js:15068
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "Змішаний дощ і град"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:15081 3.8/weather-applet.js:15082
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "Ізольовані грози"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:15088 3.8/weather-applet.js:15089
-#: 3.8/weather-applet.js:15144 3.8/weather-applet.js:15145
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "Місцями грози"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:15095 3.8/weather-applet.js:15096
-#: 3.8/weather-applet.js:15130 3.8/weather-applet.js:15131
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "Короткочасні дощі"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:15102 3.8/weather-applet.js:15103
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "Сильний дощ"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:15109 3.8/weather-applet.js:15110
-#: 3.8/weather-applet.js:15137 3.8/weather-applet.js:15138
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "Подекуди снігопади"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:15116 3.8/weather-applet.js:15117
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "Сильний сніг"
 
@@ -1401,7 +1427,7 @@ msgstr "Недоступний"
 msgid "Scattered Thundershowers"
 msgstr "Місцями грози"
 
-#: 3.8/weather-applet.js:9632
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1409,7 +1435,7 @@ msgstr ""
 "Не вдалося отримати журнали, файл журналу не знайдено за шляхом\n"
 "  {logFilePath}"
 
-#: 3.8/weather-applet.js:9636
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1418,287 +1444,303 @@ msgstr ""
 "  {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10055
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "Met Office UK"
 
-#: 3.8/weather-applet.js:10160
-msgid "MET Office UK only covers the UK, please make sure your location is in the country"
-msgstr "MET Office UK поширюється лише на Великобританію, переконайтеся, що ви перебуваєте в цій країні"
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
+msgstr ""
+"MET Office UK поширюється лише на Великобританію, переконайтеся, що ви "
+"перебуваєте в цій країні"
 
-#: 3.8/weather-applet.js:10239
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "Не знайдено даних для розташування"
 
-#: 3.8/weather-applet.js:10320
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "Дуже погано"
 
-#: 3.8/weather-applet.js:10320
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "Менше ніж {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10324
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "Відмінно"
 
-#: 3.8/weather-applet.js:10324
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "Більше ніж {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10329
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "Погано"
 
-#: 3.8/weather-applet.js:10329 3.8/weather-applet.js:10334
-#: 3.8/weather-applet.js:10339 3.8/weather-applet.js:10344
-#: 3.8/weather-applet.js:10349
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "Між {smallerDistance}-{biggerDistance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10334
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "Нормально"
 
-#: 3.8/weather-applet.js:10339
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "Добре"
 
-#: 3.8/weather-applet.js:10344 3.8/weather-applet.js:10349
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "Дуже добре"
 
-#: 3.8/weather-applet.js:10704
-msgid "DarkSky"
-msgstr "DarkSky"
-
-#: 3.8/weather-applet.js:10756
-msgid "This API has ceased to function, please use another one."
-msgstr "Цей API перестав працювати, використовуйте інший."
-
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11017
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11465
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "MET Norway"
 
-#: 3.8/weather-applet.js:12010
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12435
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12600
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "Легкий вітер"
 
-#: 3.8/weather-applet.js:12614
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "Сильний вітер"
 
-#: 3.8/weather-applet.js:12761
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "US Weather"
 
-#: 3.8/weather-applet.js:13314
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:13491
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "Задування або замети снігу"
 
-#: 3.8/weather-applet.js:13495
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "Сильна мряка"
 
-#: 3.8/weather-applet.js:13499
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "Сильний дощ/мряка"
 
-#: 3.8/weather-applet.js:13501
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "Мряка/дощ"
 
-#: 3.8/weather-applet.js:13503
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "Пилова буря"
 
-#: 3.8/weather-applet.js:13507
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "Крижаний дощ"
 
-#: 3.8/weather-applet.js:13509
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "Сильний крижаний дощ"
 
-#: 3.8/weather-applet.js:13511
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "Мряка/крижаний дощ"
 
-#: 3.8/weather-applet.js:13513
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "Крижаний туман"
 
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "Воронкова хмара/торнадо"
 
-#: 3.8/weather-applet.js:13521
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "Град"
 
-#: 3.8/weather-applet.js:13523
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "Лід"
 
-#: 3.8/weather-applet.js:13525
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "Блискавка без грому"
 
-#: 3.8/weather-applet.js:13529
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "Опади поблизу"
 
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:13822
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "Сильний дощ зі снігом"
 
-#: 3.8/weather-applet.js:13535
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "Легкий сніг з дощем"
 
-#: 3.8/weather-applet.js:13543
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "Покриття неба зменшується"
 
-#: 3.8/weather-applet.js:13545
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "Покриття неба збільшується"
 
-#: 3.8/weather-applet.js:13547
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "Небо без змін"
 
-#: 3.8/weather-applet.js:13549
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "Дим або імла"
 
-#: 3.8/weather-applet.js:13553
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "Сніг з дощем"
 
-#: 3.8/weather-applet.js:13565
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "Гроза без опадів"
 
-#: 3.8/weather-applet.js:13567
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "Алмазний пил"
 
-#: 3.8/weather-applet.js:13573
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "Мінлива хмарність"
 
-#: 3.8/weather-applet.js:13595
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "Переконайтеся, що ви правильно ввели ключ API"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13611
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "DMI Denmark"
 
-#: 3.8/weather-applet.js:13754 3.8/weather-applet.js:13755
-#: 3.8/weather-applet.js:13891 3.8/weather-applet.js:13892
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "Не знайдено"
 
-#: 3.8/weather-applet.js:13787
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "Заметіль"
 
-#: 3.8/weather-applet.js:13828 3.8/weather-applet.js:13829
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "Невеликий сніг"
 
-#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13836
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "Помірний сніг"
 
-#: 3.8/weather-applet.js:13850
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "Помірний дощ"
 
-#: 3.8/weather-applet.js:13857
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "Дощ зі снігом"
 
-#: 3.8/weather-applet.js:13864
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "Сильний дощ зі снігом"
 
-#: 3.8/weather-applet.js:13961
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:14305
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "Deutscher Wetterdienst"
 
-#: 3.8/weather-applet.js:14318
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "Будь ласка, виберіть іншого постачальника або місцезнаходження"
 
-#: 3.8/weather-applet.js:14615
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14806
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "Наданий вами ключ API недійсний."
 
-#: 3.8/weather-applet.js:14813
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "Вказане вами місце не знайдено."
 
-#: 3.8/weather-applet.js:14849 3.8/weather-applet.js:14850
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "Сильний шторм"
 
-#: 3.8/weather-applet.js:14864 3.8/weather-applet.js:14865
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "Сніг з дощем"
 
-#: 3.8/weather-applet.js:14871 3.8/weather-applet.js:14872
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "Дощ із мокрим снігом"
 
-#: 3.8/weather-applet.js:14920 3.8/weather-applet.js:14921
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "Сніг"
 
-#: 3.8/weather-applet.js:14983 3.8/weather-applet.js:14984
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "Вітряно"
 
-#: 3.8/weather-applet.js:14997 3.8/weather-applet.js:14998
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:15053 3.8/weather-applet.js:15054
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "Переважно ясно"
 
-#: 3.8/weather-applet.js:15541
+#: 3.8/weather-applet.js:15247
+#, fuzzy
+msgid "Pirate Weather"
+msgstr "US Weather"
+
+#: 3.8/weather-applet.js:15603
+#, fuzzy
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+"Служба локації відповіла помилками, перегляньте журнали в Looking Glass"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+"Переконайтеся, що ви ввели місцезнаходження, або замість цього скористайтеся "
+"автоматичним визначенням місцезнаходження"
+
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1706,63 +1748,64 @@ msgstr ""
 "Не вдалося отримати конфігурацію, файл не знайдено за шляхами \n"
 "{configFilePath}"
 
-#: 3.8/weather-applet.js:15546
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
-msgstr "Не вдалося отримати вміст конфігураційного файлу за шляхом {configFilePath}"
+msgstr ""
+"Не вдалося отримати вміст конфігураційного файлу за шляхом {configFilePath}"
 
-#: 3.8/weather-applet.js:16158
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "Для роботи цього постачальника потрібен ключ API"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "Точка роси"
 
-#: 3.8/weather-applet.js:16230
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "Опади припиняться через {precipEnd} хв"
 
-#: 3.8/weather-applet.js:16232
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "Опади не припиняться протягом години"
 
-#: 3.8/weather-applet.js:16235
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "Опади почнуться через {precipStart} хв"
 
-#: 3.8/weather-applet.js:16443
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "Помилка аналізу прогнозу, подробиці дивіться в журналах."
 
-#: 3.8/weather-applet.js:16892 3.8/weather-applet.js:17678
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "Станом на {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:16898
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "{distance} {distanceUnit} від вас"
 
-#: 3.8/weather-applet.js:16902
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "Назва станції: {stationName}"
 
-#: 3.8/weather-applet.js:16905
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "Район: {stationArea}"
 
-#: 3.8/weather-applet.js:17438 3.8/weather-applet.js:17448
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "Помилка збереження інформації про налагодження"
 
-#: 3.8/weather-applet.js:17460
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "Інформацію про налагодження успішно збережено"
 
-#: 3.8/weather-applet.js:17460
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "Збережено в {filePath}"
-
-#: 3.8/weather-applet.js:17603
-msgid "This provider requires an API key to operate"
-msgstr "Для роботи цього постачальника потрібен ключ API"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -1815,7 +1858,6 @@ msgid "Data service"
 msgstr "Служба даних"
 
 #. 3.0->settings-schema.json->dataService->options
-#. 3.8->settings-schema.json->dataService->options
 msgid "DarkSky (key needed)"
 msgstr "DarkSky (потрібен ключ)"
 
@@ -1840,7 +1882,9 @@ msgstr "Ключ API"
 #. 3.0->settings-schema.json->apiKey->tooltip
 #. 3.8->settings-schema.json->apiKey->tooltip
 msgid "Copy this from your account of the used Data service and paste it here."
-msgstr "Скопіюйте це зі свого облікового запису використаної служби даних і вставте сюди."
+msgstr ""
+"Скопіюйте це зі свого облікового запису використаної служби даних і вставте "
+"сюди."
 
 #. 3.0->settings-schema.json->manualLocation->description
 #. 3.8->settings-schema.json->manualLocation->description
@@ -1858,11 +1902,14 @@ msgstr "Розташування - Координати"
 
 #. 3.0->settings-schema.json->location->tooltip
 msgid ""
-"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an address.\n"
+"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an "
+"address.\n"
 "Waits for 3 seconds after you stop typing before refreshes the weather."
 msgstr ""
-"Прийнятні вхідні дані: широта, довгота.  наприклад: 68.1932,17.1426 або адреса.\n"
-" Очікує 3 секунди після того, як ви припините вводити, перш ніж оновити погоду."
+"Прийнятні вхідні дані: широта, довгота.  наприклад: 68.1932,17.1426 або "
+"адреса.\n"
+" Очікує 3 секунди після того, як ви припините вводити, перш ніж оновити "
+"погоду."
 
 #. 3.0->settings-schema.json->getLocation->description
 msgid "Setup API Key and Location"
@@ -1930,8 +1977,12 @@ msgstr "Фаренгейт"
 #. 3.0->settings-schema.json->distanceUnit->tooltip
 #. 3.8->settings-schema.json->temperatureUnit->tooltip
 #. 3.8->settings-schema.json->distanceUnit->tooltip
-msgid "Automatic will try to guess your preference based your current display language."
-msgstr "Автоматично спробує вгадати ваші переваги на основі поточної мови відображення."
+msgid ""
+"Automatic will try to guess your preference based your current display "
+"language."
+msgstr ""
+"Автоматично спробує вгадати ваші переваги на основі поточної мови "
+"відображення."
 
 #. 3.0->settings-schema.json->windSpeedUnit->description
 #. 3.8->settings-schema.json->windSpeedUnit->description
@@ -2045,10 +2096,13 @@ msgstr "Заміна мітки на панелі"
 #. 3.0->settings-schema.json->tempTextOverride->tooltip
 msgid ""
 "Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
-"Can be used if label does not fit on vertical panel, among other smart things."
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
 msgstr ""
-"Доступні значення: {c} — умова, {t} — температура, {u} — одиниця вимірювання.\n"
-" Можна використовувати, якщо етикетка не поміщається на вертикальній панелі, серед інших розумних речей."
+"Доступні значення: {c} — умова, {t} — температура, {u} — одиниця "
+"вимірювання.\n"
+" Можна використовувати, якщо етикетка не поміщається на вертикальній панелі, "
+"серед інших розумних речей."
 
 #. 3.0->settings-schema.json->useCustomAppletIcons->tooltip
 #. 3.0->settings-schema.json->useCustomMenuIcons->tooltip
@@ -2225,8 +2279,19 @@ msgid "Debug"
 msgstr "Відлагоджувати"
 
 #. 3.8->settings-schema.json->dataService->tooltip
-msgid "You can choose between several different weather forecast providers. Some providers require a API key to work, some have regional limits, differ in forecast length, and they all need a functional internet connection to work. The options are described in detail on the Cinnamon Spices Website which you can access with the button on the Help tab."
-msgstr "Ви можете вибрати між кількома різними постачальниками прогнозу погоди.  Деяким постачальникам для роботи потрібен ключ API, деякі мають регіональні обмеження, відрізняються тривалістю прогнозу, і всім їм для роботи потрібне функціональне підключення до Інтернету.  Параметри детально описані на веб-сайті Cinnamon Spices, доступ до якого можна отримати за допомогою кнопки на вкладці «Довідка»."
+msgid ""
+"You can choose between several different weather forecast providers. Some "
+"providers require a API key to work, some have regional limits, differ in "
+"forecast length, and they all need a functional internet connection to work. "
+"The options are described in detail on the Cinnamon Spices Website which you "
+"can access with the button on the Help tab."
+msgstr ""
+"Ви можете вибрати між кількома різними постачальниками прогнозу погоди.  "
+"Деяким постачальникам для роботи потрібен ключ API, деякі мають регіональні "
+"обмеження, відрізняються тривалістю прогнозу, і всім їм для роботи потрібне "
+"функціональне підключення до Інтернету.  Параметри детально описані на веб-"
+"сайті Cinnamon Spices, доступ до якого можна отримати за допомогою кнопки на "
+"вкладці «Довідка»."
 
 #. 3.8->settings-schema.json->dataService->options
 msgid "Deutscher Wetterdienst (Germany only)"
@@ -2239,6 +2304,11 @@ msgstr "Met Office UK (лише Великобританія)"
 #. 3.8->settings-schema.json->dataService->options
 msgid "US National Weather (US only)"
 msgstr "US National Weather  (тільки для США)"
+
+#. 3.8->settings-schema.json->dataService->options
+#, fuzzy
+msgid "Pirate Weather (key needed)"
+msgstr "Weatherbit (потрібен ключ)"
 
 #. 3.8->settings-schema.json->dataService->options
 msgid "Visual Crossing (key needed)"
@@ -2257,40 +2327,81 @@ msgid "Weather Underground (key needed)"
 msgstr "Weather Underground (потрібен ключ)"
 
 #. 3.8->settings-schema.json->location->tooltip
-msgid "You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/Town} {Postcode} {Country}. The search algorithm is very flexible with the format. After 3 seconds without typing the address you entered is replaced automatically for validating your choice."
-msgstr "Ви можете ввести координати «Широта, Довгота» (наприклад, 51.5085,-0.1257) або використати «Місто, код країни» (наприклад, Лондон, Великобританія) або спробувати ввести {House number} {Street} {City/Town} {Postcode} {Country}.  Алгоритм пошуку дуже гнучкий щодо формату.  Через 3 секунди без введення введена адреса автоматично замінюється для підтвердження вашого вибору."
+msgid ""
+"You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use "
+"'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street} "
+"{City/Town} {Postcode} {Country}. The search algorithm is very flexible with "
+"the format. After 3 seconds without typing the address you entered is "
+"replaced automatically for validating your choice."
+msgstr ""
+"Ви можете ввести координати «Широта, Довгота» (наприклад, 51.5085,-0.1257) "
+"або використати «Місто, код країни» (наприклад, Лондон, Великобританія) або "
+"спробувати ввести {House number} {Street} {City/Town} {Postcode} {Country}.  "
+"Алгоритм пошуку дуже гнучкий щодо формату.  Через 3 секунди без введення "
+"введена адреса автоматично замінюється для підтвердження вашого вибору."
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
 
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"
 msgstr "Зберегти поточне місцезнаходження в сховище"
 
 #. 3.8->settings-schema.json->saveLocation->tooltip
-msgid "Saves location information to file so you can switch between them with buttons in the applet, which will appear if you have more than one."
-msgstr "Зберігає інформацію про місцезнаходження у файлі, щоб ви могли перемикатися між ними за допомогою кнопок в аплеті, які з’являться, якщо у вас є декілька."
+msgid ""
+"Saves location information to file so you can switch between them with "
+"buttons in the applet, which will appear if you have more than one."
+msgstr ""
+"Зберігає інформацію про місцезнаходження у файлі, щоб ви могли перемикатися "
+"між ними за допомогою кнопок в аплеті, які з’являться, якщо у вас є декілька."
 
 #. 3.8->settings-schema.json->getLocation->description
 msgid "Weather Applet at Cinnamon Spices Website"
 msgstr "Weather Applet на веб-сайті Cinnamon Spices"
 
 #. 3.8->settings-schema.json->refreshInterval->tooltip
-msgid "If you are using a provider with API keys set it to an interval you won't run out of your quota with."
-msgstr "Якщо ви використовуєте постачальника з ключами API, установіть для нього інтервал, з яким ви не вичерпаєте свою квоту."
+msgid ""
+"If you are using a provider with API keys set it to an interval you won't "
+"run out of your quota with."
+msgstr ""
+"Якщо ви використовуєте постачальника з ключами API, установіть для нього "
+"інтервал, з яким ви не вичерпаєте свою квоту."
 
 #. 3.8->settings-schema.json->forecastDays->tooltip
-msgid "Maximum number of days that can be displayed, available number of data, maximum rows and columns setting in the Presentation tab will affect the final number."
-msgstr "Максимальна кількість днів, які можна відобразити, доступна кількість даних, налаштування максимальної кількості рядків і стовпців на вкладці «Презентація» впливатимуть на остаточне число."
+msgid ""
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+"Максимальна кількість днів, які можна відобразити, доступна кількість даних, "
+"налаштування максимальної кількості рядків і стовпців на вкладці "
+"«Презентація» впливатимуть на остаточне число."
 
 #. 3.8->settings-schema.json->forecastHours->tooltip
-msgid "Maximum number of hours that can be displayed, available numbers of data will affect the final number."
-msgstr "Максимальна кількість годин, які можна відобразити, доступна кількість даних вплине на остаточне число."
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
+msgstr ""
+"Максимальна кількість годин, які можна відобразити, доступна кількість даних "
+"вплине на остаточне число."
 
 #. 3.8->settings-schema.json->immediatePrecip->description
 msgid "Enable minutely precipitation forecast"
 msgstr "Увімкнути щохвилинний прогноз опадів"
 
 #. 3.8->settings-schema.json->immediatePrecip->tooltip
-msgid "If you'd like to use this make sure you use your exact coordinates/address as location to help its accuracy. Currently implemented with OpenWeatherMap and MET Norway only."
-msgstr "Якщо ви хочете використовувати це, переконайтеся, що ви використовуєте свої точні координати/адресу як місцеположення, щоб забезпечити точність.  Наразі реалізовано лише з OpenWeatherMap і MET Norway."
+#, fuzzy
+msgid ""
+"If you'd like to use this make sure you use your exact coordinates/address "
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
+msgstr ""
+"Якщо ви хочете використовувати це, переконайтеся, що ви використовуєте свої "
+"точні координати/адресу як місцеположення, щоб забезпечити точність.  Наразі "
+"реалізовано лише з OpenWeatherMap і MET Norway."
 
 #. 3.8->settings-schema.json->showBothTempUnits->description
 msgid "Show both temperature units at the same time"
@@ -2298,27 +2409,38 @@ msgstr "Показати обидві одиниці вимірювання те
 
 #. 3.8->settings-schema.json->tempTextOverride->tooltip
 msgid ""
-"Some of the available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
-"Can be used if label does not fit on vertical panel, among other smart things."
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
 msgstr ""
-"Деякі з доступних значень: {c} — умова, {t} — температура, {u} — одиниця вимірювання.\n"
-" Можна використовувати, якщо етикетка не поміщається на вертикальній панелі, серед інших розумних речей."
+"Деякі з доступних значень: {c} — умова, {t} — температура, {u} — одиниця "
+"вимірювання.\n"
+" Можна використовувати, якщо етикетка не поміщається на вертикальній панелі, "
+"серед інших розумних речей."
 
 #. 3.8->settings-schema.json->tooltipTextOverride->description
 msgid "Override tooltip on panel"
 msgstr "Перевизначити підказку на панелі"
 
 #. 3.8->settings-schema.json->tooltipTextOverride->tooltip
-msgid "Has the same behavior and available values as 'Override label on panel'."
-msgstr "Має таку саму поведінку та доступні значення, що й «Замінити мітку на панелі»."
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
+"Має таку саму поведінку та доступні значення, що й «Замінити мітку на "
+"панелі»."
 
 #. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
 msgid "Always show Hourly Weather"
 msgstr "Завжди показувати погодинну погоду"
 
 #. 3.8->settings-schema.json->alwaysShowHourlyWeather->tooltip
-msgid "Hide/Show button will be hidden and Hourly weather will be permanently visible."
-msgstr "Кнопка «Сховати/показати» буде прихована, а погодинна погода буде постійно видимою."
+msgid ""
+"Hide/Show button will be hidden and Hourly weather will be permanently "
+"visible."
+msgstr ""
+"Кнопка «Сховати/показати» буде прихована, а погодинна погода буде постійно "
+"видимою."
 
 #. 3.8->settings-schema.json->verticalOrientation->tooltip
 msgid "Displaying forecasts from top to bottom instead from left to right."
@@ -2329,8 +2451,12 @@ msgid "Your saved locations"
 msgstr "Ваші збережені місця"
 
 #. 3.8->settings-schema.json->locationList->tooltip
-msgid "You have to make sure the Search entry field is unique and your Timezone is in the IANA time zone format (e.g. 'Europe/London')"
-msgstr "Ви повинні переконатися, що поле введення Пошук є унікальним, а ваш часовий пояс має формат часового поясу IANA (наприклад, «Європа/Лондон»)."
+msgid ""
+"You have to make sure the Search entry field is unique and your Timezone is "
+"in the IANA time zone format (e.g. 'Europe/London')"
+msgstr ""
+"Ви повинні переконатися, що поле введення Пошук є унікальним, а ваш часовий "
+"пояс має формат часового поясу IANA (наприклад, «Європа/Лондон»)."
 
 #. 3.8->settings-schema.json->locationList->columns->title
 msgid "Latitude"
@@ -2366,15 +2492,25 @@ msgstr "Як Пд-Сх, П замість піктограм напрямків.
 
 #. 3.8->settings-schema.json->useSymbolicIcons->tooltip
 msgid "Does not apply to custom iconset, that is symbolic by default"
-msgstr "Не застосовується до спеціального набору значків, який за замовчуванням є символічним"
+msgstr ""
+"Не застосовується до спеціального набору значків, який за замовчуванням є "
+"символічним"
 
 #. 3.8->settings-schema.json->useSymbolicIcons->description
 msgid "Use symbolic icons throughout the applet"
 msgstr "Використовуйте символічні піктограми в аплеті"
 
 #. 3.8->settings-schema.json->more-info-label->description
-msgid "For detailed information about the applet please go to the Spices Website to find info about known issues, troubleshooting, changelog and more by clicking the button below. Here you can ask questions etc in the comment section by logging in with your Github account."
-msgstr "Для отримання детальної інформації про аплет перейдіть на веб-сайт Spices, щоб знайти інформацію про відомі проблеми, усунення несправностей, журнал змін тощо, натиснувши кнопку нижче.  Тут ви можете ставити запитання тощо в розділі коментарів, увійшовши за допомогою свого облікового запису Github."
+msgid ""
+"For detailed information about the applet please go to the Spices Website to "
+"find info about known issues, troubleshooting, changelog and more by "
+"clicking the button below. Here you can ask questions etc in the comment "
+"section by logging in with your Github account."
+msgstr ""
+"Для отримання детальної інформації про аплет перейдіть на веб-сайт Spices, "
+"щоб знайти інформацію про відомі проблеми, усунення несправностей, журнал "
+"змін тощо, натиснувши кнопку нижче.  Тут ви можете ставити запитання тощо в "
+"розділі коментарів, увійшовши за допомогою свого облікового запису Github."
 
 #. 3.8->settings-schema.json->submitIssue->description
 msgid "Submit an Issue"
@@ -2382,10 +2518,12 @@ msgstr "Надіслати проблему"
 
 #. 3.8->settings-schema.json->submitIssue->tooltip
 msgid ""
-"Opens webpage where you can fill out a new issue for the applet, needs a GitHub account.\n"
+"Opens webpage where you can fill out a new issue for the applet, needs a "
+"GitHub account.\n"
 " Please make sure that the issue is not already submitted."
 msgstr ""
-"Відкриває веб-сторінку, де можна заповнити нову проблему для аплету, потрібен обліковий запис GitHub.\n"
+"Відкриває веб-сторінку, де можна заповнити нову проблему для аплету, "
+"потрібен обліковий запис GitHub.\n"
 "  Переконайтеся, що питання ще не надіслано."
 
 #. 3.8->settings-schema.json->maintainer->description
@@ -2394,25 +2532,56 @@ msgstr "Поточний супроводжувач: Gr3q"
 
 #. 3.8->settings-schema.json->issue-reporting-explanation->description
 msgid ""
-"If you find an issue with this applet please make a report by clicking on the button below and login in with your Github account.\n"
+"If you find an issue with this applet please make a report by clicking on "
+"the button below and login in with your Github account.\n"
 "\n"
-"Before you start writing please make sure that the issue is not already submitted in the issues section and review your prefilled details in the issue description. Don't forget to add a short description in the top Title field next to the applet's name to make it easier for everyone to know what the issue is about. Logs with Debug level (which can be saved to a file below) are also appreciated."
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
 msgstr ""
-"Якщо ви виявите проблему з цим аплетом, повідомте про це, натиснувши кнопку нижче та увійшовши за допомогою свого облікового запису Github.\n"
+"Якщо ви виявите проблему з цим аплетом, повідомте про це, натиснувши кнопку "
+"нижче та увійшовши за допомогою свого облікового запису Github.\n"
 "\n"
-" Перш ніж почати писати, переконайтеся, що проблему ще не надіслано в розділі проблем, і перегляньте попередньо заповнені дані в описі проблеми.  Не забудьте додати короткий опис у верхньому полі «Назва» поруч із назвою аплету, щоб усім було легше зрозуміти, у чому полягає проблема.  Журнали з рівнем налагодження (які можна зберегти у файл нижче) також цінуються."
+" Перш ніж почати писати, переконайтеся, що проблему ще не надіслано в "
+"розділі проблем, і перегляньте попередньо заповнені дані в описі проблеми.  "
+"Не забудьте додати короткий опис у верхньому полі «Назва» поруч із назвою "
+"аплету, щоб усім було легше зрозуміти, у чому полягає проблема.  Журнали з "
+"рівнем налагодження (які можна зберегти у файл нижче) також цінуються."
 
 #. 3.8->settings-schema.json->loc-info->description
-msgid "Your location in most cases work automatically but you can enter it manually by coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/Town} {Postcode} {Country}. The search algorithm is very flexible with the format. After 3 seconds without typing the address you entered is replaced automatically for validating your choice."
-msgstr "Ваше місцезнаходження в більшості випадків працює автоматично, але ви можете ввести його вручну за координатами «Широта, Довгота» (наприклад, 51.5085,-0.1257) або використати «Код міста, країни» (наприклад, Лондон, Великобританія) або спробувати ввести {House number} {Street} {City/Town} {Postcode} {Country}.  Алгоритм пошуку дуже гнучкий щодо формату.  Через 3 секунди без введення введена адреса автоматично замінюється для підтвердження вашого вибору."
+msgid ""
+"Your location in most cases work automatically but you can enter it manually "
+"by coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,"
+"Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/"
+"Town} {Postcode} {Country}. The search algorithm is very flexible with the "
+"format. After 3 seconds without typing the address you entered is replaced "
+"automatically for validating your choice."
+msgstr ""
+"Ваше місцезнаходження в більшості випадків працює автоматично, але ви можете "
+"ввести його вручну за координатами «Широта, Довгота» (наприклад, "
+"51.5085,-0.1257) або використати «Код міста, країни» (наприклад, Лондон, "
+"Великобританія) або спробувати ввести {House number} {Street} {City/Town} "
+"{Postcode} {Country}.  Алгоритм пошуку дуже гнучкий щодо формату.  Через 3 "
+"секунди без введення введена адреса автоматично замінюється для "
+"підтвердження вашого вибору."
 
 #. 3.8->settings-schema.json->logLevel->description
 msgid "Log Level"
 msgstr "Рівень журналу"
 
 #. 3.8->settings-schema.json->logLevel->tooltip
-msgid "Info is the regular logging, Debug is debug, and Verbose also logs network request payloads. Changing this will only be effective on future logs. Only change it you are instructed or you know what you are doing."
-msgstr "Інформація — це звичайне ведення журналу, Debug — це налагодження, а Verbose також реєструє дані запитів мережі.  Зміна цього буде ефективна лише для майбутніх журналів.  Змінюйте його лише вам наказано або ви знаєте, що робите."
+msgid ""
+"Info is the regular logging, Debug is debug, and Verbose also logs network "
+"request payloads. Changing this will only be effective on future logs. Only "
+"change it you are instructed or you know what you are doing."
+msgstr ""
+"Інформація — це звичайне ведення журналу, Debug — це налагодження, а Verbose "
+"також реєструє дані запитів мережі.  Зміна цього буде ефективна лише для "
+"майбутніх журналів.  Змінюйте його лише вам наказано або ви знаєте, що "
+"робите."
 
 #. 3.8->settings-schema.json->logLevel->options
 msgid "Verbose"
@@ -2423,8 +2592,12 @@ msgid "Click Save to save debug information to a file"
 msgstr "Натисніть «Зберегти», щоб зберегти інформацію про налагодження у файлі"
 
 #. 3.8->settings-schema.json->fileSelect->tooltip
-msgid "This includes logs for the applet and the current settings with your API key redacted."
-msgstr "Це включає журнали для аплету та поточні налаштування з відредагованим ключем API."
+msgid ""
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
+msgstr ""
+"Це включає журнали для аплету та поточні налаштування з відредагованим "
+"ключем API."
 
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"

--- a/weather@mockturtl/files/weather@mockturtl/po/vi.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/vi.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-12 12:27-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2012-06-17 17:04+0700\n"
 "Last-Translator: Ngô Trung <ndtrung4419@gmail.com>\n"
 "Language-Team: \n"
@@ -17,485 +18,2579 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: applet.js:249
+#: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
+#: 3.8/weather-applet.js:17877
+msgid "Error"
+msgstr ""
+
+#: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
+#: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
+msgid "Service Error"
+msgstr ""
+
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
+msgid "Incorrect API Key"
+msgstr ""
+
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
+msgid "Incorrect Location Format"
+msgstr ""
+
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
+msgid "Key Blocked"
+msgstr ""
+
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
+msgid "Can't find location"
+msgstr ""
+
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
+msgid "No Api Key"
+msgstr ""
+
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
+msgid "No Location"
+msgstr ""
+
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
+msgid "Missing Packages"
+msgstr ""
+
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
+msgid "Location not covered"
+msgstr ""
+
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
+msgid "Weather Applet"
+msgstr ""
+
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: applet.js:250
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr ""
 
-#: applet.js:289
-#, fuzzy
-msgid "Settings"
-msgstr "Thiết lập thời tiết"
-
-#: applet.js:555
-msgid "Sunrise"
-msgstr "Bình minh"
-
-#: applet.js:556
-msgid "Sunset"
-msgstr "Hoàng hôn"
-
-#: applet.js:648
-msgid "Loading current weather ..."
-msgstr "Đang tải dữ liệu thời tiết hiện tại..."
-
-#: applet.js:649
-msgid "Loading future weather ..."
-msgstr "Đang tải dữ liệu dự báo thời tiết..."
-
-#: applet.js:671
-msgid "Loading ..."
-msgstr "Đang tải..."
-
-#: applet.js:677
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr ""
 
-#: applet.js:740
+#: 3.0/applet.js:272
+msgid "API returned status code between 400 and 500"
+msgstr ""
+
+#: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
+#: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
+msgid "Location Store"
+msgstr ""
+
+#: 3.0/applet.js:426
+msgid "You can't save a location obtained automatically, sorry"
+msgstr ""
+
+#: 3.0/applet.js:601
 #, fuzzy
-msgid "Temperature:"
+msgid "Could not get weather information"
+msgstr "Tải lại dữ liệu thời tiết"
+
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
+msgid ""
+"Unexpected Error While Refreshing Weather, please see log in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
+msgid ""
+"Could not update weather for a while...\n"
+"are you connected to the internet?"
+msgstr ""
+
+#: 3.0/applet.js:684
+msgid "Network Error, please check logs in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:969 3.0/applet.js:1110
+msgid "As of"
+msgstr ""
+
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
+msgid "Powered by"
+msgstr ""
+
+#: 3.0/applet.js:1113
+msgid "from you"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
+msgid "mm"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
+msgid "in"
+msgstr ""
+
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
+msgid "mi"
+msgstr ""
+
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
+msgid "km"
+msgstr ""
+
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
+msgid "Loading current weather ..."
+msgstr "Đang tải dữ liệu thời tiết hiện tại..."
+
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
+msgid "Loading future weather ..."
+msgstr "Đang tải dữ liệu dự báo thời tiết..."
+
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
+msgid "Loading ..."
+msgstr "Đang tải..."
+
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
+#, fuzzy
+msgid "Temperature"
 msgstr "Đơn vị đo nhiệt độ:"
 
-#: applet.js:742
-msgid "Humidity:"
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
+#, fuzzy
+msgid "Humidity"
 msgstr "Độ ẩm:"
 
-#: applet.js:744
-msgid "Pressure:"
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
+#, fuzzy
+msgid "Pressure"
 msgstr "Áp suất:"
 
-#: applet.js:746
-msgid "Wind:"
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
+#, fuzzy
+msgid "Wind"
 msgstr "Gió:"
 
-#: applet.js:748
-msgid "Wind Chill:"
-msgstr "Gió:"
+#: 3.0/applet.js:1639
+msgid "Make sure you entered a location or use Automatic location instead"
+msgstr ""
 
-#: applet.js:953
-msgid "Tornado"
-msgstr "Lốc xoáy"
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
+msgid "Could not find location based on address, please check if it's right"
+msgstr ""
 
-#: applet.js:955
-msgid "Tropical storm"
-msgstr "Bão nhiệt đới"
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
+msgid "Failed to call Geolocation API, see Looking Glass for errors."
+msgstr ""
 
-#: applet.js:957
-msgid "Hurricane"
-msgstr "Cuồng phong"
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "Warning"
+msgstr ""
 
-#: applet.js:959
-msgid "Severe thunderstorms"
-msgstr "Giông nguy hiểm"
+#: 3.0/applet.js:2032
+msgid "You can only save correct locations when the applet is not refreshing"
+msgstr ""
 
-#: applet.js:961
-msgid "Thunderstorms"
-msgstr "Giông"
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "You can't save an incorrect location"
+msgstr ""
 
-#: applet.js:963
-msgid "Mixed rain and snow"
-msgstr "Mưa và tuyết"
+#. 3.8->settings-schema.json->logLevel->options
+#: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.8/weather-applet.js:9875
+msgid "Info"
+msgstr ""
 
-#: applet.js:965
-msgid "Mixed rain and sleet"
-msgstr "Mưa và mưa tuyết"
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
+msgid "Location is already saved"
+msgstr ""
 
-#: applet.js:967
-msgid "Mixed snow and sleet"
-msgstr "Tuyết và mưa tuyết"
+#: 3.0/applet.js:2049 3.0/applet.js:2083
+msgid "Success"
+msgstr ""
 
-#: applet.js:969
-msgid "Freezing drizzle"
-msgstr "Mưa phùn rét"
+#: 3.0/applet.js:2049
+msgid "Location is saved to library"
+msgstr ""
 
-#: applet.js:971
-msgid "Drizzle"
-msgstr "Mưa phùn"
+#: 3.0/applet.js:2062
+msgid "You can't remove a location while the applet is refreshing"
+msgstr ""
 
-#: applet.js:973
+#: 3.0/applet.js:2066
+msgid "You can't remove an incorrect location"
+msgstr ""
+
+#: 3.0/applet.js:2070
+msgid "Location is not in storage, can't delete"
+msgstr ""
+
+#: 3.0/applet.js:2083
+msgid "Location is deleted from library"
+msgstr ""
+
+#: 3.0/applet.js:2131
+msgid ""
+"Failed to load in data from location storage, please see the logs for more "
+"information"
+msgstr ""
+
+#: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
+#: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
+#, fuzzy
+msgid "Feels Like"
+msgstr "Cảm giác ngoài trời:"
+
+#: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
+#: 3.8/weather-applet.js:15387
+msgid "Failed to Process Weather Info"
+msgstr ""
+
+#: 3.0/climacell.js:224
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://developer.climacell.co/sign-up"
+msgstr ""
+
+#: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
+msgid ""
+"Please Make sure you\n"
+"entered the API key correctly and your account is not locked"
+msgstr ""
+
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Climacell"
+msgstr ""
+
+#: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
+#: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
+#: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
+#, fuzzy
+msgid "Heavy rain"
+msgstr "Tuyết mạnh"
+
+#: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
+#: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
+#: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
+msgid "Rain"
+msgstr ""
+
+#: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
+#: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
+#: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
+#, fuzzy
+msgid "Light rain"
+msgstr "Mưa rét"
+
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
+#, fuzzy
+msgid "Heavy freezing rain"
+msgstr "Mưa rét"
+
+#: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
+#: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
+#: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "Mưa rét"
 
-#: applet.js:975 applet.js:977
-msgid "Showers"
-msgstr "Mưa rào"
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
+#, fuzzy
+msgid "Light freezing rain"
+msgstr "Mưa rét"
 
-#: applet.js:979
-msgid "Snow flurries"
-msgstr "Tuyết bất chợt"
+#: 3.0/climacell.js:301
+#, fuzzy
+msgid "Light freezing drizzle"
+msgstr "Mưa phùn rét"
 
-#: applet.js:981
-msgid "Light snow showers"
-msgstr "Tuyết rào nhẹ"
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
+msgid "Freezing drizzle"
+msgstr "Mưa phùn rét"
 
-#: applet.js:983
-msgid "Blowing snow"
-msgstr "Gió tuyết"
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
+#, fuzzy
+msgid "Light drizzle"
+msgstr "Mưa phùn rét"
 
-#: applet.js:985
-msgid "Snow"
-msgstr "Tuyết"
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
+msgid "Heavy ice pellets"
+msgstr ""
 
-#: applet.js:987
-msgid "Hail"
-msgstr "Mưa đá"
+#: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
+msgid "Ice pellets"
+msgstr ""
 
-#: applet.js:989
-msgid "Sleet"
-msgstr "Mưa tuyết"
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
+msgid "Light ice pellets"
+msgstr ""
 
-#: applet.js:991
-msgid "Dust"
-msgstr "Bụi mù"
-
-#: applet.js:993
-msgid "Foggy"
-msgstr "Sương mù"
-
-#: applet.js:995
-msgid "Haze"
-msgstr "Bụi mù"
-
-#: applet.js:997
-msgid "Smoky"
-msgstr "Khói mù"
-
-#: applet.js:999
-msgid "Blustery"
-msgstr "Gió dữ dội"
-
-#: applet.js:1001
-msgid "Windy"
-msgstr "Gió"
-
-#: applet.js:1003
-msgid "Cold"
-msgstr "Lạnh"
-
-#: applet.js:1005
-msgid "Cloudy"
-msgstr "Mây mù"
-
-#: applet.js:1008
-msgid "Mostly cloudy"
-msgstr "Nhiều mây"
-
-#: applet.js:1011 applet.js:1037
-msgid "Partly cloudy"
-msgstr "Ít mây"
-
-#: applet.js:1013
-msgid "Clear"
-msgstr "Trời trong"
-
-#: applet.js:1015
-msgid "Sunny"
-msgstr "Nắng"
-
-#: applet.js:1018
-msgid "Fair"
-msgstr "Bình thường"
-
-#: applet.js:1020
-msgid "Mixed rain and hail"
-msgstr "Mưa và mưa đá"
-
-#: applet.js:1022
-msgid "Hot"
-msgstr "Nóng"
-
-#: applet.js:1024
-msgid "Isolated thunderstorms"
-msgstr "Giông diện hẹp"
-
-#: applet.js:1027
-msgid "Scattered thunderstorms"
-msgstr "Giông rải rác"
-
-#: applet.js:1029
-msgid "Scattered showers"
-msgstr "Mưa rào rải rác"
-
-#: applet.js:1031 applet.js:1035
+#: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
+#: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
+#: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "Tuyết mạnh"
 
-#: applet.js:1033
-msgid "Scattered snow showers"
-msgstr "Mưa tuyết rải rác"
+#: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
+#: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
+#: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
+msgid "Snow"
+msgstr "Tuyết"
 
-#: applet.js:1039
-msgid "Thundershowers"
-msgstr "Mưa rào có sấm"
+#: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
+#: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
+#: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
+#, fuzzy
+msgid "Light snow"
+msgstr "Tuyết rào nhẹ"
 
-#: applet.js:1041
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
+#, fuzzy
+msgid "Flurries"
+msgstr "Tuyết bất chợt"
+
+#: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
+#, fuzzy
+msgid "Thunderstorm"
+msgstr "Giông"
+
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
+msgid "Light fog"
+msgstr ""
+
+#: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
+#: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
+#: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
+#, fuzzy
+msgid "Fog"
+msgstr "Sương mù"
+
+#: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
+#: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
+msgid "Cloudy"
+msgstr "Mây mù"
+
+#: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
+msgid "Mostly cloudy"
+msgstr "Nhiều mây"
+
+#: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
+#: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
+#: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
+msgid "Partly cloudy"
+msgstr "Ít mây"
+
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
+#, fuzzy
+msgid "Mostly clear"
+msgstr "Nhiều mây"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
+#: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
+#: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
+msgid "Clear"
+msgstr "Trời trong"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
+msgid "Sunny"
+msgstr "Nắng"
+
+#: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
+#: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
+#: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
+msgid "Unknown"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "and"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "until"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "Possible"
+msgstr ""
+
+#: 3.0/darkSky.js:211
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://darksky.net/dev/register"
+msgstr ""
+
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from DarkSky"
+msgstr ""
+
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
+msgid "Could not obtain location"
+msgstr ""
+
+#: 3.0/ipApi.js:95
+msgid ""
+"Location Service responded with errors, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
+#, fuzzy
+msgid "Cloudiness"
+msgstr "Mây mù"
+
+#: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
+#, fuzzy
+msgid "Clear sky"
+msgstr "Trời trong"
+
+#: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
+msgid "Fair"
+msgstr "Bình thường"
+
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
+msgid "Heavy rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
+#, fuzzy
+msgid "Heavy rain showers"
+msgstr "Tuyết mạnh"
+
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
+msgid "Heavy rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
+#, fuzzy
+msgid "Heavy sleet"
+msgstr "Tuyết mạnh"
+
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
+msgid "Heavy sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
+#, fuzzy
+msgid "Heavy sleet showers"
+msgstr "Tuyết mạnh"
+
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
+msgid "Heavy sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
+#, fuzzy
+msgid "Heavy snow and thunder"
+msgstr "Tuyết mạnh"
+
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
+#, fuzzy
+msgid "Heavy snow showers"
+msgstr "Mưa tuyết rào"
+
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
+msgid "Heavy snow showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
+msgid "Light rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
+#, fuzzy
+msgid "Light rain showers"
+msgstr "Tuyết rào nhẹ"
+
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
+#, fuzzy
+msgid "Light rain showers and thunder"
+msgstr "Tuyết rào nhẹ"
+
+#: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
+msgid "Light sleet"
+msgstr ""
+
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
+msgid "Light sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
+#, fuzzy
+msgid "Light sleet showers"
+msgstr "Tuyết rào nhẹ"
+
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
+#, fuzzy
+msgid "Light sleet showers and thunder"
+msgstr "Tuyết rào nhẹ"
+
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
+#, fuzzy
+msgid "Light snow and thunder"
+msgstr "Tuyết rào nhẹ"
+
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
+msgid "Light snow showers"
+msgstr "Tuyết rào nhẹ"
+
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
+#, fuzzy
+msgid "Light snow showers and thunder"
+msgstr "Tuyết rào nhẹ"
+
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
+msgid "Rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
+#, fuzzy
+msgid "Rain showers"
+msgstr "Mưa tuyết rào"
+
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
+msgid "Rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:511 3.0/met_norway.js:512 3.0/met_norway.js:518
+#: 3.0/met_norway.js:525 3.0/met_norway.js:532 3.0/met_uk.js:638
+#: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
+#: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
+#: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
+msgid "Sleet"
+msgstr "Mưa tuyết"
+
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
+#, fuzzy
+msgid "Sleet and thunder"
+msgstr "Giông rải rác"
+
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
+#, fuzzy
+msgid "Sleet showers"
+msgstr "Mưa rào rải rác"
+
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
+msgid "Sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
+msgid "Snow and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "Mưa tuyết rào"
 
-#: applet.js:1043
-msgid "Isolated thundershowers"
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
+#, fuzzy
+msgid "Snow showers and thunder"
+msgstr "Mưa tuyết rào"
+
+#: 3.0/met_uk.js:162 3.0/met_uk.js:192 3.0/met_uk.js:239 3.0/us_weather.js:151
+#: 3.0/us_weather.js:179
+msgid "Unexpected response from API"
+msgstr ""
+
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
+msgid "Visibility"
+msgstr ""
+
+#: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
+msgid "Failed to Process Current Weather Info"
+msgstr ""
+
+#: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
+msgid "Failed to Process Forecast Info"
+msgstr ""
+
+#: 3.0/met_uk.js:408
+msgid "Very poor - Less than"
+msgstr ""
+
+#: 3.0/met_uk.js:410
+msgid "Poor - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:412
+msgid "Moderate - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:414
+msgid "Good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:416
+msgid "Very good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:417
+msgid "Excellent - More than"
+msgstr ""
+
+#: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
+msgid "Mist"
+msgstr ""
+
+#: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
+msgid "Overcast"
+msgstr ""
+
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
+#, fuzzy
+msgid "Light rain shower"
+msgstr "Tuyết rào nhẹ"
+
+#: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
+msgid "Drizzle"
+msgstr "Mưa phùn"
+
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
+#, fuzzy
+msgid "Heavy rain shower"
+msgstr "Tuyết mạnh"
+
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
+#, fuzzy
+msgid "Sleet shower"
 msgstr "Mưa rào rải rác"
 
-#: applet.js:1046
-msgid "Not available"
-msgstr "Không có dữ liệu"
+#: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
+msgid "Hail"
+msgstr "Mưa đá"
 
-#: applet.js:1051
-msgid "Monday"
-msgstr "Thứ hai"
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
+#, fuzzy
+msgid "Hail shower"
+msgstr "Mưa tuyết rào"
 
-#: applet.js:1051
-msgid "Tuesday"
-msgstr "Thứ ba"
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
+#, fuzzy
+msgid "Light snow shower"
+msgstr "Tuyết rào nhẹ"
 
-#: applet.js:1051
-msgid "Wednesday"
-msgstr "Thứ tư"
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
+#, fuzzy
+msgid "Heavy snow shower"
+msgstr "Tuyết mạnh"
 
-#: applet.js:1051
-msgid "Thursday"
-msgstr "Thứ năm"
+#: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
+#, fuzzy
+msgid "Thunder"
+msgstr "Giông"
 
-#: applet.js:1051
-msgid "Friday"
-msgstr "Thứ sáu"
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
+#, fuzzy
+msgid "Thunder shower"
+msgstr "Mưa rào có sấm"
 
-#: applet.js:1051
-msgid "Saturday"
-msgstr "Thứ bảy"
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
+msgid "Please make sure Location is in the correct format in the Settings"
+msgstr ""
 
-#: applet.js:1051
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
+msgid "Make sure you entered the correct key in settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
+msgid ""
+"Location not found, make sure location is available or it is in the correct "
+"format"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
+msgid "If this problem persists, please contact the Author of this applet"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
+msgid "Unknown Error, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
+msgid "Thunderstorm with light rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
+#, fuzzy
+msgid "Thunderstorm with rain"
+msgstr "Giông"
+
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
+msgid "Thunderstorm with heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
+#, fuzzy
+msgid "Light thunderstorm"
+msgstr "Giông"
+
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
+#, fuzzy
+msgid "Heavy thunderstorm"
+msgstr "Giông nguy hiểm"
+
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
+#, fuzzy
+msgid "Ragged thunderstorm"
+msgstr "Giông diện hẹp"
+
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
+msgid "Thunderstorm with light drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
+#, fuzzy
+msgid "Thunderstorm with drizzle"
+msgstr "Giông"
+
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
+msgid "Thunderstorm with heavy drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
+msgid "Light intensity drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
+msgid "Heavy intensity drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
+msgid "Light intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Drizzle rain"
+msgstr "Mưa phùn"
+
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
+msgid "Heavy intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
+#, fuzzy
+msgid "Shower rain and drizzle"
+msgstr "Mưa và mưa đá"
+
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
+msgid "Heavy shower rain and drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
+#, fuzzy
+msgid "Shower drizzle"
+msgstr "Mưa phùn rét"
+
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
+msgid "Moderate rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
+msgid "Heavy intensity rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
+msgid "Very heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
+#, fuzzy
+msgid "Extreme rain"
+msgstr "Mưa rét"
+
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
+#, fuzzy
+msgid "Light intensity shower rain"
+msgstr "Tuyết rào nhẹ"
+
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
+#, fuzzy
+msgid "Shower rain"
+msgstr "Mưa rào"
+
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
+msgid "Heavy intensity shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
+msgid "Ragged shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
+#, fuzzy
+msgid "Shower sleet"
+msgstr "Mưa rào"
+
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
+#, fuzzy
+msgid "Light rain and snow"
+msgstr "Mưa và tuyết"
+
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
+#, fuzzy
+msgid "Rain and snow"
+msgstr "Mưa và tuyết"
+
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
+#, fuzzy
+msgid "Light shower snow"
+msgstr "Tuyết rào nhẹ"
+
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
+#, fuzzy
+msgid "Shower snow"
+msgstr "Mưa rào"
+
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
+#, fuzzy
+msgid "Heavy shower snow"
+msgstr "Tuyết mạnh"
+
+#: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
+#, fuzzy
+msgid "Smoke"
+msgstr "Khói mù"
+
+#: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
+msgid "Haze"
+msgstr "Bụi mù"
+
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
+msgid "Sand, dust whirls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
+msgid "Sand"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
+msgid "Dust"
+msgstr "Bụi mù"
+
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
+msgid "Volcanic ash"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
+msgid "Squalls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
+msgid "Tornado"
+msgstr "Lốc xoáy"
+
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
+msgid "Sky is clear"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
+#, fuzzy
+msgid "Clouds"
+msgstr "Mây mù"
+
+#: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
+msgid "Few clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
+#, fuzzy
+msgid "Scattered clouds"
+msgstr "Mưa rào rải rác"
+
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
+msgid "Broken clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
+msgid "Overcast clouds"
+msgstr ""
+
+#: 3.0/us_weather.js:120
+msgid "Could not get forecast for your area"
+msgstr ""
+
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
+msgid "Location is outside US, please use a different provider."
+msgstr ""
+
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
+msgid "Failed to Process Hourly Forecast Info"
+msgstr ""
+
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
+msgid "Clear and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
+msgid "Few clouds and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
+#, fuzzy
+msgid "Partly cloudy and windy"
+msgstr "Ít mây"
+
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
+#, fuzzy
+msgid "Mostly cloudy and windy"
+msgstr "Nhiều mây"
+
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
+msgid "Overcast and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
+#, fuzzy
+msgid "Snowy rain"
+msgstr "Tuyết bất chợt"
+
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
+#, fuzzy
+msgid "Freezing rain and snow"
+msgstr "Mưa rét"
+
+#: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
+msgid "Hurricane"
+msgstr "Cuồng phong"
+
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
+msgid "Storm"
+msgstr ""
+
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
+msgid "Tropical storm"
+msgstr "Bão nhiệt đới"
+
+#: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
+msgid "Hot"
+msgstr "Nóng"
+
+#: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
+msgid "Cold"
+msgstr "Lạnh"
+
+#: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
+msgid "Blizzard"
+msgstr ""
+
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
+msgid "Today"
+msgstr "Hôm nay"
+
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
+msgid "Tomorrow"
+msgstr "Ngày mai"
+
+#: 3.0/utils.js:204
 msgid "Sunday"
 msgstr "Chủ Nhật"
 
-#: applet.js:1056
+#: 3.0/utils.js:204
+msgid "Monday"
+msgstr "Thứ hai"
+
+#: 3.0/utils.js:204
+msgid "Tuesday"
+msgstr "Thứ ba"
+
+#: 3.0/utils.js:204
+msgid "Wednesday"
+msgstr "Thứ tư"
+
+#: 3.0/utils.js:204
+msgid "Thursday"
+msgstr "Thứ năm"
+
+#: 3.0/utils.js:204
+msgid "Friday"
+msgstr "Thứ sáu"
+
+#: 3.0/utils.js:204
+msgid "Saturday"
+msgstr "Thứ bảy"
+
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
+msgid "Calm"
+msgstr ""
+
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
+msgid "Light air"
+msgstr ""
+
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
+msgid "Light breeze"
+msgstr ""
+
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
+msgid "Gentle breeze"
+msgstr ""
+
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
+msgid "Moderate breeze"
+msgstr ""
+
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
+msgid "Fresh breeze"
+msgstr ""
+
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
+msgid "Strong breeze"
+msgstr ""
+
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
+msgid "Near gale"
+msgstr ""
+
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
+msgid "Gale"
+msgstr ""
+
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
+msgid "Strong gale"
+msgstr ""
+
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
+msgid "Violent storm"
+msgstr ""
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "B"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "ĐB"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "Đ"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "ĐN"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "N"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "TN"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "T"
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "TB"
 
-#. cinnamon-weather->settings-schema.json->woeidLookup->description
-msgid "Get WOEID"
+#: 3.0/weatherbit.js:312
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://www.weatherbit.io/account/create"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->verticalOrientation->description
-msgid "Vertical orientation"
+#: 3.0/yahoo.js:78
+msgid ""
+"Unknown Error happened while calling Yahoo bridge,\n"
+" see Looking Glass log for errors"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showTextInPanel->description
+#: 3.0/yahoo.js:91
+msgid ""
+"Yahoo bridge responded in bad format,\n"
+" see Looking Glass log for errors"
+msgstr ""
+
+#: 3.0/yahoo.js:177
+msgid "Missing package"
+msgstr ""
+
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
 #, fuzzy
-msgid "Display current temperature in panel"
-msgstr "Hiện nhiệt độ trên pa-nen"
+msgid "Please install '"
+msgstr "Xin đợi một lát"
 
-#. cinnamon-weather->settings-schema.json->woeid->description
-msgid "WOEID"
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+msgid "', then refresh manually."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeid->tooltip
-msgid "Where On Earth ID"
+#: 3.0/yahoo.js:182
+msgid "Could not connect to Yahoo API."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->description
+#: 3.0/yahoo.js:186
+msgid ""
+"Unknown error happened while obtaining weather, see Looking Glass logs for "
+"more information"
+msgstr ""
+
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
+#, fuzzy
+msgid "Tropical Storm"
+msgstr "Bão nhiệt đới"
+
+#: 3.0/yahoo.js:439
+#, fuzzy
+msgid "Severe Thunderstorms"
+msgstr "Giông nguy hiểm"
+
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
+msgid "Thunderstorms"
+msgstr "Giông"
+
+#: 3.0/yahoo.js:441
+#, fuzzy
+msgid "Mixed Rain and Snow"
+msgstr "Mưa và tuyết"
+
+#: 3.0/yahoo.js:442
+#, fuzzy
+msgid "Mixed Rain and Sleet"
+msgstr "Mưa và mưa tuyết"
+
+#: 3.0/yahoo.js:443
+#, fuzzy
+msgid "Mixed Snow and Sleet"
+msgstr "Tuyết và mưa tuyết"
+
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
+#, fuzzy
+msgid "Freezing Drizzle"
+msgstr "Mưa phùn rét"
+
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
+#, fuzzy
+msgid "Freezing Rain"
+msgstr "Mưa rét"
+
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
+msgid "Showers"
+msgstr "Mưa rào"
+
+#: 3.0/yahoo.js:449
+#, fuzzy
+msgid "Snow Flurries"
+msgstr "Tuyết bất chợt"
+
+#: 3.0/yahoo.js:450
+#, fuzzy
+msgid "Light Snow Showers"
+msgstr "Tuyết rào nhẹ"
+
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
+#, fuzzy
+msgid "Blowing Snow"
+msgstr "Gió tuyết"
+
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
+msgid "Foggy"
+msgstr "Sương mù"
+
+#: 3.0/yahoo.js:458
+msgid "Smoky"
+msgstr "Khói mù"
+
+#: 3.0/yahoo.js:459
+msgid "Blustery"
+msgstr "Gió dữ dội"
+
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
+msgid "Windy"
+msgstr "Gió"
+
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
+#, fuzzy
+msgid "Mostly Cloudy"
+msgstr "Nhiều mây"
+
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
+#, fuzzy
+msgid "Partly Cloudy"
+msgstr "Ít mây"
+
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
+#, fuzzy
+msgid "Mostly Sunny"
+msgstr "Nhiều mây"
+
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
+#, fuzzy
+msgid "Mixed Rain and Hail"
+msgstr "Mưa và mưa đá"
+
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
+#, fuzzy
+msgid "Isolated Thunderstorms"
+msgstr "Giông diện hẹp"
+
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
+#, fuzzy
+msgid "Scattered Thunderstorms"
+msgstr "Giông rải rác"
+
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
+#, fuzzy
+msgid "Scattered Showers"
+msgstr "Mưa rào rải rác"
+
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
+#, fuzzy
+msgid "Heavy Rain"
+msgstr "Tuyết mạnh"
+
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
+#, fuzzy
+msgid "Scattered Snow Showers"
+msgstr "Mưa tuyết rải rác"
+
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
+#, fuzzy
+msgid "Heavy Snow"
+msgstr "Tuyết mạnh"
+
+#: 3.0/yahoo.js:478
+#, fuzzy
+msgid "Not Available"
+msgstr "Không có dữ liệu"
+
+#: 3.0/yahoo.js:479
+#, fuzzy
+msgid "Scattered Thundershowers"
+msgstr "Giông rải rác"
+
+#: 3.8/weather-applet.js:9638
+msgid ""
+"Could not retrieve logs, log file was not found under path\n"
+" {logFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:9642
+msgid ""
+"Could not get contents of log file under path\n"
+" {logFilePath}"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10283
+msgid "Met Office UK"
+msgstr ""
+
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
+msgstr ""
+
+#: 3.8/weather-applet.js:10476
+msgid "Data was not found for location"
+msgstr ""
+
+#: 3.8/weather-applet.js:10557
+msgid "Very poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10557
+msgid "Less than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "Excellent"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "More than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566
+msgid "Poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
+msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10571
+msgid "Moderate"
+msgstr ""
+
+#: 3.8/weather-applet.js:10576
+msgid "Good"
+msgstr ""
+
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
+msgid "Very good"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10942
+msgid "OpenWeatherMap"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:11396
+msgid "MET Norway"
+msgstr ""
+
+#: 3.8/weather-applet.js:11955
+msgid "WeatherBit"
+msgstr ""
+
+#: 3.8/weather-applet.js:12386
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "Ngày mai"
+
+#: 3.8/weather-applet.js:12561
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12575
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12723
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:13292
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13474
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "Gió tuyết"
+
+#: 3.8/weather-applet.js:13478
+#, fuzzy
+msgid "Heavy drizzle"
+msgstr "Mưa phùn rét"
+
+#: 3.8/weather-applet.js:13482
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13484
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13486
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:13490
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "Mưa phùn rét"
+
+#: 3.8/weather-applet.js:13492
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13494
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13496
+#, fuzzy
+msgid "Freezing fog"
+msgstr "Mưa rét"
+
+#: 3.8/weather-applet.js:13502
+msgid "Funnel cloud/tornado"
+msgstr ""
+
+#: 3.8/weather-applet.js:13504
+#, fuzzy
+msgid "Hail showers"
+msgstr "Mưa tuyết rào"
+
+#: 3.8/weather-applet.js:13506
+msgid "Ice"
+msgstr ""
+
+#: 3.8/weather-applet.js:13508
+msgid "Lightning without thunder"
+msgstr ""
+
+#: 3.8/weather-applet.js:13512
+msgid "Precipitation in vicinity"
+msgstr ""
+
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
+#, fuzzy
+msgid "Heavy rain and snow"
+msgstr "Mưa và tuyết"
+
+#: 3.8/weather-applet.js:13518
+#, fuzzy
+msgid "Light rain And snow"
+msgstr "Mưa và tuyết"
+
+#: 3.8/weather-applet.js:13526
+msgid "Sky coverage decreasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13528
+msgid "Sky coverage increasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13530
+msgid "Sky unchanged"
+msgstr ""
+
+#: 3.8/weather-applet.js:13532
+msgid "Smoke or haze"
+msgstr ""
+
+#: 3.8/weather-applet.js:13536
+#, fuzzy
+msgid "Snow and rain showers"
+msgstr "Mưa tuyết rào"
+
+#: 3.8/weather-applet.js:13548
+msgid "Thunderstorm without precipitation"
+msgstr ""
+
+#: 3.8/weather-applet.js:13550
+msgid "Diamond dust"
+msgstr ""
+
+#: 3.8/weather-applet.js:13556
+#, fuzzy
+msgid "Partially cloudy"
+msgstr "Ít mây"
+
+#: 3.8/weather-applet.js:13578
+msgid "Please make sure you entered the API key correctly"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:13595
+msgid "DMI Denmark"
+msgstr ""
+
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
+msgid "NOT FOUND"
+msgstr ""
+
+#: 3.8/weather-applet.js:13779
+msgid "Blowing snow"
+msgstr "Gió tuyết"
+
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
+#, fuzzy
+msgid "Slight snow"
+msgstr "Gió tuyết"
+
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
+#, fuzzy
+msgid "Moderate snow"
+msgstr "Tuyết mạnh"
+
+#: 3.8/weather-applet.js:13842
+#, fuzzy
+msgid "Moderate rain showers"
+msgstr "Mưa rào rải rác"
+
+#: 3.8/weather-applet.js:13849
+msgid "Mixed rain and snow"
+msgstr "Mưa và tuyết"
+
+#: 3.8/weather-applet.js:13856
+#, fuzzy
+msgid "Heavy mixed rain and snow"
+msgstr "Mưa và tuyết"
+
+#: 3.8/weather-applet.js:14024
+msgid "AccuWeather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+msgid "Weather Underground"
+msgstr ""
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+msgid "The location you provided was not found."
+msgstr ""
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+msgid "Strong Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "Mưa và tuyết"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "Mưa và mưa tuyết"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "Mưa tuyết rào"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "Nhiều mây"
+
+#: 3.8/weather-applet.js:15247
+msgid "Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:15603
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+
+#: 3.8/weather-applet.js:15831
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+
+#: 3.8/weather-applet.js:15968
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:15975
+msgid ""
+"Could not get contents of config file under path\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr ""
+
+#: 3.8/weather-applet.js:16675
+msgid "Dew Point"
+msgstr ""
+
+#: 3.8/weather-applet.js:16747
+msgid "Precipitation will end in {precipEnd} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16749
+msgid "Precipitation won't end in within an hour"
+msgstr ""
+
+#: 3.8/weather-applet.js:16752
+msgid "Precipitation will start within {precipStart} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16964
+msgid "Forecast parsing failed, see logs for more details."
+msgstr ""
+
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
+msgid "As of {lastUpdatedTime}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17502
+msgid "{distance} {distanceUnit} from you"
+msgstr ""
+
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
+msgid "Error Saving Debug Information"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Debug Information saved successfully"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Saved to {filePath}"
+msgstr ""
+
+#: 3.8/LogSaver.py:16
+msgid "Save to File"
+msgstr ""
+
+#: 3.8/LogSaver.py:29
+msgid "Select a destination"
+msgstr ""
+
+#. metadata.json->name
+#. 3.8->settings-schema.json->providers->title
+msgid "Weather"
+msgstr ""
+
+#. metadata.json->description
+msgid "View your local weather forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->head->description
+msgid "Settings for weather@mockturtl 3.0+"
+msgstr ""
+
+#. 3.0->settings-schema.json->keybinding->description
+#. 3.8->settings-schema.json->keybinding->description
+msgid "Set the keybinding to call the menu"
+msgstr ""
+
+#. 3.0->settings-schema.json->descriptions->description
+#, fuzzy
+msgid "Weather service information"
+msgstr "Tải lại dữ liệu thời tiết"
+
+#. 3.0->settings-schema.json->moreInfo->description
+msgid "Click here for detailed description"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->tooltip
+#. 3.0->settings-schema.json->getLocation->tooltip
+#. 3.8->settings-schema.json->getLocation->tooltip
+msgid "Opens webpage guide"
+msgstr ""
+
+#. 3.0->settings-schema.json->providerSettings->description
+#. 3.8->settings-schema.json->provider-options->title
+msgid "Weather Provider Options"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->description
+#. 3.8->settings-schema.json->dataService->description
+msgid "Data service"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "DarkSky (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weatherbit (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Yahoo"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Climacell (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->description
+#. 3.8->settings-schema.json->apiKey->description
+msgid "API Key"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->tooltip
+#. 3.8->settings-schema.json->apiKey->tooltip
+msgid "Copy this from your account of the used Data service and paste it here."
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->description
+#. 3.8->settings-schema.json->manualLocation->description
+msgid "Manual Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->tooltip
+#. 3.8->settings-schema.json->manualLocation->tooltip
+msgid "Enable this if your location is not accurate"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->description
+msgid "Location - Coordinates"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->tooltip
+msgid ""
+"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an "
+"address.\n"
+"Waits for 3 seconds after you stop typing before refreshes the weather."
+msgstr ""
+
+#. 3.0->settings-schema.json->getLocation->description
+msgid "Setup API Key and Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->units
+#. 3.8->settings-schema.json->refreshInterval->units
+msgid "minutes"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->description
+#. 3.8->settings-schema.json->refreshInterval->description
+msgid "Update interval"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastDays->units
+#. 3.8->settings-schema.json->forecastDays->units
+msgid "days"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastDays->description
+#. 3.8->settings-schema.json->forecastDays->description
+msgid "Forecast length"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastHours->units
+#. 3.8->settings-schema.json->forecastHours->units
+msgid "hours"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastHours->description
+#. 3.8->settings-schema.json->forecastHours->description
+msgid "Hourly Forecast length"
+msgstr ""
+
+#. 3.0->settings-schema.json->unitSettings->description
+msgid "Units"
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureUnit->description
+#. 3.8->settings-schema.json->temperatureUnit->description
 #, fuzzy
 msgid "Temperature unit"
 msgstr "Đơn vị đo nhiệt độ:"
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "fahrenheit"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Automatic"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "celsius"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+msgid "Celsius"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->translateCondition->description
-#, fuzzy
-msgid "Translate condition"
-msgstr "Dịch tình hình thời tiết"
-
-#. cinnamon-weather->settings-schema.json->locationLabelOverride->description
-msgid "Override location label"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+msgid "Fahrenheit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->show24Hours->description
-msgid "Display time in 24 hour format"
+#. 3.0->settings-schema.json->temperatureUnit->tooltip
+#. 3.0->settings-schema.json->distanceUnit->tooltip
+#. 3.8->settings-schema.json->temperatureUnit->tooltip
+#. 3.8->settings-schema.json->distanceUnit->tooltip
+msgid ""
+"Automatic will try to guess your preference based your current display "
+"language."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->forecastDays->description
-msgid "Forecast length"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->forecastDays->units
-msgid "days"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->showSunrise->description
-msgid "Show sunrise / sunset times"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->description
+#. 3.0->settings-schema.json->windSpeedUnit->description
+#. 3.8->settings-schema.json->windSpeedUnit->description
 #, fuzzy
 msgid "Wind speed unit"
 msgstr "Đơn vị tốc độ gió"
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
 msgid "kph"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "m/s"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "knots"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
 msgid "mph"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showCommentInPanel->description
-msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "m/s"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->description
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "knots"
+msgstr ""
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "Beaufort"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->description
+#. 3.8->settings-schema.json->pressureUnit->description
 msgid "Atmospheric pressure unit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "psi"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "hPa"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "atm"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "kPa"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "Pa"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mm Hg"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "at"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mbar"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
 msgid "in Hg"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->description
-msgid "Update interval"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "mm Hg"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->units
-msgid "minutes"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "psi"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->useSymbolicIcons->description
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "at"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "atm"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "Pa"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->description
+#. 3.8->settings-schema.json->distanceUnit->description
+msgid "Distance unit"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Metric"
+msgstr ""
+
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Imperial"
+msgstr ""
+
+#. 3.0->settings-schema.json->panelSettings->description
+msgid "Panel options"
+msgstr ""
+
+#. 3.0->settings-schema.json->showTextInPanel->description
+#. 3.8->settings-schema.json->showTextInPanel->description
 #, fuzzy
-msgid "Symbolic icons"
-msgstr "Biểu tượng đơn giản"
+msgid "Display current temperature in panel"
+msgstr "Hiện nhiệt độ trên pa-nen"
 
-#. cinnamon-weather->metadata.json->description
-msgid "View your local weather forecast"
+#. 3.0->settings-schema.json->showCommentInPanel->description
+#. 3.8->settings-schema.json->showCommentInPanel->description
+msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
 msgstr ""
 
-#. cinnamon-weather->metadata.json->name
-msgid "Weather"
+#. 3.0->settings-schema.json->showCommentInPanel->tooltip
+#. 3.8->settings-schema.json->showCommentInPanel->tooltip
+msgid "Only works with horizontal panels"
 msgstr ""
 
-#~ msgid "Please wait"
-#~ msgstr "Xin đợi một lát"
+#. 3.0->settings-schema.json->tempTextOverride->description
+#. 3.8->settings-schema.json->tempTextOverride->description
+msgid "Override label on panel"
+msgstr ""
 
-#~ msgid "Today"
-#~ msgstr "Hôm nay"
+#. 3.0->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
 
-#~ msgid "Tomorrow"
-#~ msgstr "Ngày mai"
+#. 3.0->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.0->settings-schema.json->useCustomMenuIcons->tooltip
+#. 3.8->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.8->settings-schema.json->useCustomMenuIcons->tooltip
+msgid "Iconset is weather-icons by Erik Flowers"
+msgstr ""
 
-#~ msgid "Schema \"%s\" not found."
-#~ msgstr "Không tìm thấy schema \"%s\"."
+#. 3.0->settings-schema.json->useCustomAppletIcons->description
+#. 3.8->settings-schema.json->useCustomAppletIcons->description
+msgid "Use custom icons on the panel"
+msgstr ""
 
-#~ msgid "Reload Weather Information"
-#~ msgstr "Tải lại dữ liệu thời tiết"
+#. 3.0->settings-schema.json->displaySettings->description
+#. 3.8->settings-schema.json->presentation-section->title
+msgid "Presentation"
+msgstr ""
 
-#~ msgid "Invalid city"
-#~ msgstr "Không có thành phố này"
+#. 3.0->settings-schema.json->verticalOrientation->description
+#. 3.8->settings-schema.json->verticalOrientation->description
+msgid "Show forecast vertically"
+msgstr ""
 
-#~ msgid "Yesterday"
-#~ msgstr "Hôm qua"
+#. 3.0->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right"
+msgstr ""
 
-#~ msgid "%s days ago"
-#~ msgstr "%s ngày trước"
+#. 3.0->settings-schema.json->forecastColumns->units
+#. 3.8->settings-schema.json->forecastColumns->units
+msgid "columns"
+msgstr ""
 
+#. 3.0->settings-schema.json->forecastColumns->description
+#. 3.8->settings-schema.json->forecastColumns->description
+msgid "Maximum number of columns for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->units
+#. 3.8->settings-schema.json->forecastRows->units
+msgid "rows"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->description
+#. 3.8->settings-schema.json->forecastRows->description
+msgid "Maximum number of rows for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->showSunrise->description
+#. 3.8->settings-schema.json->showSunrise->description
+msgid "Show sunrise / sunset times"
+msgstr ""
+
+#. 3.0->settings-schema.json->show24Hours->description
+#. 3.8->settings-schema.json->show24Hours->description
+msgid "Display time in 24 hour format"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->description
+#. 3.8->settings-schema.json->shortHourlyTime->description
+msgid "Only display hours for hourly forecast time"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->tooltip
+#. 3.8->settings-schema.json->shortHourlyTime->tooltip
+msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->description
+#. 3.8->settings-schema.json->showForecastDates->description
+msgid "Display date for daily forecasts"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->tooltip
+#. 3.8->settings-schema.json->showForecastDates->tooltip
+msgid "Like \"Friday 15\""
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureHighFirst->description
+#. 3.8->settings-schema.json->temperatureHighFirst->description
+msgid "Show high temperature first in forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempRussianStyle->description
+#. 3.8->settings-schema.json->tempRussianStyle->description
 #, fuzzy
-#~ msgid "In %s days"
-#~ msgstr "%s ngày trước"
+msgid "Show temperature Russian style"
+msgstr "Đơn vị đo nhiệt độ:"
 
-#~ msgid "Feel like:"
-#~ msgstr "Cảm giác ngoài trời:"
+#. 3.0->settings-schema.json->locationLabelOverride->description
+#. 3.8->settings-schema.json->locationLabelOverride->description
+msgid "Override location label"
+msgstr ""
 
-#~ msgid "Name of the city"
-#~ msgstr "Tên thành phố"
-
-#~ msgid "Remove %s ?"
-#~ msgstr "Bạn có muốn xóa %s?"
-
+#. 3.0->settings-schema.json->conditionSettings->description
+#. 3.8->settings-schema.json->weather-conditions->title
 #, fuzzy
-#~ msgid "Pressure Unit"
-#~ msgstr "Áp suất:"
+msgid "Weather conditions"
+msgstr "Dịch tình hình thời tiết"
 
-#~ msgid "Position in Panel"
-#~ msgstr "Vị trí trên thanh pa-nen"
+#. 3.0->settings-schema.json->translateCondition->description
+#. 3.8->settings-schema.json->translateCondition->description
+#, fuzzy
+msgid "Translate conditions"
+msgstr "Dịch tình hình thời tiết"
 
-#~ msgid "Center"
-#~ msgstr "Ở giữa"
+#. 3.0->settings-schema.json->shortConditions->description
+#. 3.8->settings-schema.json->shortConditions->description
+#, fuzzy
+msgid "Less verbose conditions"
+msgstr "Dịch tình hình thời tiết"
 
-#~ msgid "Right"
-#~ msgstr "Bên phải"
+#. 3.0->settings-schema.json->iconSettings->description
+#. 3.8->settings-schema.json->icons->title
+msgid "Icons"
+msgstr ""
 
-#~ msgid "Left"
-#~ msgstr "Bên trái"
+#. 3.0->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons in the applet"
+msgstr ""
 
-#~ msgid "Conditions in Panel"
-#~ msgstr "Hiện thời tiết trên pa-nen"
+#. 3.0->settings-schema.json->useCustomMenuIcons->description
+#. 3.8->settings-schema.json->useCustomMenuIcons->description
+msgid "Use custom icons in the popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->locations-page->title
+#. 3.8->settings-schema.json->location->description
+msgid "Location"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-page->title
+msgid "Other options"
+msgstr ""
+
+#. 3.8->settings-schema.json->info-section->title
+msgid "Help"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-section->title
+msgid "Location settings"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-store->title
+msgid "Saved Locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->panel-options->title
+msgid "Panel (Taskbar)"
+msgstr ""
+
+#. 3.8->settings-schema.json->presentation->title
+msgid "Popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-section->title
+msgid "Other Units"
+msgstr ""
+
+#. 3.8->settings-schema.json->temp-unit-section->title
+#, fuzzy
+msgid "Temperature Unit"
+msgstr "Đơn vị đo nhiệt độ:"
+
+#. 3.8->settings-schema.json->keybindings->title
+msgid "Keybindings"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info->title
+msgid "More about the Weather applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->submit-issue->title
+msgid "Report an issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->debug-options->title
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Debug"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->tooltip
+msgid ""
+"You can choose between several different weather forecast providers. Some "
+"providers require a API key to work, some have regional limits, differ in "
+"forecast length, and they all need a functional internet connection to work. "
+"The options are described in detail on the Cinnamon Spices Website which you "
+"can access with the button on the Help tab."
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Met Office UK (UK only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "US National Weather (US only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Pirate Weather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Visual Crossing (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Tomorrow.io (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "AccuWeather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weather Underground (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->location->tooltip
+msgid ""
+"You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use "
+"'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street} "
+"{City/Town} {Postcode} {Country}. The search algorithm is very flexible with "
+"the format. After 3 seconds without typing the address you entered is "
+"replaced automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->description
+msgid "Save current location to storage"
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->tooltip
+msgid ""
+"Saves location information to file so you can switch between them with "
+"buttons in the applet, which will appear if you have more than one."
+msgstr ""
+
+#. 3.8->settings-schema.json->getLocation->description
+msgid "Weather Applet at Cinnamon Spices Website"
+msgstr ""
+
+#. 3.8->settings-schema.json->refreshInterval->tooltip
+msgid ""
+"If you are using a provider with API keys set it to an interval you won't "
+"run out of your quota with."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastDays->tooltip
+msgid ""
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->description
+msgid "Enable minutely precipitation forecast"
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->tooltip
+msgid ""
+"If you'd like to use this make sure you use your exact coordinates/address "
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
+msgstr ""
+
+#. 3.8->settings-schema.json->showBothTempUnits->description
+msgid "Show both temperature units at the same time"
+msgstr ""
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+msgid "Override tooltip on panel"
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
+msgid "Always show Hourly Weather"
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->tooltip
+msgid ""
+"Hide/Show button will be hidden and Hourly weather will be permanently "
+"visible."
+msgstr ""
+
+#. 3.8->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->description
+msgid "Your saved locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->tooltip
+msgid ""
+"You have to make sure the Search entry field is unique and your Timezone is "
+"in the IANA time zone format (e.g. 'Europe/London')"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Latitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Longitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "City"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Country"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Timezone"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Search entry"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->description
+msgid "Display wind direction as text"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->tooltip
+msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->tooltip
+msgid "Does not apply to custom iconset, that is symbolic by default"
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons throughout the applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info-label->description
+msgid ""
+"For detailed information about the applet please go to the Spices Website to "
+"find info about known issues, troubleshooting, changelog and more by "
+"clicking the button below. Here you can ask questions etc in the comment "
+"section by logging in with your Github account."
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->description
+msgid "Submit an Issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->tooltip
+msgid ""
+"Opens webpage where you can fill out a new issue for the applet, needs a "
+"GitHub account.\n"
+" Please make sure that the issue is not already submitted."
+msgstr ""
+
+#. 3.8->settings-schema.json->maintainer->description
+msgid "Current maintainer: Gr3q"
+msgstr ""
+
+#. 3.8->settings-schema.json->issue-reporting-explanation->description
+msgid ""
+"If you find an issue with this applet please make a report by clicking on "
+"the button below and login in with your Github account.\n"
+"\n"
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
+msgstr ""
+
+#. 3.8->settings-schema.json->loc-info->description
+msgid ""
+"Your location in most cases work automatically but you can enter it manually "
+"by coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,"
+"Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/"
+"Town} {Postcode} {Country}. The search algorithm is very flexible with the "
+"format. After 3 seconds without typing the address you entered is replaced "
+"automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->description
+msgid "Log Level"
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->tooltip
+msgid ""
+"Info is the regular logging, Debug is debug, and Verbose also logs network "
+"request payloads. Changing this will only be effective on future logs. Only "
+"change it you are instructed or you know what you are doing."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Verbose"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->description
+msgid "Click Save to save debug information to a file"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->tooltip
+msgid ""
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
+msgstr ""
+
+#. 3.8->settings-schema.json->selectedLogPath->description
+msgid "Selected path to save Logs"
+msgstr ""

--- a/weather@mockturtl/files/weather@mockturtl/po/weather@mockturtl.pot
+++ b/weather@mockturtl/files/weather@mockturtl/po/weather@mockturtl.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is put in the public domain.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-01 22:49+0000\n"
+"Project-Id-Version: weather@mockturtl 3.4.2\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,65 +18,65 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17615
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr ""
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17616 3.8/weather-applet.js:17618
-#: 3.8/weather-applet.js:17620 3.8/weather-applet.js:17623
-#: 3.8/weather-applet.js:17626 3.8/weather-applet.js:17627
-#: 3.8/weather-applet.js:17628 3.8/weather-applet.js:17629
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr ""
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17617
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr ""
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17619
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr ""
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17621
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr ""
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17622
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr ""
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17624
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr ""
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17625
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr ""
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17630
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr ""
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17631
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr ""
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9711
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr ""
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17929
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr ""
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17930
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr ""
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16220
-#: 3.8/weather-applet.js:17933
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr ""
 
@@ -86,8 +86,8 @@ msgstr ""
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr ""
 
@@ -99,12 +99,12 @@ msgstr ""
 msgid "Could not get weather information"
 msgstr ""
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17768
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr ""
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:18011
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -118,7 +118,7 @@ msgstr ""
 msgid "As of"
 msgstr ""
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:17011
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr ""
 
@@ -126,52 +126,52 @@ msgstr ""
 msgid "from you"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16924
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr ""
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:16924
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr ""
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10312
-#: 3.8/weather-applet.js:17089
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr ""
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10313
-#: 3.8/weather-applet.js:17090
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr ""
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17267
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr ""
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17270
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr ""
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16173
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr ""
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16194
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr ""
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16195
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr ""
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16196
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr ""
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12249 3.8/weather-applet.js:12256
-#: 3.8/weather-applet.js:12257 3.8/weather-applet.js:12263
-#: 3.8/weather-applet.js:14217 3.8/weather-applet.js:14218
-#: 3.8/weather-applet.js:16042
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr ""
 
@@ -179,34 +179,33 @@ msgstr ""
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr ""
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9952
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr ""
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9973
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr ""
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9872
-#: 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr ""
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9872
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr ""
 
-#: 3.0/applet.js:2036 3.8/weather-applet.js:9876
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "You can't save an incorrect location"
 msgstr ""
 
 #. 3.8->settings-schema.json->logLevel->options
 #: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.8/weather-applet.js:9880
+#: 3.8/weather-applet.js:9875
 msgid "Info"
 msgstr ""
 
-#: 3.0/applet.js:2040 3.8/weather-applet.js:9880
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
 msgid "Location is already saved"
 msgstr ""
 
@@ -242,15 +241,15 @@ msgstr ""
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10740 3.8/weather-applet.js:11711
-#: 3.8/weather-applet.js:12150 3.8/weather-applet.js:12659
-#: 3.8/weather-applet.js:13021 3.8/weather-applet.js:14388
-#: 3.8/weather-applet.js:14928
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr ""
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:14990
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr ""
 
@@ -261,13 +260,13 @@ msgid ""
 msgstr ""
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:14870
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
 msgstr ""
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12113
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -276,62 +275,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10516 3.8/weather-applet.js:10523
-#: 3.8/weather-applet.js:10530 3.8/weather-applet.js:10531
-#: 3.8/weather-applet.js:11379 3.8/weather-applet.js:11380
-#: 3.8/weather-applet.js:11386 3.8/weather-applet.js:11393
-#: 3.8/weather-applet.js:11400 3.8/weather-applet.js:12292
-#: 3.8/weather-applet.js:13187
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr ""
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11554 3.8/weather-applet.js:11555
-#: 3.8/weather-applet.js:11561 3.8/weather-applet.js:12277
-#: 3.8/weather-applet.js:12278 3.8/weather-applet.js:12284
-#: 3.8/weather-applet.js:12291 3.8/weather-applet.js:12333
-#: 3.8/weather-applet.js:12340 3.8/weather-applet.js:12347
-#: 3.8/weather-applet.js:12801 3.8/weather-applet.js:12850
-#: 3.8/weather-applet.js:12851 3.8/weather-applet.js:12858
-#: 3.8/weather-applet.js:13179 3.8/weather-applet.js:13448
-#: 3.8/weather-applet.js:13449 3.8/weather-applet.js:13490
-#: 3.8/weather-applet.js:14189 3.8/weather-applet.js:14190
-#: 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr ""
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10488
-#: 3.8/weather-applet.js:10495 3.8/weather-applet.js:10509
-#: 3.8/weather-applet.js:10510 3.8/weather-applet.js:11009
-#: 3.8/weather-applet.js:11463 3.8/weather-applet.js:11464
-#: 3.8/weather-applet.js:11470 3.8/weather-applet.js:11477
-#: 3.8/weather-applet.js:11484 3.8/weather-applet.js:12285
-#: 3.8/weather-applet.js:13189
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr ""
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12348
-#: 3.8/weather-applet.js:13163
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr ""
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11014
-#: 3.8/weather-applet.js:12334 3.8/weather-applet.js:12822
-#: 3.8/weather-applet.js:12823 3.8/weather-applet.js:12829
-#: 3.8/weather-applet.js:12830 3.8/weather-applet.js:12836
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr ""
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12341
-#: 3.8/weather-applet.js:13165
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr ""
 
@@ -339,178 +336,177 @@ msgstr ""
 msgid "Light freezing drizzle"
 msgstr ""
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12327
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr ""
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13145
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr ""
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12362
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12354
-#: 3.8/weather-applet.js:12355 3.8/weather-applet.js:12361
-#: 3.8/weather-applet.js:12368
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr ""
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12369
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr ""
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10600
-#: 3.8/weather-applet.js:10607 3.8/weather-applet.js:10614
-#: 3.8/weather-applet.js:10615 3.8/weather-applet.js:11021
-#: 3.8/weather-applet.js:11435 3.8/weather-applet.js:11436
-#: 3.8/weather-applet.js:11442 3.8/weather-applet.js:11449
-#: 3.8/weather-applet.js:11456 3.8/weather-applet.js:12320
-#: 3.8/weather-applet.js:13205 3.8/weather-applet.js:13525
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr ""
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11020 3.8/weather-applet.js:11610
-#: 3.8/weather-applet.js:11611 3.8/weather-applet.js:11617
-#: 3.8/weather-applet.js:12298 3.8/weather-applet.js:12299
-#: 3.8/weather-applet.js:12312 3.8/weather-applet.js:12319
-#: 3.8/weather-applet.js:12794 3.8/weather-applet.js:12795
-#: 3.8/weather-applet.js:13199 3.8/weather-applet.js:13434
-#: 3.8/weather-applet.js:13518 3.8/weather-applet.js:14203
-#: 3.8/weather-applet.js:14204 3.8/weather-applet.js:14581
-#: 3.8/weather-applet.js:14582
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr ""
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10579
-#: 3.8/weather-applet.js:10586 3.8/weather-applet.js:10593
-#: 3.8/weather-applet.js:10594 3.8/weather-applet.js:11019
-#: 3.8/weather-applet.js:11519 3.8/weather-applet.js:11520
-#: 3.8/weather-applet.js:11526 3.8/weather-applet.js:11533
-#: 3.8/weather-applet.js:11540 3.8/weather-applet.js:12313
-#: 3.8/weather-applet.js:13207
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr ""
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12305
-#: 3.8/weather-applet.js:12306 3.8/weather-applet.js:14560
-#: 3.8/weather-applet.js:14561
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr ""
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10994
-#: 3.8/weather-applet.js:12375 3.8/weather-applet.js:12376
-#: 3.8/weather-applet.js:12867 3.8/weather-applet.js:12868
-#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:13532
-#: 3.8/weather-applet.js:13533 3.8/weather-applet.js:14210
-#: 3.8/weather-applet.js:14211
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr ""
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12243
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr ""
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10467 3.8/weather-applet.js:10468
-#: 3.8/weather-applet.js:11033 3.8/weather-applet.js:11372
-#: 3.8/weather-applet.js:11373 3.8/weather-applet.js:12235
-#: 3.8/weather-applet.js:12236 3.8/weather-applet.js:12242
-#: 3.8/weather-applet.js:12937 3.8/weather-applet.js:12938
-#: 3.8/weather-applet.js:13153 3.8/weather-applet.js:14161
-#: 3.8/weather-applet.js:14162 3.8/weather-applet.js:14609
-#: 3.8/weather-applet.js:14610
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr ""
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10474 3.8/weather-applet.js:10475
-#: 3.8/weather-applet.js:11358 3.8/weather-applet.js:11359
-#: 3.8/weather-applet.js:12207 3.8/weather-applet.js:12208
-#: 3.8/weather-applet.js:13427 3.8/weather-applet.js:13428
-#: 3.8/weather-applet.js:14154 3.8/weather-applet.js:14155
-#: 3.8/weather-applet.js:14651 3.8/weather-applet.js:14652
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr ""
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12228
-#: 3.8/weather-applet.js:12229 3.8/weather-applet.js:12745
-#: 3.8/weather-applet.js:12746 3.8/weather-applet.js:12780
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr ""
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10439
-#: 3.8/weather-applet.js:10440 3.8/weather-applet.js:10446
-#: 3.8/weather-applet.js:10447 3.8/weather-applet.js:11547
-#: 3.8/weather-applet.js:11548 3.8/weather-applet.js:12221
-#: 3.8/weather-applet.js:12222 3.8/weather-applet.js:12738
-#: 3.8/weather-applet.js:12739 3.8/weather-applet.js:12773
-#: 3.8/weather-applet.js:13420 3.8/weather-applet.js:13421
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr ""
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12214
-#: 3.8/weather-applet.js:12215
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr ""
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10425 3.8/weather-applet.js:10426
-#: 3.8/weather-applet.js:11039 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:12724
-#: 3.8/weather-applet.js:12725 3.8/weather-applet.js:12759
-#: 3.8/weather-applet.js:13223 3.8/weather-applet.js:13413
-#: 3.8/weather-applet.js:13414 3.8/weather-applet.js:14140
-#: 3.8/weather-applet.js:14141 3.8/weather-applet.js:14147
-#: 3.8/weather-applet.js:14148 3.8/weather-applet.js:14686
-#: 3.8/weather-applet.js:14687
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr ""
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10432
-#: 3.8/weather-applet.js:10433 3.8/weather-applet.js:12200
-#: 3.8/weather-applet.js:12201 3.8/weather-applet.js:14693
-#: 3.8/weather-applet.js:14694
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr ""
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10418
-#: 3.8/weather-applet.js:10419 3.8/weather-applet.js:10453
-#: 3.8/weather-applet.js:10454 3.8/weather-applet.js:10642
-#: 3.8/weather-applet.js:10643 3.8/weather-applet.js:11341
-#: 3.8/weather-applet.js:11342 3.8/weather-applet.js:11639
-#: 3.8/weather-applet.js:11640 3.8/weather-applet.js:12192
-#: 3.8/weather-applet.js:12193 3.8/weather-applet.js:12715
-#: 3.8/weather-applet.js:12716 3.8/weather-applet.js:12944
-#: 3.8/weather-applet.js:12945 3.8/weather-applet.js:14073
-#: 3.8/weather-applet.js:14074 3.8/weather-applet.js:14224
-#: 3.8/weather-applet.js:14225 3.8/weather-applet.js:14797
-#: 3.8/weather-applet.js:14799
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr ""
 
@@ -532,13 +528,13 @@ msgid ""
 "or get one first on https://darksky.net/dev/register"
 msgstr ""
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:14880
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
 msgstr ""
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:15196
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr ""
 
@@ -547,121 +543,121 @@ msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11203
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr ""
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11040 3.8/weather-applet.js:11351
-#: 3.8/weather-applet.js:11352
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr ""
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11365 3.8/weather-applet.js:11366
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr ""
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11387
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11394
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr ""
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11401
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11407
-#: 3.8/weather-applet.js:11408 3.8/weather-applet.js:11414
-#: 3.8/weather-applet.js:11421 3.8/weather-applet.js:11428
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11415
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11422
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr ""
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11429
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11443
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11450
-#: 3.8/weather-applet.js:13526
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr ""
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11457
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11471
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11478
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr ""
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11485
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11491
-#: 3.8/weather-applet.js:11492 3.8/weather-applet.js:11498
-#: 3.8/weather-applet.js:11505 3.8/weather-applet.js:11512
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11499
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11506
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr ""
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11513
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11527
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11534
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr ""
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11541
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11562
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11568
-#: 3.8/weather-applet.js:11569 3.8/weather-applet.js:11575
-#: 3.8/weather-applet.js:12859 3.8/weather-applet.js:13185
-#: 3.8/weather-applet.js:13491 3.8/weather-applet.js:13497
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr ""
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11576
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr ""
 
@@ -670,44 +666,44 @@ msgstr ""
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10537
-#: 3.8/weather-applet.js:10544 3.8/weather-applet.js:10551
-#: 3.8/weather-applet.js:10552 3.8/weather-applet.js:11022
-#: 3.8/weather-applet.js:11582 3.8/weather-applet.js:11583
-#: 3.8/weather-applet.js:11589 3.8/weather-applet.js:11596
-#: 3.8/weather-applet.js:11603 3.8/weather-applet.js:12808
-#: 3.8/weather-applet.js:12809 3.8/weather-applet.js:12815
-#: 3.8/weather-applet.js:12816 3.8/weather-applet.js:12843
-#: 3.8/weather-applet.js:12844 3.8/weather-applet.js:14196
-#: 3.8/weather-applet.js:14197 3.8/weather-applet.js:14595
-#: 3.8/weather-applet.js:14596
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr ""
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11590
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11597
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr ""
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11604
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr ""
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11618
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr ""
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11624 3.8/weather-applet.js:11625
-#: 3.8/weather-applet.js:11631 3.8/weather-applet.js:13203
-#: 3.8/weather-applet.js:13519
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr ""
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11632
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr ""
 
@@ -716,21 +712,21 @@ msgstr ""
 msgid "Unexpected response from API"
 msgstr ""
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10237
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr ""
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10265
-#: 3.8/weather-applet.js:10817 3.8/weather-applet.js:11722
-#: 3.8/weather-applet.js:12672
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr ""
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10055
-#: 3.8/weather-applet.js:10089 3.8/weather-applet.js:11748
-#: 3.8/weather-applet.js:11782 3.8/weather-applet.js:12474
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr ""
 
@@ -759,298 +755,298 @@ msgid "Excellent - More than"
 msgstr ""
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10460 3.8/weather-applet.js:10461
-#: 3.8/weather-applet.js:11029 3.8/weather-applet.js:13175
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr ""
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10481
-#: 3.8/weather-applet.js:10482 3.8/weather-applet.js:12752
-#: 3.8/weather-applet.js:12753 3.8/weather-applet.js:12787
-#: 3.8/weather-applet.js:13219
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr ""
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10489
-#: 3.8/weather-applet.js:10496
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr ""
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10502 3.8/weather-applet.js:10503
-#: 3.8/weather-applet.js:11001 3.8/weather-applet.js:12270
-#: 3.8/weather-applet.js:12271 3.8/weather-applet.js:12326
-#: 3.8/weather-applet.js:13141 3.8/weather-applet.js:14532
-#: 3.8/weather-applet.js:14533
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr ""
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10517
-#: 3.8/weather-applet.js:10524
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr ""
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10538
-#: 3.8/weather-applet.js:10545
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr ""
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10558 3.8/weather-applet.js:10565
-#: 3.8/weather-applet.js:10572 3.8/weather-applet.js:10573
-#: 3.8/weather-applet.js:13217 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14169 3.8/weather-applet.js:14588
-#: 3.8/weather-applet.js:14589
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr ""
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10559
-#: 3.8/weather-applet.js:10566
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr ""
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10580
-#: 3.8/weather-applet.js:10587
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr ""
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10601
-#: 3.8/weather-applet.js:10608
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr ""
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10621 3.8/weather-applet.js:10628
-#: 3.8/weather-applet.js:10635 3.8/weather-applet.js:10636
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr ""
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10622
-#: 3.8/weather-applet.js:10629
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10872
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10876
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10681 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10884
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10888
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10990
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10991
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10992
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10993
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10995
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10996
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10997
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10998
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10999
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11000
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11002
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11003
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11004
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11005
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11006
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11007
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11008
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11010
-#: 3.8/weather-applet.js:13455 3.8/weather-applet.js:13456
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11011
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11012
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11013
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11015
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11016
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11017
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11018
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11023
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11024
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11025
-#: 3.8/weather-applet.js:13462 3.8/weather-applet.js:13463
-#: 3.8/weather-applet.js:13469 3.8/weather-applet.js:13504
-#: 3.8/weather-applet.js:13511
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11026
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11027
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11028
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11030 3.8/weather-applet.js:12902
-#: 3.8/weather-applet.js:12903 3.8/weather-applet.js:14623
-#: 3.8/weather-applet.js:14624
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11031 3.8/weather-applet.js:12909
-#: 3.8/weather-applet.js:12910 3.8/weather-applet.js:14616
-#: 3.8/weather-applet.js:14617
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11032
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11034
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11035 3.8/weather-applet.js:12895
-#: 3.8/weather-applet.js:12896 3.8/weather-applet.js:14602
-#: 3.8/weather-applet.js:14603
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11036
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11037
-#: 3.8/weather-applet.js:13209
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11038 3.8/weather-applet.js:12874
-#: 3.8/weather-applet.js:12875 3.8/weather-applet.js:14475
-#: 3.8/weather-applet.js:14476
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11041
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11042
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr ""
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11043
-#: 3.8/weather-applet.js:12731 3.8/weather-applet.js:12732
-#: 3.8/weather-applet.js:12766
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11044
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11045
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr ""
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11046
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr ""
 
@@ -1058,80 +1054,80 @@ msgstr ""
 msgid "Could not get forecast for your area"
 msgstr ""
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12431
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr ""
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12495
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr ""
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12760
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12767
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12774
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12781
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12788
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr ""
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12802
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr ""
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12837
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr ""
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9153 3.8/weather-applet.js:12881
-#: 3.8/weather-applet.js:12882 3.8/weather-applet.js:14489
-#: 3.8/weather-applet.js:14490
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr ""
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9148
-#: 3.8/weather-applet.js:12888
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr ""
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12889
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr ""
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12916 3.8/weather-applet.js:12917
-#: 3.8/weather-applet.js:14721 3.8/weather-applet.js:14722
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr ""
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12923 3.8/weather-applet.js:12924
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr ""
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12930 3.8/weather-applet.js:12931
-#: 3.8/weather-applet.js:14770 3.8/weather-applet.js:14771
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr ""
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9025
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr ""
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9027
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr ""
 
@@ -1163,79 +1159,79 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9118
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr ""
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9121
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr ""
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9124
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr ""
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9127
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr ""
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9130
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr ""
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9133
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr ""
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9136
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr ""
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9139
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr ""
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9142
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr ""
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9145
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr ""
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9151
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr ""
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9301
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr ""
 
@@ -1279,7 +1275,7 @@ msgid ""
 "more information"
 msgstr ""
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14482 3.8/weather-applet.js:14483
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr ""
 
@@ -1287,7 +1283,7 @@ msgstr ""
 msgid "Severe Thunderstorms"
 msgstr ""
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14503 3.8/weather-applet.js:14504
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr ""
 
@@ -1303,15 +1299,15 @@ msgstr ""
 msgid "Mixed Snow and Sleet"
 msgstr ""
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14525 3.8/weather-applet.js:14526
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr ""
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14539 3.8/weather-applet.js:14540
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr ""
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14546 3.8/weather-applet.js:14547
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr ""
 
@@ -1323,11 +1319,11 @@ msgstr ""
 msgid "Light Snow Showers"
 msgstr ""
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14574 3.8/weather-applet.js:14575
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr ""
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13441 3.8/weather-applet.js:13442
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr ""
 
@@ -1339,54 +1335,54 @@ msgstr ""
 msgid "Blustery"
 msgstr ""
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14637 3.8/weather-applet.js:14638
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr ""
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:14658 3.8/weather-applet.js:14659
-#: 3.8/weather-applet.js:14665 3.8/weather-applet.js:14666
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr ""
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14175 3.8/weather-applet.js:14176
-#: 3.8/weather-applet.js:14182 3.8/weather-applet.js:14183
-#: 3.8/weather-applet.js:14672 3.8/weather-applet.js:14673
-#: 3.8/weather-applet.js:14679 3.8/weather-applet.js:14680
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr ""
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:14707 3.8/weather-applet.js:14708
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr ""
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:14714 3.8/weather-applet.js:14715
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr ""
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:14728 3.8/weather-applet.js:14729
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr ""
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:14735 3.8/weather-applet.js:14736
-#: 3.8/weather-applet.js:14791 3.8/weather-applet.js:14792
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr ""
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:14742 3.8/weather-applet.js:14743
-#: 3.8/weather-applet.js:14777 3.8/weather-applet.js:14778
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr ""
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:14749 3.8/weather-applet.js:14750
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr ""
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:14756 3.8/weather-applet.js:14757
-#: 3.8/weather-applet.js:14784 3.8/weather-applet.js:14785
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr ""
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:14763 3.8/weather-applet.js:14764
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr ""
 
@@ -1398,369 +1394,369 @@ msgstr ""
 msgid "Scattered Thundershowers"
 msgstr ""
 
-#: 3.8/weather-applet.js:9637
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:9641
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10013
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr ""
 
-#: 3.8/weather-applet.js:10118
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr ""
 
-#: 3.8/weather-applet.js:10197
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr ""
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10278
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr ""
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10287
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr ""
 
-#: 3.8/weather-applet.js:10287 3.8/weather-applet.js:10292
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:10302
-#: 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr ""
 
-#: 3.8/weather-applet.js:10292
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr ""
 
-#: 3.8/weather-applet.js:10297
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr ""
 
-#: 3.8/weather-applet.js:10302 3.8/weather-applet.js:10307
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10662
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr ""
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11110
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr ""
 
-#: 3.8/weather-applet.js:11659
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr ""
 
-#: 3.8/weather-applet.js:12080
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr ""
 
-#: 3.8/weather-applet.js:12250
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr ""
 
-#: 3.8/weather-applet.js:12264
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr ""
 
-#: 3.8/weather-applet.js:12411
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr ""
 
-#: 3.8/weather-applet.js:12962
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr ""
 
-#: 3.8/weather-applet.js:13139
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:13143
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr ""
 
-#: 3.8/weather-applet.js:13147
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr ""
 
-#: 3.8/weather-applet.js:13149
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr ""
 
-#: 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr ""
 
-#: 3.8/weather-applet.js:13155
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr ""
 
-#: 3.8/weather-applet.js:13157
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr ""
 
-#: 3.8/weather-applet.js:13159
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr ""
 
-#: 3.8/weather-applet.js:13161
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr ""
 
-#: 3.8/weather-applet.js:13167
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr ""
 
-#: 3.8/weather-applet.js:13169
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr ""
 
-#: 3.8/weather-applet.js:13171
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr ""
 
-#: 3.8/weather-applet.js:13173
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr ""
 
-#: 3.8/weather-applet.js:13177
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr ""
 
-#: 3.8/weather-applet.js:13181 3.8/weather-applet.js:13470
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:13183
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:13191
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:13193
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr ""
 
-#: 3.8/weather-applet.js:13195
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr ""
 
-#: 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr ""
 
-#: 3.8/weather-applet.js:13201
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr ""
 
-#: 3.8/weather-applet.js:13213
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr ""
 
-#: 3.8/weather-applet.js:13215
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr ""
 
-#: 3.8/weather-applet.js:13221
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr ""
 
-#: 3.8/weather-applet.js:13243
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr ""
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13259
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr ""
 
-#: 3.8/weather-applet.js:13402 3.8/weather-applet.js:13403
-#: 3.8/weather-applet.js:13539 3.8/weather-applet.js:13540
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr ""
 
-#: 3.8/weather-applet.js:13435
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:13477
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:13483 3.8/weather-applet.js:13484
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:13498
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr ""
 
-#: 3.8/weather-applet.js:13505
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:13512
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:13657
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr ""
 
-#: 3.8/weather-applet.js:13953
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr ""
 
-#: 3.8/weather-applet.js:13966
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr ""
 
-#: 3.8/weather-applet.js:14263
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr ""
 
-#: 3.8/weather-applet.js:14453
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr ""
 
-#: 3.8/weather-applet.js:14460
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr ""
 
-#: 3.8/weather-applet.js:14496 3.8/weather-applet.js:14497
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr ""
 
-#: 3.8/weather-applet.js:14511 3.8/weather-applet.js:14512
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr ""
 
-#: 3.8/weather-applet.js:14518 3.8/weather-applet.js:14519
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr ""
 
-#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr ""
 
-#: 3.8/weather-applet.js:14630 3.8/weather-applet.js:14631
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr ""
 
-#: 3.8/weather-applet.js:14644 3.8/weather-applet.js:14645
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr ""
 
-#: 3.8/weather-applet.js:14700 3.8/weather-applet.js:14701
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr ""
 
-#: 3.8/weather-applet.js:14853
+#: 3.8/weather-applet.js:15247
 msgid "Pirate Weather"
 msgstr ""
 
-#: 3.8/weather-applet.js:15205
+#: 3.8/weather-applet.js:15603
 msgid ""
-"Location Service couldn't find your location, please see the logs in Looking"
-" Glass"
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
 msgstr ""
 
-#: 3.8/weather-applet.js:15433
+#: 3.8/weather-applet.js:15831
 msgid "Make sure you entered a location or use Automatic location instead."
 msgstr ""
 
-#: 3.8/weather-applet.js:15570
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:15577
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
 msgstr ""
 
-#: 3.8/weather-applet.js:16197
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr ""
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr ""
 
-#: 3.8/weather-applet.js:16269
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:16271
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr ""
 
-#: 3.8/weather-applet.js:16274
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr ""
 
-#: 3.8/weather-applet.js:16486
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr ""
 
-#: 3.8/weather-applet.js:17018 3.8/weather-applet.js:17810
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17024
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr ""
 
-#: 3.8/weather-applet.js:17028
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17031
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr ""
 
-#: 3.8/weather-applet.js:17581 3.8/weather-applet.js:17591
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr ""
 
-#: 3.8/weather-applet.js:17603
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr ""
 
-#: 3.8/weather-applet.js:17603
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
-msgstr ""
-
-#: 3.8/weather-applet.js:17734
-msgid "This provider requires an API key to operate"
 msgstr ""
 
 #: 3.8/LogSaver.py:16
@@ -1837,8 +1833,7 @@ msgstr ""
 
 #. 3.0->settings-schema.json->apiKey->tooltip
 #. 3.8->settings-schema.json->apiKey->tooltip
-msgid ""
-"Copy this from your account of the used Data service and paste it here."
+msgid "Copy this from your account of the used Data service and paste it here."
 msgstr ""
 
 #. 3.0->settings-schema.json->manualLocation->description
@@ -1857,7 +1852,8 @@ msgstr ""
 
 #. 3.0->settings-schema.json->location->tooltip
 msgid ""
-"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an address.\n"
+"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an "
+"address.\n"
 "Waits for 3 seconds after you stop typing before refreshes the weather."
 msgstr ""
 
@@ -2044,7 +2040,8 @@ msgstr ""
 #. 3.0->settings-schema.json->tempTextOverride->tooltip
 msgid ""
 "Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
-"Can be used if label does not fit on vertical panel, among other smart things."
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
 msgstr ""
 
 #. 3.0->settings-schema.json->useCustomAppletIcons->tooltip
@@ -2225,9 +2222,9 @@ msgstr ""
 msgid ""
 "You can choose between several different weather forecast providers. Some "
 "providers require a API key to work, some have regional limits, differ in "
-"forecast length, and they all need a functional internet connection to work."
-" The options are described in detail on the Cinnamon Spices Website which "
-"you can access with the button on the Help tab."
+"forecast length, and they all need a functional internet connection to work. "
+"The options are described in detail on the Cinnamon Spices Website which you "
+"can access with the button on the Help tab."
 msgstr ""
 
 #. 3.8->settings-schema.json->dataService->options
@@ -2264,11 +2261,11 @@ msgstr ""
 
 #. 3.8->settings-schema.json->location->tooltip
 msgid ""
-"You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use"
-" 'City,Country-code' (e.g. London,UK) or try to enter {House number} "
-"{Street} {City/Town} {Postcode} {Country}. The search algorithm is very "
-"flexible with the format. After 3 seconds without typing the address you "
-"entered is replaced automatically for validating your choice."
+"You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use "
+"'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street} "
+"{City/Town} {Postcode} {Country}. The search algorithm is very flexible with "
+"the format. After 3 seconds without typing the address you entered is "
+"replaced automatically for validating your choice."
 msgstr ""
 
 #. 3.8->settings-schema.json->locationDescription->description
@@ -2327,8 +2324,10 @@ msgstr ""
 
 #. 3.8->settings-schema.json->tempTextOverride->tooltip
 msgid ""
-"Some of the available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
-"Can be used if label does not fit on vertical panel, among other smart things."
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
 msgstr ""
 
 #. 3.8->settings-schema.json->tooltipTextOverride->description
@@ -2406,8 +2405,8 @@ msgstr ""
 
 #. 3.8->settings-schema.json->more-info-label->description
 msgid ""
-"For detailed information about the applet please go to the Spices Website to"
-" find info about known issues, troubleshooting, changelog and more by "
+"For detailed information about the applet please go to the Spices Website to "
+"find info about known issues, troubleshooting, changelog and more by "
 "clicking the button below. Here you can ask questions etc in the comment "
 "section by logging in with your Github account."
 msgstr ""
@@ -2418,7 +2417,8 @@ msgstr ""
 
 #. 3.8->settings-schema.json->submitIssue->tooltip
 msgid ""
-"Opens webpage where you can fill out a new issue for the applet, needs a GitHub account.\n"
+"Opens webpage where you can fill out a new issue for the applet, needs a "
+"GitHub account.\n"
 " Please make sure that the issue is not already submitted."
 msgstr ""
 
@@ -2428,19 +2428,25 @@ msgstr ""
 
 #. 3.8->settings-schema.json->issue-reporting-explanation->description
 msgid ""
-"If you find an issue with this applet please make a report by clicking on the button below and login in with your Github account.\n"
+"If you find an issue with this applet please make a report by clicking on "
+"the button below and login in with your Github account.\n"
 "\n"
-"Before you start writing please make sure that the issue is not already submitted in the issues section and review your prefilled details in the issue description. Don't forget to add a short description in the top Title field next to the applet's name to make it easier for everyone to know what the issue is about. Logs with Debug level (which can be saved to a file below) are also appreciated."
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
 msgstr ""
 
 #. 3.8->settings-schema.json->loc-info->description
 msgid ""
-"Your location in most cases work automatically but you can enter it manually"
-" by coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use "
-"'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street}"
-" {City/Town} {Postcode} {Country}. The search algorithm is very flexible "
-"with the format. After 3 seconds without typing the address you entered is "
-"replaced automatically for validating your choice."
+"Your location in most cases work automatically but you can enter it manually "
+"by coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,"
+"Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/"
+"Town} {Postcode} {Country}. The search algorithm is very flexible with the "
+"format. After 3 seconds without typing the address you entered is replaced "
+"automatically for validating your choice."
 msgstr ""
 
 #. 3.8->settings-schema.json->logLevel->description
@@ -2464,8 +2470,8 @@ msgstr ""
 
 #. 3.8->settings-schema.json->fileSelect->tooltip
 msgid ""
-"This includes logs for the applet and the current settings with your API key"
-" redacted."
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
 msgstr ""
 
 #. 3.8->settings-schema.json->selectedLogPath->description

--- a/weather@mockturtl/files/weather@mockturtl/po/zh_CN.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/zh_CN.po
@@ -10,8 +10,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 3.2.12\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-29 19:42+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2023-05-31 19:39+0800\n"
 "Last-Translator: Slinet6056 <slinet6056@gmail.com>\n"
 "Language-Team: Chinese (simplified)\n"
@@ -22,65 +23,65 @@ msgstr ""
 "X-Generator: Poedit 3.3.1\n"
 
 #: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
-#: 3.8/weather-applet.js:17427
+#: 3.8/weather-applet.js:17877
 msgid "Error"
 msgstr "错误"
 
 #: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
 #: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
-#: 3.8/weather-applet.js:17428 3.8/weather-applet.js:17430
-#: 3.8/weather-applet.js:17432 3.8/weather-applet.js:17435
-#: 3.8/weather-applet.js:17438 3.8/weather-applet.js:17439
-#: 3.8/weather-applet.js:17440 3.8/weather-applet.js:17441
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
 msgid "Service Error"
 msgstr "服务错误"
 
-#: 3.0/applet.js:168 3.8/weather-applet.js:17429
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
 msgid "Incorrect API Key"
 msgstr "不正确的 API 密钥"
 
-#: 3.0/applet.js:170 3.8/weather-applet.js:17431
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
 msgid "Incorrect Location Format"
 msgstr "不正确的位置格式"
 
-#: 3.0/applet.js:172 3.8/weather-applet.js:17433
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
 msgid "Key Blocked"
 msgstr "密钥已被封禁"
 
-#: 3.0/applet.js:173 3.8/weather-applet.js:17434
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
 msgid "Can't find location"
 msgstr "找不到位置"
 
-#: 3.0/applet.js:175 3.8/weather-applet.js:17436
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
 msgid "No Api Key"
 msgstr "没有 API 密钥"
 
-#: 3.0/applet.js:176 3.8/weather-applet.js:17437
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
 msgid "No Location"
 msgstr "没有位置信息"
 
-#: 3.0/applet.js:181 3.8/weather-applet.js:17442
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
 msgid "Missing Packages"
 msgstr "缺失的软件包"
 
-#: 3.0/applet.js:182 3.8/weather-applet.js:17443
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
 msgid "Location not covered"
 msgstr "地点未被覆盖"
 
-#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9706
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
 msgid "Weather Applet"
 msgstr "天气小程序"
 
-#: 3.0/applet.js:217 3.8/weather-applet.js:17738
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: 3.0/applet.js:218 3.8/weather-applet.js:17739
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "点击打开"
 
-#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16112
-#: 3.8/weather-applet.js:17742
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr "刷新"
 
@@ -90,8 +91,8 @@ msgstr "API 返回在 400 与 500 之间的状态码"
 
 #: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
 #: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
-#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9867
-#: 3.8/weather-applet.js:9871 3.8/weather-applet.js:9875
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
 msgid "Location Store"
 msgstr "保存位置"
 
@@ -103,12 +104,12 @@ msgstr "抱歉，您不能保存一个自动获得的位置"
 msgid "Could not get weather information"
 msgstr "无法获取天气信息"
 
-#: 3.0/applet.js:624 3.8/weather-applet.js:17577
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
 msgid ""
 "Unexpected Error While Refreshing Weather, please see log in Looking Glass"
 msgstr "刷新天气时出现意外错误，请查看 Looking Glass 中的日志"
 
-#: 3.0/applet.js:670 3.8/weather-applet.js:17820
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
 msgid ""
 "Could not update weather for a while...\n"
 "are you connected to the internet?"
@@ -124,7 +125,7 @@ msgstr "网络错误，请检查 Looking Glass 中的日志"
 msgid "As of"
 msgstr "更新于"
 
-#: 3.0/applet.js:1108 3.8/weather-applet.js:16826
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
 msgid "Powered by"
 msgstr "数据来源"
 
@@ -132,73 +133,72 @@ msgstr "数据来源"
 msgid "from you"
 msgstr "外"
 
-#: 3.0/applet.js:1132 3.8/weather-applet.js:16739
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
 msgid "mm"
 msgstr "毫米"
 
-#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:16739
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
 msgid "in"
 msgstr "英寸"
 
-#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10307
-#: 3.8/weather-applet.js:16904
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
 msgid "mi"
 msgstr "英里"
 
-#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10308
-#: 3.8/weather-applet.js:16905
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
 msgid "km"
 msgstr "千米"
 
-#: 3.0/applet.js:1227 3.8/weather-applet.js:17084
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
 msgid "Loading current weather ..."
 msgstr "正在加载当前天气…"
 
-#: 3.0/applet.js:1230 3.8/weather-applet.js:17087
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
 msgid "Loading future weather ..."
 msgstr "正在加载未来天气…"
 
-#: 3.0/applet.js:1280 3.8/weather-applet.js:16065
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
 msgid "Loading ..."
 msgstr "正在加载…"
 
-#: 3.0/applet.js:1329 3.8/weather-applet.js:16086
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
 msgid "Temperature"
 msgstr "气温"
 
-#: 3.0/applet.js:1330 3.8/weather-applet.js:16087
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
 msgid "Humidity"
 msgstr "湿度"
 
-#: 3.0/applet.js:1331 3.8/weather-applet.js:16088
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
 msgid "Pressure"
 msgstr "压力"
 
-#: 3.0/applet.js:1332 3.8/weather-applet.js:12239 3.8/weather-applet.js:12246
-#: 3.8/weather-applet.js:12247 3.8/weather-applet.js:12253
-#: 3.8/weather-applet.js:14209 3.8/weather-applet.js:14210
-#: 3.8/weather-applet.js:15937
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
 msgid "Wind"
 msgstr "风速"
 
-#: 3.0/applet.js:1639 3.8/weather-applet.js:15334
+#: 3.0/applet.js:1639
 msgid "Make sure you entered a location or use Automatic location instead"
 msgstr "确保您输入了一个位置或使用自动定位代替"
 
-#: 3.0/applet.js:1877 3.8/weather-applet.js:9947
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
 msgid "Could not find location based on address, please check if it's right"
 msgstr "无法根据地址找到位置，请检查是否正确"
 
-#: 3.0/applet.js:1901 3.8/weather-applet.js:9968
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
 msgid "Failed to call Geolocation API, see Looking Glass for errors."
 msgstr "调用 Geolocation API 失败，请参阅 Looking Glass 中的错误。"
 
-#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9867
-#: 3.8/weather-applet.js:9871
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
 msgid "Warning"
 msgstr "警告"
 
-#: 3.0/applet.js:2032 3.8/weather-applet.js:9867
+#: 3.0/applet.js:2032
 msgid "You can only save correct locations when the applet is not refreshing"
 msgstr "只有在小程序不刷新的情况下，您才能正确保存位置"
 
@@ -248,15 +248,15 @@ msgstr "从位置存储中加载数据失败，请查看日志以了解更多信
 
 #: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
 #: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
-#: 3.8/weather-applet.js:10735 3.8/weather-applet.js:11706
-#: 3.8/weather-applet.js:12142 3.8/weather-applet.js:12649
-#: 3.8/weather-applet.js:13013 3.8/weather-applet.js:14380
-#: 3.8/weather-applet.js:14970
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
 msgid "Feels Like"
 msgstr "体感"
 
 #: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
-#: 3.8/weather-applet.js:15032
+#: 3.8/weather-applet.js:15387
 msgid "Failed to Process Weather Info"
 msgstr "处理天气信息失败"
 
@@ -269,7 +269,7 @@ msgstr ""
 "或先在 https://developer.climacell.co/sign-up 上获取一个"
 
 #: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
-#: 3.8/weather-applet.js:11872 3.8/weather-applet.js:14912
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
 msgid ""
 "Please Make sure you\n"
 "entered the API key correctly and your account is not locked"
@@ -277,7 +277,7 @@ msgstr ""
 "请确保您\n"
 "输入正确的 API 密钥，并且您的账户没有被封禁"
 
-#: 3.0/climacell.js:248 3.8/weather-applet.js:12108
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from Climacell"
@@ -288,60 +288,60 @@ msgstr ""
 #: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
 #: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
 #: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
-#: 3.0/met_uk.js:632 3.8/weather-applet.js:10511 3.8/weather-applet.js:10518
-#: 3.8/weather-applet.js:10525 3.8/weather-applet.js:10526
-#: 3.8/weather-applet.js:11374 3.8/weather-applet.js:11375
-#: 3.8/weather-applet.js:11381 3.8/weather-applet.js:11388
-#: 3.8/weather-applet.js:11395 3.8/weather-applet.js:12282
-#: 3.8/weather-applet.js:13179
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
 msgid "Heavy rain"
 msgstr "大雨"
 
 #: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
 #: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
 #: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
-#: 3.0/yahoo.js:448 3.8/weather-applet.js:11549 3.8/weather-applet.js:11550
-#: 3.8/weather-applet.js:11556 3.8/weather-applet.js:12267
-#: 3.8/weather-applet.js:12268 3.8/weather-applet.js:12274
-#: 3.8/weather-applet.js:12281 3.8/weather-applet.js:12323
-#: 3.8/weather-applet.js:12330 3.8/weather-applet.js:12337
-#: 3.8/weather-applet.js:12793 3.8/weather-applet.js:12842
-#: 3.8/weather-applet.js:12843 3.8/weather-applet.js:12850
-#: 3.8/weather-applet.js:13171 3.8/weather-applet.js:13440
-#: 3.8/weather-applet.js:13441 3.8/weather-applet.js:13482
-#: 3.8/weather-applet.js:14181 3.8/weather-applet.js:14182
-#: 3.8/weather-applet.js:14545 3.8/weather-applet.js:14546
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
 msgid "Rain"
 msgstr "雨"
 
 #: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
 #: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
 #: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
-#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10483
-#: 3.8/weather-applet.js:10490 3.8/weather-applet.js:10504
-#: 3.8/weather-applet.js:10505 3.8/weather-applet.js:11004
-#: 3.8/weather-applet.js:11458 3.8/weather-applet.js:11459
-#: 3.8/weather-applet.js:11465 3.8/weather-applet.js:11472
-#: 3.8/weather-applet.js:11479 3.8/weather-applet.js:12275
-#: 3.8/weather-applet.js:13181
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
 msgid "Light rain"
 msgstr "小雨"
 
-#: 3.0/climacell.js:280 3.8/weather-applet.js:12338 3.8/weather-applet.js:13155
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
 msgid "Heavy freezing rain"
 msgstr "大冻雨"
 
 #: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
 #: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
 #: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
-#: 3.0/us_weather.js:519 3.8/weather-applet.js:11009
-#: 3.8/weather-applet.js:12324 3.8/weather-applet.js:12814
-#: 3.8/weather-applet.js:12815 3.8/weather-applet.js:12821
-#: 3.8/weather-applet.js:12822 3.8/weather-applet.js:12828
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "冻雨"
 
-#: 3.0/climacell.js:294 3.8/weather-applet.js:12331 3.8/weather-applet.js:13157
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
 msgid "Light freezing rain"
 msgstr "小冻雨"
 
@@ -349,177 +349,177 @@ msgstr "小冻雨"
 msgid "Light freezing drizzle"
 msgstr "小冻毛雨"
 
-#: 3.0/climacell.js:302 3.8/weather-applet.js:12317
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
 msgid "Freezing drizzle"
 msgstr "冻毛雨"
 
-#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13137
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
 msgid "Light drizzle"
 msgstr "小毛雨"
 
-#: 3.0/climacell.js:315 3.8/weather-applet.js:12352
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
 msgid "Heavy ice pellets"
 msgstr "大冰丸"
 
 #: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
-#: 3.0/climacell.js:330 3.8/weather-applet.js:12344 3.8/weather-applet.js:12345
-#: 3.8/weather-applet.js:12351 3.8/weather-applet.js:12358
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
 msgid "Ice pellets"
 msgstr "冰丸"
 
-#: 3.0/climacell.js:329 3.8/weather-applet.js:12359
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
 msgid "Light ice pellets"
 msgstr "小冰丸"
 
 #: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
 #: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
 #: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
-#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10595
-#: 3.8/weather-applet.js:10602 3.8/weather-applet.js:10609
-#: 3.8/weather-applet.js:10610 3.8/weather-applet.js:11016
-#: 3.8/weather-applet.js:11430 3.8/weather-applet.js:11431
-#: 3.8/weather-applet.js:11437 3.8/weather-applet.js:11444
-#: 3.8/weather-applet.js:11451 3.8/weather-applet.js:12310
-#: 3.8/weather-applet.js:13197 3.8/weather-applet.js:13517
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "大雪"
 
 #: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
 #: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
 #: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
-#: 3.8/weather-applet.js:11015 3.8/weather-applet.js:11605
-#: 3.8/weather-applet.js:11606 3.8/weather-applet.js:11612
-#: 3.8/weather-applet.js:12288 3.8/weather-applet.js:12289
-#: 3.8/weather-applet.js:12302 3.8/weather-applet.js:12309
-#: 3.8/weather-applet.js:12786 3.8/weather-applet.js:12787
-#: 3.8/weather-applet.js:13191 3.8/weather-applet.js:13426
-#: 3.8/weather-applet.js:13510 3.8/weather-applet.js:14195
-#: 3.8/weather-applet.js:14196 3.8/weather-applet.js:14573
-#: 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
 msgid "Snow"
 msgstr "雪"
 
 #: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
 #: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
 #: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
-#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10574
-#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10588
-#: 3.8/weather-applet.js:10589 3.8/weather-applet.js:11014
-#: 3.8/weather-applet.js:11514 3.8/weather-applet.js:11515
-#: 3.8/weather-applet.js:11521 3.8/weather-applet.js:11528
-#: 3.8/weather-applet.js:11535 3.8/weather-applet.js:12303
-#: 3.8/weather-applet.js:13199
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
 msgid "Light snow"
 msgstr "小雪"
 
-#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12295
-#: 3.8/weather-applet.js:12296 3.8/weather-applet.js:14552
-#: 3.8/weather-applet.js:14553
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
 msgid "Flurries"
 msgstr "零星小雪"
 
 #: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
-#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:10989
-#: 3.8/weather-applet.js:12365 3.8/weather-applet.js:12366
-#: 3.8/weather-applet.js:12859 3.8/weather-applet.js:12860
-#: 3.8/weather-applet.js:13203 3.8/weather-applet.js:13524
-#: 3.8/weather-applet.js:13525 3.8/weather-applet.js:14202
-#: 3.8/weather-applet.js:14203
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
 msgid "Thunderstorm"
 msgstr "雷暴"
 
-#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12233
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
 msgid "Light fog"
 msgstr "轻雾"
 
 #: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
 #: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
 #: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
-#: 3.8/weather-applet.js:10462 3.8/weather-applet.js:10463
-#: 3.8/weather-applet.js:11028 3.8/weather-applet.js:11367
-#: 3.8/weather-applet.js:11368 3.8/weather-applet.js:12225
-#: 3.8/weather-applet.js:12226 3.8/weather-applet.js:12232
-#: 3.8/weather-applet.js:12929 3.8/weather-applet.js:12930
-#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:14153
-#: 3.8/weather-applet.js:14154 3.8/weather-applet.js:14601
-#: 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
 msgid "Fog"
 msgstr "雾"
 
 #: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
 #: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
-#: 3.8/weather-applet.js:10469 3.8/weather-applet.js:10470
-#: 3.8/weather-applet.js:11353 3.8/weather-applet.js:11354
-#: 3.8/weather-applet.js:12197 3.8/weather-applet.js:12198
-#: 3.8/weather-applet.js:13419 3.8/weather-applet.js:13420
-#: 3.8/weather-applet.js:14146 3.8/weather-applet.js:14147
-#: 3.8/weather-applet.js:14643 3.8/weather-applet.js:14644
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
 msgid "Cloudy"
 msgstr "多云"
 
 #: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
-#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12218
-#: 3.8/weather-applet.js:12219 3.8/weather-applet.js:12737
-#: 3.8/weather-applet.js:12738 3.8/weather-applet.js:12772
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
 msgid "Mostly cloudy"
 msgstr "多云"
 
 #: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
 #: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
 #: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
-#: 3.0/us_weather.js:456 3.8/weather-applet.js:10434
-#: 3.8/weather-applet.js:10435 3.8/weather-applet.js:10441
-#: 3.8/weather-applet.js:10442 3.8/weather-applet.js:11542
-#: 3.8/weather-applet.js:11543 3.8/weather-applet.js:12211
-#: 3.8/weather-applet.js:12212 3.8/weather-applet.js:12730
-#: 3.8/weather-applet.js:12731 3.8/weather-applet.js:12765
-#: 3.8/weather-applet.js:13412 3.8/weather-applet.js:13413
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
 msgid "Partly cloudy"
 msgstr "少云"
 
-#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12204
-#: 3.8/weather-applet.js:12205
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
 msgid "Mostly clear"
 msgstr "少云"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
 #: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
 #: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
-#: 3.8/weather-applet.js:10420 3.8/weather-applet.js:10421
-#: 3.8/weather-applet.js:11034 3.8/weather-applet.js:12190
-#: 3.8/weather-applet.js:12191 3.8/weather-applet.js:12716
-#: 3.8/weather-applet.js:12717 3.8/weather-applet.js:12751
-#: 3.8/weather-applet.js:13215 3.8/weather-applet.js:13405
-#: 3.8/weather-applet.js:13406 3.8/weather-applet.js:14132
-#: 3.8/weather-applet.js:14133 3.8/weather-applet.js:14139
-#: 3.8/weather-applet.js:14140 3.8/weather-applet.js:14678
-#: 3.8/weather-applet.js:14679
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
 msgid "Clear"
 msgstr "晴"
 
 #: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
-#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10427
-#: 3.8/weather-applet.js:10428 3.8/weather-applet.js:12190
-#: 3.8/weather-applet.js:12191 3.8/weather-applet.js:14685
-#: 3.8/weather-applet.js:14686
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
 msgid "Sunny"
 msgstr "晴"
 
 #: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
 #: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
 #: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
-#: 3.0/us_weather.js:628 3.8/weather-applet.js:10413
-#: 3.8/weather-applet.js:10414 3.8/weather-applet.js:10448
-#: 3.8/weather-applet.js:10449 3.8/weather-applet.js:10637
-#: 3.8/weather-applet.js:10638 3.8/weather-applet.js:11336
-#: 3.8/weather-applet.js:11337 3.8/weather-applet.js:11634
-#: 3.8/weather-applet.js:11635 3.8/weather-applet.js:12182
-#: 3.8/weather-applet.js:12183 3.8/weather-applet.js:12707
-#: 3.8/weather-applet.js:12708 3.8/weather-applet.js:12936
-#: 3.8/weather-applet.js:12937 3.8/weather-applet.js:14065
-#: 3.8/weather-applet.js:14066 3.8/weather-applet.js:14216
-#: 3.8/weather-applet.js:14217 3.8/weather-applet.js:14789
-#: 3.8/weather-applet.js:14791
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
 msgid "Unknown"
 msgstr "未知"
 
@@ -543,7 +543,7 @@ msgstr ""
 "请在设置中输入 API 密钥，\n"
 "或先在 https://darksky.net/dev/register 上获取一个"
 
-#: 3.0/darkSky.js:238 3.8/weather-applet.js:14922
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
 msgid ""
 "Please Make sure you\n"
 "entered the API key that you have from DarkSky"
@@ -551,130 +551,130 @@ msgstr ""
 "请确保您\n"
 "输入从 DarkSky 获取的 API 密钥"
 
-#: 3.0/ipApi.js:89 3.8/weather-applet.js:14870
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
 msgid "Could not obtain location"
 msgstr "无法获取位置"
 
-#: 3.0/ipApi.js:95 3.8/weather-applet.js:14876
+#: 3.0/ipApi.js:95
 msgid ""
 "Location Service responded with errors, please see the logs in Looking Glass"
 msgstr "定位服务响应错误，请查看 Looking Glass 中的日志"
 
-#: 3.0/met_norway.js:131 3.8/weather-applet.js:11198
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
 msgid "Cloudiness"
 msgstr "云量"
 
 #: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
-#: 3.8/weather-applet.js:11035 3.8/weather-applet.js:11346
-#: 3.8/weather-applet.js:11347
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
 msgid "Clear sky"
 msgstr "晴"
 
 #: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
-#: 3.8/weather-applet.js:11360 3.8/weather-applet.js:11361
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
 msgid "Fair"
 msgstr "晴"
 
-#: 3.0/met_norway.js:316 3.8/weather-applet.js:11382
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
 msgid "Heavy rain and thunder"
 msgstr "强雷雨"
 
-#: 3.0/met_norway.js:323 3.8/weather-applet.js:11389
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
 msgid "Heavy rain showers"
 msgstr "强阵雨"
 
-#: 3.0/met_norway.js:330 3.8/weather-applet.js:11396
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
 msgid "Heavy rain showers and thunder"
 msgstr "强雷阵雨"
 
 #: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
-#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11402
-#: 3.8/weather-applet.js:11403 3.8/weather-applet.js:11409
-#: 3.8/weather-applet.js:11416 3.8/weather-applet.js:11423
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
 msgid "Heavy sleet"
 msgstr "大雨夹雪"
 
-#: 3.0/met_norway.js:344 3.8/weather-applet.js:11410
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
 msgid "Heavy sleet and thunder"
 msgstr "大雨夹雪，伴有雷电"
 
-#: 3.0/met_norway.js:351 3.8/weather-applet.js:11417
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
 msgid "Heavy sleet showers"
 msgstr "短时大雨夹雪"
 
-#: 3.0/met_norway.js:358 3.8/weather-applet.js:11424
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
 msgid "Heavy sleet showers and thunder"
 msgstr "短时大雨夹雪，伴有雷电"
 
-#: 3.0/met_norway.js:372 3.8/weather-applet.js:11438
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
 msgid "Heavy snow and thunder"
 msgstr "强雷雪"
 
-#: 3.0/met_norway.js:379 3.8/weather-applet.js:11445
-#: 3.8/weather-applet.js:13518
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
 msgid "Heavy snow showers"
 msgstr "强阵雪"
 
-#: 3.0/met_norway.js:386 3.8/weather-applet.js:11452
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
 msgid "Heavy snow showers and thunder"
 msgstr "强雷阵雪"
 
-#: 3.0/met_norway.js:400 3.8/weather-applet.js:11466
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
 msgid "Light rain and thunder"
 msgstr "小雷雨"
 
-#: 3.0/met_norway.js:407 3.8/weather-applet.js:11473
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
 msgid "Light rain showers"
 msgstr "小阵雨"
 
-#: 3.0/met_norway.js:414 3.8/weather-applet.js:11480
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
 msgid "Light rain showers and thunder"
 msgstr "小雷阵雨"
 
 #: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
-#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11486
-#: 3.8/weather-applet.js:11487 3.8/weather-applet.js:11493
-#: 3.8/weather-applet.js:11500 3.8/weather-applet.js:11507
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
 msgid "Light sleet"
 msgstr "小雨夹雪"
 
-#: 3.0/met_norway.js:428 3.8/weather-applet.js:11494
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
 msgid "Light sleet and thunder"
 msgstr "小雨夹雪，伴有雷电"
 
-#: 3.0/met_norway.js:435 3.8/weather-applet.js:11501
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
 msgid "Light sleet showers"
 msgstr "短时小雨夹雪"
 
-#: 3.0/met_norway.js:442 3.8/weather-applet.js:11508
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
 msgid "Light sleet showers and thunder"
 msgstr "短时小雨夹雪，伴有雷电"
 
-#: 3.0/met_norway.js:456 3.8/weather-applet.js:11522
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
 msgid "Light snow and thunder"
 msgstr "小雷雪"
 
-#: 3.0/met_norway.js:463 3.8/weather-applet.js:11529
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
 msgid "Light snow showers"
 msgstr "小阵雪"
 
-#: 3.0/met_norway.js:470 3.8/weather-applet.js:11536
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
 msgid "Light snow showers and thunder"
 msgstr "小雷阵雪"
 
-#: 3.0/met_norway.js:491 3.8/weather-applet.js:11557
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
 msgid "Rain and thunder"
 msgstr "雷雨"
 
 #: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
-#: 3.0/us_weather.js:542 3.8/weather-applet.js:11563
-#: 3.8/weather-applet.js:11564 3.8/weather-applet.js:11570
-#: 3.8/weather-applet.js:12851 3.8/weather-applet.js:13177
-#: 3.8/weather-applet.js:13483 3.8/weather-applet.js:13489
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
 msgid "Rain showers"
 msgstr "阵雨"
 
-#: 3.0/met_norway.js:505 3.8/weather-applet.js:11571
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
 msgid "Rain showers and thunder"
 msgstr "雷阵雨"
 
@@ -683,44 +683,44 @@ msgstr "雷阵雨"
 #: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
 #: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
 #: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
-#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10532
-#: 3.8/weather-applet.js:10539 3.8/weather-applet.js:10546
-#: 3.8/weather-applet.js:10547 3.8/weather-applet.js:11017
-#: 3.8/weather-applet.js:11577 3.8/weather-applet.js:11578
-#: 3.8/weather-applet.js:11584 3.8/weather-applet.js:11591
-#: 3.8/weather-applet.js:11598 3.8/weather-applet.js:12800
-#: 3.8/weather-applet.js:12801 3.8/weather-applet.js:12807
-#: 3.8/weather-applet.js:12808 3.8/weather-applet.js:12835
-#: 3.8/weather-applet.js:12836 3.8/weather-applet.js:14188
-#: 3.8/weather-applet.js:14189 3.8/weather-applet.js:14587
-#: 3.8/weather-applet.js:14588
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
 msgid "Sleet"
 msgstr "雨夹雪"
 
-#: 3.0/met_norway.js:519 3.8/weather-applet.js:11585
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
 msgid "Sleet and thunder"
 msgstr "雨夹雪，伴有雷电"
 
-#: 3.0/met_norway.js:526 3.8/weather-applet.js:11592
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
 msgid "Sleet showers"
 msgstr "短时雨夹雪"
 
-#: 3.0/met_norway.js:533 3.8/weather-applet.js:11599
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
 msgid "Sleet showers and thunder"
 msgstr "短时雨夹雪，伴有雷电"
 
-#: 3.0/met_norway.js:547 3.8/weather-applet.js:11613
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
 msgid "Snow and thunder"
 msgstr "雷雪"
 
 #: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
-#: 3.8/weather-applet.js:11619 3.8/weather-applet.js:11620
-#: 3.8/weather-applet.js:11626 3.8/weather-applet.js:13195
-#: 3.8/weather-applet.js:13511
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "阵雪"
 
-#: 3.0/met_norway.js:561 3.8/weather-applet.js:11627
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
 msgid "Snow showers and thunder"
 msgstr "雷阵雪"
 
@@ -729,21 +729,21 @@ msgstr "雷阵雪"
 msgid "Unexpected response from API"
 msgstr "来自 API 的意外响应"
 
-#: 3.0/met_uk.js:316 3.8/weather-applet.js:10232
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
 msgid "Visibility"
 msgstr "能见度"
 
 #: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
-#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10260
-#: 3.8/weather-applet.js:10812 3.8/weather-applet.js:11717
-#: 3.8/weather-applet.js:12662
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
 msgid "Failed to Process Current Weather Info"
 msgstr "处理当前天气信息失败"
 
 #: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
-#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10050
-#: 3.8/weather-applet.js:10084 3.8/weather-applet.js:11743
-#: 3.8/weather-applet.js:11777 3.8/weather-applet.js:12464
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
 msgid "Failed to Process Forecast Info"
 msgstr "处理未来天气信息失败"
 
@@ -772,298 +772,298 @@ msgid "Excellent - More than"
 msgstr "极佳 - 高于"
 
 #: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
-#: 3.8/weather-applet.js:10455 3.8/weather-applet.js:10456
-#: 3.8/weather-applet.js:11024 3.8/weather-applet.js:13167
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
 msgid "Mist"
 msgstr "雾"
 
 #: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
-#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10476
-#: 3.8/weather-applet.js:10477 3.8/weather-applet.js:12744
-#: 3.8/weather-applet.js:12745 3.8/weather-applet.js:12779
-#: 3.8/weather-applet.js:13211
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
 msgid "Overcast"
 msgstr "阴"
 
-#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10484
-#: 3.8/weather-applet.js:10491
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
 msgid "Light rain shower"
 msgstr "小阵雨"
 
 #: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
-#: 3.0/yahoo.js:445 3.8/weather-applet.js:10497 3.8/weather-applet.js:10498
-#: 3.8/weather-applet.js:10996 3.8/weather-applet.js:12260
-#: 3.8/weather-applet.js:12261 3.8/weather-applet.js:12316
-#: 3.8/weather-applet.js:13133 3.8/weather-applet.js:14524
-#: 3.8/weather-applet.js:14525
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
 msgid "Drizzle"
 msgstr "毛毛雨"
 
-#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10512
-#: 3.8/weather-applet.js:10519
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
 msgid "Heavy rain shower"
 msgstr "强阵雨"
 
-#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10533
-#: 3.8/weather-applet.js:10540
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
 msgid "Sleet shower"
 msgstr "短时雨夹雪"
 
 #: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
-#: 3.0/yahoo.js:453 3.8/weather-applet.js:10553 3.8/weather-applet.js:10560
-#: 3.8/weather-applet.js:10567 3.8/weather-applet.js:10568
-#: 3.8/weather-applet.js:13209 3.8/weather-applet.js:14160
-#: 3.8/weather-applet.js:14161 3.8/weather-applet.js:14580
-#: 3.8/weather-applet.js:14581
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
 msgid "Hail"
 msgstr "冰雹"
 
-#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10554
-#: 3.8/weather-applet.js:10561
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
 msgid "Hail shower"
 msgstr "短时冰雹"
 
-#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10575
-#: 3.8/weather-applet.js:10582
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
 msgid "Light snow shower"
 msgstr "小阵雪"
 
-#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10596
-#: 3.8/weather-applet.js:10603
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
 msgid "Heavy snow shower"
 msgstr "强阵雪"
 
 #: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
-#: 3.8/weather-applet.js:10616 3.8/weather-applet.js:10623
-#: 3.8/weather-applet.js:10630 3.8/weather-applet.js:10631
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
 msgid "Thunder"
 msgstr "雷"
 
-#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10617
-#: 3.8/weather-applet.js:10624
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
 msgid "Thunder shower"
 msgstr "阵雷"
 
-#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:10867
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
 msgid "Please make sure Location is in the correct format in the Settings"
 msgstr "请确保设置中的位置格式正确"
 
-#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:10871
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
 msgid "Make sure you entered the correct key in settings"
 msgstr "确保您在设置中输入了正确的密钥"
 
 #: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
-#: 3.8/weather-applet.js:10676 3.8/weather-applet.js:10875
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
 msgid ""
 "Location not found, make sure location is available or it is in the correct "
 "format"
 msgstr "未找到位置，请确保位置可用或格式正确"
 
-#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:10879
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
 msgid "If this problem persists, please contact the Author of this applet"
 msgstr "如果这个问题持续存在，请联系本小程序的作者"
 
-#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:10883
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
 msgid "Unknown Error, please see the logs in Looking Glass"
 msgstr "未知的错误，请查看 Looking Glass 中的日志"
 
-#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:10985
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
 msgid "Thunderstorm with light rain"
 msgstr "雷暴，伴有小雨"
 
-#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:10986
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
 msgid "Thunderstorm with rain"
 msgstr "雷暴，伴有雨"
 
-#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:10987
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
 msgid "Thunderstorm with heavy rain"
 msgstr "雷暴，伴有大雨"
 
-#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:10988
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
 msgid "Light thunderstorm"
 msgstr "小雷暴"
 
-#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:10990
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
 msgid "Heavy thunderstorm"
 msgstr "强雷暴"
 
-#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:10991
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
 msgid "Ragged thunderstorm"
 msgstr "局部雷暴"
 
-#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:10992
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
 msgid "Thunderstorm with light drizzle"
 msgstr "雷暴，伴有小毛雨"
 
-#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:10993
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
 msgid "Thunderstorm with drizzle"
 msgstr "雷暴，伴有毛毛雨"
 
-#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:10994
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
 msgid "Thunderstorm with heavy drizzle"
 msgstr "雷暴，伴有强毛雨"
 
-#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:10995
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
 msgid "Light intensity drizzle"
 msgstr "小毛雨"
 
-#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:10997
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
 msgid "Heavy intensity drizzle"
 msgstr "强毛雨"
 
-#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:10998
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
 msgid "Light intensity drizzle rain"
 msgstr "毛毛细雨"
 
-#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:10999
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
 msgid "Drizzle rain"
 msgstr "细雨"
 
-#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11000
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
 msgid "Heavy intensity drizzle rain"
 msgstr "强细雨"
 
-#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11001
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
 msgid "Shower rain and drizzle"
 msgstr "毛毛雨，时有阵雨"
 
-#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11002
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
 msgid "Heavy shower rain and drizzle"
 msgstr "毛毛雨，时有强阵雨"
 
-#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11003
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
 msgid "Shower drizzle"
 msgstr "短时毛毛雨"
 
-#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11005
-#: 3.8/weather-applet.js:13447 3.8/weather-applet.js:13448
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
 msgid "Moderate rain"
 msgstr "中雨"
 
-#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11006
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
 msgid "Heavy intensity rain"
 msgstr "大雨"
 
-#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11007
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
 msgid "Very heavy rain"
 msgstr "暴雨"
 
-#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11008
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
 msgid "Extreme rain"
 msgstr "大暴雨"
 
-#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11010
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
 msgid "Light intensity shower rain"
 msgstr "小阵雨"
 
-#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11011
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
 msgid "Shower rain"
 msgstr "阵雨"
 
-#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11012
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
 msgid "Heavy intensity shower rain"
 msgstr "强阵雨"
 
-#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11013
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
 msgid "Ragged shower rain"
 msgstr "局部阵雨"
 
-#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11018
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
 msgid "Shower sleet"
 msgstr "短时雨夹雪"
 
-#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11019
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
 msgid "Light rain and snow"
 msgstr "小雨夹雪"
 
-#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11020
-#: 3.8/weather-applet.js:13454 3.8/weather-applet.js:13455
-#: 3.8/weather-applet.js:13461 3.8/weather-applet.js:13496
-#: 3.8/weather-applet.js:13503
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
 msgid "Rain and snow"
 msgstr "雨夹雪"
 
-#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11021
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
 msgid "Light shower snow"
 msgstr "小阵雪"
 
-#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11022
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
 msgid "Shower snow"
 msgstr "阵雪"
 
-#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11023
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
 msgid "Heavy shower snow"
 msgstr "强阵雪"
 
 #: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
-#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12894
-#: 3.8/weather-applet.js:12895 3.8/weather-applet.js:14615
-#: 3.8/weather-applet.js:14616
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
 msgid "Smoke"
 msgstr "烟"
 
 #: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
-#: 3.0/yahoo.js:457 3.8/weather-applet.js:11026 3.8/weather-applet.js:12901
-#: 3.8/weather-applet.js:12902 3.8/weather-applet.js:14608
-#: 3.8/weather-applet.js:14609
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
 msgid "Haze"
 msgstr "霾"
 
-#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11027
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
 msgid "Sand, dust whirls"
 msgstr "沙尘暴"
 
-#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11029
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
 msgid "Sand"
 msgstr "扬沙"
 
 #: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
-#: 3.0/yahoo.js:455 3.8/weather-applet.js:11030 3.8/weather-applet.js:12887
-#: 3.8/weather-applet.js:12888 3.8/weather-applet.js:14594
-#: 3.8/weather-applet.js:14595
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
 msgid "Dust"
 msgstr "浮尘"
 
-#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11031
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
 msgid "Volcanic ash"
 msgstr "火山灰"
 
-#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11032
-#: 3.8/weather-applet.js:13201
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
 msgid "Squalls"
 msgstr "飑"
 
 #: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
-#: 3.0/yahoo.js:436 3.8/weather-applet.js:11033 3.8/weather-applet.js:12866
-#: 3.8/weather-applet.js:12867 3.8/weather-applet.js:14467
-#: 3.8/weather-applet.js:14468
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
 msgid "Tornado"
 msgstr "龙卷风"
 
-#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11036
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
 msgid "Sky is clear"
 msgstr "晴"
 
-#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11037
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
 msgid "Clouds"
 msgstr "云"
 
 #: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
-#: 3.0/us_weather.js:449 3.8/weather-applet.js:11038
-#: 3.8/weather-applet.js:12723 3.8/weather-applet.js:12724
-#: 3.8/weather-applet.js:12758
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
 msgid "Few clouds"
 msgstr "少云"
 
-#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11039
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
 msgid "Scattered clouds"
 msgstr "疏云"
 
-#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11040
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
 msgid "Broken clouds"
 msgstr "碎云"
 
-#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11041
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
 msgid "Overcast clouds"
 msgstr "阴"
 
@@ -1071,80 +1071,80 @@ msgstr "阴"
 msgid "Could not get forecast for your area"
 msgstr "无法获取您所在地区的预报"
 
-#: 3.0/us_weather.js:231 3.8/weather-applet.js:12421
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
 msgid "Location is outside US, please use a different provider."
 msgstr "您的位置在美国以外，请使用其他数据源。"
 
-#: 3.0/us_weather.js:394 3.8/weather-applet.js:12485
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
 msgid "Failed to Process Hourly Forecast Info"
 msgstr "处理每小时预测信息失败"
 
-#: 3.0/us_weather.js:443 3.8/weather-applet.js:12752
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
 msgid "Clear and windy"
 msgstr "晴朗，有风"
 
-#: 3.0/us_weather.js:450 3.8/weather-applet.js:12759
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
 msgid "Few clouds and windy"
 msgstr "少云，有风"
 
-#: 3.0/us_weather.js:457 3.8/weather-applet.js:12766
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
 msgid "Partly cloudy and windy"
 msgstr "疏云，有风"
 
-#: 3.0/us_weather.js:464 3.8/weather-applet.js:12773
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
 msgid "Mostly cloudy and windy"
 msgstr "多云，有风"
 
-#: 3.0/us_weather.js:471 3.8/weather-applet.js:12780
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
 msgid "Overcast and windy"
 msgstr "阴，有风"
 
-#: 3.0/us_weather.js:485 3.8/weather-applet.js:12794
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
 msgid "Snowy rain"
 msgstr "雨夹雪"
 
-#: 3.0/us_weather.js:520 3.8/weather-applet.js:12829
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
 msgid "Freezing rain and snow"
 msgstr "冻雨夹雪"
 
 #: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
-#: 3.0/yahoo.js:438 3.8/weather-applet.js:9148 3.8/weather-applet.js:12873
-#: 3.8/weather-applet.js:12874 3.8/weather-applet.js:14481
-#: 3.8/weather-applet.js:14482
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
 msgid "Hurricane"
 msgstr "飓风"
 
-#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9143
-#: 3.8/weather-applet.js:12880
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
 msgid "Storm"
 msgstr "风暴"
 
-#: 3.0/us_weather.js:572 3.8/weather-applet.js:12881
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
 msgid "Tropical storm"
 msgstr "热带风暴"
 
 #: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
-#: 3.8/weather-applet.js:12908 3.8/weather-applet.js:12909
-#: 3.8/weather-applet.js:14713 3.8/weather-applet.js:14714
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
 msgid "Hot"
 msgstr "热"
 
 #: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
-#: 3.8/weather-applet.js:12915 3.8/weather-applet.js:12916
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
 msgid "Cold"
 msgstr "冷"
 
 #: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
-#: 3.8/weather-applet.js:12922 3.8/weather-applet.js:12923
-#: 3.8/weather-applet.js:14762 3.8/weather-applet.js:14763
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
 msgid "Blizzard"
 msgstr "暴风雪"
 
-#: 3.0/utils.js:146 3.8/weather-applet.js:9021
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
 msgid "Today"
 msgstr "今天"
 
-#: 3.0/utils.js:148 3.8/weather-applet.js:9023
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
 msgid "Tomorrow"
 msgstr "明天"
 
@@ -1176,79 +1176,79 @@ msgstr "星期五"
 msgid "Saturday"
 msgstr "星期六"
 
-#: 3.0/utils.js:301 3.8/weather-applet.js:9113
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
 msgid "Calm"
 msgstr "无风"
 
-#: 3.0/utils.js:304 3.8/weather-applet.js:9116
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
 msgid "Light air"
 msgstr "软风"
 
-#: 3.0/utils.js:307 3.8/weather-applet.js:9119
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
 msgid "Light breeze"
 msgstr "轻风"
 
-#: 3.0/utils.js:310 3.8/weather-applet.js:9122
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
 msgid "Gentle breeze"
 msgstr "微风"
 
-#: 3.0/utils.js:313 3.8/weather-applet.js:9125
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
 msgid "Moderate breeze"
 msgstr "和风"
 
-#: 3.0/utils.js:316 3.8/weather-applet.js:9128
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
 msgid "Fresh breeze"
 msgstr "劲风"
 
-#: 3.0/utils.js:319 3.8/weather-applet.js:9131
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
 msgid "Strong breeze"
 msgstr "强风"
 
-#: 3.0/utils.js:322 3.8/weather-applet.js:9134
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
 msgid "Near gale"
 msgstr "疾风"
 
-#: 3.0/utils.js:325 3.8/weather-applet.js:9137
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
 msgid "Gale"
 msgstr "大风"
 
-#: 3.0/utils.js:328 3.8/weather-applet.js:9140
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
 msgid "Strong gale"
 msgstr "烈风"
 
-#: 3.0/utils.js:334 3.8/weather-applet.js:9146
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
 msgid "Violent storm"
 msgstr "狂风"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr "北"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr "东北"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr "东"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr "东南"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr "南"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr "西南"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr "西"
 
-#: 3.0/utils.js:429 3.8/weather-applet.js:9296
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr "西北"
 
@@ -1298,7 +1298,7 @@ msgid ""
 "more information"
 msgstr "在获取天气时发生了未知的错误，更多信息请参见 Looking Glass 日志"
 
-#: 3.0/yahoo.js:437 3.8/weather-applet.js:14474 3.8/weather-applet.js:14475
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
 msgid "Tropical Storm"
 msgstr "热带风暴"
 
@@ -1306,7 +1306,7 @@ msgstr "热带风暴"
 msgid "Severe Thunderstorms"
 msgstr "强雷暴"
 
-#: 3.0/yahoo.js:440 3.8/weather-applet.js:14495 3.8/weather-applet.js:14496
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
 msgid "Thunderstorms"
 msgstr "雷暴"
 
@@ -1322,15 +1322,15 @@ msgstr "雨夹雪"
 msgid "Mixed Snow and Sleet"
 msgstr "雨夹雪"
 
-#: 3.0/yahoo.js:444 3.8/weather-applet.js:14517 3.8/weather-applet.js:14518
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
 msgid "Freezing Drizzle"
 msgstr "冻毛雨"
 
-#: 3.0/yahoo.js:446 3.8/weather-applet.js:14531 3.8/weather-applet.js:14532
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
 msgid "Freezing Rain"
 msgstr "冻雨"
 
-#: 3.0/yahoo.js:447 3.8/weather-applet.js:14538 3.8/weather-applet.js:14539
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
 msgid "Showers"
 msgstr "阵雨"
 
@@ -1342,11 +1342,11 @@ msgstr "小雪"
 msgid "Light Snow Showers"
 msgstr "小阵雪"
 
-#: 3.0/yahoo.js:451 3.8/weather-applet.js:14566 3.8/weather-applet.js:14567
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
 msgid "Blowing Snow"
 msgstr "吹雪"
 
-#: 3.0/yahoo.js:456 3.8/weather-applet.js:13433 3.8/weather-applet.js:13434
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
 msgid "Foggy"
 msgstr "雾"
 
@@ -1358,54 +1358,54 @@ msgstr "烟"
 msgid "Blustery"
 msgstr "大风"
 
-#: 3.0/yahoo.js:460 3.8/weather-applet.js:14629 3.8/weather-applet.js:14630
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
 msgid "Windy"
 msgstr "有风"
 
-#: 3.0/yahoo.js:463 3.8/weather-applet.js:14650 3.8/weather-applet.js:14651
-#: 3.8/weather-applet.js:14657 3.8/weather-applet.js:14658
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
 msgid "Mostly Cloudy"
 msgstr "多云"
 
-#: 3.0/yahoo.js:464 3.8/weather-applet.js:14167 3.8/weather-applet.js:14168
-#: 3.8/weather-applet.js:14174 3.8/weather-applet.js:14175
-#: 3.8/weather-applet.js:14664 3.8/weather-applet.js:14665
-#: 3.8/weather-applet.js:14671 3.8/weather-applet.js:14672
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
 msgid "Partly Cloudy"
 msgstr "疏云"
 
-#: 3.0/yahoo.js:467 3.8/weather-applet.js:14699 3.8/weather-applet.js:14700
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
 msgid "Mostly Sunny"
 msgstr "少云"
 
-#: 3.0/yahoo.js:469 3.8/weather-applet.js:14706 3.8/weather-applet.js:14707
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
 msgid "Mixed Rain and Hail"
 msgstr "雨和冰雹"
 
-#: 3.0/yahoo.js:471 3.8/weather-applet.js:14720 3.8/weather-applet.js:14721
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
 msgid "Isolated Thunderstorms"
 msgstr "孤立雷暴"
 
-#: 3.0/yahoo.js:472 3.8/weather-applet.js:14727 3.8/weather-applet.js:14728
-#: 3.8/weather-applet.js:14783 3.8/weather-applet.js:14784
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
 msgid "Scattered Thunderstorms"
 msgstr "零星雷暴"
 
-#: 3.0/yahoo.js:473 3.8/weather-applet.js:14734 3.8/weather-applet.js:14735
-#: 3.8/weather-applet.js:14769 3.8/weather-applet.js:14770
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
 msgid "Scattered Showers"
 msgstr "零星阵雨"
 
-#: 3.0/yahoo.js:474 3.8/weather-applet.js:14741 3.8/weather-applet.js:14742
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
 msgid "Heavy Rain"
 msgstr "大雨"
 
-#: 3.0/yahoo.js:475 3.8/weather-applet.js:14748 3.8/weather-applet.js:14749
-#: 3.8/weather-applet.js:14776 3.8/weather-applet.js:14777
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
 msgid "Scattered Snow Showers"
 msgstr "零星阵雪"
 
-#: 3.0/yahoo.js:476 3.8/weather-applet.js:14755 3.8/weather-applet.js:14756
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
 msgid "Heavy Snow"
 msgstr "大雪"
 
@@ -1417,7 +1417,7 @@ msgstr "不可用"
 msgid "Scattered Thundershowers"
 msgstr "零星雷阵雨"
 
-#: 3.8/weather-applet.js:9632
+#: 3.8/weather-applet.js:9638
 msgid ""
 "Could not retrieve logs, log file was not found under path\n"
 " {logFilePath}"
@@ -1425,7 +1425,7 @@ msgstr ""
 "无法检索日志，在以下路径没有找到日志文件\n"
 " {logFilePath}"
 
-#: 3.8/weather-applet.js:9636
+#: 3.8/weather-applet.js:9642
 msgid ""
 "Could not get contents of log file under path\n"
 " {logFilePath}"
@@ -1434,285 +1434,297 @@ msgstr ""
 " {logFilePath}"
 
 #. 3.0->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10008
+#: 3.8/weather-applet.js:10283
 msgid "Met Office UK"
 msgstr "英国气象局"
 
-#: 3.8/weather-applet.js:10113
+#: 3.8/weather-applet.js:10388
 msgid ""
 "MET Office UK only covers the UK, please make sure your location is in the "
 "country"
 msgstr "英国气象局数据服务仅覆盖英国，请确认您的位置"
 
-#: 3.8/weather-applet.js:10192
+#: 3.8/weather-applet.js:10476
 msgid "Data was not found for location"
 msgstr "没有找到当前位置的数据"
 
-#: 3.8/weather-applet.js:10273
+#: 3.8/weather-applet.js:10557
 msgid "Very poor"
 msgstr "很差"
 
-#: 3.8/weather-applet.js:10273
+#: 3.8/weather-applet.js:10557
 msgid "Less than {distance} {distanceUnit}"
 msgstr "小于 {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10277
+#: 3.8/weather-applet.js:10561
 msgid "Excellent"
 msgstr "极好"
 
-#: 3.8/weather-applet.js:10277
+#: 3.8/weather-applet.js:10561
 msgid "More than {distance} {distanceUnit}"
 msgstr "大于 {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:10282
+#: 3.8/weather-applet.js:10566
 msgid "Poor"
 msgstr "差"
 
-#: 3.8/weather-applet.js:10282 3.8/weather-applet.js:10287
-#: 3.8/weather-applet.js:10292 3.8/weather-applet.js:10297
-#: 3.8/weather-applet.js:10302
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
 msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
 msgstr "在 {smallerDistance}~{biggerDistance} {distanceUnit} 之间"
 
-#: 3.8/weather-applet.js:10287
+#: 3.8/weather-applet.js:10571
 msgid "Moderate"
 msgstr "一般"
 
-#: 3.8/weather-applet.js:10292
+#: 3.8/weather-applet.js:10576
 msgid "Good"
 msgstr "好"
 
-#: 3.8/weather-applet.js:10297 3.8/weather-applet.js:10302
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
 msgid "Very good"
 msgstr "很好"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:10657
+#: 3.8/weather-applet.js:10942
 msgid "OpenWeatherMap"
 msgstr "OpenWeatherMap"
 
 #. 3.0->settings-schema.json->dataService->options
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:11105
+#: 3.8/weather-applet.js:11396
 msgid "MET Norway"
 msgstr "挪威气象研究所"
 
-#: 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:11955
 msgid "WeatherBit"
 msgstr "WeatherBit"
 
-#: 3.8/weather-applet.js:12075
+#: 3.8/weather-applet.js:12386
 msgid "Tomorrow.io"
 msgstr "Tomorrow.io"
 
-#: 3.8/weather-applet.js:12240
+#: 3.8/weather-applet.js:12561
 msgid "Light wind"
 msgstr "小风"
 
-#: 3.8/weather-applet.js:12254
+#: 3.8/weather-applet.js:12575
 msgid "Strong wind"
 msgstr "大风"
 
-#: 3.8/weather-applet.js:12401
+#: 3.8/weather-applet.js:12723
 msgid "US Weather"
 msgstr "美国国家气象局"
 
-#: 3.8/weather-applet.js:12954
+#: 3.8/weather-applet.js:13292
 msgid "Visual Crossing"
 msgstr "Visual Crossing"
 
-#: 3.8/weather-applet.js:13131
+#: 3.8/weather-applet.js:13474
 msgid "Blowing or drifting snow"
 msgstr "吹雪或飘雪"
 
-#: 3.8/weather-applet.js:13135
+#: 3.8/weather-applet.js:13478
 msgid "Heavy drizzle"
 msgstr "强毛雨"
 
-#: 3.8/weather-applet.js:13139
+#: 3.8/weather-applet.js:13482
 msgid "Heavy drizzle/rain"
 msgstr "强毛雨或雨"
 
-#: 3.8/weather-applet.js:13141
+#: 3.8/weather-applet.js:13484
 msgid "Light drizzle/rain"
 msgstr "小毛雨或雨"
 
-#: 3.8/weather-applet.js:13143
+#: 3.8/weather-applet.js:13486
 msgid "Dust Storm"
 msgstr "沙尘暴"
 
-#: 3.8/weather-applet.js:13147
+#: 3.8/weather-applet.js:13490
 msgid "Freezing drizzle/freezing rain"
 msgstr "冻毛雨或冻雨"
 
-#: 3.8/weather-applet.js:13149
+#: 3.8/weather-applet.js:13492
 msgid "Heavy freezing drizzle/freezing rain"
 msgstr "强冻毛雨或冻雨"
 
-#: 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13494
 msgid "Light freezing drizzle/freezing rain"
 msgstr "小冻毛雨或冻雨"
 
-#: 3.8/weather-applet.js:13153
+#: 3.8/weather-applet.js:13496
 msgid "Freezing fog"
 msgstr "冻雾"
 
-#: 3.8/weather-applet.js:13159
+#: 3.8/weather-applet.js:13502
 msgid "Funnel cloud/tornado"
 msgstr "漏斗云或龙卷风"
 
-#: 3.8/weather-applet.js:13161
+#: 3.8/weather-applet.js:13504
 msgid "Hail showers"
 msgstr "短时冰雹"
 
-#: 3.8/weather-applet.js:13163
+#: 3.8/weather-applet.js:13506
 msgid "Ice"
 msgstr "冰"
 
-#: 3.8/weather-applet.js:13165
+#: 3.8/weather-applet.js:13508
 msgid "Lightning without thunder"
 msgstr "没有雷声的闪电"
 
-#: 3.8/weather-applet.js:13169
+#: 3.8/weather-applet.js:13512
 msgid "Precipitation in vicinity"
 msgstr "附近有降水"
 
-#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:13462
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
 msgid "Heavy rain and snow"
 msgstr "大雨夹雪"
 
-#: 3.8/weather-applet.js:13175
+#: 3.8/weather-applet.js:13518
 msgid "Light rain And snow"
 msgstr "小雨夹雪"
 
-#: 3.8/weather-applet.js:13183
+#: 3.8/weather-applet.js:13526
 msgid "Sky coverage decreasing"
 msgstr "天空覆盖率下降"
 
-#: 3.8/weather-applet.js:13185
+#: 3.8/weather-applet.js:13528
 msgid "Sky coverage increasing"
 msgstr "天空覆盖率增加"
 
-#: 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13530
 msgid "Sky unchanged"
 msgstr "天空没有变化"
 
-#: 3.8/weather-applet.js:13189
+#: 3.8/weather-applet.js:13532
 msgid "Smoke or haze"
 msgstr "烟或霾"
 
-#: 3.8/weather-applet.js:13193
+#: 3.8/weather-applet.js:13536
 msgid "Snow and rain showers"
 msgstr "雪和阵雨"
 
-#: 3.8/weather-applet.js:13205
+#: 3.8/weather-applet.js:13548
 msgid "Thunderstorm without precipitation"
 msgstr "无降水的雷暴"
 
-#: 3.8/weather-applet.js:13207
+#: 3.8/weather-applet.js:13550
 msgid "Diamond dust"
 msgstr "钻石尘"
 
-#: 3.8/weather-applet.js:13213
+#: 3.8/weather-applet.js:13556
 msgid "Partially cloudy"
 msgstr "疏云"
 
-#: 3.8/weather-applet.js:13235
+#: 3.8/weather-applet.js:13578
 msgid "Please make sure you entered the API key correctly"
 msgstr "请确保您输入了正确的 API 密钥"
 
 #. 3.8->settings-schema.json->dataService->options
-#: 3.8/weather-applet.js:13251
+#: 3.8/weather-applet.js:13595
 msgid "DMI Denmark"
 msgstr "丹麦气象研究所"
 
-#: 3.8/weather-applet.js:13394 3.8/weather-applet.js:13395
-#: 3.8/weather-applet.js:13531 3.8/weather-applet.js:13532
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
 msgid "NOT FOUND"
 msgstr "找不到"
 
-#: 3.8/weather-applet.js:13427
+#: 3.8/weather-applet.js:13779
 msgid "Blowing snow"
 msgstr "吹雪"
 
-#: 3.8/weather-applet.js:13468 3.8/weather-applet.js:13469
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
 msgid "Slight snow"
 msgstr "小雪"
 
-#: 3.8/weather-applet.js:13475 3.8/weather-applet.js:13476
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
 msgid "Moderate snow"
 msgstr "中雪"
 
-#: 3.8/weather-applet.js:13490
+#: 3.8/weather-applet.js:13842
 msgid "Moderate rain showers"
 msgstr "中等规模的阵雨"
 
-#: 3.8/weather-applet.js:13497
+#: 3.8/weather-applet.js:13849
 msgid "Mixed rain and snow"
 msgstr "雨夹雪"
 
-#: 3.8/weather-applet.js:13504
+#: 3.8/weather-applet.js:13856
 msgid "Heavy mixed rain and snow"
 msgstr "强雨夹雪"
 
-#: 3.8/weather-applet.js:13649
+#: 3.8/weather-applet.js:14024
 msgid "AccuWeather"
 msgstr "AccuWeather"
 
-#: 3.8/weather-applet.js:13945
+#: 3.8/weather-applet.js:14321
 msgid "Deutscher Wetterdienst"
 msgstr "德国气象局"
 
-#: 3.8/weather-applet.js:13958
+#: 3.8/weather-applet.js:14334
 msgid "Please select a different provider or location"
 msgstr "请选择一个不同的数据源或地点"
 
-#: 3.8/weather-applet.js:14255
+#: 3.8/weather-applet.js:14642
 msgid "Weather Underground"
 msgstr "Weather Underground"
 
-#: 3.8/weather-applet.js:14445
+#: 3.8/weather-applet.js:14846
 msgid "The API key you provided is invalid."
 msgstr "您提供的 API 密钥无效。"
 
-#: 3.8/weather-applet.js:14452
+#: 3.8/weather-applet.js:14853
 msgid "The location you provided was not found."
 msgstr "没有找到您提供的位置。"
 
-#: 3.8/weather-applet.js:14488 3.8/weather-applet.js:14489
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
 msgid "Strong Storm"
 msgstr "强风暴"
 
-#: 3.8/weather-applet.js:14503 3.8/weather-applet.js:14504
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
 msgid "Rain and Snow"
 msgstr "雨夹雪"
 
-#: 3.8/weather-applet.js:14510 3.8/weather-applet.js:14511
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
 msgid "Rain and Sleet"
 msgstr "雨夹雪"
 
-#: 3.8/weather-applet.js:14559 3.8/weather-applet.js:14560
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
 msgid "Snow Showers"
 msgstr "阵雪"
 
-#: 3.8/weather-applet.js:14622 3.8/weather-applet.js:14623
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
 msgid "Breezy"
 msgstr "微风"
 
-#: 3.8/weather-applet.js:14636 3.8/weather-applet.js:14637
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
 msgid "Frigid"
 msgstr "寒冷"
 
-#: 3.8/weather-applet.js:14692 3.8/weather-applet.js:14693
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
 msgid "Mostly Clear"
 msgstr "少云"
 
-#: 3.8/weather-applet.js:14894
+#: 3.8/weather-applet.js:15247
 msgid "Pirate Weather"
 msgstr "Pirate Weather"
 
-#: 3.8/weather-applet.js:15472
+#: 3.8/weather-applet.js:15603
+#, fuzzy
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr "定位服务响应错误，请查看 Looking Glass 中的日志"
+
+#: 3.8/weather-applet.js:15831
+#, fuzzy
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr "确保您输入了一个位置或使用自动定位代替"
+
+#: 3.8/weather-applet.js:15968
 msgid ""
 "Could not retrieve config, file was not found under paths\n"
 " {configFilePath}"
@@ -1720,7 +1732,7 @@ msgstr ""
 "无法检索配置，在以下路径找不到文件\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:15477
+#: 3.8/weather-applet.js:15975
 msgid ""
 "Could not get contents of config file under path\n"
 " {configFilePath}"
@@ -1728,57 +1740,57 @@ msgstr ""
 "无法获取以下路径配置文件的内容\n"
 " {configFilePath}"
 
-#: 3.8/weather-applet.js:16089
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr "该数据源需要一个 API 密钥来操作"
+
+#: 3.8/weather-applet.js:16675
 msgid "Dew Point"
 msgstr "露点"
 
-#: 3.8/weather-applet.js:16161
+#: 3.8/weather-applet.js:16747
 msgid "Precipitation will end in {precipEnd} minutes"
 msgstr "降水将在 {precipEnd} 分钟内结束"
 
-#: 3.8/weather-applet.js:16163
+#: 3.8/weather-applet.js:16749
 msgid "Precipitation won't end in within an hour"
 msgstr "降水在一小时内不会结束"
 
-#: 3.8/weather-applet.js:16166
+#: 3.8/weather-applet.js:16752
 msgid "Precipitation will start within {precipStart} minutes"
 msgstr "降水将在 {precipStart} 分钟内开始"
 
-#: 3.8/weather-applet.js:16374
+#: 3.8/weather-applet.js:16964
 msgid "Forecast parsing failed, see logs for more details."
 msgstr "天气预测解析失败，详情请查看日志。"
 
-#: 3.8/weather-applet.js:16833 3.8/weather-applet.js:17619
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
 msgid "As of {lastUpdatedTime}"
 msgstr "更新于 {lastUpdatedTime}"
 
-#: 3.8/weather-applet.js:16839
+#: 3.8/weather-applet.js:17502
 msgid "{distance} {distanceUnit} from you"
 msgstr "距您 {distance} {distanceUnit}"
 
-#: 3.8/weather-applet.js:16843
+#: 3.8/weather-applet.js:17506
 msgid "Station Name: {stationName}"
 msgstr "气象站名称：{stationName}"
 
-#: 3.8/weather-applet.js:16846
+#: 3.8/weather-applet.js:17509
 msgid "Area: {stationArea}"
 msgstr "地区：{stationArea}"
 
-#: 3.8/weather-applet.js:17393 3.8/weather-applet.js:17403
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
 msgid "Error Saving Debug Information"
 msgstr "保存调试信息时出错"
 
-#: 3.8/weather-applet.js:17415
+#: 3.8/weather-applet.js:17865
 msgid "Debug Information saved successfully"
 msgstr "调试信息保存成功"
 
-#: 3.8/weather-applet.js:17415
+#: 3.8/weather-applet.js:17865
 msgid "Saved to {filePath}"
 msgstr "已保存到 {filePath}"
-
-#: 3.8/weather-applet.js:17544
-msgid "This provider requires an API key to operate"
-msgstr "该数据源需要一个 API 密钥来操作"
 
 #: 3.8/LogSaver.py:16
 msgid "Save to File"
@@ -2301,6 +2313,12 @@ msgstr ""
 "家}，搜索算法非常灵活。停止输入 3 秒后，您输入的地址将被自动替换，以验证您的"
 "选择。"
 
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
+
 #. 3.8->settings-schema.json->saveLocation->description
 msgid "Save current location to storage"
 msgstr "保存当前位置"
@@ -2534,56 +2552,3 @@ msgstr "它将包含小程序的日志和当前的设置，其中您的 API 密�
 #. 3.8->settings-schema.json->selectedLogPath->description
 msgid "Selected path to save Logs"
 msgstr "选择保存日志的路径"
-
-#~ msgid "DarkSky"
-#~ msgstr "DarkSky"
-
-#~ msgid "This API has ceased to function, please use another one."
-#~ msgstr "这个 API 已经停止运作，请使用其他 API。"
-
-#~ msgid "Settings"
-#~ msgstr "设置"
-
-#~ msgid "Sunrise"
-#~ msgstr "日出"
-
-#~ msgid "Sunset"
-#~ msgstr "日落"
-
-#~ msgid "Service Unavailable"
-#~ msgstr "服务不可用"
-
-#~ msgid "City Not found"
-#~ msgstr "城市不存在"
-
-#~ msgid "Wrong Location"
-#~ msgstr "位置错误"
-
-#~ msgid "Parsing weather information failed :("
-#~ msgstr "解析天气信息失败 :("
-
-#~ msgid "No/Bad response from Data Service"
-#~ msgstr "数据服务返回为空或者错误"
-
-#~ msgid "Settings for weather@mockturtl 1.8"
-#~ msgstr "设置weather@mockturtl 1.8"
-
-#~ msgid ""
-#~ "Acceptable inputs: City,CountryCode or Zipcode,CountryCode or Latitude,"
-#~ "Longtitude"
-#~ msgstr "合法输入：城市名, 国家代码；邮政编码, 国家代码；纬度, 经度"
-
-#~ msgid "Personal Settings"
-#~ msgstr "个性化设置"
-
-#~ msgid "Vertical orientation"
-#~ msgstr "纵向排列"
-
-#~ msgid "Translate condition"
-#~ msgstr "翻译天气状况"
-
-#~ msgid "Symbolic icons"
-#~ msgstr "使用气象符号"
-
-#~ msgid "Settings for weather@mockturtl 3.8"
-#~ msgstr "设置weather@mockturtl 3.8"

--- a/weather@mockturtl/files/weather@mockturtl/po/zh_TW.po
+++ b/weather@mockturtl/files/weather@mockturtl/po/zh_TW.po
@@ -7,8 +7,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: simon 04-gnome-shell-extension-weather-452bcfe\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-12 12:27-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
+"issues\n"
+"POT-Creation-Date: 2024-05-01 17:52+0100\n"
 "PO-Revision-Date: 2011-12-02 14:44+0800\n"
 "Last-Translator: Wenjie Huang\n"
 "Language-Team: Chinese (Traditional)\n"
@@ -17,432 +18,2571 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:249
+#: 3.0/applet.js:166 3.0/applet.js:426 3.0/applet.js:2131
+#: 3.8/weather-applet.js:17877
+msgid "Error"
+msgstr ""
+
+#: 3.0/applet.js:167 3.0/applet.js:169 3.0/applet.js:171 3.0/applet.js:174
+#: 3.0/applet.js:177 3.0/applet.js:178 3.0/applet.js:179 3.0/applet.js:180
+#: 3.8/weather-applet.js:17878 3.8/weather-applet.js:17880
+#: 3.8/weather-applet.js:17882 3.8/weather-applet.js:17885
+#: 3.8/weather-applet.js:17888 3.8/weather-applet.js:17889
+#: 3.8/weather-applet.js:17890 3.8/weather-applet.js:17891
+msgid "Service Error"
+msgstr ""
+
+#: 3.0/applet.js:168 3.8/weather-applet.js:17879
+msgid "Incorrect API Key"
+msgstr ""
+
+#: 3.0/applet.js:170 3.8/weather-applet.js:17881
+msgid "Incorrect Location Format"
+msgstr ""
+
+#: 3.0/applet.js:172 3.8/weather-applet.js:17883
+msgid "Key Blocked"
+msgstr ""
+
+#: 3.0/applet.js:173 3.8/weather-applet.js:17884
+msgid "Can't find location"
+msgstr ""
+
+#: 3.0/applet.js:175 3.8/weather-applet.js:17886
+msgid "No Api Key"
+msgstr ""
+
+#: 3.0/applet.js:176 3.8/weather-applet.js:17887
+msgid "No Location"
+msgstr ""
+
+#: 3.0/applet.js:181 3.8/weather-applet.js:17892
+msgid "Missing Packages"
+msgstr ""
+
+#: 3.0/applet.js:182 3.8/weather-applet.js:17893
+msgid "Location not covered"
+msgstr ""
+
+#: 3.0/applet.js:193 3.0/applet.js:378 3.8/weather-applet.js:9712
+msgid "Weather Applet"
+msgstr ""
+
+#: 3.0/applet.js:217 3.8/weather-applet.js:18106
 msgid "..."
 msgstr "..."
 
-#: applet.js:250
+#: 3.0/applet.js:218 3.8/weather-applet.js:18107
 msgid "Click to open"
 msgstr "開啟"
 
-#: applet.js:289
-msgid "Settings"
-msgstr ""
-
-#: applet.js:555
-msgid "Sunrise"
-msgstr "日出"
-
-#: applet.js:556
-msgid "Sunset"
-msgstr "日落"
-
-#: applet.js:648
-msgid "Loading current weather ..."
-msgstr "正在載入目前天氣 ..."
-
-#: applet.js:649
-msgid "Loading future weather ..."
-msgstr "正在載入天氣預報 ..."
-
-#: applet.js:671
-msgid "Loading ..."
-msgstr "正在載入 ..."
-
-#: applet.js:677
+#: 3.0/applet.js:232 3.0/applet.js:1244 3.8/weather-applet.js:16698
+#: 3.8/weather-applet.js:18110
 msgid "Refresh"
 msgstr ""
 
-#: applet.js:740
-msgid "Temperature:"
+#: 3.0/applet.js:272
+msgid "API returned status code between 400 and 500"
+msgstr ""
+
+#: 3.0/applet.js:426 3.0/applet.js:2032 3.0/applet.js:2036 3.0/applet.js:2040
+#: 3.0/applet.js:2049 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.0/applet.js:2083 3.0/applet.js:2131 3.8/weather-applet.js:9871
+#: 3.8/weather-applet.js:9875
+msgid "Location Store"
+msgstr ""
+
+#: 3.0/applet.js:426
+msgid "You can't save a location obtained automatically, sorry"
+msgstr ""
+
+#: 3.0/applet.js:601
+msgid "Could not get weather information"
+msgstr ""
+
+#: 3.0/applet.js:624 3.8/weather-applet.js:17973
+msgid ""
+"Unexpected Error While Refreshing Weather, please see log in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:670 3.8/weather-applet.js:18188
+msgid ""
+"Could not update weather for a while...\n"
+"are you connected to the internet?"
+msgstr ""
+
+#: 3.0/applet.js:684
+msgid "Network Error, please check logs in Looking Glass"
+msgstr ""
+
+#: 3.0/applet.js:969 3.0/applet.js:1110
+msgid "As of"
+msgstr ""
+
+#: 3.0/applet.js:1108 3.8/weather-applet.js:17489
+msgid "Powered by"
+msgstr ""
+
+#: 3.0/applet.js:1113
+msgid "from you"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.8/weather-applet.js:17402
+msgid "mm"
+msgstr ""
+
+#: 3.0/applet.js:1132 3.0/darkSky.js:71 3.8/weather-applet.js:17402
+msgid "in"
+msgstr ""
+
+#: 3.0/applet.js:1205 3.0/met_uk.js:421 3.8/weather-applet.js:10591
+#: 3.8/weather-applet.js:17567
+msgid "mi"
+msgstr ""
+
+#: 3.0/applet.js:1206 3.0/met_uk.js:422 3.8/weather-applet.js:10592
+#: 3.8/weather-applet.js:17568
+msgid "km"
+msgstr ""
+
+#: 3.0/applet.js:1227 3.8/weather-applet.js:17745
+msgid "Loading current weather ..."
+msgstr "正在載入目前天氣 ..."
+
+#: 3.0/applet.js:1230 3.8/weather-applet.js:17748
+msgid "Loading future weather ..."
+msgstr "正在載入天氣預報 ..."
+
+#: 3.0/applet.js:1280 3.8/weather-applet.js:16651
+msgid "Loading ..."
+msgstr "正在載入 ..."
+
+#: 3.0/applet.js:1329 3.8/weather-applet.js:16672
+#, fuzzy
+msgid "Temperature"
 msgstr "溫度："
 
-#: applet.js:742
-msgid "Humidity:"
+#: 3.0/applet.js:1330 3.8/weather-applet.js:16673
+#, fuzzy
+msgid "Humidity"
 msgstr "濕度："
 
-#: applet.js:744
-msgid "Pressure:"
+#: 3.0/applet.js:1331 3.8/weather-applet.js:16674
+#, fuzzy
+msgid "Pressure"
 msgstr "氣壓："
 
-#: applet.js:746
-msgid "Wind:"
+#: 3.0/applet.js:1332 3.8/weather-applet.js:12560 3.8/weather-applet.js:12567
+#: 3.8/weather-applet.js:12568 3.8/weather-applet.js:12574
+#: 3.8/weather-applet.js:14595 3.8/weather-applet.js:14596
+#: 3.8/weather-applet.js:16520
+#, fuzzy
+msgid "Wind"
 msgstr "風力："
 
-#: applet.js:748
-msgid "Wind Chill:"
-msgstr "風力："
+#: 3.0/applet.js:1639
+msgid "Make sure you entered a location or use Automatic location instead"
+msgstr ""
 
-#: applet.js:953
-msgid "Tornado"
-msgstr "龍捲風"
+#: 3.0/applet.js:1877 3.8/weather-applet.js:10221
+msgid "Could not find location based on address, please check if it's right"
+msgstr ""
 
-#: applet.js:955
-msgid "Tropical storm"
-msgstr "熱帶風暴"
+#: 3.0/applet.js:1901 3.8/weather-applet.js:10242
+msgid "Failed to call Geolocation API, see Looking Glass for errors."
+msgstr ""
 
-#: applet.js:957
-msgid "Hurricane"
-msgstr "颶風"
+#: 3.0/applet.js:2032 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "Warning"
+msgstr ""
 
-#: applet.js:959
-msgid "Severe thunderstorms"
-msgstr "強雷暴雨"
+#: 3.0/applet.js:2032
+msgid "You can only save correct locations when the applet is not refreshing"
+msgstr ""
 
-#: applet.js:961
-msgid "Thunderstorms"
-msgstr "雷雨"
+#: 3.0/applet.js:2036 3.8/weather-applet.js:9871
+msgid "You can't save an incorrect location"
+msgstr ""
 
-#: applet.js:963
-msgid "Mixed rain and snow"
-msgstr "雨雪交加"
+#. 3.8->settings-schema.json->logLevel->options
+#: 3.0/applet.js:2040 3.0/applet.js:2062 3.0/applet.js:2066 3.0/applet.js:2070
+#: 3.8/weather-applet.js:9875
+msgid "Info"
+msgstr ""
 
-#: applet.js:965
-msgid "Mixed rain and sleet"
-msgstr "雨霰交加"
+#: 3.0/applet.js:2040 3.8/weather-applet.js:9875
+msgid "Location is already saved"
+msgstr ""
 
-#: applet.js:967
-msgid "Mixed snow and sleet"
-msgstr "雪霰交加"
+#: 3.0/applet.js:2049 3.0/applet.js:2083
+msgid "Success"
+msgstr ""
 
-#: applet.js:969
-msgid "Freezing drizzle"
-msgstr "凍毛毛雨"
+#: 3.0/applet.js:2049
+msgid "Location is saved to library"
+msgstr ""
 
-#: applet.js:971
-msgid "Drizzle"
-msgstr "小雨"
+#: 3.0/applet.js:2062
+msgid "You can't remove a location while the applet is refreshing"
+msgstr ""
 
-#: applet.js:973
+#: 3.0/applet.js:2066
+msgid "You can't remove an incorrect location"
+msgstr ""
+
+#: 3.0/applet.js:2070
+msgid "Location is not in storage, can't delete"
+msgstr ""
+
+#: 3.0/applet.js:2083
+msgid "Location is deleted from library"
+msgstr ""
+
+#: 3.0/applet.js:2131
+msgid ""
+"Failed to load in data from location storage, please see the logs for more "
+"information"
+msgstr ""
+
+#: 3.0/climacell.js:163 3.0/darkSky.js:143 3.0/openWeatherMap.js:129
+#: 3.0/us_weather.js:322 3.0/weatherbit.js:202 3.0/yahoo.js:141
+#: 3.8/weather-applet.js:11025 3.8/weather-applet.js:12007
+#: 3.8/weather-applet.js:12461 3.8/weather-applet.js:12988
+#: 3.8/weather-applet.js:13356 3.8/weather-applet.js:14776
+#: 3.8/weather-applet.js:15325
+msgid "Feels Like"
+msgstr ""
+
+#: 3.0/climacell.js:174 3.0/darkSky.js:189 3.0/yahoo.js:166
+#: 3.8/weather-applet.js:15387
+msgid "Failed to Process Weather Info"
+msgstr ""
+
+#: 3.0/climacell.js:224
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://developer.climacell.co/sign-up"
+msgstr ""
+
+#: 3.0/climacell.js:239 3.0/darkSky.js:229 3.0/weatherbit.js:331
+#: 3.8/weather-applet.js:12181 3.8/weather-applet.js:15264
+msgid ""
+"Please Make sure you\n"
+"entered the API key correctly and your account is not locked"
+msgstr ""
+
+#: 3.0/climacell.js:248 3.8/weather-applet.js:12424
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from Climacell"
+msgstr ""
+
+#: 3.0/climacell.js:259 3.0/climacell.js:260 3.0/met_norway.js:308
+#: 3.0/met_norway.js:309 3.0/met_norway.js:315 3.0/met_norway.js:322
+#: 3.0/met_norway.js:329 3.0/met_uk.js:617 3.0/met_uk.js:624 3.0/met_uk.js:631
+#: 3.0/met_uk.js:632 3.8/weather-applet.js:10795 3.8/weather-applet.js:10802
+#: 3.8/weather-applet.js:10809 3.8/weather-applet.js:10810
+#: 3.8/weather-applet.js:11674 3.8/weather-applet.js:11675
+#: 3.8/weather-applet.js:11681 3.8/weather-applet.js:11688
+#: 3.8/weather-applet.js:11695 3.8/weather-applet.js:12603
+#: 3.8/weather-applet.js:13522
+#, fuzzy
+msgid "Heavy rain"
+msgstr "大雪"
+
+#: 3.0/climacell.js:266 3.0/climacell.js:267 3.0/met_norway.js:483
+#: 3.0/met_norway.js:484 3.0/met_norway.js:490 3.0/us_weather.js:484
+#: 3.0/us_weather.js:533 3.0/us_weather.js:534 3.0/us_weather.js:541
+#: 3.0/yahoo.js:448 3.8/weather-applet.js:11849 3.8/weather-applet.js:11850
+#: 3.8/weather-applet.js:11856 3.8/weather-applet.js:12588
+#: 3.8/weather-applet.js:12589 3.8/weather-applet.js:12595
+#: 3.8/weather-applet.js:12602 3.8/weather-applet.js:12644
+#: 3.8/weather-applet.js:12651 3.8/weather-applet.js:12658
+#: 3.8/weather-applet.js:13130 3.8/weather-applet.js:13179
+#: 3.8/weather-applet.js:13180 3.8/weather-applet.js:13187
+#: 3.8/weather-applet.js:13514 3.8/weather-applet.js:13792
+#: 3.8/weather-applet.js:13793 3.8/weather-applet.js:13834
+#: 3.8/weather-applet.js:14567 3.8/weather-applet.js:14568
+#: 3.8/weather-applet.js:14946 3.8/weather-applet.js:14947
+msgid "Rain"
+msgstr ""
+
+#: 3.0/climacell.js:273 3.0/climacell.js:274 3.0/met_norway.js:392
+#: 3.0/met_norway.js:393 3.0/met_norway.js:399 3.0/met_norway.js:406
+#: 3.0/met_norway.js:413 3.0/met_uk.js:589 3.0/met_uk.js:596 3.0/met_uk.js:610
+#: 3.0/met_uk.js:611 3.0/openWeatherMap.js:381 3.8/weather-applet.js:10767
+#: 3.8/weather-applet.js:10774 3.8/weather-applet.js:10788
+#: 3.8/weather-applet.js:10789 3.8/weather-applet.js:11294
+#: 3.8/weather-applet.js:11758 3.8/weather-applet.js:11759
+#: 3.8/weather-applet.js:11765 3.8/weather-applet.js:11772
+#: 3.8/weather-applet.js:11779 3.8/weather-applet.js:12596
+#: 3.8/weather-applet.js:13524
+#, fuzzy
+msgid "Light rain"
+msgstr "凍雨"
+
+#: 3.0/climacell.js:280 3.8/weather-applet.js:12659 3.8/weather-applet.js:13498
+#, fuzzy
+msgid "Heavy freezing rain"
+msgstr "凍雨"
+
+#: 3.0/climacell.js:281 3.0/climacell.js:287 3.0/climacell.js:288
+#: 3.0/climacell.js:295 3.0/openWeatherMap.js:386 3.0/us_weather.js:505
+#: 3.0/us_weather.js:506 3.0/us_weather.js:512 3.0/us_weather.js:513
+#: 3.0/us_weather.js:519 3.8/weather-applet.js:11299
+#: 3.8/weather-applet.js:12645 3.8/weather-applet.js:13151
+#: 3.8/weather-applet.js:13152 3.8/weather-applet.js:13158
+#: 3.8/weather-applet.js:13159 3.8/weather-applet.js:13165
 msgid "Freezing rain"
 msgstr "凍雨"
 
-#: applet.js:975 applet.js:977
-msgid "Showers"
-msgstr "陣雨"
+#: 3.0/climacell.js:294 3.8/weather-applet.js:12652 3.8/weather-applet.js:13500
+#, fuzzy
+msgid "Light freezing rain"
+msgstr "凍雨"
 
-#: applet.js:979
-msgid "Snow flurries"
-msgstr "飄雪"
+#: 3.0/climacell.js:301
+#, fuzzy
+msgid "Light freezing drizzle"
+msgstr "凍毛毛雨"
 
-#: applet.js:981
-msgid "Light snow showers"
-msgstr "小雪"
+#: 3.0/climacell.js:302 3.8/weather-applet.js:12638
+msgid "Freezing drizzle"
+msgstr "凍毛毛雨"
 
-#: applet.js:983
-msgid "Blowing snow"
-msgstr "暴雪"
+#: 3.0/climacell.js:308 3.0/climacell.js:309 3.8/weather-applet.js:13480
+#, fuzzy
+msgid "Light drizzle"
+msgstr "凍毛毛雨"
 
-#: applet.js:985
-msgid "Snow"
-msgstr "雪"
+#: 3.0/climacell.js:315 3.8/weather-applet.js:12673
+msgid "Heavy ice pellets"
+msgstr ""
 
-#: applet.js:987
-msgid "Hail"
-msgstr "冰雹"
+#: 3.0/climacell.js:316 3.0/climacell.js:322 3.0/climacell.js:323
+#: 3.0/climacell.js:330 3.8/weather-applet.js:12665 3.8/weather-applet.js:12666
+#: 3.8/weather-applet.js:12672 3.8/weather-applet.js:12679
+msgid "Ice pellets"
+msgstr ""
 
-#: applet.js:989
-msgid "Sleet"
-msgstr "霰"
+#: 3.0/climacell.js:329 3.8/weather-applet.js:12680
+msgid "Light ice pellets"
+msgstr ""
 
-#: applet.js:991
-msgid "Dust"
-msgstr "灰塵"
-
-#: applet.js:993
-msgid "Foggy"
-msgstr "霧"
-
-#: applet.js:995
-msgid "Haze"
-msgstr "陰霾"
-
-#: applet.js:997
-msgid "Smoky"
-msgstr "煙霧"
-
-#: applet.js:999
-msgid "Blustery"
-msgstr "大風"
-
-#: applet.js:1001
-msgid "Windy"
-msgstr "有風"
-
-#: applet.js:1003
-msgid "Cold"
-msgstr "冷"
-
-#: applet.js:1005
-msgid "Cloudy"
-msgstr "有雲"
-
-#: applet.js:1008
-msgid "Mostly cloudy"
-msgstr "多雲"
-
-#: applet.js:1011 applet.js:1037
-msgid "Partly cloudy"
-msgstr "晴時多雲"
-
-#: applet.js:1013
-msgid "Clear"
-msgstr "明朗"
-
-#: applet.js:1015
-msgid "Sunny"
-msgstr "晴"
-
-#: applet.js:1018
-msgid "Fair"
-msgstr "晴"
-
-#: applet.js:1020
-msgid "Mixed rain and hail"
-msgstr "冰雹"
-
-#: applet.js:1022
-msgid "Hot"
-msgstr "炎熱"
-
-#: applet.js:1024
-msgid "Isolated thunderstorms"
-msgstr "局部地區有雷暴"
-
-#: applet.js:1027
-msgid "Scattered thunderstorms"
-msgstr "零星雷暴"
-
-#: applet.js:1029
-msgid "Scattered showers"
-msgstr "零星陣雨"
-
-#: applet.js:1031 applet.js:1035
+#: 3.0/climacell.js:336 3.0/climacell.js:337 3.0/met_norway.js:364
+#: 3.0/met_norway.js:365 3.0/met_norway.js:371 3.0/met_norway.js:378
+#: 3.0/met_norway.js:385 3.0/met_uk.js:701 3.0/met_uk.js:708 3.0/met_uk.js:715
+#: 3.0/met_uk.js:716 3.0/openWeatherMap.js:393 3.8/weather-applet.js:10879
+#: 3.8/weather-applet.js:10886 3.8/weather-applet.js:10893
+#: 3.8/weather-applet.js:10894 3.8/weather-applet.js:11306
+#: 3.8/weather-applet.js:11730 3.8/weather-applet.js:11731
+#: 3.8/weather-applet.js:11737 3.8/weather-applet.js:11744
+#: 3.8/weather-applet.js:11751 3.8/weather-applet.js:12631
+#: 3.8/weather-applet.js:13540 3.8/weather-applet.js:13869
 msgid "Heavy snow"
 msgstr "大雪"
 
-#: applet.js:1033
-msgid "Scattered snow showers"
-msgstr "零星陣雪"
+#: 3.0/climacell.js:343 3.0/climacell.js:344 3.0/met_norway.js:539
+#: 3.0/met_norway.js:540 3.0/met_norway.js:546 3.0/openWeatherMap.js:392
+#: 3.0/us_weather.js:477 3.0/us_weather.js:478 3.0/yahoo.js:452
+#: 3.8/weather-applet.js:11305 3.8/weather-applet.js:11905
+#: 3.8/weather-applet.js:11906 3.8/weather-applet.js:11912
+#: 3.8/weather-applet.js:12609 3.8/weather-applet.js:12610
+#: 3.8/weather-applet.js:12623 3.8/weather-applet.js:12630
+#: 3.8/weather-applet.js:13123 3.8/weather-applet.js:13124
+#: 3.8/weather-applet.js:13534 3.8/weather-applet.js:13778
+#: 3.8/weather-applet.js:13862 3.8/weather-applet.js:14581
+#: 3.8/weather-applet.js:14582 3.8/weather-applet.js:14974
+#: 3.8/weather-applet.js:14975
+msgid "Snow"
+msgstr "雪"
 
-#: applet.js:1039
-msgid "Thundershowers"
-msgstr "雷陣雨"
+#: 3.0/climacell.js:350 3.0/climacell.js:351 3.0/met_norway.js:448
+#: 3.0/met_norway.js:449 3.0/met_norway.js:455 3.0/met_norway.js:462
+#: 3.0/met_norway.js:469 3.0/met_uk.js:680 3.0/met_uk.js:687 3.0/met_uk.js:694
+#: 3.0/met_uk.js:695 3.0/openWeatherMap.js:391 3.8/weather-applet.js:10858
+#: 3.8/weather-applet.js:10865 3.8/weather-applet.js:10872
+#: 3.8/weather-applet.js:10873 3.8/weather-applet.js:11304
+#: 3.8/weather-applet.js:11814 3.8/weather-applet.js:11815
+#: 3.8/weather-applet.js:11821 3.8/weather-applet.js:11828
+#: 3.8/weather-applet.js:11835 3.8/weather-applet.js:12624
+#: 3.8/weather-applet.js:13542
+#, fuzzy
+msgid "Light snow"
+msgstr "小雪"
 
-#: applet.js:1041
+#: 3.0/climacell.js:357 3.0/climacell.js:358 3.8/weather-applet.js:12616
+#: 3.8/weather-applet.js:12617 3.8/weather-applet.js:14953
+#: 3.8/weather-applet.js:14954
+#, fuzzy
+msgid "Flurries"
+msgstr "飄雪"
+
+#: 3.0/climacell.js:364 3.0/climacell.js:365 3.0/openWeatherMap.js:366
+#: 3.0/us_weather.js:550 3.0/us_weather.js:551 3.8/weather-applet.js:11279
+#: 3.8/weather-applet.js:12686 3.8/weather-applet.js:12687
+#: 3.8/weather-applet.js:13196 3.8/weather-applet.js:13197
+#: 3.8/weather-applet.js:13546 3.8/weather-applet.js:13876
+#: 3.8/weather-applet.js:13877 3.8/weather-applet.js:14588
+#: 3.8/weather-applet.js:14589
+#, fuzzy
+msgid "Thunderstorm"
+msgstr "雷雨"
+
+#: 3.0/climacell.js:371 3.0/climacell.js:372 3.8/weather-applet.js:12554
+msgid "Light fog"
+msgstr ""
+
+#: 3.0/climacell.js:378 3.0/climacell.js:379 3.0/met_norway.js:301
+#: 3.0/met_norway.js:302 3.0/met_uk.js:568 3.0/met_uk.js:569
+#: 3.0/openWeatherMap.js:405 3.0/us_weather.js:620 3.0/us_weather.js:621
+#: 3.8/weather-applet.js:10746 3.8/weather-applet.js:10747
+#: 3.8/weather-applet.js:11318 3.8/weather-applet.js:11667
+#: 3.8/weather-applet.js:11668 3.8/weather-applet.js:12546
+#: 3.8/weather-applet.js:12547 3.8/weather-applet.js:12553
+#: 3.8/weather-applet.js:13266 3.8/weather-applet.js:13267
+#: 3.8/weather-applet.js:13488 3.8/weather-applet.js:14539
+#: 3.8/weather-applet.js:14540 3.8/weather-applet.js:15002
+#: 3.8/weather-applet.js:15003
+#, fuzzy
+msgid "Fog"
+msgstr "霧"
+
+#: 3.0/climacell.js:385 3.0/climacell.js:386 3.0/met_norway.js:287
+#: 3.0/met_norway.js:288 3.0/met_uk.js:575 3.0/met_uk.js:576 3.0/yahoo.js:462
+#: 3.8/weather-applet.js:10753 3.8/weather-applet.js:10754
+#: 3.8/weather-applet.js:11653 3.8/weather-applet.js:11654
+#: 3.8/weather-applet.js:12518 3.8/weather-applet.js:12519
+#: 3.8/weather-applet.js:13771 3.8/weather-applet.js:13772
+#: 3.8/weather-applet.js:14532 3.8/weather-applet.js:14533
+#: 3.8/weather-applet.js:15044 3.8/weather-applet.js:15045
+msgid "Cloudy"
+msgstr "有雲"
+
+#: 3.0/climacell.js:392 3.0/climacell.js:393 3.0/us_weather.js:428
+#: 3.0/us_weather.js:429 3.0/us_weather.js:463 3.8/weather-applet.js:12539
+#: 3.8/weather-applet.js:12540 3.8/weather-applet.js:13074
+#: 3.8/weather-applet.js:13075 3.8/weather-applet.js:13109
+msgid "Mostly cloudy"
+msgstr "多雲"
+
+#: 3.0/climacell.js:399 3.0/climacell.js:400 3.0/met_norway.js:476
+#: 3.0/met_norway.js:477 3.0/met_uk.js:540 3.0/met_uk.js:541 3.0/met_uk.js:547
+#: 3.0/met_uk.js:548 3.0/us_weather.js:421 3.0/us_weather.js:422
+#: 3.0/us_weather.js:456 3.8/weather-applet.js:10718
+#: 3.8/weather-applet.js:10719 3.8/weather-applet.js:10725
+#: 3.8/weather-applet.js:10726 3.8/weather-applet.js:11842
+#: 3.8/weather-applet.js:11843 3.8/weather-applet.js:12532
+#: 3.8/weather-applet.js:12533 3.8/weather-applet.js:13067
+#: 3.8/weather-applet.js:13068 3.8/weather-applet.js:13102
+#: 3.8/weather-applet.js:13764 3.8/weather-applet.js:13765
+msgid "Partly cloudy"
+msgstr "晴時多雲"
+
+#: 3.0/climacell.js:406 3.0/climacell.js:407 3.8/weather-applet.js:12525
+#: 3.8/weather-applet.js:12526
+#, fuzzy
+msgid "Mostly clear"
+msgstr "多雲"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:526
+#: 3.0/met_uk.js:527 3.0/openWeatherMap.js:411 3.0/us_weather.js:407
+#: 3.0/us_weather.js:408 3.0/us_weather.js:442 3.0/yahoo.js:465
+#: 3.8/weather-applet.js:10704 3.8/weather-applet.js:10705
+#: 3.8/weather-applet.js:11324 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:13053
+#: 3.8/weather-applet.js:13054 3.8/weather-applet.js:13088
+#: 3.8/weather-applet.js:13558 3.8/weather-applet.js:13757
+#: 3.8/weather-applet.js:13758 3.8/weather-applet.js:14518
+#: 3.8/weather-applet.js:14519 3.8/weather-applet.js:14525
+#: 3.8/weather-applet.js:14526 3.8/weather-applet.js:15079
+#: 3.8/weather-applet.js:15080
+msgid "Clear"
+msgstr "明朗"
+
+#: 3.0/climacell.js:413 3.0/climacell.js:414 3.0/met_uk.js:533
+#: 3.0/met_uk.js:534 3.0/yahoo.js:466 3.8/weather-applet.js:10711
+#: 3.8/weather-applet.js:10712 3.8/weather-applet.js:12511
+#: 3.8/weather-applet.js:12512 3.8/weather-applet.js:15086
+#: 3.8/weather-applet.js:15087
+msgid "Sunny"
+msgstr "晴"
+
+#: 3.0/climacell.js:421 3.0/climacell.js:422 3.0/met_norway.js:568
+#: 3.0/met_norway.js:569 3.0/met_uk.js:519 3.0/met_uk.js:520 3.0/met_uk.js:554
+#: 3.0/met_uk.js:555 3.0/met_uk.js:743 3.0/met_uk.js:744 3.0/us_weather.js:627
+#: 3.0/us_weather.js:628 3.8/weather-applet.js:10697
+#: 3.8/weather-applet.js:10698 3.8/weather-applet.js:10732
+#: 3.8/weather-applet.js:10733 3.8/weather-applet.js:10921
+#: 3.8/weather-applet.js:10922 3.8/weather-applet.js:11636
+#: 3.8/weather-applet.js:11637 3.8/weather-applet.js:11934
+#: 3.8/weather-applet.js:11935 3.8/weather-applet.js:12503
+#: 3.8/weather-applet.js:12504 3.8/weather-applet.js:13044
+#: 3.8/weather-applet.js:13045 3.8/weather-applet.js:13273
+#: 3.8/weather-applet.js:13274 3.8/weather-applet.js:14451
+#: 3.8/weather-applet.js:14452 3.8/weather-applet.js:14602
+#: 3.8/weather-applet.js:14603 3.8/weather-applet.js:15190
+#: 3.8/weather-applet.js:15192
+msgid "Unknown"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "and"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "until"
+msgstr ""
+
+#: 3.0/darkSky.js:71
+msgid "Possible"
+msgstr ""
+
+#: 3.0/darkSky.js:211
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://darksky.net/dev/register"
+msgstr ""
+
+#: 3.0/darkSky.js:238 3.8/weather-applet.js:15274
+msgid ""
+"Please Make sure you\n"
+"entered the API key that you have from DarkSky"
+msgstr ""
+
+#: 3.0/ipApi.js:89 3.8/weather-applet.js:15594
+msgid "Could not obtain location"
+msgstr ""
+
+#: 3.0/ipApi.js:95
+msgid ""
+"Location Service responded with errors, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/met_norway.js:131 3.8/weather-applet.js:11498
+#, fuzzy
+msgid "Cloudiness"
+msgstr "有雲"
+
+#: 3.0/met_norway.js:280 3.0/met_norway.js:281 3.0/openWeatherMap.js:412
+#: 3.8/weather-applet.js:11325 3.8/weather-applet.js:11646
+#: 3.8/weather-applet.js:11647
+#, fuzzy
+msgid "Clear sky"
+msgstr "明朗"
+
+#: 3.0/met_norway.js:294 3.0/met_norway.js:295 3.0/yahoo.js:468
+#: 3.8/weather-applet.js:11660 3.8/weather-applet.js:11661
+msgid "Fair"
+msgstr "晴"
+
+#: 3.0/met_norway.js:316 3.8/weather-applet.js:11682
+msgid "Heavy rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:323 3.8/weather-applet.js:11689
+#, fuzzy
+msgid "Heavy rain showers"
+msgstr "大雪"
+
+#: 3.0/met_norway.js:330 3.8/weather-applet.js:11696
+msgid "Heavy rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:336 3.0/met_norway.js:337 3.0/met_norway.js:343
+#: 3.0/met_norway.js:350 3.0/met_norway.js:357 3.8/weather-applet.js:11702
+#: 3.8/weather-applet.js:11703 3.8/weather-applet.js:11709
+#: 3.8/weather-applet.js:11716 3.8/weather-applet.js:11723
+#, fuzzy
+msgid "Heavy sleet"
+msgstr "大雪"
+
+#: 3.0/met_norway.js:344 3.8/weather-applet.js:11710
+msgid "Heavy sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:351 3.8/weather-applet.js:11717
+#, fuzzy
+msgid "Heavy sleet showers"
+msgstr "大雪"
+
+#: 3.0/met_norway.js:358 3.8/weather-applet.js:11724
+msgid "Heavy sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:372 3.8/weather-applet.js:11738
+#, fuzzy
+msgid "Heavy snow and thunder"
+msgstr "大雪"
+
+#: 3.0/met_norway.js:379 3.8/weather-applet.js:11745
+#: 3.8/weather-applet.js:13870
+#, fuzzy
+msgid "Heavy snow showers"
+msgstr "陣雪"
+
+#: 3.0/met_norway.js:386 3.8/weather-applet.js:11752
+msgid "Heavy snow showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:400 3.8/weather-applet.js:11766
+msgid "Light rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:407 3.8/weather-applet.js:11773
+#, fuzzy
+msgid "Light rain showers"
+msgstr "小雪"
+
+#: 3.0/met_norway.js:414 3.8/weather-applet.js:11780
+#, fuzzy
+msgid "Light rain showers and thunder"
+msgstr "小雪"
+
+#: 3.0/met_norway.js:420 3.0/met_norway.js:421 3.0/met_norway.js:427
+#: 3.0/met_norway.js:434 3.0/met_norway.js:441 3.8/weather-applet.js:11786
+#: 3.8/weather-applet.js:11787 3.8/weather-applet.js:11793
+#: 3.8/weather-applet.js:11800 3.8/weather-applet.js:11807
+msgid "Light sleet"
+msgstr ""
+
+#: 3.0/met_norway.js:428 3.8/weather-applet.js:11794
+msgid "Light sleet and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:435 3.8/weather-applet.js:11801
+#, fuzzy
+msgid "Light sleet showers"
+msgstr "小雪"
+
+#: 3.0/met_norway.js:442 3.8/weather-applet.js:11808
+#, fuzzy
+msgid "Light sleet showers and thunder"
+msgstr "小雪"
+
+#: 3.0/met_norway.js:456 3.8/weather-applet.js:11822
+#, fuzzy
+msgid "Light snow and thunder"
+msgstr "小雪"
+
+#: 3.0/met_norway.js:463 3.8/weather-applet.js:11829
+msgid "Light snow showers"
+msgstr "小雪"
+
+#: 3.0/met_norway.js:470 3.8/weather-applet.js:11836
+#, fuzzy
+msgid "Light snow showers and thunder"
+msgstr "小雪"
+
+#: 3.0/met_norway.js:491 3.8/weather-applet.js:11857
+msgid "Rain and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:497 3.0/met_norway.js:498 3.0/met_norway.js:504
+#: 3.0/us_weather.js:542 3.8/weather-applet.js:11863
+#: 3.8/weather-applet.js:11864 3.8/weather-applet.js:11870
+#: 3.8/weather-applet.js:13188 3.8/weather-applet.js:13520
+#: 3.8/weather-applet.js:13835 3.8/weather-applet.js:13841
+#, fuzzy
+msgid "Rain showers"
+msgstr "陣雪"
+
+#: 3.0/met_norway.js:505 3.8/weather-applet.js:11871
+msgid "Rain showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:511 3.0/met_norway.js:512 3.0/met_norway.js:518
+#: 3.0/met_norway.js:525 3.0/met_norway.js:532 3.0/met_uk.js:638
+#: 3.0/met_uk.js:645 3.0/met_uk.js:652 3.0/met_uk.js:653
+#: 3.0/openWeatherMap.js:394 3.0/us_weather.js:491 3.0/us_weather.js:492
+#: 3.0/us_weather.js:498 3.0/us_weather.js:499 3.0/us_weather.js:526
+#: 3.0/us_weather.js:527 3.0/yahoo.js:454 3.8/weather-applet.js:10816
+#: 3.8/weather-applet.js:10823 3.8/weather-applet.js:10830
+#: 3.8/weather-applet.js:10831 3.8/weather-applet.js:11307
+#: 3.8/weather-applet.js:11877 3.8/weather-applet.js:11878
+#: 3.8/weather-applet.js:11884 3.8/weather-applet.js:11891
+#: 3.8/weather-applet.js:11898 3.8/weather-applet.js:13137
+#: 3.8/weather-applet.js:13138 3.8/weather-applet.js:13144
+#: 3.8/weather-applet.js:13145 3.8/weather-applet.js:13172
+#: 3.8/weather-applet.js:13173 3.8/weather-applet.js:14574
+#: 3.8/weather-applet.js:14575 3.8/weather-applet.js:14988
+#: 3.8/weather-applet.js:14989
+msgid "Sleet"
+msgstr "霰"
+
+#: 3.0/met_norway.js:519 3.8/weather-applet.js:11885
+#, fuzzy
+msgid "Sleet and thunder"
+msgstr "零星雷暴"
+
+#: 3.0/met_norway.js:526 3.8/weather-applet.js:11892
+#, fuzzy
+msgid "Sleet showers"
+msgstr "零星陣雨"
+
+#: 3.0/met_norway.js:533 3.8/weather-applet.js:11899
+msgid "Sleet showers and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:547 3.8/weather-applet.js:11913
+msgid "Snow and thunder"
+msgstr ""
+
+#: 3.0/met_norway.js:553 3.0/met_norway.js:554 3.0/met_norway.js:560
+#: 3.8/weather-applet.js:11919 3.8/weather-applet.js:11920
+#: 3.8/weather-applet.js:11926 3.8/weather-applet.js:13538
+#: 3.8/weather-applet.js:13863
 msgid "Snow showers"
 msgstr "陣雪"
 
-#: applet.js:1043
-msgid "Isolated thundershowers"
-msgstr "局部地區有雷陣雨"
+#: 3.0/met_norway.js:561 3.8/weather-applet.js:11927
+#, fuzzy
+msgid "Snow showers and thunder"
+msgstr "陣雪"
 
-#: applet.js:1046
-msgid "Not available"
-msgstr "不可用"
+#: 3.0/met_uk.js:162 3.0/met_uk.js:192 3.0/met_uk.js:239 3.0/us_weather.js:151
+#: 3.0/us_weather.js:179
+msgid "Unexpected response from API"
+msgstr ""
 
-#: applet.js:1051
-msgid "Monday"
-msgstr "星期一"
+#: 3.0/met_uk.js:316 3.8/weather-applet.js:10516
+msgid "Visibility"
+msgstr ""
 
-#: applet.js:1051
-msgid "Tuesday"
-msgstr "星期二"
+#: 3.0/met_uk.js:340 3.0/openWeatherMap.js:190 3.0/us_weather.js:334
+#: 3.0/weatherbit.js:212 3.8/weather-applet.js:10544
+#: 3.8/weather-applet.js:11102 3.8/weather-applet.js:12018
+#: 3.8/weather-applet.js:13001
+msgid "Failed to Process Current Weather Info"
+msgstr ""
 
-#: applet.js:1051
-msgid "Wednesday"
-msgstr "星期三"
+#: 3.0/met_uk.js:364 3.0/met_uk.js:400 3.0/us_weather.js:371
+#: 3.0/weatherbit.js:239 3.0/weatherbit.js:274 3.8/weather-applet.js:10325
+#: 3.8/weather-applet.js:10359 3.8/weather-applet.js:12044
+#: 3.8/weather-applet.js:12078 3.8/weather-applet.js:12786
+msgid "Failed to Process Forecast Info"
+msgstr ""
 
-#: applet.js:1051
-msgid "Thursday"
-msgstr "星期四"
+#: 3.0/met_uk.js:408
+msgid "Very poor - Less than"
+msgstr ""
 
-#: applet.js:1051
-msgid "Friday"
-msgstr "星期五"
+#: 3.0/met_uk.js:410
+msgid "Poor - Between"
+msgstr ""
 
-#: applet.js:1051
-msgid "Saturday"
-msgstr "星期六"
+#: 3.0/met_uk.js:412
+msgid "Moderate - Between"
+msgstr ""
 
-#: applet.js:1051
+#: 3.0/met_uk.js:414
+msgid "Good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:416
+msgid "Very good - Between"
+msgstr ""
+
+#: 3.0/met_uk.js:417
+msgid "Excellent - More than"
+msgstr ""
+
+#: 3.0/met_uk.js:561 3.0/met_uk.js:562 3.0/openWeatherMap.js:401
+#: 3.8/weather-applet.js:10739 3.8/weather-applet.js:10740
+#: 3.8/weather-applet.js:11314 3.8/weather-applet.js:13510
+msgid "Mist"
+msgstr ""
+
+#: 3.0/met_uk.js:582 3.0/met_uk.js:583 3.0/us_weather.js:435
+#: 3.0/us_weather.js:436 3.0/us_weather.js:470 3.8/weather-applet.js:10760
+#: 3.8/weather-applet.js:10761 3.8/weather-applet.js:13081
+#: 3.8/weather-applet.js:13082 3.8/weather-applet.js:13116
+#: 3.8/weather-applet.js:13554
+msgid "Overcast"
+msgstr ""
+
+#: 3.0/met_uk.js:590 3.0/met_uk.js:597 3.8/weather-applet.js:10768
+#: 3.8/weather-applet.js:10775
+#, fuzzy
+msgid "Light rain shower"
+msgstr "小雪"
+
+#: 3.0/met_uk.js:603 3.0/met_uk.js:604 3.0/openWeatherMap.js:373
+#: 3.0/yahoo.js:445 3.8/weather-applet.js:10781 3.8/weather-applet.js:10782
+#: 3.8/weather-applet.js:11286 3.8/weather-applet.js:12581
+#: 3.8/weather-applet.js:12582 3.8/weather-applet.js:12637
+#: 3.8/weather-applet.js:13476 3.8/weather-applet.js:14925
+#: 3.8/weather-applet.js:14926
+msgid "Drizzle"
+msgstr "小雨"
+
+#: 3.0/met_uk.js:618 3.0/met_uk.js:625 3.8/weather-applet.js:10796
+#: 3.8/weather-applet.js:10803
+#, fuzzy
+msgid "Heavy rain shower"
+msgstr "大雪"
+
+#: 3.0/met_uk.js:639 3.0/met_uk.js:646 3.8/weather-applet.js:10817
+#: 3.8/weather-applet.js:10824
+#, fuzzy
+msgid "Sleet shower"
+msgstr "零星陣雨"
+
+#: 3.0/met_uk.js:659 3.0/met_uk.js:666 3.0/met_uk.js:673 3.0/met_uk.js:674
+#: 3.0/yahoo.js:453 3.8/weather-applet.js:10837 3.8/weather-applet.js:10844
+#: 3.8/weather-applet.js:10851 3.8/weather-applet.js:10852
+#: 3.8/weather-applet.js:13552 3.8/weather-applet.js:14546
+#: 3.8/weather-applet.js:14547 3.8/weather-applet.js:14981
+#: 3.8/weather-applet.js:14982
+msgid "Hail"
+msgstr "冰雹"
+
+#: 3.0/met_uk.js:660 3.0/met_uk.js:667 3.8/weather-applet.js:10838
+#: 3.8/weather-applet.js:10845
+#, fuzzy
+msgid "Hail shower"
+msgstr "陣雪"
+
+#: 3.0/met_uk.js:681 3.0/met_uk.js:688 3.8/weather-applet.js:10859
+#: 3.8/weather-applet.js:10866
+#, fuzzy
+msgid "Light snow shower"
+msgstr "小雪"
+
+#: 3.0/met_uk.js:702 3.0/met_uk.js:709 3.8/weather-applet.js:10880
+#: 3.8/weather-applet.js:10887
+#, fuzzy
+msgid "Heavy snow shower"
+msgstr "大雪"
+
+#: 3.0/met_uk.js:722 3.0/met_uk.js:729 3.0/met_uk.js:736 3.0/met_uk.js:737
+#: 3.8/weather-applet.js:10900 3.8/weather-applet.js:10907
+#: 3.8/weather-applet.js:10914 3.8/weather-applet.js:10915
+#, fuzzy
+msgid "Thunder"
+msgstr "雷雨"
+
+#: 3.0/met_uk.js:723 3.0/met_uk.js:730 3.8/weather-applet.js:10901
+#: 3.8/weather-applet.js:10908
+#, fuzzy
+msgid "Thunder shower"
+msgstr "雷陣雨"
+
+#: 3.0/openWeatherMap.js:238 3.8/weather-applet.js:11157
+msgid "Please make sure Location is in the correct format in the Settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:242 3.8/weather-applet.js:11161
+msgid "Make sure you entered the correct key in settings"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:246 3.0/openWeatherMap.js:266
+#: 3.8/weather-applet.js:10961 3.8/weather-applet.js:11165
+msgid ""
+"Location not found, make sure location is available or it is in the correct "
+"format"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:250 3.8/weather-applet.js:11169
+msgid "If this problem persists, please contact the Author of this applet"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:254 3.8/weather-applet.js:11173
+msgid "Unknown Error, please see the logs in Looking Glass"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:362 3.8/weather-applet.js:11275
+msgid "Thunderstorm with light rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:363 3.8/weather-applet.js:11276
+#, fuzzy
+msgid "Thunderstorm with rain"
+msgstr "雷雨"
+
+#: 3.0/openWeatherMap.js:364 3.8/weather-applet.js:11277
+msgid "Thunderstorm with heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:365 3.8/weather-applet.js:11278
+#, fuzzy
+msgid "Light thunderstorm"
+msgstr "雷雨"
+
+#: 3.0/openWeatherMap.js:367 3.8/weather-applet.js:11280
+#, fuzzy
+msgid "Heavy thunderstorm"
+msgstr "強雷暴雨"
+
+#: 3.0/openWeatherMap.js:368 3.8/weather-applet.js:11281
+#, fuzzy
+msgid "Ragged thunderstorm"
+msgstr "局部地區有雷暴"
+
+#: 3.0/openWeatherMap.js:369 3.8/weather-applet.js:11282
+msgid "Thunderstorm with light drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:370 3.8/weather-applet.js:11283
+#, fuzzy
+msgid "Thunderstorm with drizzle"
+msgstr "雷雨"
+
+#: 3.0/openWeatherMap.js:371 3.8/weather-applet.js:11284
+msgid "Thunderstorm with heavy drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:372 3.8/weather-applet.js:11285
+msgid "Light intensity drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:374 3.8/weather-applet.js:11287
+msgid "Heavy intensity drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:375 3.8/weather-applet.js:11288
+msgid "Light intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:376 3.8/weather-applet.js:11289
+#, fuzzy
+msgid "Drizzle rain"
+msgstr "小雨"
+
+#: 3.0/openWeatherMap.js:377 3.8/weather-applet.js:11290
+msgid "Heavy intensity drizzle rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:378 3.8/weather-applet.js:11291
+#, fuzzy
+msgid "Shower rain and drizzle"
+msgstr "冰雹"
+
+#: 3.0/openWeatherMap.js:379 3.8/weather-applet.js:11292
+msgid "Heavy shower rain and drizzle"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:380 3.8/weather-applet.js:11293
+#, fuzzy
+msgid "Shower drizzle"
+msgstr "凍毛毛雨"
+
+#: 3.0/openWeatherMap.js:382 3.8/weather-applet.js:11295
+#: 3.8/weather-applet.js:13799 3.8/weather-applet.js:13800
+msgid "Moderate rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:383 3.8/weather-applet.js:11296
+msgid "Heavy intensity rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:384 3.8/weather-applet.js:11297
+msgid "Very heavy rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:385 3.8/weather-applet.js:11298
+#, fuzzy
+msgid "Extreme rain"
+msgstr "凍雨"
+
+#: 3.0/openWeatherMap.js:387 3.8/weather-applet.js:11300
+#, fuzzy
+msgid "Light intensity shower rain"
+msgstr "小雪"
+
+#: 3.0/openWeatherMap.js:388 3.8/weather-applet.js:11301
+#, fuzzy
+msgid "Shower rain"
+msgstr "陣雨"
+
+#: 3.0/openWeatherMap.js:389 3.8/weather-applet.js:11302
+msgid "Heavy intensity shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:390 3.8/weather-applet.js:11303
+msgid "Ragged shower rain"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:395 3.8/weather-applet.js:11308
+#, fuzzy
+msgid "Shower sleet"
+msgstr "陣雨"
+
+#: 3.0/openWeatherMap.js:396 3.8/weather-applet.js:11309
+#, fuzzy
+msgid "Light rain and snow"
+msgstr "雨雪交加"
+
+#: 3.0/openWeatherMap.js:397 3.8/weather-applet.js:11310
+#: 3.8/weather-applet.js:13806 3.8/weather-applet.js:13807
+#: 3.8/weather-applet.js:13813 3.8/weather-applet.js:13848
+#: 3.8/weather-applet.js:13855
+#, fuzzy
+msgid "Rain and snow"
+msgstr "雨雪交加"
+
+#: 3.0/openWeatherMap.js:398 3.8/weather-applet.js:11311
+#, fuzzy
+msgid "Light shower snow"
+msgstr "小雪"
+
+#: 3.0/openWeatherMap.js:399 3.8/weather-applet.js:11312
+#, fuzzy
+msgid "Shower snow"
+msgstr "陣雨"
+
+#: 3.0/openWeatherMap.js:400 3.8/weather-applet.js:11313
+#, fuzzy
+msgid "Heavy shower snow"
+msgstr "大雪"
+
+#: 3.0/openWeatherMap.js:402 3.0/us_weather.js:585 3.0/us_weather.js:586
+#: 3.8/weather-applet.js:11315 3.8/weather-applet.js:13231
+#: 3.8/weather-applet.js:13232 3.8/weather-applet.js:15016
+#: 3.8/weather-applet.js:15017
+#, fuzzy
+msgid "Smoke"
+msgstr "煙霧"
+
+#: 3.0/openWeatherMap.js:403 3.0/us_weather.js:592 3.0/us_weather.js:593
+#: 3.0/yahoo.js:457 3.8/weather-applet.js:11316 3.8/weather-applet.js:13238
+#: 3.8/weather-applet.js:13239 3.8/weather-applet.js:15009
+#: 3.8/weather-applet.js:15010
+msgid "Haze"
+msgstr "陰霾"
+
+#: 3.0/openWeatherMap.js:404 3.8/weather-applet.js:11317
+msgid "Sand, dust whirls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:406 3.8/weather-applet.js:11319
+msgid "Sand"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:407 3.0/us_weather.js:578 3.0/us_weather.js:579
+#: 3.0/yahoo.js:455 3.8/weather-applet.js:11320 3.8/weather-applet.js:13224
+#: 3.8/weather-applet.js:13225 3.8/weather-applet.js:14995
+#: 3.8/weather-applet.js:14996
+msgid "Dust"
+msgstr "灰塵"
+
+#: 3.0/openWeatherMap.js:408 3.8/weather-applet.js:11321
+msgid "Volcanic ash"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:409 3.8/weather-applet.js:11322
+#: 3.8/weather-applet.js:13544
+msgid "Squalls"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:410 3.0/us_weather.js:557 3.0/us_weather.js:558
+#: 3.0/yahoo.js:436 3.8/weather-applet.js:11323 3.8/weather-applet.js:13203
+#: 3.8/weather-applet.js:13204 3.8/weather-applet.js:14868
+#: 3.8/weather-applet.js:14869
+msgid "Tornado"
+msgstr "龍捲風"
+
+#: 3.0/openWeatherMap.js:413 3.8/weather-applet.js:11326
+msgid "Sky is clear"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:414 3.8/weather-applet.js:11327
+#, fuzzy
+msgid "Clouds"
+msgstr "有雲"
+
+#: 3.0/openWeatherMap.js:415 3.0/us_weather.js:414 3.0/us_weather.js:415
+#: 3.0/us_weather.js:449 3.8/weather-applet.js:11328
+#: 3.8/weather-applet.js:13060 3.8/weather-applet.js:13061
+#: 3.8/weather-applet.js:13095
+msgid "Few clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:416 3.8/weather-applet.js:11329
+#, fuzzy
+msgid "Scattered clouds"
+msgstr "零星陣雨"
+
+#: 3.0/openWeatherMap.js:417 3.8/weather-applet.js:11330
+msgid "Broken clouds"
+msgstr ""
+
+#: 3.0/openWeatherMap.js:418 3.8/weather-applet.js:11331
+msgid "Overcast clouds"
+msgstr ""
+
+#: 3.0/us_weather.js:120
+msgid "Could not get forecast for your area"
+msgstr ""
+
+#: 3.0/us_weather.js:231 3.8/weather-applet.js:12743
+msgid "Location is outside US, please use a different provider."
+msgstr ""
+
+#: 3.0/us_weather.js:394 3.8/weather-applet.js:12807
+msgid "Failed to Process Hourly Forecast Info"
+msgstr ""
+
+#: 3.0/us_weather.js:443 3.8/weather-applet.js:13089
+msgid "Clear and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:450 3.8/weather-applet.js:13096
+msgid "Few clouds and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:457 3.8/weather-applet.js:13103
+#, fuzzy
+msgid "Partly cloudy and windy"
+msgstr "晴時多雲"
+
+#: 3.0/us_weather.js:464 3.8/weather-applet.js:13110
+#, fuzzy
+msgid "Mostly cloudy and windy"
+msgstr "多雲"
+
+#: 3.0/us_weather.js:471 3.8/weather-applet.js:13117
+msgid "Overcast and windy"
+msgstr ""
+
+#: 3.0/us_weather.js:485 3.8/weather-applet.js:13131
+#, fuzzy
+msgid "Snowy rain"
+msgstr "飄雪"
+
+#: 3.0/us_weather.js:520 3.8/weather-applet.js:13166
+#, fuzzy
+msgid "Freezing rain and snow"
+msgstr "凍雨"
+
+#: 3.0/us_weather.js:564 3.0/us_weather.js:565 3.0/utils.js:336
+#: 3.0/yahoo.js:438 3.8/weather-applet.js:9154 3.8/weather-applet.js:13210
+#: 3.8/weather-applet.js:13211 3.8/weather-applet.js:14882
+#: 3.8/weather-applet.js:14883
+msgid "Hurricane"
+msgstr "颶風"
+
+#: 3.0/us_weather.js:571 3.0/utils.js:331 3.8/weather-applet.js:9149
+#: 3.8/weather-applet.js:13217
+msgid "Storm"
+msgstr ""
+
+#: 3.0/us_weather.js:572 3.8/weather-applet.js:13218
+msgid "Tropical storm"
+msgstr "熱帶風暴"
+
+#: 3.0/us_weather.js:599 3.0/us_weather.js:600 3.0/yahoo.js:470
+#: 3.8/weather-applet.js:13245 3.8/weather-applet.js:13246
+#: 3.8/weather-applet.js:15114 3.8/weather-applet.js:15115
+msgid "Hot"
+msgstr "炎熱"
+
+#: 3.0/us_weather.js:606 3.0/us_weather.js:607 3.0/yahoo.js:461
+#: 3.8/weather-applet.js:13252 3.8/weather-applet.js:13253
+msgid "Cold"
+msgstr "冷"
+
+#: 3.0/us_weather.js:613 3.0/us_weather.js:614 3.0/yahoo.js:477
+#: 3.8/weather-applet.js:13259 3.8/weather-applet.js:13260
+#: 3.8/weather-applet.js:15163 3.8/weather-applet.js:15164
+msgid "Blizzard"
+msgstr ""
+
+#: 3.0/utils.js:146 3.8/weather-applet.js:9026
+msgid "Today"
+msgstr "今天"
+
+#: 3.0/utils.js:148 3.8/weather-applet.js:9028
+msgid "Tomorrow"
+msgstr "明天"
+
+#: 3.0/utils.js:204
 msgid "Sunday"
 msgstr "星期日"
 
-#: applet.js:1056
+#: 3.0/utils.js:204
+msgid "Monday"
+msgstr "星期一"
+
+#: 3.0/utils.js:204
+msgid "Tuesday"
+msgstr "星期二"
+
+#: 3.0/utils.js:204
+msgid "Wednesday"
+msgstr "星期三"
+
+#: 3.0/utils.js:204
+msgid "Thursday"
+msgstr "星期四"
+
+#: 3.0/utils.js:204
+msgid "Friday"
+msgstr "星期五"
+
+#: 3.0/utils.js:204
+msgid "Saturday"
+msgstr "星期六"
+
+#: 3.0/utils.js:301 3.8/weather-applet.js:9119
+msgid "Calm"
+msgstr ""
+
+#: 3.0/utils.js:304 3.8/weather-applet.js:9122
+msgid "Light air"
+msgstr ""
+
+#: 3.0/utils.js:307 3.8/weather-applet.js:9125
+msgid "Light breeze"
+msgstr ""
+
+#: 3.0/utils.js:310 3.8/weather-applet.js:9128
+msgid "Gentle breeze"
+msgstr ""
+
+#: 3.0/utils.js:313 3.8/weather-applet.js:9131
+msgid "Moderate breeze"
+msgstr ""
+
+#: 3.0/utils.js:316 3.8/weather-applet.js:9134
+msgid "Fresh breeze"
+msgstr ""
+
+#: 3.0/utils.js:319 3.8/weather-applet.js:9137
+msgid "Strong breeze"
+msgstr ""
+
+#: 3.0/utils.js:322 3.8/weather-applet.js:9140
+msgid "Near gale"
+msgstr ""
+
+#: 3.0/utils.js:325 3.8/weather-applet.js:9143
+msgid "Gale"
+msgstr ""
+
+#: 3.0/utils.js:328 3.8/weather-applet.js:9146
+msgid "Strong gale"
+msgstr ""
+
+#: 3.0/utils.js:334 3.8/weather-applet.js:9152
+msgid "Violent storm"
+msgstr ""
+
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "N"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NE"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "E"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SE"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "S"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "SW"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "W"
 msgstr ""
 
-#: applet.js:1056
+#: 3.0/utils.js:429 3.8/weather-applet.js:9302
 msgid "NW"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeidLookup->description
-msgid "Get WOEID"
+#: 3.0/weatherbit.js:312
+msgid ""
+"Please enter API key in settings,\n"
+"or get one first on https://www.weatherbit.io/account/create"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->verticalOrientation->description
-msgid "Vertical orientation"
+#: 3.0/yahoo.js:78
+msgid ""
+"Unknown Error happened while calling Yahoo bridge,\n"
+" see Looking Glass log for errors"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showTextInPanel->description
-msgid "Display current temperature in panel"
+#: 3.0/yahoo.js:91
+msgid ""
+"Yahoo bridge responded in bad format,\n"
+" see Looking Glass log for errors"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeid->description
-msgid "WOEID"
+#: 3.0/yahoo.js:177
+msgid "Missing package"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->woeid->tooltip
-msgid "Where On Earth ID"
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+#, fuzzy
+msgid "Please install '"
+msgstr "請稍候"
+
+#: 3.0/yahoo.js:177 3.0/yahoo.js:179
+msgid "', then refresh manually."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->description
+#: 3.0/yahoo.js:182
+msgid "Could not connect to Yahoo API."
+msgstr ""
+
+#: 3.0/yahoo.js:186
+msgid ""
+"Unknown error happened while obtaining weather, see Looking Glass logs for "
+"more information"
+msgstr ""
+
+#: 3.0/yahoo.js:437 3.8/weather-applet.js:14875 3.8/weather-applet.js:14876
+#, fuzzy
+msgid "Tropical Storm"
+msgstr "熱帶風暴"
+
+#: 3.0/yahoo.js:439
+#, fuzzy
+msgid "Severe Thunderstorms"
+msgstr "強雷暴雨"
+
+#: 3.0/yahoo.js:440 3.8/weather-applet.js:14896 3.8/weather-applet.js:14897
+msgid "Thunderstorms"
+msgstr "雷雨"
+
+#: 3.0/yahoo.js:441
+#, fuzzy
+msgid "Mixed Rain and Snow"
+msgstr "雨雪交加"
+
+#: 3.0/yahoo.js:442
+#, fuzzy
+msgid "Mixed Rain and Sleet"
+msgstr "雨霰交加"
+
+#: 3.0/yahoo.js:443
+#, fuzzy
+msgid "Mixed Snow and Sleet"
+msgstr "雪霰交加"
+
+#: 3.0/yahoo.js:444 3.8/weather-applet.js:14918 3.8/weather-applet.js:14919
+#, fuzzy
+msgid "Freezing Drizzle"
+msgstr "凍毛毛雨"
+
+#: 3.0/yahoo.js:446 3.8/weather-applet.js:14932 3.8/weather-applet.js:14933
+#, fuzzy
+msgid "Freezing Rain"
+msgstr "凍雨"
+
+#: 3.0/yahoo.js:447 3.8/weather-applet.js:14939 3.8/weather-applet.js:14940
+msgid "Showers"
+msgstr "陣雨"
+
+#: 3.0/yahoo.js:449
+#, fuzzy
+msgid "Snow Flurries"
+msgstr "飄雪"
+
+#: 3.0/yahoo.js:450
+#, fuzzy
+msgid "Light Snow Showers"
+msgstr "小雪"
+
+#: 3.0/yahoo.js:451 3.8/weather-applet.js:14967 3.8/weather-applet.js:14968
+#, fuzzy
+msgid "Blowing Snow"
+msgstr "暴雪"
+
+#: 3.0/yahoo.js:456 3.8/weather-applet.js:13785 3.8/weather-applet.js:13786
+msgid "Foggy"
+msgstr "霧"
+
+#: 3.0/yahoo.js:458
+msgid "Smoky"
+msgstr "煙霧"
+
+#: 3.0/yahoo.js:459
+msgid "Blustery"
+msgstr "大風"
+
+#: 3.0/yahoo.js:460 3.8/weather-applet.js:15030 3.8/weather-applet.js:15031
+msgid "Windy"
+msgstr "有風"
+
+#: 3.0/yahoo.js:463 3.8/weather-applet.js:15051 3.8/weather-applet.js:15052
+#: 3.8/weather-applet.js:15058 3.8/weather-applet.js:15059
+#, fuzzy
+msgid "Mostly Cloudy"
+msgstr "多雲"
+
+#: 3.0/yahoo.js:464 3.8/weather-applet.js:14553 3.8/weather-applet.js:14554
+#: 3.8/weather-applet.js:14560 3.8/weather-applet.js:14561
+#: 3.8/weather-applet.js:15065 3.8/weather-applet.js:15066
+#: 3.8/weather-applet.js:15072 3.8/weather-applet.js:15073
+#, fuzzy
+msgid "Partly Cloudy"
+msgstr "晴時多雲"
+
+#: 3.0/yahoo.js:467 3.8/weather-applet.js:15100 3.8/weather-applet.js:15101
+#, fuzzy
+msgid "Mostly Sunny"
+msgstr "多雲"
+
+#: 3.0/yahoo.js:469 3.8/weather-applet.js:15107 3.8/weather-applet.js:15108
+#, fuzzy
+msgid "Mixed Rain and Hail"
+msgstr "冰雹"
+
+#: 3.0/yahoo.js:471 3.8/weather-applet.js:15121 3.8/weather-applet.js:15122
+#, fuzzy
+msgid "Isolated Thunderstorms"
+msgstr "局部地區有雷暴"
+
+#: 3.0/yahoo.js:472 3.8/weather-applet.js:15128 3.8/weather-applet.js:15129
+#: 3.8/weather-applet.js:15184 3.8/weather-applet.js:15185
+#, fuzzy
+msgid "Scattered Thunderstorms"
+msgstr "零星雷暴"
+
+#: 3.0/yahoo.js:473 3.8/weather-applet.js:15135 3.8/weather-applet.js:15136
+#: 3.8/weather-applet.js:15170 3.8/weather-applet.js:15171
+#, fuzzy
+msgid "Scattered Showers"
+msgstr "零星陣雨"
+
+#: 3.0/yahoo.js:474 3.8/weather-applet.js:15142 3.8/weather-applet.js:15143
+#, fuzzy
+msgid "Heavy Rain"
+msgstr "大雪"
+
+#: 3.0/yahoo.js:475 3.8/weather-applet.js:15149 3.8/weather-applet.js:15150
+#: 3.8/weather-applet.js:15177 3.8/weather-applet.js:15178
+#, fuzzy
+msgid "Scattered Snow Showers"
+msgstr "零星陣雪"
+
+#: 3.0/yahoo.js:476 3.8/weather-applet.js:15156 3.8/weather-applet.js:15157
+#, fuzzy
+msgid "Heavy Snow"
+msgstr "大雪"
+
+#: 3.0/yahoo.js:478
+#, fuzzy
+msgid "Not Available"
+msgstr "不可用"
+
+#: 3.0/yahoo.js:479
+#, fuzzy
+msgid "Scattered Thundershowers"
+msgstr "零星雷暴"
+
+#: 3.8/weather-applet.js:9638
+msgid ""
+"Could not retrieve logs, log file was not found under path\n"
+" {logFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:9642
+msgid ""
+"Could not get contents of log file under path\n"
+" {logFilePath}"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10283
+msgid "Met Office UK"
+msgstr ""
+
+#: 3.8/weather-applet.js:10388
+msgid ""
+"MET Office UK only covers the UK, please make sure your location is in the "
+"country"
+msgstr ""
+
+#: 3.8/weather-applet.js:10476
+msgid "Data was not found for location"
+msgstr ""
+
+#: 3.8/weather-applet.js:10557
+msgid "Very poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10557
+msgid "Less than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "Excellent"
+msgstr ""
+
+#: 3.8/weather-applet.js:10561
+msgid "More than {distance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566
+msgid "Poor"
+msgstr ""
+
+#: 3.8/weather-applet.js:10566 3.8/weather-applet.js:10571
+#: 3.8/weather-applet.js:10576 3.8/weather-applet.js:10581
+#: 3.8/weather-applet.js:10586
+msgid "Between {smallerDistance}-{biggerDistance} {distanceUnit}"
+msgstr ""
+
+#: 3.8/weather-applet.js:10571
+msgid "Moderate"
+msgstr ""
+
+#: 3.8/weather-applet.js:10576
+msgid "Good"
+msgstr ""
+
+#: 3.8/weather-applet.js:10581 3.8/weather-applet.js:10586
+msgid "Very good"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:10942
+msgid "OpenWeatherMap"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:11396
+msgid "MET Norway"
+msgstr ""
+
+#: 3.8/weather-applet.js:11955
+msgid "WeatherBit"
+msgstr ""
+
+#: 3.8/weather-applet.js:12386
+#, fuzzy
+msgid "Tomorrow.io"
+msgstr "明天"
+
+#: 3.8/weather-applet.js:12561
+msgid "Light wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12575
+msgid "Strong wind"
+msgstr ""
+
+#: 3.8/weather-applet.js:12723
+msgid "US Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:13292
+msgid "Visual Crossing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13474
+#, fuzzy
+msgid "Blowing or drifting snow"
+msgstr "暴雪"
+
+#: 3.8/weather-applet.js:13478
+#, fuzzy
+msgid "Heavy drizzle"
+msgstr "凍毛毛雨"
+
+#: 3.8/weather-applet.js:13482
+msgid "Heavy drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13484
+msgid "Light drizzle/rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13486
+msgid "Dust Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:13490
+#, fuzzy
+msgid "Freezing drizzle/freezing rain"
+msgstr "凍毛毛雨"
+
+#: 3.8/weather-applet.js:13492
+msgid "Heavy freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13494
+msgid "Light freezing drizzle/freezing rain"
+msgstr ""
+
+#: 3.8/weather-applet.js:13496
+#, fuzzy
+msgid "Freezing fog"
+msgstr "凍雨"
+
+#: 3.8/weather-applet.js:13502
+msgid "Funnel cloud/tornado"
+msgstr ""
+
+#: 3.8/weather-applet.js:13504
+#, fuzzy
+msgid "Hail showers"
+msgstr "陣雪"
+
+#: 3.8/weather-applet.js:13506
+msgid "Ice"
+msgstr ""
+
+#: 3.8/weather-applet.js:13508
+msgid "Lightning without thunder"
+msgstr ""
+
+#: 3.8/weather-applet.js:13512
+msgid "Precipitation in vicinity"
+msgstr ""
+
+#: 3.8/weather-applet.js:13516 3.8/weather-applet.js:13814
+#, fuzzy
+msgid "Heavy rain and snow"
+msgstr "雨雪交加"
+
+#: 3.8/weather-applet.js:13518
+#, fuzzy
+msgid "Light rain And snow"
+msgstr "雨雪交加"
+
+#: 3.8/weather-applet.js:13526
+msgid "Sky coverage decreasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13528
+msgid "Sky coverage increasing"
+msgstr ""
+
+#: 3.8/weather-applet.js:13530
+msgid "Sky unchanged"
+msgstr ""
+
+#: 3.8/weather-applet.js:13532
+msgid "Smoke or haze"
+msgstr ""
+
+#: 3.8/weather-applet.js:13536
+#, fuzzy
+msgid "Snow and rain showers"
+msgstr "陣雪"
+
+#: 3.8/weather-applet.js:13548
+msgid "Thunderstorm without precipitation"
+msgstr ""
+
+#: 3.8/weather-applet.js:13550
+msgid "Diamond dust"
+msgstr ""
+
+#: 3.8/weather-applet.js:13556
+#, fuzzy
+msgid "Partially cloudy"
+msgstr "晴時多雲"
+
+#: 3.8/weather-applet.js:13578
+msgid "Please make sure you entered the API key correctly"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+#: 3.8/weather-applet.js:13595
+msgid "DMI Denmark"
+msgstr ""
+
+#: 3.8/weather-applet.js:13746 3.8/weather-applet.js:13747
+#: 3.8/weather-applet.js:13883 3.8/weather-applet.js:13884
+msgid "NOT FOUND"
+msgstr ""
+
+#: 3.8/weather-applet.js:13779
+msgid "Blowing snow"
+msgstr "暴雪"
+
+#: 3.8/weather-applet.js:13820 3.8/weather-applet.js:13821
+#, fuzzy
+msgid "Slight snow"
+msgstr "暴雪"
+
+#: 3.8/weather-applet.js:13827 3.8/weather-applet.js:13828
+#, fuzzy
+msgid "Moderate snow"
+msgstr "大雪"
+
+#: 3.8/weather-applet.js:13842
+#, fuzzy
+msgid "Moderate rain showers"
+msgstr "零星陣雨"
+
+#: 3.8/weather-applet.js:13849
+msgid "Mixed rain and snow"
+msgstr "雨雪交加"
+
+#: 3.8/weather-applet.js:13856
+#, fuzzy
+msgid "Heavy mixed rain and snow"
+msgstr "雨雪交加"
+
+#: 3.8/weather-applet.js:14024
+msgid "AccuWeather"
+msgstr ""
+
+#: 3.8/weather-applet.js:14321
+msgid "Deutscher Wetterdienst"
+msgstr ""
+
+#: 3.8/weather-applet.js:14334
+msgid "Please select a different provider or location"
+msgstr ""
+
+#: 3.8/weather-applet.js:14642
+msgid "Weather Underground"
+msgstr ""
+
+#: 3.8/weather-applet.js:14846
+msgid "The API key you provided is invalid."
+msgstr ""
+
+#: 3.8/weather-applet.js:14853
+msgid "The location you provided was not found."
+msgstr ""
+
+#: 3.8/weather-applet.js:14889 3.8/weather-applet.js:14890
+msgid "Strong Storm"
+msgstr ""
+
+#: 3.8/weather-applet.js:14904 3.8/weather-applet.js:14905
+#, fuzzy
+msgid "Rain and Snow"
+msgstr "雨雪交加"
+
+#: 3.8/weather-applet.js:14911 3.8/weather-applet.js:14912
+#, fuzzy
+msgid "Rain and Sleet"
+msgstr "雨霰交加"
+
+#: 3.8/weather-applet.js:14960 3.8/weather-applet.js:14961
+#, fuzzy
+msgid "Snow Showers"
+msgstr "陣雪"
+
+#: 3.8/weather-applet.js:15023 3.8/weather-applet.js:15024
+msgid "Breezy"
+msgstr ""
+
+#: 3.8/weather-applet.js:15037 3.8/weather-applet.js:15038
+msgid "Frigid"
+msgstr ""
+
+#: 3.8/weather-applet.js:15093 3.8/weather-applet.js:15094
+#, fuzzy
+msgid "Mostly Clear"
+msgstr "多雲"
+
+#: 3.8/weather-applet.js:15247
+msgid "Pirate Weather"
+msgstr ""
+
+#: 3.8/weather-applet.js:15603
+msgid ""
+"Location Service couldn't find your location, please see the logs in Looking "
+"Glass"
+msgstr ""
+
+#: 3.8/weather-applet.js:15831
+msgid "Make sure you entered a location or use Automatic location instead."
+msgstr ""
+
+#: 3.8/weather-applet.js:15968
+msgid ""
+"Could not retrieve config, file was not found under paths\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:15975
+msgid ""
+"Could not get contents of config file under path\n"
+" {configFilePath}"
+msgstr ""
+
+#: 3.8/weather-applet.js:16233
+msgid "This provider requires an API key to operate"
+msgstr ""
+
+#: 3.8/weather-applet.js:16675
+msgid "Dew Point"
+msgstr ""
+
+#: 3.8/weather-applet.js:16747
+msgid "Precipitation will end in {precipEnd} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16749
+msgid "Precipitation won't end in within an hour"
+msgstr ""
+
+#: 3.8/weather-applet.js:16752
+msgid "Precipitation will start within {precipStart} minutes"
+msgstr ""
+
+#: 3.8/weather-applet.js:16964
+msgid "Forecast parsing failed, see logs for more details."
+msgstr ""
+
+#: 3.8/weather-applet.js:17496 3.8/weather-applet.js:18014
+msgid "As of {lastUpdatedTime}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17502
+msgid "{distance} {distanceUnit} from you"
+msgstr ""
+
+#: 3.8/weather-applet.js:17506
+msgid "Station Name: {stationName}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17509
+msgid "Area: {stationArea}"
+msgstr ""
+
+#: 3.8/weather-applet.js:17843 3.8/weather-applet.js:17853
+msgid "Error Saving Debug Information"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Debug Information saved successfully"
+msgstr ""
+
+#: 3.8/weather-applet.js:17865
+msgid "Saved to {filePath}"
+msgstr ""
+
+#: 3.8/LogSaver.py:16
+msgid "Save to File"
+msgstr ""
+
+#: 3.8/LogSaver.py:29
+msgid "Select a destination"
+msgstr ""
+
+#. metadata.json->name
+#. 3.8->settings-schema.json->providers->title
+msgid "Weather"
+msgstr ""
+
+#. metadata.json->description
+msgid "View your local weather forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->head->description
+msgid "Settings for weather@mockturtl 3.0+"
+msgstr ""
+
+#. 3.0->settings-schema.json->keybinding->description
+#. 3.8->settings-schema.json->keybinding->description
+msgid "Set the keybinding to call the menu"
+msgstr ""
+
+#. 3.0->settings-schema.json->descriptions->description
+msgid "Weather service information"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->description
+msgid "Click here for detailed description"
+msgstr ""
+
+#. 3.0->settings-schema.json->moreInfo->tooltip
+#. 3.0->settings-schema.json->getLocation->tooltip
+#. 3.8->settings-schema.json->getLocation->tooltip
+msgid "Opens webpage guide"
+msgstr ""
+
+#. 3.0->settings-schema.json->providerSettings->description
+#. 3.8->settings-schema.json->provider-options->title
+msgid "Weather Provider Options"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->description
+#. 3.8->settings-schema.json->dataService->description
+msgid "Data service"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "DarkSky (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weatherbit (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Yahoo"
+msgstr ""
+
+#. 3.0->settings-schema.json->dataService->options
+msgid "Climacell (key needed)"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->description
+#. 3.8->settings-schema.json->apiKey->description
+msgid "API Key"
+msgstr ""
+
+#. 3.0->settings-schema.json->apiKey->tooltip
+#. 3.8->settings-schema.json->apiKey->tooltip
+msgid "Copy this from your account of the used Data service and paste it here."
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->description
+#. 3.8->settings-schema.json->manualLocation->description
+msgid "Manual Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->manualLocation->tooltip
+#. 3.8->settings-schema.json->manualLocation->tooltip
+msgid "Enable this if your location is not accurate"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->description
+msgid "Location - Coordinates"
+msgstr ""
+
+#. 3.0->settings-schema.json->location->tooltip
+msgid ""
+"Acceptable inputs are Latitude,Longitude. e.g.: 68.1932,17.1426 or an "
+"address.\n"
+"Waits for 3 seconds after you stop typing before refreshes the weather."
+msgstr ""
+
+#. 3.0->settings-schema.json->getLocation->description
+msgid "Setup API Key and Location"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->units
+#. 3.8->settings-schema.json->refreshInterval->units
+msgid "minutes"
+msgstr ""
+
+#. 3.0->settings-schema.json->refreshInterval->description
+#. 3.8->settings-schema.json->refreshInterval->description
+msgid "Update interval"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastDays->units
+#. 3.8->settings-schema.json->forecastDays->units
+msgid "days"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastDays->description
+#. 3.8->settings-schema.json->forecastDays->description
+msgid "Forecast length"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastHours->units
+#. 3.8->settings-schema.json->forecastHours->units
+msgid "hours"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastHours->description
+#. 3.8->settings-schema.json->forecastHours->description
+msgid "Hourly Forecast length"
+msgstr ""
+
+#. 3.0->settings-schema.json->unitSettings->description
+msgid "Units"
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureUnit->description
+#. 3.8->settings-schema.json->temperatureUnit->description
 #, fuzzy
 msgid "Temperature unit"
 msgstr "溫度："
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "fahrenheit"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Automatic"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->temperatureUnit->options
-msgid "celsius"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+msgid "Celsius"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->translateCondition->description
-msgid "Translate condition"
+#. 3.0->settings-schema.json->temperatureUnit->options
+#. 3.8->settings-schema.json->temperatureUnit->options
+msgid "Fahrenheit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->locationLabelOverride->description
-msgid "Override location label"
+#. 3.0->settings-schema.json->temperatureUnit->tooltip
+#. 3.0->settings-schema.json->distanceUnit->tooltip
+#. 3.8->settings-schema.json->temperatureUnit->tooltip
+#. 3.8->settings-schema.json->distanceUnit->tooltip
+msgid ""
+"Automatic will try to guess your preference based your current display "
+"language."
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->show24Hours->description
-msgid "Display time in 24 hour format"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->forecastDays->description
-msgid "Forecast length"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->forecastDays->units
-msgid "days"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->showSunrise->description
-msgid "Show sunrise / sunset times"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->description
+#. 3.0->settings-schema.json->windSpeedUnit->description
+#. 3.8->settings-schema.json->windSpeedUnit->description
 msgid "Wind speed unit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
 msgid "kph"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "m/s"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
-msgid "knots"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->windSpeedUnit->options
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
 msgid "mph"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->showCommentInPanel->description
-msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "m/s"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->description
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "knots"
+msgstr ""
+
+#. 3.0->settings-schema.json->windSpeedUnit->options
+#. 3.8->settings-schema.json->windSpeedUnit->options
+msgid "Beaufort"
+msgstr ""
+
+#. 3.0->settings-schema.json->pressureUnit->description
+#. 3.8->settings-schema.json->pressureUnit->description
 msgid "Atmospheric pressure unit"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "psi"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "hPa"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "atm"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "kPa"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "Pa"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mm Hg"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "at"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
-msgid "mbar"
-msgstr ""
-
-#. cinnamon-weather->settings-schema.json->pressureUnit->options
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
 msgid "in Hg"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->description
-msgid "Update interval"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "mm Hg"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->refreshInterval->units
-msgid "minutes"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "psi"
 msgstr ""
 
-#. cinnamon-weather->settings-schema.json->useSymbolicIcons->description
-msgid "Symbolic icons"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "at"
 msgstr ""
 
-#. cinnamon-weather->metadata.json->description
-msgid "View your local weather forecast"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "atm"
 msgstr ""
 
-#. cinnamon-weather->metadata.json->name
-msgid "Weather"
+#. 3.0->settings-schema.json->pressureUnit->options
+#. 3.8->settings-schema.json->pressureUnit->options
+msgid "Pa"
 msgstr ""
 
-#~ msgid "Please wait"
-#~ msgstr "請稍候"
+#. 3.0->settings-schema.json->distanceUnit->description
+#. 3.8->settings-schema.json->distanceUnit->description
+msgid "Distance unit"
+msgstr ""
 
-#~ msgid "Today"
-#~ msgstr "今天"
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Metric"
+msgstr ""
 
-#~ msgid "Tomorrow"
-#~ msgstr "明天"
+#. 3.0->settings-schema.json->distanceUnit->options
+#. 3.8->settings-schema.json->distanceUnit->options
+msgid "Imperial"
+msgstr ""
+
+#. 3.0->settings-schema.json->panelSettings->description
+msgid "Panel options"
+msgstr ""
+
+#. 3.0->settings-schema.json->showTextInPanel->description
+#. 3.8->settings-schema.json->showTextInPanel->description
+msgid "Display current temperature in panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->showCommentInPanel->description
+#. 3.8->settings-schema.json->showCommentInPanel->description
+msgid "Show the weather condition (e.g., \"Windy\", \"Clear\") in the panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->showCommentInPanel->tooltip
+#. 3.8->settings-schema.json->showCommentInPanel->tooltip
+msgid "Only works with horizontal panels"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempTextOverride->description
+#. 3.8->settings-schema.json->tempTextOverride->description
+msgid "Override label on panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Available values are: {c} is condition, {t} is temperature and {u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.0->settings-schema.json->useCustomMenuIcons->tooltip
+#. 3.8->settings-schema.json->useCustomAppletIcons->tooltip
+#. 3.8->settings-schema.json->useCustomMenuIcons->tooltip
+msgid "Iconset is weather-icons by Erik Flowers"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomAppletIcons->description
+#. 3.8->settings-schema.json->useCustomAppletIcons->description
+msgid "Use custom icons on the panel"
+msgstr ""
+
+#. 3.0->settings-schema.json->displaySettings->description
+#. 3.8->settings-schema.json->presentation-section->title
+msgid "Presentation"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->description
+#. 3.8->settings-schema.json->verticalOrientation->description
+msgid "Show forecast vertically"
+msgstr ""
+
+#. 3.0->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->units
+#. 3.8->settings-schema.json->forecastColumns->units
+msgid "columns"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastColumns->description
+#. 3.8->settings-schema.json->forecastColumns->description
+msgid "Maximum number of columns for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->units
+#. 3.8->settings-schema.json->forecastRows->units
+msgid "rows"
+msgstr ""
+
+#. 3.0->settings-schema.json->forecastRows->description
+#. 3.8->settings-schema.json->forecastRows->description
+msgid "Maximum number of rows for forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->showSunrise->description
+#. 3.8->settings-schema.json->showSunrise->description
+msgid "Show sunrise / sunset times"
+msgstr ""
+
+#. 3.0->settings-schema.json->show24Hours->description
+#. 3.8->settings-schema.json->show24Hours->description
+msgid "Display time in 24 hour format"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->description
+#. 3.8->settings-schema.json->shortHourlyTime->description
+msgid "Only display hours for hourly forecast time"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortHourlyTime->tooltip
+#. 3.8->settings-schema.json->shortHourlyTime->tooltip
+msgid "Instead of 15:00 or 3:00 pm it will show up as 15 or 3 pm"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->description
+#. 3.8->settings-schema.json->showForecastDates->description
+msgid "Display date for daily forecasts"
+msgstr ""
+
+#. 3.0->settings-schema.json->showForecastDates->tooltip
+#. 3.8->settings-schema.json->showForecastDates->tooltip
+msgid "Like \"Friday 15\""
+msgstr ""
+
+#. 3.0->settings-schema.json->temperatureHighFirst->description
+#. 3.8->settings-schema.json->temperatureHighFirst->description
+msgid "Show high temperature first in forecast"
+msgstr ""
+
+#. 3.0->settings-schema.json->tempRussianStyle->description
+#. 3.8->settings-schema.json->tempRussianStyle->description
+#, fuzzy
+msgid "Show temperature Russian style"
+msgstr "溫度："
+
+#. 3.0->settings-schema.json->locationLabelOverride->description
+#. 3.8->settings-schema.json->locationLabelOverride->description
+msgid "Override location label"
+msgstr ""
+
+#. 3.0->settings-schema.json->conditionSettings->description
+#. 3.8->settings-schema.json->weather-conditions->title
+msgid "Weather conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->translateCondition->description
+#. 3.8->settings-schema.json->translateCondition->description
+msgid "Translate conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->shortConditions->description
+#. 3.8->settings-schema.json->shortConditions->description
+msgid "Less verbose conditions"
+msgstr ""
+
+#. 3.0->settings-schema.json->iconSettings->description
+#. 3.8->settings-schema.json->icons->title
+msgid "Icons"
+msgstr ""
+
+#. 3.0->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons in the applet"
+msgstr ""
+
+#. 3.0->settings-schema.json->useCustomMenuIcons->description
+#. 3.8->settings-schema.json->useCustomMenuIcons->description
+msgid "Use custom icons in the popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->locations-page->title
+#. 3.8->settings-schema.json->location->description
+msgid "Location"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-page->title
+msgid "Other options"
+msgstr ""
+
+#. 3.8->settings-schema.json->info-section->title
+msgid "Help"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-section->title
+msgid "Location settings"
+msgstr ""
+
+#. 3.8->settings-schema.json->location-store->title
+msgid "Saved Locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->panel-options->title
+msgid "Panel (Taskbar)"
+msgstr ""
+
+#. 3.8->settings-schema.json->presentation->title
+msgid "Popup menu"
+msgstr ""
+
+#. 3.8->settings-schema.json->units-section->title
+msgid "Other Units"
+msgstr ""
+
+#. 3.8->settings-schema.json->temp-unit-section->title
+#, fuzzy
+msgid "Temperature Unit"
+msgstr "溫度："
+
+#. 3.8->settings-schema.json->keybindings->title
+msgid "Keybindings"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info->title
+msgid "More about the Weather applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->submit-issue->title
+msgid "Report an issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->debug-options->title
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Debug"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->tooltip
+msgid ""
+"You can choose between several different weather forecast providers. Some "
+"providers require a API key to work, some have regional limits, differ in "
+"forecast length, and they all need a functional internet connection to work. "
+"The options are described in detail on the Cinnamon Spices Website which you "
+"can access with the button on the Help tab."
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Deutscher Wetterdienst (Germany only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Met Office UK (UK only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "US National Weather (US only)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Pirate Weather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Visual Crossing (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Tomorrow.io (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "AccuWeather (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->dataService->options
+msgid "Weather Underground (key needed)"
+msgstr ""
+
+#. 3.8->settings-schema.json->location->tooltip
+msgid ""
+"You can enter coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use "
+"'City,Country-code' (e.g. London,UK) or try to enter {House number} {Street} "
+"{City/Town} {Postcode} {Country}. The search algorithm is very flexible with "
+"the format. After 3 seconds without typing the address you entered is "
+"replaced automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationDescription->description
+msgid ""
+"If the location field matches a saved location's 'Search Entry' field, the "
+"saved location will be used instead."
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->description
+msgid "Save current location to storage"
+msgstr ""
+
+#. 3.8->settings-schema.json->saveLocation->tooltip
+msgid ""
+"Saves location information to file so you can switch between them with "
+"buttons in the applet, which will appear if you have more than one."
+msgstr ""
+
+#. 3.8->settings-schema.json->getLocation->description
+msgid "Weather Applet at Cinnamon Spices Website"
+msgstr ""
+
+#. 3.8->settings-schema.json->refreshInterval->tooltip
+msgid ""
+"If you are using a provider with API keys set it to an interval you won't "
+"run out of your quota with."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastDays->tooltip
+msgid ""
+"Maximum number of days that can be displayed, available number of data, "
+"maximum rows and columns setting in the Presentation tab will affect the "
+"final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->forecastHours->tooltip
+msgid ""
+"Maximum number of hours that can be displayed, available numbers of data "
+"will affect the final number."
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->description
+msgid "Enable minutely precipitation forecast"
+msgstr ""
+
+#. 3.8->settings-schema.json->immediatePrecip->tooltip
+msgid ""
+"If you'd like to use this make sure you use your exact coordinates/address "
+"as location to help its accuracy. See Feature map on website on support for "
+"your provider"
+msgstr ""
+
+#. 3.8->settings-schema.json->showBothTempUnits->description
+msgid "Show both temperature units at the same time"
+msgstr ""
+
+#. 3.8->settings-schema.json->tempTextOverride->tooltip
+msgid ""
+"Some of the available values are: {c} is condition, {t} is temperature and "
+"{u} is unit.\n"
+"Can be used if label does not fit on vertical panel, among other smart "
+"things."
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->description
+msgid "Override tooltip on panel"
+msgstr ""
+
+#. 3.8->settings-schema.json->tooltipTextOverride->tooltip
+msgid ""
+"Has the same behavior and available values as 'Override label on panel'."
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->description
+msgid "Always show Hourly Weather"
+msgstr ""
+
+#. 3.8->settings-schema.json->alwaysShowHourlyWeather->tooltip
+msgid ""
+"Hide/Show button will be hidden and Hourly weather will be permanently "
+"visible."
+msgstr ""
+
+#. 3.8->settings-schema.json->verticalOrientation->tooltip
+msgid "Displaying forecasts from top to bottom instead from left to right."
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->description
+msgid "Your saved locations"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->tooltip
+msgid ""
+"You have to make sure the Search entry field is unique and your Timezone is "
+"in the IANA time zone format (e.g. 'Europe/London')"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Latitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Longitude"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "City"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Country"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Timezone"
+msgstr ""
+
+#. 3.8->settings-schema.json->locationList->columns->title
+msgid "Search entry"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->description
+msgid "Display wind direction as text"
+msgstr ""
+
+#. 3.8->settings-schema.json->displayWindAsText->tooltip
+msgid "Like SE, N instead of direction icons."
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->tooltip
+msgid "Does not apply to custom iconset, that is symbolic by default"
+msgstr ""
+
+#. 3.8->settings-schema.json->useSymbolicIcons->description
+msgid "Use symbolic icons throughout the applet"
+msgstr ""
+
+#. 3.8->settings-schema.json->more-info-label->description
+msgid ""
+"For detailed information about the applet please go to the Spices Website to "
+"find info about known issues, troubleshooting, changelog and more by "
+"clicking the button below. Here you can ask questions etc in the comment "
+"section by logging in with your Github account."
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->description
+msgid "Submit an Issue"
+msgstr ""
+
+#. 3.8->settings-schema.json->submitIssue->tooltip
+msgid ""
+"Opens webpage where you can fill out a new issue for the applet, needs a "
+"GitHub account.\n"
+" Please make sure that the issue is not already submitted."
+msgstr ""
+
+#. 3.8->settings-schema.json->maintainer->description
+msgid "Current maintainer: Gr3q"
+msgstr ""
+
+#. 3.8->settings-schema.json->issue-reporting-explanation->description
+msgid ""
+"If you find an issue with this applet please make a report by clicking on "
+"the button below and login in with your Github account.\n"
+"\n"
+"Before you start writing please make sure that the issue is not already "
+"submitted in the issues section and review your prefilled details in the "
+"issue description. Don't forget to add a short description in the top Title "
+"field next to the applet's name to make it easier for everyone to know what "
+"the issue is about. Logs with Debug level (which can be saved to a file "
+"below) are also appreciated."
+msgstr ""
+
+#. 3.8->settings-schema.json->loc-info->description
+msgid ""
+"Your location in most cases work automatically but you can enter it manually "
+"by coordinates 'Latitude,Longitude' (e.g. 51.5085,-0.1257) or use 'City,"
+"Country-code' (e.g. London,UK) or try to enter {House number} {Street} {City/"
+"Town} {Postcode} {Country}. The search algorithm is very flexible with the "
+"format. After 3 seconds without typing the address you entered is replaced "
+"automatically for validating your choice."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->description
+msgid "Log Level"
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->tooltip
+msgid ""
+"Info is the regular logging, Debug is debug, and Verbose also logs network "
+"request payloads. Changing this will only be effective on future logs. Only "
+"change it you are instructed or you know what you are doing."
+msgstr ""
+
+#. 3.8->settings-schema.json->logLevel->options
+msgid "Verbose"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->description
+msgid "Click Save to save debug information to a file"
+msgstr ""
+
+#. 3.8->settings-schema.json->fileSelect->tooltip
+msgid ""
+"This includes logs for the applet and the current settings with your API key "
+"redacted."
+msgstr ""
+
+#. 3.8->settings-schema.json->selectedLogPath->description
+msgid "Selected path to save Logs"
+msgstr ""

--- a/weather@mockturtl/package.json
+++ b/weather@mockturtl/package.json
@@ -23,7 +23,7 @@
     "babel-loader": "8.2.2",
     "terser-webpack-plugin": "5.3.6",
     "ts-loader": "9.4.2",
-    "typescript": "5.0.2",
+    "typescript": "5.4.5",
     "webpack": "5.75.0",
     "webpack-bundle-analyzer": "4.4.2",
     "webpack-cli": "4.7.2"

--- a/weather@mockturtl/src/3_8/config.ts
+++ b/weather@mockturtl/src/3_8/config.ts
@@ -466,14 +466,14 @@ export class Config {
 
 	private OnFontChanged = () => {
 		this.currentFontSize = this.GetCurrentFontSize();
-		this.app.Refresh({ rebuild: true, immediate: true});
+		this.app.Refresh({ rebuild: true});
 	}
 
 	/** Called when 3 seconds is up with no change in location */
 	private DoneTypingLocation() {
 		Logger.Debug("User has finished typing, beginning refresh");
 		this.doneTypingLocation = null;
-		this.app.Refresh();
+		this.app.Refresh({ rebuild: true });
 	}
 
 	private SetLocation(value: string) {

--- a/weather@mockturtl/src/3_8/config.ts
+++ b/weather@mockturtl/src/3_8/config.ts
@@ -473,7 +473,7 @@ export class Config {
 	private DoneTypingLocation() {
 		Logger.Debug("User has finished typing, beginning refresh");
 		this.doneTypingLocation = null;
-		this.app.Refresh({ rebuild: true });
+		this.app.Refresh();
 	}
 
 	private SetLocation(value: string) {

--- a/weather@mockturtl/src/3_8/consts.ts
+++ b/weather@mockturtl/src/3_8/consts.ts
@@ -27,6 +27,8 @@ export const STYLE_HIDDEN = "weather-hidden";
 
 export type LogLevel = "info" | "debug" | "verbose" | "critical" | "error" | "always";
 
+export const REQUEST_TIMEOUT_SECONDS = 30;
+
 const US_TIMEZONES: string[] = [
     "America/Adak",
     "America/Anchorage",

--- a/weather@mockturtl/src/3_8/lib/httpLib.ts
+++ b/weather@mockturtl/src/3_8/lib/httpLib.ts
@@ -3,6 +3,13 @@ import { ErrorDetail } from "../types";
 import { _ } from "../utils";
 import { soupLib, SoupResponse } from "./soupLib";
 
+export type LoadAsyncOptions = {
+	params?: HTTPParams;
+	headers?: HTTPHeaders;
+	method?: Method;
+	cancellable?: imports.gi.Gio.Cancellable;
+};
+
 export class HttpLib {
 	private static instance: HttpLib;
 	/** Single instance of log */
@@ -17,12 +24,9 @@ export class HttpLib {
 	 */
 	public async LoadJsonAsync<T, E = any>(
 		url: string,
-		cancellable?: imports.gi.Gio.Cancellable,
-		params?: HTTPParams,
-		headers?: HTTPHeaders,
-		method: Method = "GET",
+		options: LoadAsyncOptions = {}
 	): Promise<Response<T, E>> {
-		const response = await this.LoadAsync(url, cancellable, params, headers, method);
+		const response = await this.LoadAsync(url, options);
 
 		try {
 			const payload = JSON.parse(response.Data);
@@ -51,12 +55,9 @@ export class HttpLib {
 	 */
 	public async LoadAsync<E = any>(
 		url: string,
-		cancellable?: imports.gi.Gio.Cancellable,
-		params?: HTTPParams,
-		headers?: HTTPHeaders,
-		method: Method = "GET",
+		options: LoadAsyncOptions = {}
 	): Promise<Response<string | null, E>> {
-		const message = await soupLib.Send(url, params, headers, method, cancellable);
+		const message = await soupLib.Send(url, options);
 
 		let error: HttpError | undefined = undefined;
 

--- a/weather@mockturtl/src/3_8/lib/httpLib.ts
+++ b/weather@mockturtl/src/3_8/lib/httpLib.ts
@@ -15,8 +15,14 @@ export class HttpLib {
 	/**
 	 * Handles obtaining JSON over http.
 	 */
-	public async LoadJsonAsync<T, E = any>(url: string, params?: HTTPParams, headers?: HTTPHeaders, method: Method = "GET"): Promise<Response<T, E>> {
-		const response = await this.LoadAsync(url, params, headers, method);
+	public async LoadJsonAsync<T, E = any>(
+		url: string,
+		cancellable?: imports.gi.Gio.Cancellable,
+		params?: HTTPParams,
+		headers?: HTTPHeaders,
+		method: Method = "GET",
+	): Promise<Response<T, E>> {
+		const response = await this.LoadAsync(url, cancellable, params, headers, method);
 
 		try {
 			const payload = JSON.parse(response.Data);
@@ -43,8 +49,14 @@ export class HttpLib {
 	/**
 	 * Handles obtaining data over http.
 	 */
-	public async LoadAsync<E = any>(url: string, params?: HTTPParams, headers?: HTTPHeaders, method: Method = "GET"): Promise<Response<string | null, E>> {
-		const message = await soupLib.Send(url, params, headers, method);
+	public async LoadAsync<E = any>(
+		url: string,
+		cancellable?: imports.gi.Gio.Cancellable,
+		params?: HTTPParams,
+		headers?: HTTPHeaders,
+		method: Method = "GET",
+	): Promise<Response<string | null, E>> {
+		const message = await soupLib.Send(url, params, headers, method, cancellable);
 
 		let error: HttpError | undefined = undefined;
 

--- a/weather@mockturtl/src/3_8/lib/io_lib.ts
+++ b/weather@mockturtl/src/3_8/lib/io_lib.ts
@@ -10,12 +10,19 @@ const ByteArray = imports.byteArray;
  * NOT WORKING, fileInfo completely empty atm
  * @param file
  */
-export async function GetFileInfo(file: imports.gi.Gio.File): Promise<imports.gi.Gio.FileInfo> {
+export async function GetFileInfo(file: imports.gi.Gio.File): Promise<imports.gi.Gio.FileInfo | null> {
 	return new Promise((resolve, reject) => {
 		file.query_info_async("", Gio.FileQueryInfoFlags.NONE, null, null, (obj, res) => {
-			const result = file.query_info_finish(res);
-			resolve(result);
-			return result;
+			try {
+				const result = file.query_info_finish(res);
+				resolve(result);
+				return result;
+			}
+			catch (e) {
+				Logger.Error("Error getting file info: ", e);
+				resolve(null);
+				return null;
+			}
 		});
 	});
 }
@@ -91,16 +98,23 @@ export async function DeleteFile(file: imports.gi.Gio.File): Promise<boolean> {
 	return result;
 }
 
-export async function OverwriteAndGetIOStream(file: imports.gi.Gio.File): Promise<imports.gi.Gio.FileIOStream> {
+export async function OverwriteAndGetIOStream(file: imports.gi.Gio.File): Promise<imports.gi.Gio.FileIOStream | null> {
 	const parent = file.get_parent();
 	if (parent != null && !FileExists(parent))
 		parent.make_directory_with_parents(null); //don't know if this is a blocking call or not
 
 	return new Promise((resolve, reject) => {
 		file.replace_readwrite_async(null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null, null, (source_object, result) => {
-			const ioStream = file.replace_readwrite_finish(result);
-			resolve(ioStream);
-			return ioStream;
+			try {
+				const ioStream = file.replace_readwrite_finish(result);
+				resolve(ioStream);
+				return ioStream;
+			}
+			catch (e) {
+				Logger.Error("Error overwriting file: ", e);
+				resolve(null);
+				return null;
+			}
 		});
 	});
 }
@@ -109,13 +123,21 @@ export async function WriteAsync(outputStream: imports.gi.Gio.OutputStream, buff
 	// normal write_async can't use normal string or ByteArray.fromString
 	// so we save using write_bytes_async, seem to work well.
 	const text = ByteArray.fromString(buffer);
-	if (outputStream.is_closed()) return false;
+	if (outputStream.is_closed())
+		return false;
 
 	return new Promise((resolve, reject) => {
 		outputStream.write_bytes_async(text as any, null, null, (obj, res) => {
-			const ioStream = outputStream.write_bytes_finish(res);
-			resolve(true);
-			return true;
+			try {
+				outputStream.write_bytes_finish(res);
+				resolve(true);
+				return true;
+			}
+			catch (e) {
+				Logger.Error("Error writing to stream: ", e);
+				resolve(false);
+				return false;
+			}
 		});
 	});
 }
@@ -123,9 +145,16 @@ export async function WriteAsync(outputStream: imports.gi.Gio.OutputStream, buff
 export async function CloseStream(stream: imports.gi.Gio.OutputStream | imports.gi.Gio.InputStream | imports.gi.Gio.FileIOStream): Promise<boolean> {
 	return new Promise((resolve, reject) => {
 		stream.close_async(null, null, (obj, res) => {
-			const result = stream.close_finish(res);
-			resolve(result);
-			return result;
+			try {
+				const result = stream.close_finish(res);
+				resolve(result);
+				return result;
+			}
+			catch (e) {
+				Logger.Error("Error closing stream: ", e);
+				resolve(false);
+				return false;
+			}
 		});
 	});
 }

--- a/weather@mockturtl/src/3_8/lib/logger.ts
+++ b/weather@mockturtl/src/3_8/lib/logger.ts
@@ -62,7 +62,6 @@ const IOErrorEnumNames: Record<imports.gi.Gio.IOErrorEnum, string> = {
 	[imports.gi.Gio.IOErrorEnum.PROXY_AUTH_FAILED]: "PROXY_AUTH_FAILED",
 	[imports.gi.Gio.IOErrorEnum.PROXY_NEED_AUTH]: "PROXY_NEED_AUTH",
 	[imports.gi.Gio.IOErrorEnum.PROXY_NOT_ALLOWED]: "PROXY_NOT_ALLOWED",
-	[imports.gi.Gio.IOErrorEnum.BROKEN_PIPE]: "BROKEN_PIPE",
 	[imports.gi.Gio.IOErrorEnum.CONNECTION_CLOSED]: "CONNECTION_CLOSED",
 	[imports.gi.Gio.IOErrorEnum.NOT_CONNECTED]: "NOT_CONNECTED",
 	[imports.gi.Gio.IOErrorEnum.MESSAGE_TOO_LARGE]: "MESSAGE_TOO_LARGE",

--- a/weather@mockturtl/src/3_8/lib/logger.ts
+++ b/weather@mockturtl/src/3_8/lib/logger.ts
@@ -14,6 +14,61 @@ const LogLevelSeverity: Record<LogLevel, number> = {
 	verbose: 100
 }
 
+/**
+ * For each error create an error name.
+ */
+const IOErrorEnumNames: Record<imports.gi.Gio.IOErrorEnum, string> = {
+	[imports.gi.Gio.IOErrorEnum.FAILED]: "FAILED",
+	[imports.gi.Gio.IOErrorEnum.NOT_FOUND]: "NOT_FOUND",
+	[imports.gi.Gio.IOErrorEnum.EXISTS]: "EXISTS",
+	[imports.gi.Gio.IOErrorEnum.IS_DIRECTORY]: "IS_DIRECTORY",
+	[imports.gi.Gio.IOErrorEnum.NOT_DIRECTORY]: "NOT_DIRECTORY",
+	[imports.gi.Gio.IOErrorEnum.NOT_EMPTY]: "NOT_EMPTY",
+	[imports.gi.Gio.IOErrorEnum.NOT_REGULAR_FILE]: "NOT_REGULAR_FILE",
+	[imports.gi.Gio.IOErrorEnum.NOT_SYMBOLIC_LINK]: "NOT_SYMBOLIC_LINK",
+	[imports.gi.Gio.IOErrorEnum.NOT_MOUNTABLE_FILE]: "NOT_MOUNTABLE_FILE",
+	[imports.gi.Gio.IOErrorEnum.FILENAME_TOO_LONG]: "FILENAME_TOO_LONG",
+	[imports.gi.Gio.IOErrorEnum.INVALID_FILENAME]: "INVALID_FILENAME",
+	[imports.gi.Gio.IOErrorEnum.TOO_MANY_LINKS]: "TOO_MANY_LINKS",
+	[imports.gi.Gio.IOErrorEnum.NO_SPACE]: "NO_SPACE",
+	[imports.gi.Gio.IOErrorEnum.INVALID_ARGUMENT]: "INVALID_ARGUMENT",
+	[imports.gi.Gio.IOErrorEnum.PERMISSION_DENIED]: "PERMISSION_DENIED",
+	[imports.gi.Gio.IOErrorEnum.NOT_SUPPORTED]: "NOT_SUPPORTED",
+	[imports.gi.Gio.IOErrorEnum.NOT_MOUNTED]: "NOT_MOUNTED",
+	[imports.gi.Gio.IOErrorEnum.ALREADY_MOUNTED]: "ALREADY_MOUNTED",
+	[imports.gi.Gio.IOErrorEnum.CLOSED]: "CLOSED",
+	[imports.gi.Gio.IOErrorEnum.CANCELLED]: "CANCELLED",
+	[imports.gi.Gio.IOErrorEnum.PENDING]: "PENDING",
+	[imports.gi.Gio.IOErrorEnum.READ_ONLY]: "READ_ONLY",
+	[imports.gi.Gio.IOErrorEnum.CANT_CREATE_BACKUP]: "CANT_CREATE_BACKUP",
+	[imports.gi.Gio.IOErrorEnum.WRONG_ETAG]: "WRONG_ETAG",
+	[imports.gi.Gio.IOErrorEnum.TIMED_OUT]: "TIMED_OUT",
+	[imports.gi.Gio.IOErrorEnum.WOULD_RECURSE]: "WOULD_RECURSE",
+	[imports.gi.Gio.IOErrorEnum.BUSY]: "BUSY",
+	[imports.gi.Gio.IOErrorEnum.WOULD_BLOCK]: "WOULD_BLOCK",
+	[imports.gi.Gio.IOErrorEnum.HOST_NOT_FOUND]: "HOST_NOT_FOUND",
+	[imports.gi.Gio.IOErrorEnum.WOULD_MERGE]: "WOULD_MERGE",
+	[imports.gi.Gio.IOErrorEnum.FAILED_HANDLED]: "FAILED_HANDLED",
+	[imports.gi.Gio.IOErrorEnum.TOO_MANY_OPEN_FILES]: "TOO_MANY_OPEN_FILES",
+	[imports.gi.Gio.IOErrorEnum.NOT_INITIALIZED]: "NOT_INITIALIZED",
+	[imports.gi.Gio.IOErrorEnum.ADDRESS_IN_USE]: "ADDRESS_IN_USE",
+	[imports.gi.Gio.IOErrorEnum.PARTIAL_INPUT]: "PARTIAL_INPUT",
+	[imports.gi.Gio.IOErrorEnum.INVALID_DATA]: "INVALID_DATA",
+	[imports.gi.Gio.IOErrorEnum.DBUS_ERROR]: "DBUS_ERROR",
+	[imports.gi.Gio.IOErrorEnum.HOST_UNREACHABLE]: "HOST_UNREACHABLE",
+	[imports.gi.Gio.IOErrorEnum.NETWORK_UNREACHABLE]: "NETWORK_UNREACHABLE",
+	[imports.gi.Gio.IOErrorEnum.CONNECTION_REFUSED]: "CONNECTION_REFUSED",
+	[imports.gi.Gio.IOErrorEnum.PROXY_FAILED]: "PROXY_FAILED",
+	[imports.gi.Gio.IOErrorEnum.PROXY_AUTH_FAILED]: "PROXY_AUTH_FAILED",
+	[imports.gi.Gio.IOErrorEnum.PROXY_NEED_AUTH]: "PROXY_NEED_AUTH",
+	[imports.gi.Gio.IOErrorEnum.PROXY_NOT_ALLOWED]: "PROXY_NOT_ALLOWED",
+	[imports.gi.Gio.IOErrorEnum.BROKEN_PIPE]: "BROKEN_PIPE",
+	[imports.gi.Gio.IOErrorEnum.CONNECTION_CLOSED]: "CONNECTION_CLOSED",
+	[imports.gi.Gio.IOErrorEnum.NOT_CONNECTED]: "NOT_CONNECTED",
+	[imports.gi.Gio.IOErrorEnum.MESSAGE_TOO_LARGE]: "MESSAGE_TOO_LARGE",
+	[imports.gi.Gio.IOErrorEnum.NO_SUCH_DEVICE]: "NO_SUCH_DEVICE",
+}
+
 class Log {
 	private ID: number | undefined;
 	private logLevel: LogLevel = "info";
@@ -38,13 +93,21 @@ class Log {
 		global.log(msg);
 	}
 
-	Error(error: string, e?: Error): void {
+	Error(error: string, e?: unknown): void {
 		if (!this.CanLog("error"))
 			return;
 
 		global.logError("[" + UUID + "#" + this.ID + ":Error]: " + error.toString());
-		if (!!e?.stack)
-			global.logError(e.stack);
+		if (typeof e === "string") {
+			return;
+		}
+
+		const gjsE = e as GJSError;
+		global.logError(`GJS Error context - Name: ${gjsE.name}, domain: ${gjsE.domain}, code: ${IOErrorEnumNames[gjsE.code as imports.gi.Gio.IOErrorEnum] ?? gjsE.code}, message: ${gjsE.message}`);
+
+		if (gjsE.stack)
+			global.logError(gjsE.stack);
+
 	};
 
 	Debug(message: string): void {

--- a/weather@mockturtl/src/3_8/lib/soupLib.ts
+++ b/weather@mockturtl/src/3_8/lib/soupLib.ts
@@ -200,7 +200,13 @@ class Soup2 implements SoupLib {
 		const read_chunk_async = () => {
 			return new Promise<imports.gi.GLib.Bytes>((resolve) => {
 				stream.read_bytes_async(8192, 0, cancellable, (source, read_result) => {
-					resolve(stream.read_bytes_finish(read_result));
+					try {
+						resolve(stream.read_bytes_finish(read_result));
+					}
+					catch(e) {
+						Logger.Error("Error reading chunk from http request stream: " + e);
+						resolve(imports.gi.GLib.Bytes.new());
+					}
 				});
 			})
 		}

--- a/weather@mockturtl/src/3_8/lib/soupLib.ts
+++ b/weather@mockturtl/src/3_8/lib/soupLib.ts
@@ -7,13 +7,16 @@ const { PRIORITY_DEFAULT }  = imports.gi.GLib;
 const { Cancellable } = imports.gi.Gio;
 const ByteArray = imports.byteArray;
 
+export interface SoupLibSendOptions {
+	params?: HTTPParams | null,
+	headers?: HTTPHeaders,
+	method?: Method,
+	cancellable?: imports.gi.Gio.Cancellable
+}
 export interface SoupLib {
     Send: (
 		url: string,
-		params?: HTTPParams | null,
-		headers?: HTTPHeaders,
-		method?: Method,
-		cancellable?: imports.gi.Gio.Cancellable
+		options?: SoupLibSendOptions
 	) => Promise<SoupResponse | null>;
 }
 
@@ -57,11 +60,14 @@ class Soup3 implements SoupLib {
 
     async Send(
 		url: string,
-		params?: HTTPParams | null | undefined,
-		headers?: HTTPHeaders | undefined,
-		method: Method = "GET",
-		cancellable?: imports.gi.Gio.Cancellable,
+		options: SoupLibSendOptions = {}
 	): Promise<SoupResponse | null> {
+		const {
+			params,
+			headers,
+			method = "GET",
+			cancellable
+		} = options;
 
 		if (cancellable?.is_cancelled()) {
 			return Promise.resolve(null);
@@ -133,11 +139,15 @@ class Soup2 implements SoupLib {
 	 */
 	public async Send(
 		url: string,
-		params?: HTTPParams | null,
-		headers?: HTTPHeaders,
-		method: Method = "GET",
-		cancellable?: imports.gi.Gio.Cancellable
+		options: SoupLibSendOptions = {}
 	): Promise<SoupResponse | null> {
+		const {
+			params,
+			headers,
+			method = "GET",
+			cancellable
+		} = options;
+
 		if (cancellable?.is_cancelled()) {
 			return Promise.resolve(null);
 		}
@@ -168,14 +178,14 @@ class Soup2 implements SoupLib {
 					catch(e) {
 						Logger.Error("Error reading http request's response: " + e);
 					}
-					
+
 					resolve({
 						reason_phrase: message.reason_phrase,
 						status_code: message.status_code,
 						response_body: res,
 						response_headers: headers
 					});
-					
+
 				});
 			}
 		});

--- a/weather@mockturtl/src/3_8/location_services/geoip_services/base.ts
+++ b/weather@mockturtl/src/3_8/location_services/geoip_services/base.ts
@@ -2,5 +2,5 @@ import { WeatherApplet } from "../../main";
 import { LocationData } from "../../types";
 
 export interface GeoIP {
-	GetLocation: () => Promise<LocationData | null>;
+	GetLocation: (cancellable: imports.gi.Gio.Cancellable) => Promise<LocationData | null>;
 }

--- a/weather@mockturtl/src/3_8/location_services/geoip_services/geoclue.ts
+++ b/weather@mockturtl/src/3_8/location_services/geoip_services/geoclue.ts
@@ -105,6 +105,9 @@ export class GeoClue implements GeoIP {
 		)
 
 		const geoCodeRes = GeocodeGlib.Reverse.new_for_location(geoCodeLoc);
+		// Gnome's default Nominatim instance is fucked, or Cinnamon misconfigures it but it's permanently not working.
+		// I set to OpenStreetMaps instance because that works.
+		geoCodeRes.set_backend(GeocodeGlib.Nominatim.new("https://nominatim.openstreetmap.org", "weatherapplet@gmail.com"))
 		return new Promise<Partial<LocationData> | null>((resolve, reject) => {
 			Logger.Debug("Requesting location data from GeoCode");
 			const start = DateTime.now();
@@ -126,7 +129,7 @@ export class GeoClue implements GeoIP {
 						return;
 					}
 
-					Logger.Debug(`GeoCode location data received ${JSON.stringify(result)}`);
+					Logger.Debug(`GeoCode location data received ${result.town}, ${result.country}`);
 					resolve({
 						city: result.town,
 						country: result.country,

--- a/weather@mockturtl/src/3_8/location_services/geoip_services/geoclue.ts
+++ b/weather@mockturtl/src/3_8/location_services/geoip_services/geoclue.ts
@@ -26,14 +26,14 @@ export class GeoClue implements GeoIP {
 		}
 	}
 
-	public async GetLocation(): Promise<LocationData | null> {
+	public async GetLocation(cancellable?: imports.gi.Gio.Cancellable): Promise<LocationData | null> {
 		if (GeoClueLib == null || GeocodeGlib == null) {
 			return null;
 		}
 
 		const { AccuracyLevel, Simple: GeoClue } = GeoClueLib;
 		const res = await new Promise<ExtendedLocationData | null>((resolve, reject) => {
-			GeoClue.new_with_thresholds("weather_mockturtl", AccuracyLevel.EXACT, 0, 0, null, (client, res) => {
+			GeoClue.new_with_thresholds("weather_mockturtl", AccuracyLevel.EXACT, 0, 0, cancellable ?? null, (client, res) => {
 				const simple = GeoClue.new_finish(res);
 				const clientObj = simple.get_client();
 				if (clientObj == null || !clientObj.active) {

--- a/weather@mockturtl/src/3_8/location_services/geoip_services/geoclue.ts
+++ b/weather@mockturtl/src/3_8/location_services/geoip_services/geoclue.ts
@@ -1,3 +1,4 @@
+import { DateTime } from "luxon";
 import { Logger } from "../../lib/logger";
 import { WeatherApplet } from "../../main";
 import { LocationData } from "../../types";
@@ -26,24 +27,36 @@ export class GeoClue implements GeoIP {
 		}
 	}
 
-	public async GetLocation(cancellable?: imports.gi.Gio.Cancellable): Promise<LocationData | null> {
+	public async GetLocation(cancellable: imports.gi.Gio.Cancellable): Promise<LocationData | null> {
 		if (GeoClueLib == null || GeocodeGlib == null) {
 			return null;
 		}
 
 		const { AccuracyLevel, Simple: GeoClue } = GeoClueLib;
 		const res = await new Promise<ExtendedLocationData | null>((resolve, reject) => {
-			GeoClue.new_with_thresholds("weather_mockturtl", AccuracyLevel.EXACT, 0, 0, cancellable ?? null, (client, res) => {
-				const simple = GeoClue.new_finish(res);
-				const clientObj = simple.get_client();
-				if (clientObj == null || !clientObj.active) {
-					Logger.Debug("GeoGlue2 Geolocation disabled, skipping");
+			Logger.Debug("Requesting coordinates from GeoClue");
+			const start = DateTime.now();
+			GeoClue.new_with_thresholds("weather_mockturtl", AccuracyLevel.EXACT, 0, 0, cancellable, (client, res) => {
+				Logger.Debug(`Getting GeoClue coordinates finished, took ${start.diffNow().negate().as("seconds")} seconds.`);
+				let simple: imports.gi.Geoclue.Simple | null = null;
+				try {
+					simple = GeoClue.new_finish(res);
+					const clientObj = simple.get_client();
+					if (clientObj == null || !clientObj.active) {
+						Logger.Debug("GeoGlue Geolocation disabled, skipping");
+						resolve(null);
+						return;
+					}
+				}
+				catch (e) {
+					Logger.Error("Error while fetching GeoClue coordinates: ", e);
 					resolve(null);
 					return;
 				}
 
 				const loc = simple.get_location();
 				if (loc == null) {
+					Logger.Debug("GeoGlue coordinates is not known.");
 					resolve(null);
 					return;
 				}
@@ -59,7 +72,9 @@ export class GeoClue implements GeoIP {
 					accuracy: loc.accuracy,
 				}
 
+				Logger.Debug(`GeoClue coordinates received ${JSON.stringify(result)}`);
 				resolve(result);
+				return;
 			})
 		});
 
@@ -67,7 +82,7 @@ export class GeoClue implements GeoIP {
 			return null;
 		}
 
-		const geoCodeRes = await this.GetGeoCodeData(res.lat, res.lon, res.accuracy);
+		const geoCodeRes = await this.GetGeoCodeData(cancellable, res.lat, res.lon, res.accuracy);
 		if (geoCodeRes == null) {
 			return res;
 		}
@@ -78,7 +93,7 @@ export class GeoClue implements GeoIP {
 		};
 	};
 
-	private async GetGeoCodeData(lat: number, lon: number, accuracy: imports.gi.Geoclue.AccuracyLevel): Promise<Partial<LocationData> | null> {
+	private async GetGeoCodeData(cancellable: imports.gi.Gio.Cancellable, lat: number, lon: number, accuracy: imports.gi.Geoclue.AccuracyLevel): Promise<Partial<LocationData> | null> {
 		if (GeocodeGlib == null) {
 			return null;
 		}
@@ -91,18 +106,34 @@ export class GeoClue implements GeoIP {
 
 		const geoCodeRes = GeocodeGlib.Reverse.new_for_location(geoCodeLoc);
 		return new Promise<Partial<LocationData> | null>((resolve, reject) => {
-			geoCodeRes.resolve_async(null, (obj, res) => {
-				const result = geoCodeRes.resolve_finish(res);
-				if (result == null) {
-					resolve(null);
-					return;
-				}
+			Logger.Debug("Requesting location data from GeoCode");
+			const start = DateTime.now();
+				geoCodeRes.resolve_async(cancellable, (obj, res) => {
+					Logger.Debug(`Getting GeoCode location data finished, took ${start.diffNow().negate().as("seconds")} seconds.`);
+					let result: imports.gi.GeocodeGlib.Place | null = null;
+					try {
+						result = geoCodeRes.resolve_finish(res);
+					}
+					catch (e) {
+						Logger.Error("Error while fetching GeoCode data: ", e);
+						resolve(null);
+						return;
+					}
 
-				resolve({
-					city: result.town,
-					country: result.country,
-				})
-			});
-		})
+					if (result == null) {
+						Logger.Debug("GeoCode location data not available.");
+						resolve(null);
+						return;
+					}
+
+					Logger.Debug(`GeoCode location data received ${JSON.stringify(result)}`);
+					resolve({
+						city: result.town,
+						country: result.country,
+					})
+					return;
+				});
+			}
+		)
 	}
 }

--- a/weather@mockturtl/src/3_8/location_services/geoip_services/geoip.fedora.ts
+++ b/weather@mockturtl/src/3_8/location_services/geoip_services/geoip.fedora.ts
@@ -18,7 +18,7 @@ export class GeoIPFedora implements GeoIP {
 	}
 
 	public async GetLocation(cancellable: imports.gi.Gio.Cancellable): Promise<LocationData | null> {
-		const json = await this.app.LoadJsonAsync<GeoIPFedoraPayload>(this.query, cancellable);
+		const json = await this.app.LoadJsonAsync<GeoIPFedoraPayload>({ url: this.query, cancellable });
 
 		if (!json) {
 			Logger.Info("geoip.fedoraproject didn't return any data");

--- a/weather@mockturtl/src/3_8/location_services/geoip_services/geoip.fedora.ts
+++ b/weather@mockturtl/src/3_8/location_services/geoip_services/geoip.fedora.ts
@@ -17,8 +17,8 @@ export class GeoIPFedora implements GeoIP {
 		this.app = app;
 	}
 
-	public async GetLocation(): Promise<LocationData | null> {
-		const json = await this.app.LoadJsonAsync<GeoIPFedoraPayload>(this.query);
+	public async GetLocation(cancellable: imports.gi.Gio.Cancellable): Promise<LocationData | null> {
+		const json = await this.app.LoadJsonAsync<GeoIPFedoraPayload>(this.query, cancellable);
 
 		if (!json) {
 			Logger.Info("geoip.fedoraproject didn't return any data");

--- a/weather@mockturtl/src/3_8/location_services/geoip_services/geoip.fedora.ts
+++ b/weather@mockturtl/src/3_8/location_services/geoip_services/geoip.fedora.ts
@@ -1,3 +1,4 @@
+import { HttpLib } from "../../lib/httpLib";
 import { Logger } from "../../lib/logger";
 import { WeatherApplet } from "../../main";
 import { LocationData } from "../../types";
@@ -18,7 +19,7 @@ export class GeoIPFedora implements GeoIP {
 	}
 
 	public async GetLocation(cancellable: imports.gi.Gio.Cancellable): Promise<LocationData | null> {
-		const json = await this.app.LoadJsonAsync<GeoIPFedoraPayload>({ url: this.query, cancellable });
+		const json = await HttpLib.Instance.LoadJsonSimple<GeoIPFedoraPayload>({ url: this.query, cancellable });
 
 		if (!json) {
 			Logger.Info("geoip.fedoraproject didn't return any data");

--- a/weather@mockturtl/src/3_8/location_services/geoip_services/geoiplookup.io.ts
+++ b/weather@mockturtl/src/3_8/location_services/geoip_services/geoiplookup.io.ts
@@ -17,7 +17,7 @@ export class GeoIPLookupIO implements GeoIP {
 	}
 
 	public async GetLocation(cancellable: imports.gi.Gio.Cancellable): Promise<LocationData | null> {
-		const json = await this.app.LoadJsonAsync<GeoIPLookupPayload>(this.query, cancellable);
+		const json = await this.app.LoadJsonAsync<GeoIPLookupPayload>({ url: this.query, cancellable });
 
 		if (!json) {
 			return null;

--- a/weather@mockturtl/src/3_8/location_services/geoip_services/geoiplookup.io.ts
+++ b/weather@mockturtl/src/3_8/location_services/geoip_services/geoiplookup.io.ts
@@ -16,8 +16,8 @@ export class GeoIPLookupIO implements GeoIP {
 		this.app = app;
 	}
 
-	public async GetLocation(): Promise<LocationData | null> {
-		const json = await this.app.LoadJsonAsync<GeoIPLookupPayload>(this.query);
+	public async GetLocation(cancellable: imports.gi.Gio.Cancellable): Promise<LocationData | null> {
+		const json = await this.app.LoadJsonAsync<GeoIPLookupPayload>(this.query, cancellable);
 
 		if (!json) {
 			return null;

--- a/weather@mockturtl/src/3_8/location_services/geoip_services/geoiplookup.io.ts
+++ b/weather@mockturtl/src/3_8/location_services/geoip_services/geoiplookup.io.ts
@@ -1,3 +1,4 @@
+import { HttpLib } from "../../lib/httpLib";
 import { Logger } from "../../lib/logger";
 import { WeatherApplet } from "../../main";
 import { LocationData } from "../../types";
@@ -17,7 +18,7 @@ export class GeoIPLookupIO implements GeoIP {
 	}
 
 	public async GetLocation(cancellable: imports.gi.Gio.Cancellable): Promise<LocationData | null> {
-		const json = await this.app.LoadJsonAsync<GeoIPLookupPayload>({ url: this.query, cancellable });
+		const json = await HttpLib.Instance.LoadJsonSimple<GeoIPLookupPayload>({ url: this.query, cancellable });
 
 		if (!json) {
 			return null;

--- a/weather@mockturtl/src/3_8/location_services/geoip_services/geojs.io.ts
+++ b/weather@mockturtl/src/3_8/location_services/geoip_services/geojs.io.ts
@@ -16,7 +16,7 @@ export class GeoJS implements GeoIP {
 	}
 
 	public async GetLocation(cancellable: imports.gi.Gio.Cancellable): Promise<LocationData | null> {
-		const json = await this.app.LoadJsonAsync<GeoJsPayload>(this.query, cancellable);
+		const json = await this.app.LoadJsonAsync<GeoJsPayload>({ url: this.query, cancellable });
 
 		if (!json) {
 			return null;

--- a/weather@mockturtl/src/3_8/location_services/geoip_services/geojs.io.ts
+++ b/weather@mockturtl/src/3_8/location_services/geoip_services/geojs.io.ts
@@ -15,8 +15,8 @@ export class GeoJS implements GeoIP {
 		this.app = _app;
 	}
 
-	public async GetLocation(): Promise<LocationData | null> {
-		const json = await this.app.LoadJsonAsync<GeoJsPayload>(this.query);
+	public async GetLocation(cancellable: imports.gi.Gio.Cancellable): Promise<LocationData | null> {
+		const json = await this.app.LoadJsonAsync<GeoJsPayload>(this.query, cancellable);
 
 		if (!json) {
 			return null;

--- a/weather@mockturtl/src/3_8/location_services/geoip_services/geojs.io.ts
+++ b/weather@mockturtl/src/3_8/location_services/geoip_services/geojs.io.ts
@@ -1,3 +1,4 @@
+import { HttpLib } from "../../lib/httpLib";
 import { Logger } from "../../lib/logger";
 import { WeatherApplet } from "../../main";
 import { LocationData } from "../../types";
@@ -16,7 +17,7 @@ export class GeoJS implements GeoIP {
 	}
 
 	public async GetLocation(cancellable: imports.gi.Gio.Cancellable): Promise<LocationData | null> {
-		const json = await this.app.LoadJsonAsync<GeoJsPayload>({ url: this.query, cancellable });
+		const json = await HttpLib.Instance.LoadJsonSimple<GeoJsPayload>({ url: this.query, cancellable });
 
 		if (!json) {
 			return null;

--- a/weather@mockturtl/src/3_8/location_services/geoip_services/ipApi.ts
+++ b/weather@mockturtl/src/3_8/location_services/geoip_services/ipApi.ts
@@ -24,7 +24,7 @@ export class IpApi implements GeoIP {
 	}
 
 	public async GetLocation(cancellable: imports.gi.Gio.Cancellable): Promise<LocationData | null> {
-		const json = await this.app.LoadJsonAsync<IpApiPayload>(this.query, cancellable);
+		const json = await this.app.LoadJsonAsync<IpApiPayload>({ url: this.query, cancellable });
 
 		if (!json) {
 			return null;

--- a/weather@mockturtl/src/3_8/location_services/geoip_services/ipApi.ts
+++ b/weather@mockturtl/src/3_8/location_services/geoip_services/ipApi.ts
@@ -6,6 +6,7 @@
 //////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////
 
+import { HttpLib } from "../../lib/httpLib";
 import { Logger } from "../../lib/logger";
 import { WeatherApplet } from "../../main";
 import { LocationData } from "../../types";
@@ -24,7 +25,7 @@ export class IpApi implements GeoIP {
 	}
 
 	public async GetLocation(cancellable: imports.gi.Gio.Cancellable): Promise<LocationData | null> {
-		const json = await this.app.LoadJsonAsync<IpApiPayload>({ url: this.query, cancellable });
+		const json = await HttpLib.Instance.LoadJsonSimple<IpApiPayload>({ url: this.query, cancellable });
 
 		if (!json) {
 			return null;

--- a/weather@mockturtl/src/3_8/location_services/geoip_services/ipApi.ts
+++ b/weather@mockturtl/src/3_8/location_services/geoip_services/ipApi.ts
@@ -23,8 +23,8 @@ export class IpApi implements GeoIP {
 		this.app = _app;
 	}
 
-	public async GetLocation(): Promise<LocationData | null> {
-		const json = await this.app.LoadJsonAsync<IpApiPayload>(this.query);
+	public async GetLocation(cancellable: imports.gi.Gio.Cancellable): Promise<LocationData | null> {
+		const json = await this.app.LoadJsonAsync<IpApiPayload>(this.query, cancellable);
 
 		if (!json) {
 			return null;

--- a/weather@mockturtl/src/3_8/location_services/locationstore.ts
+++ b/weather@mockturtl/src/3_8/location_services/locationstore.ts
@@ -31,10 +31,6 @@ export class LocationStore {
 	}
 
 	public OnLocationChanged(locs: LocationData[]) {
-		// this is called 4 times in a row, try to prevent that
-		if (this.app.Locked())
-			return;
-
 		// Ensure Entry text is not empty
 		for (let index = 0; index < locs.length; index++) {
 			const element = locs[index];
@@ -69,7 +65,7 @@ export class LocationStore {
 
 		if (currentlyDisplayedChanged || currentlyDisplayedDeleted) {
 			Logger.Debug("Currently used location was changed or deleted from locationstore, triggering refresh.")
-			this.app.Refresh();
+			this.app.Refresh({immediate: true});
 		}
 		this.InvokeStorageChanged();
 	}
@@ -205,10 +201,10 @@ export class LocationStore {
 	}
 
 	public async SaveCurrentLocation(loc: LocationData | null) {
-		if (this.app.Locked()) {
-			NotificationService.Instance.Send(_("Warning") + " - " + _("Location Store"), _("You can only save correct locations when the applet is not refreshing"), true);
-			return;
-		}
+		// if (this.app.Locked()) {
+		// 	NotificationService.Instance.Send(_("Warning") + " - " + _("Location Store"), _("You can only save correct locations when the applet is not refreshing"), true);
+		// 	return;
+		// }
 		if (loc == null) {
 			NotificationService.Instance.Send(_("Warning") + " - " + _("Location Store"), _("You can't save an incorrect location"), true);
 			return;

--- a/weather@mockturtl/src/3_8/location_services/locationstore.ts
+++ b/weather@mockturtl/src/3_8/location_services/locationstore.ts
@@ -65,7 +65,7 @@ export class LocationStore {
 
 		if (currentlyDisplayedChanged || currentlyDisplayedDeleted) {
 			Logger.Debug("Currently used location was changed or deleted from locationstore, triggering refresh.")
-			this.app.Refresh({immediate: true});
+			this.app.Refresh();
 		}
 		this.InvokeStorageChanged();
 	}

--- a/weather@mockturtl/src/3_8/location_services/nominatim.ts
+++ b/weather@mockturtl/src/3_8/location_services/nominatim.ts
@@ -21,7 +21,7 @@ export class GeoLocation {
 	 * Finds location and rebuilds entryText so it can be looked up again
 	 * @param searchText
 	 */
-	public async GetLocation(searchText: string): Promise<LocationData | null> {
+	public async GetLocation(searchText: string, cancellable: imports.gi.Gio.Cancellable): Promise<LocationData | null> {
 		try {
 			searchText = searchText.trim();
 			const cached = this.cache?.searchText;
@@ -30,7 +30,10 @@ export class GeoLocation {
 				return cached;
 			}
 
-			const locationData = await this.App.LoadJsonAsync<any>(`${this.url}?q=${searchText}&${this.params}`);
+			const locationData = await this.App.LoadJsonAsync<any>(
+				`${this.url}?q=${searchText}&${this.params}`,
+				cancellable
+			);
 			if (locationData == null)
 				return null;
 

--- a/weather@mockturtl/src/3_8/location_services/nominatim.ts
+++ b/weather@mockturtl/src/3_8/location_services/nominatim.ts
@@ -3,6 +3,7 @@ import { Logger } from "../lib/logger";
 import { WeatherApplet } from "../main";
 import { LocationData } from "../types";
 import { _ } from "../utils";
+import { HttpLib } from "../lib/httpLib";
 
 /**
  * Nominatim communication interface
@@ -30,7 +31,7 @@ export class GeoLocation {
 				return cached;
 			}
 
-			const locationData = await this.App.LoadJsonAsync<any>({
+			const locationData = await HttpLib.Instance.LoadJsonSimple<any>({
 				url: `${this.url}?q=${searchText}&${this.params}`,
 				cancellable
 			});

--- a/weather@mockturtl/src/3_8/location_services/nominatim.ts
+++ b/weather@mockturtl/src/3_8/location_services/nominatim.ts
@@ -30,10 +30,11 @@ export class GeoLocation {
 				return cached;
 			}
 
-			const locationData = await this.App.LoadJsonAsync<any>(
-				`${this.url}?q=${searchText}&${this.params}`,
+			const locationData = await this.App.LoadJsonAsync<any>({
+				url: `${this.url}?q=${searchText}&${this.params}`,
 				cancellable
-			);
+			});
+
 			if (locationData == null)
 				return null;
 

--- a/weather@mockturtl/src/3_8/loop.ts
+++ b/weather@mockturtl/src/3_8/loop.ts
@@ -86,7 +86,7 @@ export class WeatherLoop {
 					: "PORTAL";
 
 				Logger.Info(`Internet access "${name} (${NetworkMonitor.get_default().connectivity})" now available, initiating refresh.`);
-				this.DoCheck();
+				this.Resume();
 				break;
 			case NetworkConnectivity.LOCAL:
 				Logger.Info(`Internet access now down with "${NetworkMonitor.get_default().connectivity}".`);

--- a/weather@mockturtl/src/3_8/loop.ts
+++ b/weather@mockturtl/src/3_8/loop.ts
@@ -201,6 +201,7 @@ export class WeatherLoop {
 		finally {
 			this.refreshingResolver?.();
 			this.refreshingResolver = null;
+			this.runningRefresh?.cancel();
 			this.runningRefresh = null;
 		}
 	}

--- a/weather@mockturtl/src/3_8/loop.ts
+++ b/weather@mockturtl/src/3_8/loop.ts
@@ -163,7 +163,6 @@ export class WeatherLoop {
 		catch (e) {
 			if (e instanceof Error)
 				Logger.Error("Error in Main loop: " + e, e);
-			this.app.encounteredError = true;
 		}
 		finally {
 			this.refreshingResolver?.();
@@ -218,7 +217,6 @@ export class WeatherLoop {
 	}
 
 	private IncrementErrorCount(): void {
-		this.app.encounteredError = false;
 		this.errorCount++;
 		Logger.Debug("Encountered error in previous loop");
 		// Limiting count so timeout does not expand forever

--- a/weather@mockturtl/src/3_8/loop.ts
+++ b/weather@mockturtl/src/3_8/loop.ts
@@ -10,8 +10,15 @@ import { delay, Guid } from "./utils";
 var weatherAppletGUIDs: GUIDStore = {};
 
 export interface RefreshOptions {
+	/** default false */
 	rebuild?: boolean,
+	/**
+	 *  default undefined
+	 */
 	location?: LocationData | undefined,
+	/**
+	 * default true
+	 */
 	immediate?: boolean
 }
 
@@ -57,7 +64,7 @@ export class WeatherLoop {
 	public async Start(): Promise<void> {
 		Logger.Info("Main Loop started.")
 		while (true) {
-			await this.DoCheck();
+			await this.DoCheck({immediate: false});
 			await delay(this.LoopInterval());
 		}
 		Logger.Error("Main Loop stopped.")
@@ -71,7 +78,7 @@ export class WeatherLoop {
 		const {
 			rebuild = false,
 			location = null,
-			immediate = false
+			immediate = true
 		} = options;
 
 		// We are in the middle of an update, just skip
@@ -93,7 +100,7 @@ export class WeatherLoop {
 			}
 
 			const needToUpdate = this.errorCount > 0 || this.NextUpdate() < new Date();
-			if (!needToUpdate) {
+			if (!needToUpdate && !immediate) {
 				Logger.Debug("No need to update yet, skipping.")
 				return;
 			}
@@ -162,7 +169,7 @@ export class WeatherLoop {
 	 */
 	public async Refresh(options?: RefreshOptions): Promise<void> {
 		this.pauseRefresh = false;
-		await this.DoCheck();
+		await this.DoCheck(options);
 	}
 
 	/** Used after a successful weather refresh. */

--- a/weather@mockturtl/src/3_8/main.ts
+++ b/weather@mockturtl/src/3_8/main.ts
@@ -100,7 +100,7 @@ export class WeatherApplet extends TextIconApplet {
 		}
 		this.loop.Start();
 		// We need a full rebuild and refresh for these
-		this.config.DataServiceChanged.Subscribe(() => this.loop.Refresh({immediate: true, rebuild: true}));
+		this.config.DataServiceChanged.Subscribe(() => this.loop.Refresh({rebuild: true}));
 
 		// We need a full rebuild without refresh for these
 		this.config.VerticalOrientationChanged.Subscribe(this.AfterRefresh(this.onSettingNeedsRebuild));
@@ -112,15 +112,15 @@ export class WeatherApplet extends TextIconApplet {
 		this.config.ForecastHoursChanged.Subscribe(this.AfterRefresh(this.onSettingNeedsRebuild));
 
 		// We need a full refresh for these
-		this.config.ApiKeyChanged.Subscribe(() => this.loop.Refresh({immediate: true}));
+		this.config.ApiKeyChanged.Subscribe(() => this.loop.Refresh());
 		// We change how we process data when this is changed
-		this.config.ShortConditionsChanged.Subscribe(() => this.loop.Refresh({immediate: true}));
+		this.config.ShortConditionsChanged.Subscribe(() => this.loop.Refresh());
 		// Some translations come from the API we need a refresh
-		this.config.TranslateConditionChanged.Subscribe(() => this.loop.Refresh({immediate: true}));
-		this.config.ManualLocationChanged.Subscribe(() => this.loop.Refresh({immediate: true}));
+		this.config.TranslateConditionChanged.Subscribe(() => this.loop.Refresh());
+		this.config.ManualLocationChanged.Subscribe(() => this.loop.Refresh());
 
 		// Misc Triggers
-		this.config.RefreshIntervalChanged.Subscribe(() => this.loop.Refresh());
+		this.config.RefreshIntervalChanged.Subscribe(() => this.loop.Refresh({immediate: false}));
 
 		// Panel
 		this.config.ShowCommentInPanelChanged.Subscribe(this.RefreshLabel);
@@ -152,7 +152,7 @@ export class WeatherApplet extends TextIconApplet {
 				Logger.Info(`Internet access "${name} (${NetworkMonitor.get_default().connectivity})" now available, resuming operations.`);
 				this.encounteredError = false;
 				this.loop.ResetErrorCount();
-				this.loop.Refresh({immediate: true});
+				this.loop.Refresh();
 				this.online = true;
 				break;
 			case NetworkConnectivity.LOCAL:
@@ -586,7 +586,7 @@ The contents of the file saved from the applet help page goes here
 	/** Into right-click context menu */
 	private AddRefreshButton(): void {
 		const itemLabel = _("Refresh")
-		const refreshMenuItem = new MenuItem(itemLabel, REFRESH_ICON, () => this.loop.Refresh({immediate: true, rebuild: true}));
+		const refreshMenuItem = new MenuItem(itemLabel, REFRESH_ICON, () => this.loop.Refresh({rebuild: true}));
 		this._applet_context_menu.addMenuItem(refreshMenuItem);
 	}
 

--- a/weather@mockturtl/src/3_8/main.ts
+++ b/weather@mockturtl/src/3_8/main.ts
@@ -34,18 +34,9 @@ export interface LoadJsonAsyncOptions extends LoadAsyncOptions {
 
 export class WeatherApplet extends TextIconApplet {
 	private readonly loop: WeatherLoop;
-	private refreshing: Promise<void> | null = null;
-
 	private currentWeatherInfo: WeatherData | null = null;
 	public get CurrentData(): WeatherData | null {
 		return this.currentWeatherInfo;
-	}
-
-	public get Refreshing(): Promise<void> {
-		if (this.refreshing == null)
-			return Promise.resolve();
-
-		return this.refreshing;
 	}
 
 	/** Chosen API */
@@ -516,7 +507,7 @@ The contents of the file saved from the applet help page goes here
 	 */
 	public AfterRefresh = <T, TT>(callback: (owner: T, data: TT, weatherData: WeatherData) => void | Promise<void>): ((owner: T, data: TT) => Promise<void>) => {
 		return async (owner, data) => {
-			await this.Refreshing;
+			await this.loop.Refreshing;
 			const weatherData = this.CurrentData;
 			if (weatherData == null)
 				return;

--- a/weather@mockturtl/src/3_8/main.ts
+++ b/weather@mockturtl/src/3_8/main.ts
@@ -80,6 +80,7 @@ export class WeatherApplet extends TextIconApplet {
 		this.ui = new UI(this, orientation);
 		this.ui.Rebuild(this.config);
 		this.loop = new WeatherLoop(this, instanceId);
+		HttpLib.Instance.UnhandledError.Subscribe((sender, error) => this.HandleHTTPError(error));
 		try {
 			this.setAllowedLayout(AllowedLayout.BOTH);
 		} catch (e) {
@@ -338,79 +339,6 @@ export class WeatherApplet extends TextIconApplet {
 		return Math.min(this.config._forecastHours, this.provider.maxHourlyForecastSupport);
 	}
 
-	// ------------------------------------------------------------------------
-	// IO Helpers
-
-	/**
-	 * Loads JSON response from specified URL, returns the whole response not just data
-	 * @param url URL without params
-	 * @param params param object
-	 * @param HandleError should return false to mark error handled, else true
-	 * @param method default is GET
-	 */
-	public async LoadJsonAsyncWithDetails<T, E = any>(
-		this: WeatherApplet,
-		options: LoadJsonAsyncOptions
-	): Promise<Response<T, E>> {
-		const { HandleError, url, ...params } = options;
-		const response = await HttpLib.Instance.LoadJsonAsync<T, E>(url, params);
-
-		// We have errorData inside
-		if (!response.Success) {
-			// check if caller wants
-			if (!!HandleError && !HandleError(response))
-				return response;
-			else {
-				this.HandleHTTPError(response.ErrorData);
-				return response;
-			}
-		}
-
-		return response;
-	}
-
-	/**
-	 * Loads JSON response from specified URLs
-	 * @param url URL without params
-	 * @param params param object
-	 * @param HandleError should return false to mark error handled, else true
-	 * @param method default is GET
-	 */
-	public async LoadJsonAsync<T, E = any>(
-		this: WeatherApplet,
-		options: LoadJsonAsyncOptions
-	): Promise<T | null> {
-		const response = await this.LoadJsonAsyncWithDetails<T, E>(options);
-		return (response.Success) ? response.Data : null;
-	}
-
-	/**
-	 * Loads response from specified URLs
-	 * @param url URL without params
-	 * @param params param object
-	 * @param HandleError should return false to mark error handled, else true
-	 * @param method default is GET
-	 */
-	public async LoadAsync<E = any>(
-		this: WeatherApplet,
-		options: LoadJsonAsyncOptions
-	): Promise<string | null> {
-		const { HandleError, url, ...params } = options;
-		const response = await HttpLib.Instance.LoadAsync(url, params);
-
-		// We have errorData inside
-		if (!response.Success) {
-			// check if caller wants
-			if (!!HandleError && !HandleError(response))
-				return null;
-			else {
-				this.HandleHTTPError(response.ErrorData);
-				return null;
-			}
-		}
-
-		return response.Data;
-	}
 
 	// ----------------------------------------------------------------------------
 	// Config Callbacks, do not delete

--- a/weather@mockturtl/src/3_8/main.ts
+++ b/weather@mockturtl/src/3_8/main.ts
@@ -380,6 +380,11 @@ The contents of the file saved from the applet help page goes here
 
 		const appletLogFile = File.new_for_path(this.config._selectedLogPath);
 		const stream = await OverwriteAndGetIOStream(appletLogFile);
+		if (stream == null) {
+			NotificationService.Instance.Send(_("Error Saving Debug Information"), _("Could not open file {filePath} for writing", {filePath: this.config._selectedLogPath} ));
+			return;
+		}
+
 		await WriteAsync(stream.get_output_stream(), logLines.join("\n"));
 
 		if (settings != null) {

--- a/weather@mockturtl/src/3_8/main.ts
+++ b/weather@mockturtl/src/3_8/main.ts
@@ -151,7 +151,6 @@ export class WeatherApplet extends TextIconApplet {
 
 				Logger.Info(`Internet access "${name} (${NetworkMonitor.get_default().connectivity})" now available, resuming operations.`);
 				this.encounteredError = false;
-				this.loop.ResetErrorCount();
 				this.loop.Refresh();
 				this.online = true;
 				break;
@@ -182,6 +181,11 @@ export class WeatherApplet extends TextIconApplet {
 		this.ui.Display(data, conf, this.Provider);
 	}
 
+	/**
+	 *
+	 * @param options By default it will cancel the current refresh (if any) then start a new one.
+	 * @returns
+	 */
 	public async Refresh(options?: RefreshOptions): Promise<void> {
 		return this.loop.Refresh(options);
 	}
@@ -213,23 +217,10 @@ export class WeatherApplet extends TextIconApplet {
 
 			// No key
 			if (this.provider.needsApiKey && this.config.NoApiKey()) {
-				Logger.Error("No API Key given");
-				this.ShowError({
-					type: "hard",
-					userError: true,
-					detail: "no key",
-					message: _("This provider requires an API key to operate")
-				});
 				return RefreshState.NoKey;
 			}
 			let weatherInfo = await this.provider.GetWeather(location, cancellable);
 			if (weatherInfo == null) {
-				Logger.Error("Could not refresh weather, data could not be obtained.");
-				this.ShowError({
-					type: "hard",
-					detail: "no api response",
-					message: "API did not return data"
-				})
 				return RefreshState.NoWeather;
 			}
 
@@ -245,8 +236,6 @@ export class WeatherApplet extends TextIconApplet {
 			}
 
 			this.currentWeatherInfo = weatherInfo;
-			Logger.Info("Weather Information refreshed");
-			this.loop.ResetErrorCount();
 			return RefreshState.Success;
 		}
 		catch (e) {

--- a/weather@mockturtl/src/3_8/main.ts
+++ b/weather@mockturtl/src/3_8/main.ts
@@ -367,7 +367,7 @@ export class WeatherApplet extends TextIconApplet {
 	public async LoadJsonAsyncWithDetails<T, E = any>(
 		this: WeatherApplet,
 		url: string,
-		cancellable?: imports.gi.Gio.Cancellable,
+		cancellable: imports.gi.Gio.Cancellable,
 		params?: HTTPParams,
 		HandleError?: (message: ErrorResponse<E>) => boolean,
 		headers?: HTTPHeaders,

--- a/weather@mockturtl/src/3_8/providers/BaseProvider.ts
+++ b/weather@mockturtl/src/3_8/providers/BaseProvider.ts
@@ -16,7 +16,7 @@ export abstract class BaseProvider implements WeatherProvider {
 
     protected readonly app: WeatherApplet;
 
-    public abstract GetWeather(loc: LocationData): Promise<WeatherData | null>;
+    public abstract GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null>;
 
     public constructor(app: WeatherApplet) {
         this.app = app;

--- a/weather@mockturtl/src/3_8/providers/accuWeather.ts
+++ b/weather@mockturtl/src/3_8/providers/accuWeather.ts
@@ -56,7 +56,7 @@ export class AccuWeather extends BaseProvider {
 
     private readonly locationCache: {[key: string]: LocationPayload} = {};
 
-    public async GetWeather(loc: LocationData): Promise<WeatherData | null> {
+    public async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> {
         const locationID = `${loc.lat},${loc.lon}`;
         const userLocale = this.app.config.currentLocale?.toLowerCase() ?? "en-us";
         const locale = this.app.config._translateCondition ? userLocale : "en-us";
@@ -65,7 +65,7 @@ export class AccuWeather extends BaseProvider {
         if (this.locationCache[locationID] != null)
             location = this.locationCache[locationID];
         else
-            location = await this.app.LoadJsonAsync<LocationPayload>(this.locSearchUrl, { q: locationID, details: true, language: userLocale, apikey: this.app.config.ApiKey }, this.HandleErrors);
+            location = await this.app.LoadJsonAsync<LocationPayload>(this.locSearchUrl, cancellable, { q: locationID, details: true, language: userLocale, apikey: this.app.config.ApiKey }, this.HandleErrors);
 
         if (location == null) {
             /** Error, probably handled already */
@@ -73,9 +73,9 @@ export class AccuWeather extends BaseProvider {
         }
 
         const [current, forecast, hourly] = await Promise.all([
-            this.app.LoadJsonAsyncWithDetails<CurrentPayload[]>(this.currentConditionUrl + location.Key, { apikey: this.app.config.ApiKey, details: true, language: locale, }, this.HandleErrors),
-            this.app.LoadJsonAsyncWithDetails<DailyPayload>(this.dailyForecastUrl + location.Key, { apikey: this.app.config.ApiKey, details: true, metric: true, language: locale, }, this.HandleErrors),
-            this.app.LoadJsonAsyncWithDetails<HourlyPayload[]>(this.hourlyForecastUrl + location.Key, { apikey: this.app.config.ApiKey, details: true, metric: true, language: locale, }, this.HandleErrors)
+            this.app.LoadJsonAsyncWithDetails<CurrentPayload[]>(this.currentConditionUrl + location.Key, cancellable, { apikey: this.app.config.ApiKey, details: true, language: locale, }, this.HandleErrors),
+            this.app.LoadJsonAsyncWithDetails<DailyPayload>(this.dailyForecastUrl + location.Key, cancellable, { apikey: this.app.config.ApiKey, details: true, metric: true, language: locale, }, this.HandleErrors),
+            this.app.LoadJsonAsyncWithDetails<HourlyPayload[]>(this.hourlyForecastUrl + location.Key, cancellable, { apikey: this.app.config.ApiKey, details: true, metric: true, language: locale, }, this.HandleErrors)
         ])
 
         if (!current.Success || !forecast.Success || !hourly.Success)

--- a/weather@mockturtl/src/3_8/providers/accuWeather.ts
+++ b/weather@mockturtl/src/3_8/providers/accuWeather.ts
@@ -1,6 +1,6 @@
 import { DateTime } from "luxon";
 import { Services } from "../config";
-import { ErrorResponse, HttpError } from "../lib/httpLib";
+import { ErrorResponse, HttpError, HttpLib } from "../lib/httpLib";
 import { WeatherApplet } from "../main";
 import { Condition, ForecastData, HourlyForecastData, LocationData, Precipitation, WeatherData } from "../types";
 import { CelsiusToKelvin, KPHtoMPS, _ } from "../utils";
@@ -66,7 +66,7 @@ export class AccuWeather extends BaseProvider {
             location = this.locationCache[locationID];
 		}
         else {
-            location = await this.app.LoadJsonAsync<LocationPayload>({
+            location = await HttpLib.Instance.LoadJsonSimple<LocationPayload>({
 				url: this.locSearchUrl,
 				cancellable,
 				params: { q: locationID, details: true, language: userLocale, apikey: this.app.config.ApiKey },
@@ -80,19 +80,19 @@ export class AccuWeather extends BaseProvider {
         }
 
         const [current, forecast, hourly] = await Promise.all([
-            this.app.LoadJsonAsyncWithDetails<CurrentPayload[]>({
+            HttpLib.Instance.LoadJsonAsync<CurrentPayload[]>({
 				url: this.currentConditionUrl + location.Key,
 				cancellable,
 				params: { apikey: this.app.config.ApiKey, details: true, language: locale, },
 				HandleError: this.HandleErrors
 			}),
-            this.app.LoadJsonAsyncWithDetails<DailyPayload>({
+            HttpLib.Instance.LoadJsonAsync<DailyPayload>({
 				url: this.dailyForecastUrl + location.Key,
 				cancellable,
 				params: { apikey: this.app.config.ApiKey, details: true, metric: true, language: locale, },
 				HandleError: this.HandleErrors
 			}),
-            this.app.LoadJsonAsyncWithDetails<HourlyPayload[]>({
+            HttpLib.Instance.LoadJsonAsync<HourlyPayload[]>({
 				url: this.hourlyForecastUrl + location.Key,
 				cancellable,
 				params: { apikey: this.app.config.ApiKey, details: true, metric: true, language: locale, },

--- a/weather@mockturtl/src/3_8/providers/accuWeather.ts
+++ b/weather@mockturtl/src/3_8/providers/accuWeather.ts
@@ -62,10 +62,17 @@ export class AccuWeather extends BaseProvider {
         const locale = this.app.config._translateCondition ? userLocale : "en-us";
 
         let location: LocationPayload | null;
-        if (this.locationCache[locationID] != null)
+        if (this.locationCache[locationID] != null) {
             location = this.locationCache[locationID];
-        else
-            location = await this.app.LoadJsonAsync<LocationPayload>(this.locSearchUrl, cancellable, { q: locationID, details: true, language: userLocale, apikey: this.app.config.ApiKey }, this.HandleErrors);
+		}
+        else {
+            location = await this.app.LoadJsonAsync<LocationPayload>({
+				url: this.locSearchUrl,
+				cancellable,
+				params: { q: locationID, details: true, language: userLocale, apikey: this.app.config.ApiKey },
+				HandleError: this.HandleErrors
+			});
+		}
 
         if (location == null) {
             /** Error, probably handled already */
@@ -73,9 +80,24 @@ export class AccuWeather extends BaseProvider {
         }
 
         const [current, forecast, hourly] = await Promise.all([
-            this.app.LoadJsonAsyncWithDetails<CurrentPayload[]>(this.currentConditionUrl + location.Key, cancellable, { apikey: this.app.config.ApiKey, details: true, language: locale, }, this.HandleErrors),
-            this.app.LoadJsonAsyncWithDetails<DailyPayload>(this.dailyForecastUrl + location.Key, cancellable, { apikey: this.app.config.ApiKey, details: true, metric: true, language: locale, }, this.HandleErrors),
-            this.app.LoadJsonAsyncWithDetails<HourlyPayload[]>(this.hourlyForecastUrl + location.Key, cancellable, { apikey: this.app.config.ApiKey, details: true, metric: true, language: locale, }, this.HandleErrors)
+            this.app.LoadJsonAsyncWithDetails<CurrentPayload[]>({
+				url: this.currentConditionUrl + location.Key,
+				cancellable,
+				params: { apikey: this.app.config.ApiKey, details: true, language: locale, },
+				HandleError: this.HandleErrors
+			}),
+            this.app.LoadJsonAsyncWithDetails<DailyPayload>({
+				url: this.dailyForecastUrl + location.Key,
+				cancellable,
+				params: { apikey: this.app.config.ApiKey, details: true, metric: true, language: locale, },
+				HandleError: this.HandleErrors
+			}),
+            this.app.LoadJsonAsyncWithDetails<HourlyPayload[]>({
+				url: this.hourlyForecastUrl + location.Key,
+				cancellable,
+				params: { apikey: this.app.config.ApiKey, details: true, metric: true, language: locale, },
+				HandleError: this.HandleErrors
+			})
         ])
 
         if (!current.Success || !forecast.Success || !hourly.Success)

--- a/weather@mockturtl/src/3_8/providers/climacellV4.ts
+++ b/weather@mockturtl/src/3_8/providers/climacellV4.ts
@@ -31,14 +31,14 @@ export class ClimacellV4 extends BaseProvider {
 		super(app);
 	}
 
-	public async GetWeather(loc: LocationData): Promise<WeatherData | null> {
+	public async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> {
 		if (loc == null)
 			return null;
 
 		this.params.apikey = this.app.config.ApiKey;
 		this.params.location = loc.lat + "," + loc.lon;
 
-		const response = await this.app.LoadJsonAsync<ClimacellV4Payload>(this.url, this.params, (m) => this.HandleHTTPError(m));
+		const response = await this.app.LoadJsonAsync<ClimacellV4Payload>(this.url, cancellable, this.params, (m) => this.HandleHTTPError(m));
 
 		if (response == null)
 			return null;
@@ -119,7 +119,7 @@ export class ClimacellV4 extends BaseProvider {
 			// bit sneaky, but setting the hourly forecast startTime to beginning of the hour
 			// so it is displayed properly
 			date = date.set({ minute: 0, second: 0, millisecond: 0 });
-			
+
 			const hour: HourlyForecastData = {
 				condition: this.ResolveCondition(element.values.weatherCode, IsNight({sunrise, sunset}, date)),
 				date,

--- a/weather@mockturtl/src/3_8/providers/climacellV4.ts
+++ b/weather@mockturtl/src/3_8/providers/climacellV4.ts
@@ -38,7 +38,12 @@ export class ClimacellV4 extends BaseProvider {
 		this.params.apikey = this.app.config.ApiKey;
 		this.params.location = loc.lat + "," + loc.lon;
 
-		const response = await this.app.LoadJsonAsync<ClimacellV4Payload>(this.url, cancellable, this.params, (m) => this.HandleHTTPError(m));
+		const response = await this.app.LoadJsonAsync<ClimacellV4Payload>({
+			url: this.url,
+			cancellable,
+			params: this.params,
+			HandleError: (m) => this.HandleHTTPError(m)
+		});
 
 		if (response == null)
 			return null;

--- a/weather@mockturtl/src/3_8/providers/climacellV4.ts
+++ b/weather@mockturtl/src/3_8/providers/climacellV4.ts
@@ -1,6 +1,6 @@
 import { DateTime } from "luxon";
 import { Services } from "../config";
-import { ErrorResponse, HttpError, HTTPParams } from "../lib/httpLib";
+import { ErrorResponse, HttpError, HttpLib, HTTPParams } from "../lib/httpLib";
 import { WeatherApplet } from "../main";
 import { Condition, ForecastData, HourlyForecastData, LocationData, PrecipitationType, WeatherData, WeatherProvider } from "../types";
 import { CelsiusToKelvin, IsNight, _ } from "../utils";
@@ -38,7 +38,7 @@ export class ClimacellV4 extends BaseProvider {
 		this.params.apikey = this.app.config.ApiKey;
 		this.params.location = loc.lat + "," + loc.lon;
 
-		const response = await this.app.LoadJsonAsync<ClimacellV4Payload>({
+		const response = await HttpLib.Instance.LoadJsonSimple<ClimacellV4Payload>({
 			url: this.url,
 			cancellable,
 			params: this.params,

--- a/weather@mockturtl/src/3_8/providers/danishMI.ts
+++ b/weather@mockturtl/src/3_8/providers/danishMI.ts
@@ -1,6 +1,6 @@
 import { DateTime } from "luxon";
 import { Services } from "../config";
-import { HTTPParams } from "../lib/httpLib";
+import { HTTPParams, HttpLib } from "../lib/httpLib";
 import { WeatherApplet } from "../main";
 import { Condition, ForecastData, HourlyForecastData, LocationData, PrecipitationType, WeatherData, WeatherProvider } from "../types";
 import { CelsiusToKelvin, GetDistance, mode, _ } from "../utils";
@@ -43,7 +43,7 @@ export class DanishMI extends BaseProvider {
 			return null;
 
 		this.GetLocationBoundingBox(loc);
-		const observations = this.OrderObservations(await this.app.LoadJsonAsync<DanishObservationPayloads>({
+		const observations = this.OrderObservations(await HttpLib.Instance.LoadJsonSimple<DanishObservationPayloads>({
 			url: this.url,
 			cancellable,
 			params: this.observationParams
@@ -52,7 +52,7 @@ export class DanishMI extends BaseProvider {
 		this.forecastParams.lat = loc.lat;
 		this.forecastParams.lon = loc.lon;
 
-		const forecasts = await this.app.LoadJsonAsync<DanishMIPayload>({
+		const forecasts = await HttpLib.Instance.LoadJsonSimple<DanishMIPayload>({
 			url: this.url,
 			cancellable,
 			params: this.forecastParams

--- a/weather@mockturtl/src/3_8/providers/danishMI.ts
+++ b/weather@mockturtl/src/3_8/providers/danishMI.ts
@@ -43,12 +43,21 @@ export class DanishMI extends BaseProvider {
 			return null;
 
 		this.GetLocationBoundingBox(loc);
-		const observations = this.OrderObservations(await this.app.LoadJsonAsync<DanishObservationPayloads>(this.url, cancellable, this.observationParams), loc);
+		const observations = this.OrderObservations(await this.app.LoadJsonAsync<DanishObservationPayloads>({
+			url: this.url,
+			cancellable,
+			params: this.observationParams
+		}), loc);
 
 		this.forecastParams.lat = loc.lat;
 		this.forecastParams.lon = loc.lon;
 
-		const forecasts = await this.app.LoadJsonAsync<DanishMIPayload>(this.url, cancellable, this.forecastParams);
+		const forecasts = await this.app.LoadJsonAsync<DanishMIPayload>({
+			url: this.url,
+			cancellable,
+			params: this.forecastParams
+		});
+
 		if (forecasts == null)
 			return null;
 

--- a/weather@mockturtl/src/3_8/providers/danishMI.ts
+++ b/weather@mockturtl/src/3_8/providers/danishMI.ts
@@ -38,17 +38,17 @@ export class DanishMI extends BaseProvider {
 		super(app);
 	}
 
-	async GetWeather(loc: LocationData): Promise<WeatherData | null> {
+	async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> {
 		if (loc == null)
 			return null;
 
 		this.GetLocationBoundingBox(loc);
-		const observations = this.OrderObservations(await this.app.LoadJsonAsync<DanishObservationPayloads>(this.url, this.observationParams), loc);
+		const observations = this.OrderObservations(await this.app.LoadJsonAsync<DanishObservationPayloads>(this.url, cancellable, this.observationParams), loc);
 
 		this.forecastParams.lat = loc.lat;
 		this.forecastParams.lon = loc.lon;
 
-		const forecasts = await this.app.LoadJsonAsync<DanishMIPayload>(this.url, this.forecastParams);
+		const forecasts = await this.app.LoadJsonAsync<DanishMIPayload>(this.url, cancellable, this.forecastParams);
 		if (forecasts == null)
 			return null;
 

--- a/weather@mockturtl/src/3_8/providers/deutscherWetterdienst.ts
+++ b/weather@mockturtl/src/3_8/providers/deutscherWetterdienst.ts
@@ -22,18 +22,18 @@ export class DeutscherWetterdienst extends BaseProvider {
 
     public async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> {
         const [current, hourly] = await Promise.all([
-            this.app.LoadJsonAsync<CurrentWeatherPayload>(
-				`${this.baseUrl}current_weather`,
+            this.app.LoadJsonAsync<CurrentWeatherPayload>({
+				url: `${this.baseUrl}current_weather`,
 				cancellable,
-				this.GetDefaultParams(loc),
-				this.HandleErrors
-			),
-            this.app.LoadJsonAsync<HourlyForecastPayload>(
-				`${this.baseUrl}weather`,
+				params: this.GetDefaultParams(loc),
+				HandleError: this.HandleErrors
+			}),
+            this.app.LoadJsonAsync<HourlyForecastPayload>({
+				url: `${this.baseUrl}weather`,
 				cancellable,
-				this.GetHourlyParams(loc),
-				this.HandleErrors,
-			)
+				params: this.GetHourlyParams(loc),
+				HandleError: this.HandleErrors,
+			})
         ]);
 
         if (current == null || hourly == null)

--- a/weather@mockturtl/src/3_8/providers/deutscherWetterdienst.ts
+++ b/weather@mockturtl/src/3_8/providers/deutscherWetterdienst.ts
@@ -1,7 +1,7 @@
 import { DateTime } from "luxon";
 import { getTimes, GetTimesResult } from "suncalc";
 import { Services } from "../config";
-import { ErrorResponse, HTTPParams } from "../lib/httpLib";
+import { ErrorResponse, HttpLib, HTTPParams } from "../lib/httpLib";
 import { Condition, ForecastData, HourlyForecastData, LocationData, WeatherData, PrecipitationType } from "../types";
 import { IsNight, _ } from "../utils";
 import { BaseProvider } from "./BaseProvider"
@@ -22,13 +22,13 @@ export class DeutscherWetterdienst extends BaseProvider {
 
     public async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> {
         const [current, hourly] = await Promise.all([
-            this.app.LoadJsonAsync<CurrentWeatherPayload>({
+            HttpLib.Instance.LoadJsonSimple<CurrentWeatherPayload>({
 				url: `${this.baseUrl}current_weather`,
 				cancellable,
 				params: this.GetDefaultParams(loc),
 				HandleError: this.HandleErrors
 			}),
-            this.app.LoadJsonAsync<HourlyForecastPayload>({
+            HttpLib.Instance.LoadJsonSimple<HourlyForecastPayload>({
 				url: `${this.baseUrl}weather`,
 				cancellable,
 				params: this.GetHourlyParams(loc),

--- a/weather@mockturtl/src/3_8/providers/deutscherWetterdienst.ts
+++ b/weather@mockturtl/src/3_8/providers/deutscherWetterdienst.ts
@@ -20,10 +20,20 @@ export class DeutscherWetterdienst extends BaseProvider {
 
     private readonly baseUrl: string = "https://api.brightsky.dev/";
 
-    public async GetWeather(loc: LocationData): Promise<WeatherData | null> {
+    public async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> {
         const [current, hourly] = await Promise.all([
-            this.app.LoadJsonAsync<CurrentWeatherPayload>(`${this.baseUrl}current_weather`, this.GetDefaultParams(loc), this.HandleErrors),
-            this.app.LoadJsonAsync<HourlyForecastPayload>(`${this.baseUrl}weather`, this.GetHourlyParams(loc), this.HandleErrors)
+            this.app.LoadJsonAsync<CurrentWeatherPayload>(
+				`${this.baseUrl}current_weather`,
+				cancellable,
+				this.GetDefaultParams(loc),
+				this.HandleErrors
+			),
+            this.app.LoadJsonAsync<HourlyForecastPayload>(
+				`${this.baseUrl}weather`,
+				cancellable,
+				this.GetHourlyParams(loc),
+				this.HandleErrors,
+			)
         ]);
 
         if (current == null || hourly == null)

--- a/weather@mockturtl/src/3_8/providers/met_norway/provider.ts
+++ b/weather@mockturtl/src/3_8/providers/met_norway/provider.ts
@@ -23,17 +23,17 @@ export class MetNorway extends BaseProvider {
 
 	public async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> {
 		const [forecast, nowcast] = await Promise.all([
-			this.app.LoadJsonAsync<MetNorwayForecastPayload>(
-				`${this.baseUrl}/locationforecast/2.0/complete`,
+			this.app.LoadJsonAsync<MetNorwayForecastPayload>({
+				url: `${this.baseUrl}/locationforecast/2.0/complete`,
 				cancellable,
-				{lat: loc.lat, lon: loc.lon}
-			),
-			this.app.LoadJsonAsync<MetNorwayNowcastPayload>(
-				`${this.baseUrl}/nowcast/2.0/complete`,
+				params: {lat: loc.lat, lon: loc.lon}
+			}),
+			this.app.LoadJsonAsync<MetNorwayNowcastPayload>({
+				url: `${this.baseUrl}/nowcast/2.0/complete`,
 				cancellable,
-				{lat: loc.lat, lon: loc.lon},
-				(e) => e.ErrorData.code != 422
-			),
+				params: {lat: loc.lat, lon: loc.lon},
+				HandleError: (e) => e.ErrorData.code != 422
+			}),
 		]);
 
 		if (!forecast) {

--- a/weather@mockturtl/src/3_8/providers/met_norway/provider.ts
+++ b/weather@mockturtl/src/3_8/providers/met_norway/provider.ts
@@ -21,10 +21,19 @@ export class MetNorway extends BaseProvider {
 
 	private baseUrl = "https://api.met.no/weatherapi";
 
-	public async GetWeather(loc: LocationData): Promise<WeatherData | null> {
+	public async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> {
 		const [forecast, nowcast] = await Promise.all([
-			this.app.LoadJsonAsync<MetNorwayForecastPayload>(`${this.baseUrl}/locationforecast/2.0/complete`, {lat: loc.lat, lon: loc.lon}),
-			this.app.LoadJsonAsync<MetNorwayNowcastPayload>(`${this.baseUrl}/nowcast/2.0/complete`, {lat: loc.lat, lon: loc.lon}, (e) => e.ErrorData.code != 422),
+			this.app.LoadJsonAsync<MetNorwayForecastPayload>(
+				`${this.baseUrl}/locationforecast/2.0/complete`,
+				cancellable,
+				{lat: loc.lat, lon: loc.lon}
+			),
+			this.app.LoadJsonAsync<MetNorwayNowcastPayload>(
+				`${this.baseUrl}/nowcast/2.0/complete`,
+				cancellable,
+				{lat: loc.lat, lon: loc.lon},
+				(e) => e.ErrorData.code != 422
+			),
 		]);
 
 		if (!forecast) {

--- a/weather@mockturtl/src/3_8/providers/met_norway/provider.ts
+++ b/weather@mockturtl/src/3_8/providers/met_norway/provider.ts
@@ -7,6 +7,7 @@ import { BaseProvider } from "../BaseProvider";
 import { Conditions, conditionSeverity, TimeOfDay } from "./types/common";
 import { IsCovered, MetNorwayNowcastPayload } from "./types/nowcast";
 import { MetNorwayForecastData, MetNorwayForecastPayload } from "./types/forecast";
+import { HttpLib } from "../../lib/httpLib";
 
 export class MetNorway extends BaseProvider {
 	public readonly prettyName = _("MET Norway");
@@ -23,12 +24,12 @@ export class MetNorway extends BaseProvider {
 
 	public async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> {
 		const [forecast, nowcast] = await Promise.all([
-			this.app.LoadJsonAsync<MetNorwayForecastPayload>({
+			HttpLib.Instance.LoadJsonSimple<MetNorwayForecastPayload>({
 				url: `${this.baseUrl}/locationforecast/2.0/complete`,
 				cancellable,
 				params: {lat: loc.lat, lon: loc.lon}
 			}),
-			this.app.LoadJsonAsync<MetNorwayNowcastPayload>({
+			HttpLib.Instance.LoadJsonSimple<MetNorwayNowcastPayload>({
 				url: `${this.baseUrl}/nowcast/2.0/complete`,
 				cancellable,
 				params: {lat: loc.lat, lon: loc.lon},

--- a/weather@mockturtl/src/3_8/providers/met_uk.ts
+++ b/weather@mockturtl/src/3_8/providers/met_uk.ts
@@ -14,6 +14,7 @@ import { WeatherProvider, WeatherData, ForecastData, HourlyForecastData, Conditi
 import { _, GetDistance, MPHtoMPS, CompassToDeg, CelsiusToKelvin, MetreToUserUnits, OnSameDay } from "../utils";
 import { DateTime } from "luxon";
 import { BaseProvider } from "./BaseProvider";
+import { HttpLib } from "../lib/httpLib";
 
 export class MetUk extends BaseProvider {
 
@@ -109,7 +110,7 @@ export class MetUk extends BaseProvider {
 	};
 
 	private async GetClosestForecastSite(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherSite | null> {
-		const forecastSitelist = await this.app.LoadJsonAsync({
+		const forecastSitelist = await HttpLib.Instance.LoadJsonSimple({
 			url: this.baseUrl + this.forecastPrefix + this.sitesUrl + "?" + this.key,
 			cancellable
 		});
@@ -121,7 +122,7 @@ export class MetUk extends BaseProvider {
 	}
 
 	private async GetObservationSitesInRange(loc: LocationData, range: number, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherSite[] | null> {
-		const observationSiteList = await this.app.LoadJsonAsync<any>({
+		const observationSiteList = await HttpLib.Instance.LoadJsonSimple<any>({
 			url: this.baseUrl + this.currentPrefix + this.sitesUrl + "?" + this.key,
 			cancellable
 		});
@@ -147,7 +148,7 @@ export class MetUk extends BaseProvider {
 		const observations: METPayload<true>[] = [];
 		for (const element of observationSites) {
 			Logger.Debug("Getting observation data from station: " + element.id);
-			const payload = await this.app.LoadJsonAsync<METPayload<true>>({
+			const payload = await HttpLib.Instance.LoadJsonSimple<METPayload<true>>({
 				url: this.baseUrl + this.currentPrefix + element.id + "?res=hourly&" + this.key,
 				cancellable
 			});
@@ -173,7 +174,7 @@ export class MetUk extends BaseProvider {
 			return null;
 
 		Logger.Debug("Query: " + query);
-		const json = await this.app.LoadJsonAsync({ url: query, cancellable });
+		const json = await HttpLib.Instance.LoadJsonSimple({ url: query, cancellable });
 
 		if (json == null)
 			return null;

--- a/weather@mockturtl/src/3_8/providers/met_uk.ts
+++ b/weather@mockturtl/src/3_8/providers/met_uk.ts
@@ -109,7 +109,11 @@ export class MetUk extends BaseProvider {
 	};
 
 	private async GetClosestForecastSite(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherSite | null> {
-		const forecastSitelist = await this.app.LoadJsonAsync(this.baseUrl + this.forecastPrefix + this.sitesUrl + "?" + this.key, cancellable);
+		const forecastSitelist = await this.app.LoadJsonAsync({
+			url: this.baseUrl + this.forecastPrefix + this.sitesUrl + "?" + this.key,
+			cancellable
+		});
+
 		if (forecastSitelist == null)
 			return null;
 
@@ -117,7 +121,11 @@ export class MetUk extends BaseProvider {
 	}
 
 	private async GetObservationSitesInRange(loc: LocationData, range: number, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherSite[] | null> {
-		const observationSiteList = await this.app.LoadJsonAsync<any>(this.baseUrl + this.currentPrefix + this.sitesUrl + "?" + this.key, cancellable);
+		const observationSiteList = await this.app.LoadJsonAsync<any>({
+			url: this.baseUrl + this.currentPrefix + this.sitesUrl + "?" + this.key,
+			cancellable
+		});
+
 		if (observationSiteList == null)
 			return null;
 
@@ -139,7 +147,11 @@ export class MetUk extends BaseProvider {
 		const observations: METPayload<true>[] = [];
 		for (const element of observationSites) {
 			Logger.Debug("Getting observation data from station: " + element.id);
-			const payload = await this.app.LoadJsonAsync<METPayload<true>>(this.baseUrl + this.currentPrefix + element.id + "?res=hourly&" + this.key, cancellable);
+			const payload = await this.app.LoadJsonAsync<METPayload<true>>({
+				url: this.baseUrl + this.currentPrefix + element.id + "?res=hourly&" + this.key,
+				cancellable
+			});
+
 			if (!!payload)
 				observations.push(payload);
 			else {
@@ -161,7 +173,7 @@ export class MetUk extends BaseProvider {
 			return null;
 
 		Logger.Debug("Query: " + query);
-		const json = await this.app.LoadJsonAsync(query, cancellable);
+		const json = await this.app.LoadJsonAsync({ url: query, cancellable });
 
 		if (json == null)
 			return null;

--- a/weather@mockturtl/src/3_8/providers/openWeatherMap.ts
+++ b/weather@mockturtl/src/3_8/providers/openWeatherMap.ts
@@ -7,7 +7,7 @@
 //////////////////////////////////////////////////////////////
 
 import { DateTime } from "luxon";
-import { ErrorResponse, HttpError, HTTPParams } from "../lib/httpLib";
+import { ErrorResponse, HttpError, HttpLib, HTTPParams } from "../lib/httpLib";
 import { Logger } from "../lib/logger";
 import { WeatherApplet } from "../main";
 import { WeatherProvider, WeatherData, ForecastData, HourlyForecastData, AppletError, BuiltinIcons, CustomIcons, LocationData, ImmediatePrecipitation } from "../types";
@@ -55,13 +55,13 @@ export class OpenWeatherMap extends BaseProvider {
 		// Await both of them, if already have it idPayload will be null
 		// If we don't have the ID we push a call to get it
 		const [ json, idPayload ] = await Promise.all([
-			this.app.LoadJsonAsync<OWMPayload>({
+			HttpLib.Instance.LoadJsonSimple<OWMPayload>({
 				url: this.base_url,
 				cancellable,
 				params: params,
 				HandleError: this.HandleError
 			}),
-			(cachedID == null) ? this.app.LoadJsonAsync<any>({url: this.id_irl, cancellable, params}) : Promise.resolve()
+			(cachedID == null) ? HttpLib.Instance.LoadJsonSimple<any>({url: this.id_irl, cancellable, params}) : Promise.resolve()
 		]);
 
 		// We store the newly gotten ID if we got it

--- a/weather@mockturtl/src/3_8/providers/openWeatherMap.ts
+++ b/weather@mockturtl/src/3_8/providers/openWeatherMap.ts
@@ -55,8 +55,13 @@ export class OpenWeatherMap extends BaseProvider {
 		// Await both of them, if already have it idPayload will be null
 		// If we don't have the ID we push a call to get it
 		const [ json, idPayload ] = await Promise.all([
-			this.app.LoadJsonAsync<OWMPayload>(this.base_url, cancellable, params, this.HandleError),
-			(cachedID == null) ? this.app.LoadJsonAsync<any>(this.id_irl, cancellable, params) : Promise.resolve()
+			this.app.LoadJsonAsync<OWMPayload>({
+				url: this.base_url,
+				cancellable,
+				params: params,
+				HandleError: this.HandleError
+			}),
+			(cachedID == null) ? this.app.LoadJsonAsync<any>({url: this.id_irl, cancellable, params}) : Promise.resolve()
 		]);
 
 		// We store the newly gotten ID if we got it

--- a/weather@mockturtl/src/3_8/providers/openWeatherMap.ts
+++ b/weather@mockturtl/src/3_8/providers/openWeatherMap.ts
@@ -47,7 +47,7 @@ export class OpenWeatherMap extends BaseProvider {
 	//  Functions
 	//--------------------------------------------------------
 
-	public async GetWeather(loc: LocationData): Promise<WeatherData | null> {
+	public async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> {
 		const params = this.ConstructParams(loc);
 
 		const cachedID = IDCache[`${loc.lat},${loc.lon}`];
@@ -55,8 +55,8 @@ export class OpenWeatherMap extends BaseProvider {
 		// Await both of them, if already have it idPayload will be null
 		// If we don't have the ID we push a call to get it
 		const [ json, idPayload ] = await Promise.all([
-			this.app.LoadJsonAsync<OWMPayload>(this.base_url, params, this.HandleError),
-			(cachedID == null) ? this.app.LoadJsonAsync<any>(this.id_irl, params) : Promise.resolve()
+			this.app.LoadJsonAsync<OWMPayload>(this.base_url, cancellable, params, this.HandleError),
+			(cachedID == null) ? this.app.LoadJsonAsync<any>(this.id_irl, cancellable, params) : Promise.resolve()
 		]);
 
 		// We store the newly gotten ID if we got it

--- a/weather@mockturtl/src/3_8/providers/pirate_weather/pirateWeather.ts
+++ b/weather@mockturtl/src/3_8/providers/pirate_weather/pirateWeather.ts
@@ -38,11 +38,12 @@ export class PirateWeather extends BaseProvider {
 	//--------------------------------------------------------
 	//  Functions
 	//--------------------------------------------------------
-	public async GetWeather(loc: LocationData): Promise<WeatherData | null> {
+	public async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> {
 		const unit = this.GetQueryUnit();
 
 		const response = await this.app.LoadJsonAsyncWithDetails<PirateWeatherPayload>(
 			`${this.query}${this.app.config.ApiKey}/${loc.lat},${loc.lon}`,
+			cancellable,
 			{
 				units: this.GetQueryUnit()
 			},

--- a/weather@mockturtl/src/3_8/providers/pirate_weather/pirateWeather.ts
+++ b/weather@mockturtl/src/3_8/providers/pirate_weather/pirateWeather.ts
@@ -1,4 +1,4 @@
-import { ErrorResponse, HttpError } from "../../lib/httpLib";
+import { ErrorResponse, HttpError, HttpLib } from "../../lib/httpLib";
 import { Logger } from "../../lib/logger";
 import { WeatherApplet } from "../../main";
 import { WeatherProvider, WeatherData, ForecastData, HourlyForecastData, PrecipitationType, BuiltinIcons, CustomIcons, LocationData, SunTime, ImmediatePrecipitation } from "../../types";
@@ -41,7 +41,7 @@ export class PirateWeather extends BaseProvider {
 	public async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> {
 		const unit = this.GetQueryUnit();
 
-		const response = await this.app.LoadJsonAsyncWithDetails<PirateWeatherPayload>({
+		const response = await HttpLib.Instance.LoadJsonAsync<PirateWeatherPayload>({
 			url: `${this.query}${this.app.config.ApiKey}/${loc.lat},${loc.lon}`,
 			cancellable,
 			params: { units: this.GetQueryUnit()},

--- a/weather@mockturtl/src/3_8/providers/pirate_weather/pirateWeather.ts
+++ b/weather@mockturtl/src/3_8/providers/pirate_weather/pirateWeather.ts
@@ -41,14 +41,12 @@ export class PirateWeather extends BaseProvider {
 	public async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> {
 		const unit = this.GetQueryUnit();
 
-		const response = await this.app.LoadJsonAsyncWithDetails<PirateWeatherPayload>(
-			`${this.query}${this.app.config.ApiKey}/${loc.lat},${loc.lon}`,
+		const response = await this.app.LoadJsonAsyncWithDetails<PirateWeatherPayload>({
+			url: `${this.query}${this.app.config.ApiKey}/${loc.lat},${loc.lon}`,
 			cancellable,
-			{
-				units: this.GetQueryUnit()
-			},
-			this.HandleError
-		);
+			params: { units: this.GetQueryUnit()},
+			HandleError: this.HandleError
+		});
 
 		if (!response.Success)
 			return null;

--- a/weather@mockturtl/src/3_8/providers/us_weather.ts
+++ b/weather@mockturtl/src/3_8/providers/us_weather.ts
@@ -47,7 +47,7 @@ export class USWeather extends BaseProvider {
 	//--------------------------------------------------------
 	//  Functions
 	//--------------------------------------------------------
-	public async GetWeather(loc: LocationData): Promise<WeatherData | null> {
+	public async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> {
 		// getting grid and station data first time or location changed
 		const locID = loc.lat.toString() + "," + loc.lon.toString();
 		if (!this.grid || !this.observationStations || this.currentLocID != locID) {
@@ -55,11 +55,11 @@ export class USWeather extends BaseProvider {
 			this.currentLoc = loc;
 			this.currentLocID = locID;
 
-			const grid = await this.GetGridData(loc);
+			const grid = await this.GetGridData(loc, cancellable);
 			if (grid == null) return null;
 			Logger.Debug("Grid found: " + JSON.stringify(grid, null, 2));
 
-			const observationStations = await this.GetStationData(grid.properties.observationStations);
+			const observationStations = await this.GetStationData(grid.properties.observationStations, cancellable);
 			if (observationStations == null)
 				return null;
 
@@ -72,10 +72,10 @@ export class USWeather extends BaseProvider {
 		}
 
 		// Long wait time, can't do Promise.all because US weather will ban IP for some time on spamming
-		const observations = await this.GetObservationsInRange(this.MAX_STATION_DIST, loc, this.observationStations);
+		const observations = await this.GetObservationsInRange(this.MAX_STATION_DIST, loc, this.observationStations, cancellable);
 
-		const hourlyForecastPromise = this.app.LoadJsonAsync<ForecastsPayload>(this.grid.properties.forecastHourly + "?units=si");
-		const forecastPromise = this.app.LoadJsonAsync<ForecastsPayload>(this.grid.properties.forecast);
+		const hourlyForecastPromise = this.app.LoadJsonAsync<ForecastsPayload>(this.grid.properties.forecastHourly + "?units=si", cancellable);
+		const forecastPromise = this.app.LoadJsonAsync<ForecastsPayload>(this.grid.properties.forecast, cancellable);
 		const hourly = await hourlyForecastPromise;
 		const forecast = await forecastPromise;
 
@@ -98,9 +98,9 @@ export class USWeather extends BaseProvider {
 	 * Handles App errors internally
 	 * @param loc
 	 */
-	private async GetGridData(loc: LocationData): Promise<GridPayload | null> {
+	private async GetGridData(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<GridPayload | null> {
 		// Handling out of country errors in callback
-		const siteData = await this.app.LoadJsonAsync<GridPayload>(this.sitesUrl + loc.lat.toString() + "," + loc.lon.toString(), {}, this.OnObtainingGridData);
+		const siteData = await this.app.LoadJsonAsync<GridPayload>(this.sitesUrl + loc.lat.toString() + "," + loc.lon.toString(), cancellable, {}, this.OnObtainingGridData);
 		return siteData;
 	}
 
@@ -108,8 +108,8 @@ export class USWeather extends BaseProvider {
 	 * Handles app errors internally
 	 * @param stationListUrl
 	 */
-	private async GetStationData(stationListUrl: string): Promise<StationPayload[] | undefined> {
-		const stations = await this.app.LoadJsonAsync<StationsPayload>(stationListUrl);
+	private async GetStationData(stationListUrl: string, cancellable: imports.gi.Gio.Cancellable): Promise<StationPayload[] | undefined> {
+		const stations = await this.app.LoadJsonAsync<StationsPayload>(stationListUrl, cancellable);
 		return stations?.features;
 	}
 
@@ -118,13 +118,13 @@ export class USWeather extends BaseProvider {
 	 * Data is pretty spotty so we can fill them up from stations further away later
 	 * @param range in metres
 	 */
-	private async GetObservationsInRange(range: number, loc: LocationData, stations: StationPayload[]): Promise<ObservationPayload[]> {
+	private async GetObservationsInRange(range: number, loc: LocationData, stations: StationPayload[], cancellable: imports.gi.Gio.Cancellable): Promise<ObservationPayload[]> {
 		const observations = [];
 		for (const element of stations) {
 			element.dist = GetDistance(element.geometry.coordinates[1], element.geometry.coordinates[0], loc.lat, loc.lon);
 			if (element.dist > range) break;
 			// do not show errors here, we call multiple observation sites
-			const observation = await this.app.LoadJsonAsync<ObservationPayload>(element.id + "/observations/latest", {}, (msg) => false);
+			const observation = await this.app.LoadJsonAsync<ObservationPayload>(element.id + "/observations/latest", cancellable, {}, (msg) => false);
 			if (observation == null) {
 				Logger.Debug("Failed to get observations from " + element.id);
 			}

--- a/weather@mockturtl/src/3_8/providers/us_weather.ts
+++ b/weather@mockturtl/src/3_8/providers/us_weather.ts
@@ -6,7 +6,7 @@
 //////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////
 
-import { ErrorResponse, HttpError } from "../lib/httpLib";
+import { ErrorResponse, HttpError, HttpLib } from "../lib/httpLib";
 import { Logger } from "../lib/logger";
 import { WeatherApplet } from "../main";
 import { getTimes } from "suncalc";
@@ -74,11 +74,11 @@ export class USWeather extends BaseProvider {
 		// Long wait time, can't do Promise.all because US weather will ban IP for some time on spamming
 		const observations = await this.GetObservationsInRange(this.MAX_STATION_DIST, loc, this.observationStations, cancellable);
 
-		const hourlyForecastPromise = this.app.LoadJsonAsync<ForecastsPayload>({
+		const hourlyForecastPromise = HttpLib.Instance.LoadJsonSimple<ForecastsPayload>({
 			url: this.grid.properties.forecastHourly + "?units=si",
 			cancellable
 		});
-		const forecastPromise = this.app.LoadJsonAsync<ForecastsPayload>({
+		const forecastPromise = HttpLib.Instance.LoadJsonSimple<ForecastsPayload>({
 			url: this.grid.properties.forecast,
 			cancellable
 		});
@@ -106,7 +106,7 @@ export class USWeather extends BaseProvider {
 	 */
 	private async GetGridData(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<GridPayload | null> {
 		// Handling out of country errors in callback
-		const siteData = await this.app.LoadJsonAsync<GridPayload>({
+		const siteData = await HttpLib.Instance.LoadJsonSimple<GridPayload>({
 			url: this.sitesUrl + loc.lat.toString() + "," + loc.lon.toString(),
 			cancellable,
 			HandleError: this.OnObtainingGridData
@@ -119,7 +119,7 @@ export class USWeather extends BaseProvider {
 	 * @param stationListUrl
 	 */
 	private async GetStationData(stationListUrl: string, cancellable: imports.gi.Gio.Cancellable): Promise<StationPayload[] | undefined> {
-		const stations = await this.app.LoadJsonAsync<StationsPayload>({
+		const stations = await HttpLib.Instance.LoadJsonSimple<StationsPayload>({
 			url: stationListUrl,
 			cancellable
 		});
@@ -137,7 +137,7 @@ export class USWeather extends BaseProvider {
 			element.dist = GetDistance(element.geometry.coordinates[1], element.geometry.coordinates[0], loc.lat, loc.lon);
 			if (element.dist > range) break;
 			// do not show errors here, we call multiple observation sites
-			const observation = await this.app.LoadJsonAsync<ObservationPayload>({
+			const observation = await HttpLib.Instance.LoadJsonSimple<ObservationPayload>({
 				url: element.id + "/observations/latest",
 				cancellable,
 				HandleError: (msg) => false

--- a/weather@mockturtl/src/3_8/providers/visualcrossing.ts
+++ b/weather@mockturtl/src/3_8/providers/visualcrossing.ts
@@ -33,7 +33,7 @@ export class VisualCrossing extends BaseProvider {
 		super(app);
 	}
 
-	public async GetWeather(loc: LocationData): Promise<WeatherData | null> {
+	public async GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> {
 		if (loc == null) return null;
 		this.params['key'] = this.app.config.ApiKey;
 		let translate = true;
@@ -43,7 +43,7 @@ export class VisualCrossing extends BaseProvider {
 		}
 
 		const url = this.url + loc.lat + "," + loc.lon;
-		const json = await this.app.LoadJsonAsync<VisualCrossingPayload>(url, this.params, (e) => this.HandleHttpError(e));
+		const json = await this.app.LoadJsonAsync<VisualCrossingPayload>(url, cancellable, this.params, (e) => this.HandleHttpError(e));
 
 		if (!json) return null;
 		return this.ParseWeather(json, translate);

--- a/weather@mockturtl/src/3_8/providers/visualcrossing.ts
+++ b/weather@mockturtl/src/3_8/providers/visualcrossing.ts
@@ -1,6 +1,6 @@
 import { DateTime } from "luxon";
 import { Services } from "../config";
-import { ErrorResponse, HttpError, HTTPParams } from "../lib/httpLib";
+import { ErrorResponse, HttpError, HttpLib, HTTPParams } from "../lib/httpLib";
 import { WeatherApplet } from "../main";
 import { Condition, ForecastData, HourlyForecastData, LocationData, PrecipitationType, WeatherData, WeatherProvider } from "../types";
 import { CelsiusToKelvin, IsLangSupported, _ } from "../utils";
@@ -43,7 +43,7 @@ export class VisualCrossing extends BaseProvider {
 		}
 
 		const url = this.url + loc.lat + "," + loc.lon;
-		const json = await this.app.LoadJsonAsync<VisualCrossingPayload>({
+		const json = await HttpLib.Instance.LoadJsonSimple<VisualCrossingPayload>({
 			url,
 			cancellable,
 			params: this.params,

--- a/weather@mockturtl/src/3_8/providers/visualcrossing.ts
+++ b/weather@mockturtl/src/3_8/providers/visualcrossing.ts
@@ -43,9 +43,15 @@ export class VisualCrossing extends BaseProvider {
 		}
 
 		const url = this.url + loc.lat + "," + loc.lon;
-		const json = await this.app.LoadJsonAsync<VisualCrossingPayload>(url, cancellable, this.params, (e) => this.HandleHttpError(e));
+		const json = await this.app.LoadJsonAsync<VisualCrossingPayload>({
+			url,
+			cancellable,
+			params: this.params,
+			HandleError: (e) => this.HandleHttpError(e)
+		});
 
-		if (!json) return null;
+		if (!json)
+			return null;
 		return this.ParseWeather(json, translate);
 	}
 

--- a/weather@mockturtl/src/3_8/providers/weatherUnderground.ts
+++ b/weather@mockturtl/src/3_8/providers/weatherUnderground.ts
@@ -1,7 +1,7 @@
 import { DateTime } from "luxon";
 import { getTimes } from "suncalc";
 import { Services } from "../config";
-import { ErrorResponse, HttpError } from "../lib/httpLib";
+import { ErrorResponse, HttpError, HttpLib } from "../lib/httpLib";
 import { Logger } from "../lib/logger";
 import { Condition, ForecastData, LocationData, WeatherData } from "../types";
 import { CelsiusToKelvin, FahrenheitToKelvin, GetDistance, _ } from "../utils";
@@ -50,7 +50,7 @@ export class WeatherUnderground extends BaseProvider {
         }
         this.locationCache[locString] = location;
 
-        const forecast = await this.app.LoadJsonAsync<ForecastPayload>({
+        const forecast = await HttpLib.Instance.LoadJsonSimple<ForecastPayload>({
 			url: `${this.baseURl}v3/wx/forecast/daily/5day`,
 			cancellable,
 			params: {
@@ -119,7 +119,7 @@ export class WeatherUnderground extends BaseProvider {
 
     private GetNearbyStations = async (loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<NearbyStation[] | null> => {
         const result: NearbyStation[] = [];
-        const payload = await this.app.LoadJsonAsync<NearObservationPayload>({
+        const payload = await HttpLib.Instance.LoadJsonSimple<NearObservationPayload>({
 			url: `${this.baseURl}v3/location/near`,
 			cancellable,
 			params: {
@@ -240,7 +240,7 @@ export class WeatherUnderground extends BaseProvider {
     }
 
     private GetObservation = async (stationID: string, cancellable: imports.gi.Gio.Cancellable): Promise<ObservationData | null> => {
-        const observationString = await this.app.LoadAsync({
+        const observationString = await HttpLib.Instance.LoadAsyncSimple({
 			url: `${this.baseURl}v2/pws/observations/current`,
 			cancellable,
 			params: {

--- a/weather@mockturtl/src/3_8/providers/weatherUnderground.ts
+++ b/weather@mockturtl/src/3_8/providers/weatherUnderground.ts
@@ -41,27 +41,31 @@ export class WeatherUnderground extends BaseProvider {
             return unitTypeMap[this.app.config.countryCode.toLowerCase()] ?? "m";
     }
 
-    public GetWeather = async (loc: LocationData): Promise<WeatherData | null> => {
+    public GetWeather = async (loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null> => {
         const locString = `${loc.lat},${loc.lon}`;
-        const location = this.locationCache[locString] ?? (await this.GetNearbyStations(loc));
+        const location = this.locationCache[locString] ?? (await this.GetNearbyStations(loc, cancellable));
         if (location == null) {
             // TODO: handle error
             return null;
         }
         this.locationCache[locString] = location;
 
-        const forecast = await this.app.LoadJsonAsync<ForecastPayload>(`${this.baseURl}v3/wx/forecast/daily/5day`, {
-            geocode: locString,
-            language: this.app.config.currentLocale ?? "en-US",
-            format: "json",
-            apiKey: this.app.config.ApiKey,
-            units: this.currentUnit,
-        });
+        const forecast = await this.app.LoadJsonAsync<ForecastPayload>(
+			`${this.baseURl}v3/wx/forecast/daily/5day`,
+			cancellable,
+			{
+				geocode: locString,
+				language: this.app.config.currentLocale ?? "en-US",
+				format: "json",
+				apiKey: this.app.config.ApiKey,
+				units: this.currentUnit,
+			}
+		);
 
         if (forecast == null)
             return null;
 
-        const observation = await this.GetObservations(location, forecast, loc);
+        const observation = await this.GetObservations(location, forecast, loc, cancellable);
 
         return {
             date: observation.date!,
@@ -113,14 +117,19 @@ export class WeatherUnderground extends BaseProvider {
         return result;
     }
 
-    private GetNearbyStations = async (loc: LocationData): Promise<NearbyStation[] | null> => {
+    private GetNearbyStations = async (loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<NearbyStation[] | null> => {
         const result: NearbyStation[] = [];
-        const payload = await this.app.LoadJsonAsync<NearObservationPayload>(`${this.baseURl}v3/location/near`, {
-            geocode: `${loc.lat},${loc.lon}`,
-            format: "json",
-            apiKey: this.app.config.ApiKey,
-            product: "pws"
-        }, this.HandleErrors);
+        const payload = await this.app.LoadJsonAsync<NearObservationPayload>(
+			`${this.baseURl}v3/location/near`,
+			cancellable,
+			{
+				geocode: `${loc.lat},${loc.lon}`,
+				format: "json",
+				apiKey: this.app.config.ApiKey,
+				product: "pws"
+			},
+			this.HandleErrors
+		);
 
         if (payload == null)
             return null;
@@ -145,8 +154,8 @@ export class WeatherUnderground extends BaseProvider {
         return result;
     }
 
-    private GetObservations = async (stations: NearbyStation[], forecast: ForecastPayload, loc: LocationData): Promise<ObservationInternalData> => {
-        const observationData: ObservationData[] = (await Promise.all(stations.map(v => this.GetObservation(v.stationId)))).filter(v => v != null) as ObservationData[];
+    private GetObservations = async (stations: NearbyStation[], forecast: ForecastPayload, loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<ObservationInternalData> => {
+        const observationData: ObservationData[] = (await Promise.all(stations.map(v => this.GetObservation(v.stationId, cancellable)))).filter(v => v != null) as ObservationData[];
         const tz = loc.timeZone;
 
         const result: ObservationInternalData = {
@@ -230,14 +239,19 @@ export class WeatherUnderground extends BaseProvider {
         return result;
     }
 
-    private GetObservation = async (stationID: string): Promise<ObservationData | null> => {
-        const observationString = await this.app.LoadAsync(`${this.baseURl}v2/pws/observations/current`, {
-            format: "json",
-            stationId: stationID,
-            apiKey: this.app.config.ApiKey,
-            units: "s",
-            numericPrecision: "decimal",
-        }, this.HandleErrors);
+    private GetObservation = async (stationID: string, cancellable: imports.gi.Gio.Cancellable): Promise<ObservationData | null> => {
+        const observationString = await this.app.LoadAsync(
+			`${this.baseURl}v2/pws/observations/current`,
+			cancellable,
+			{
+				format: "json",
+				stationId: stationID,
+				apiKey: this.app.config.ApiKey,
+				units: "s",
+				numericPrecision: "decimal",
+			},
+			this.HandleErrors
+		);
 
         let observation: ObservationPayload | null = null;
         if (observationString != null) {

--- a/weather@mockturtl/src/3_8/providers/weatherUnderground.ts
+++ b/weather@mockturtl/src/3_8/providers/weatherUnderground.ts
@@ -50,17 +50,17 @@ export class WeatherUnderground extends BaseProvider {
         }
         this.locationCache[locString] = location;
 
-        const forecast = await this.app.LoadJsonAsync<ForecastPayload>(
-			`${this.baseURl}v3/wx/forecast/daily/5day`,
+        const forecast = await this.app.LoadJsonAsync<ForecastPayload>({
+			url: `${this.baseURl}v3/wx/forecast/daily/5day`,
 			cancellable,
-			{
+			params: {
 				geocode: locString,
 				language: this.app.config.currentLocale ?? "en-US",
 				format: "json",
 				apiKey: this.app.config.ApiKey,
 				units: this.currentUnit,
 			}
-		);
+		});
 
         if (forecast == null)
             return null;
@@ -119,17 +119,17 @@ export class WeatherUnderground extends BaseProvider {
 
     private GetNearbyStations = async (loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<NearbyStation[] | null> => {
         const result: NearbyStation[] = [];
-        const payload = await this.app.LoadJsonAsync<NearObservationPayload>(
-			`${this.baseURl}v3/location/near`,
+        const payload = await this.app.LoadJsonAsync<NearObservationPayload>({
+			url: `${this.baseURl}v3/location/near`,
 			cancellable,
-			{
+			params: {
 				geocode: `${loc.lat},${loc.lon}`,
 				format: "json",
 				apiKey: this.app.config.ApiKey,
 				product: "pws"
 			},
-			this.HandleErrors
-		);
+			HandleError: this.HandleErrors
+		});
 
         if (payload == null)
             return null;
@@ -240,18 +240,18 @@ export class WeatherUnderground extends BaseProvider {
     }
 
     private GetObservation = async (stationID: string, cancellable: imports.gi.Gio.Cancellable): Promise<ObservationData | null> => {
-        const observationString = await this.app.LoadAsync(
-			`${this.baseURl}v2/pws/observations/current`,
+        const observationString = await this.app.LoadAsync({
+			url: `${this.baseURl}v2/pws/observations/current`,
 			cancellable,
-			{
+			params: {
 				format: "json",
 				stationId: stationID,
 				apiKey: this.app.config.ApiKey,
 				units: "s",
 				numericPrecision: "decimal",
 			},
-			this.HandleErrors
-		);
+			HandleError: this.HandleErrors
+		});
 
         let observation: ObservationPayload | null = null;
         if (observationString != null) {

--- a/weather@mockturtl/src/3_8/providers/weatherbit.ts
+++ b/weather@mockturtl/src/3_8/providers/weatherbit.ts
@@ -7,7 +7,7 @@
 //////////////////////////////////////////////////////////////
 
 import { DateTime } from "luxon";
-import { ErrorResponse, HttpError } from "../lib/httpLib";
+import { ErrorResponse, HttpError, HttpLib } from "../lib/httpLib";
 import { Logger } from "../lib/logger";
 import { WeatherApplet } from "../main";
 import { WeatherProvider, WeatherData, ForecastData, HourlyForecastData, BuiltinIcons, CustomIcons, LocationData } from "../types";
@@ -77,7 +77,7 @@ export class Weatherbit extends BaseProvider {
 		if (query == null)
 			return null;
 
-		const json = await this.app.LoadJsonAsync({
+		const json = await HttpLib.Instance.LoadJsonSimple({
 			url: query,
 			cancellable,
 			HandleError: (e) => this.HandleError(e)
@@ -94,7 +94,7 @@ export class Weatherbit extends BaseProvider {
 		if (query == null)
 			return null;
 
-		const json = await this.app.LoadJsonAsync<any>({
+		const json = await HttpLib.Instance.LoadJsonSimple<any>({
 			url: query,
 			cancellable,
 			HandleError: (e) => this.HandleHourlyError(e)
@@ -301,6 +301,7 @@ export class Weatherbit extends BaseProvider {
 				service: "weatherbit",
 				message: _("Please Make sure you\nentered the API key correctly and your account is not locked")
 			});
+			return false;
 		}
 		return true;
 	}

--- a/weather@mockturtl/src/3_8/providers/weatherbit.ts
+++ b/weather@mockturtl/src/3_8/providers/weatherbit.ts
@@ -77,7 +77,11 @@ export class Weatherbit extends BaseProvider {
 		if (query == null)
 			return null;
 
-		const json = await this.app.LoadJsonAsync(query, cancellable, undefined, (e) => this.HandleError(e));
+		const json = await this.app.LoadJsonAsync({
+			url: query,
+			cancellable,
+			HandleError: (e) => this.HandleError(e)
+		});
 
 		if (json == null)
 			return null;
@@ -90,7 +94,11 @@ export class Weatherbit extends BaseProvider {
 		if (query == null)
 			return null;
 
-		const json = await this.app.LoadJsonAsync<any>(query, cancellable, undefined, (e) => this.HandleHourlyError(e));
+		const json = await this.app.LoadJsonAsync<any>({
+			url: query,
+			cancellable,
+			HandleError: (e) => this.HandleHourlyError(e)
+		});
 
 		if (!!json?.error) {
 			return null;

--- a/weather@mockturtl/src/3_8/types.ts
+++ b/weather@mockturtl/src/3_8/types.ts
@@ -32,10 +32,6 @@ export const enum RefreshState {
 	 */
 	Error = "error",
 	/**
-	 * Already refreshing
-	 */
-	Locked = "locked",
-	/**
 	 * Location not obtained
 	 */
 	NoLocation = "no location",

--- a/weather@mockturtl/src/3_8/types.ts
+++ b/weather@mockturtl/src/3_8/types.ts
@@ -22,14 +22,26 @@ export interface WeatherProvider {
 	readonly supportHourlyPrecipChance: boolean;
     readonly supportHourlyPrecipVolume: boolean;
 
-	GetWeather(loc: LocationData): Promise<WeatherData | null>;
+	GetWeather(loc: LocationData, cancellable: imports.gi.Gio.Cancellable): Promise<WeatherData | null>;
 }
 
 export const enum RefreshState {
 	Success = "success",
-	Failure = "fail",
+	/**
+	 * Pure technical error
+	 */
 	Error = "error",
-	Locked = "locked"
+	/**
+	 * Already refreshing
+	 */
+	Locked = "locked",
+	/**
+	 * Location not obtained
+	 */
+	NoLocation = "no location",
+	NoWeather = "no weather",
+	NoKey = "no key",
+	DisplayFailure = "display failure",
 }
 
 export interface WeatherData {

--- a/weather@mockturtl/src/3_8/ui.ts
+++ b/weather@mockturtl/src/3_8/ui.ts
@@ -166,7 +166,7 @@ export class UI {
 		if (newThemeIsLight != this.lightTheme) {
 			this.lightTheme = newThemeIsLight;
 		}
-		this.App.Refresh({rebuild: true, immediate: true});
+		this.App.Refresh({rebuild: true});
 	}
 
 	private async PopupMenuToggled(caller: any, data: any) {

--- a/weather@mockturtl/src/3_8/ui.ts
+++ b/weather@mockturtl/src/3_8/ui.ts
@@ -166,7 +166,7 @@ export class UI {
 		if (newThemeIsLight != this.lightTheme) {
 			this.lightTheme = newThemeIsLight;
 		}
-		this.App.RefreshAndRebuild();
+		this.App.Refresh({rebuild: true, immediate: true});
 	}
 
 	private async PopupMenuToggled(caller: any, data: any) {

--- a/weather@mockturtl/src/3_8/ui_elements/uiCurrentWeather.ts
+++ b/weather@mockturtl/src/3_8/ui_elements/uiCurrentWeather.ts
@@ -365,12 +365,12 @@ export class CurrentWeather {
 
 	private NextLocationClicked() {
 		const loc = this.app.config.SwitchToNextLocation();
-		this.app.Refresh({location: loc ?? undefined, immediate: true});
+		this.app.Refresh({location: loc ?? undefined});
 	}
 
 	private PreviousLocationClicked() {
 		const loc = this.app.config.SwitchToPreviousLocation();
-		this.app.Refresh({location: loc ?? undefined, immediate: true});
+		this.app.Refresh({location: loc ?? undefined});
 	}
 
 	private onLocationStorageChanged(sender: LocationStore, itemCount: number): void {

--- a/weather@mockturtl/src/3_8/ui_elements/uiCurrentWeather.ts
+++ b/weather@mockturtl/src/3_8/ui_elements/uiCurrentWeather.ts
@@ -200,9 +200,12 @@ export class CurrentWeather {
 		this.locationButton = new WeatherButton({ reactive: true, label: _('Refresh'), x_expand: true, x_align: Align.MIDDLE });
 		this.location = this.locationButton.actor;
 		this.location.connect(SIGNAL_CLICKED, () => {
-			if (this.app.encounteredError) this.app.RefreshWeather(true);
-			else if (this.locationButton.url == null) return;
-			else OpenUrl(this.locationButton);
+			if (this.app.encounteredError)
+				this.app.Refresh({rebuild: true});
+			else if (this.locationButton.url == null)
+				return;
+			else
+				OpenUrl(this.locationButton);
 		});
 
 		this.nextLocationButton = new WeatherButton({
@@ -362,12 +365,12 @@ export class CurrentWeather {
 
 	private NextLocationClicked() {
 		const loc = this.app.config.SwitchToNextLocation();
-		this.app.Refresh(loc);
+		this.app.Refresh({location: loc ?? undefined, immediate: true});
 	}
 
 	private PreviousLocationClicked() {
 		const loc = this.app.config.SwitchToPreviousLocation();
-		this.app.Refresh(loc);
+		this.app.Refresh({location: loc ?? undefined, immediate: true});
 	}
 
 	private onLocationStorageChanged(sender: LocationStore, itemCount: number): void {


### PR DESCRIPTION
This is a big enough PR already (excluding translations...) to put new features in so they go to the next version.

* Fix https://github.com/linuxmint/cinnamon-spices-applets/issues/5419
* Fix https://github.com/linuxmint/cinnamon-spices-applets/issues/5680

Changes
* Made HTTP requests cancellable and enforce using them
* All HTTP requests are now have  
* Simplify HTTPLib call signatures (and removing intermediary calls from `main.ts`
* All data refresh goes through the main loop now to avoid parallel refreshing
* If the loop is requested to refresh immediately by the user it cancels the previous one if it's in progress and immediately begins a new one.
* Loop only gives 30 seconds for each refresh on JS level, then it cancels them to avoid the loop deadlocking.
* Fix all instances where it's possible not to resolve promisified Glib/Gio/Soup library async functions by adding try/catch inside.
* Use `https://nominatim.openstreetmap.org/` as a GeoCode backend instead of the default `https://nominatim.gnome.org/`

- [x] Tested on Cinnamon 3.8 but I will test it again when the PR is ready.