### PR TITLE
Fix prayer times appearance

### DIFF
--- a/azan@fahri.nurul.id/files/azan@fahri.nurul.id/applet.js
+++ b/azan@fahri.nurul.id/files/azan@fahri.nurul.id/applet.js
@@ -130,7 +130,7 @@ AzanApplet.prototype = {
                 bin.add_actor(prayLabel);
 
                 prayMenuItem.addActor(bin, {
-                    expand: true,
+                    expand: false,
                     span: -1,
                     align: St.Align.END
                 });


### PR DESCRIPTION
Set "expand" to "false" to address the issue of prayer times not being displayed correctly.