### PR TITLE
mylauncher@markbokil.com: Fix issue where updating the applet will remove custom menu config

### DIFF
--- a/mylauncher@markbokil.com/files/mylauncher@markbokil.com/mylauncher.properties
+++ b/mylauncher@markbokil.com/files/mylauncher@markbokil.com/mylauncher.properties
@@ -35,7 +35,7 @@ Search for files=gnome-search-tool
 Restart Cinnamon=[RC]
 Suspend=dbus-send --print-reply --system --dest=org.freedesktop.UPower /org/freedesktop/UPower org.freedesktop.UPower.Suspend
 [MS] -----------------
-Home=xdg-open /home/mark/
+Home=xdg-open ~
 Terminal=gnome-terminal
 Browser=firefox
 Run...=gmrun


### PR DESCRIPTION
When updating the mylauncher@markbokil.com, it will overwrite any custom menu settings. This is due to the configuration file being present in the applets code directory. This change uses the applets files as a default configuration and copies the contents to the .config sub directory in the users home. This means that the configuration will survive applet updates in the future.

Fixed a hardcoded username in the default configuration for the home directory to the tilde shortcut

Fixed command line library references from Main.Util to Util.

@mbokil
