### PR TITLE
Auto copy setting, sound feedback, reorganized settings

### DIFF
--- a/password-generator@spencerlommel.com/files/password-generator@spencerlommel.com/applet.js
+++ b/password-generator@spencerlommel.com/files/password-generator@spencerlommel.com/applet.js
@@ -23,6 +23,8 @@ class CinnamonRandomPasswordApplet extends Applet.IconApplet {
         this.settings.bind("include-uppercase", "includeUppercase", this.onSettingsChanged);
         this.settings.bind("include-symbols", "includeSymbols", this.onSettingsChanged);
         this.settings.bind("include-numbers", "includeNumbers", this.onSettingsChanged);
+        this.settings.bind("auto-copy", "autoCopy", this.onSettingsChanged);
+
 
         this.set_applet_icon_name("dialog-password");
         this.set_applet_tooltip(_("Generate Random Password"));
@@ -57,10 +59,15 @@ class CinnamonRandomPasswordApplet extends Applet.IconApplet {
     }
 
     on_applet_clicked(event) {
-        this.menu.toggle();
         let newPassword = this.generateRandomPassword();
         this.textBox.set_text(newPassword);
+        if (this.autoCopy) {
+            St.Clipboard.get_default().set_text(St.ClipboardType.CLIPBOARD, newPassword);
+        } else {
+            this.menu.toggle();
+        }
     }
+    
 
     generateRandomPassword() {
         let charset = "";

--- a/password-generator@spencerlommel.com/files/password-generator@spencerlommel.com/applet.js
+++ b/password-generator@spencerlommel.com/files/password-generator@spencerlommel.com/applet.js
@@ -5,6 +5,7 @@ const GLib = imports.gi.GLib;
 const St = imports.gi.St;
 const Settings = imports.ui.settings; // Import the Settings module
 
+
 const UUID = "password-generator@spencerlommel.com"
 Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
 

--- a/password-generator@spencerlommel.com/files/password-generator@spencerlommel.com/po/password-generator@spencerlommel.com.pot
+++ b/password-generator@spencerlommel.com/files/password-generator@spencerlommel.com/po/password-generator@spencerlommel.com.pot
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: password-generator@spencerlommel.com 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-06 23:31-0500\n"
+"POT-Creation-Date: 2024-05-07 20:32-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,15 +17,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applet.js:26
+#: applet.js:33
 msgid "Generate Random Password"
 msgstr ""
 
-#: applet.js:35
+#: applet.js:42
 msgid "Please enable at least one value in settings."
 msgstr ""
 
-#: applet.js:42
+#: applet.js:49
 msgid "Copy"
 msgstr ""
 
@@ -37,12 +37,20 @@ msgstr ""
 msgid "Password Generator"
 msgstr ""
 
+#. settings-schema.json->password-settings-header->description
+msgid "Password Settings"
+msgstr ""
+
 #. settings-schema.json->password-length->units
 msgid "characters"
 msgstr ""
 
 #. settings-schema.json->password-length->description
 msgid "Password Length"
+msgstr ""
+
+#. settings-schema.json->password-length->tooltip
+msgid "The password can be any length from 1 to 32 characters."
 msgstr ""
 
 #. settings-schema.json->include-lowercase->description
@@ -59,4 +67,33 @@ msgstr ""
 
 #. settings-schema.json->include-symbols->description
 msgid "Include Symbols"
+msgstr ""
+
+#. settings-schema.json->copy-settings-header->description
+msgid "Copy Settings"
+msgstr ""
+
+#. settings-schema.json->auto-copy->description
+msgid "Automatically Copy To Clipboard"
+msgstr ""
+
+#. settings-schema.json->auto-copy->tooltip
+msgid ""
+"When clicking the lock icon, instead of opening a window where the password "
+"can be copied it is instead automatically copied to your Clipboard."
+msgstr ""
+
+#. settings-schema.json->play-sound->description
+#. settings-schema.json->sound-file->description
+msgid "Play sound on copy"
+msgstr ""
+
+#. settings-schema.json->play-sound->tooltip
+msgid ""
+"Toggles whether or not a sound is played when the password is copied to the "
+"Clipboard"
+msgstr ""
+
+#. settings-schema.json->sound-file->tooltip
+msgid "Select a sound to play when the password is copied"
 msgstr ""

--- a/password-generator@spencerlommel.com/files/password-generator@spencerlommel.com/settings-schema.json
+++ b/password-generator@spencerlommel.com/files/password-generator@spencerlommel.com/settings-schema.json
@@ -31,7 +31,8 @@
     "auto-copy": {
         "type": "checkbox",
         "default": false,
-        "description": "Automatically Copy To Clipboard"
+        "description": "Automatically Copy To Clipboard",
+        "tooltip": "When clicking the lock icon, instead of opening a window where the password can be copied it is instead automatically copied to your Clipboard."
     }
     
 }

--- a/password-generator@spencerlommel.com/files/password-generator@spencerlommel.com/settings-schema.json
+++ b/password-generator@spencerlommel.com/files/password-generator@spencerlommel.com/settings-schema.json
@@ -27,5 +27,11 @@
         "type": "checkbox",
         "default": true,
         "description": "Include Symbols"
+    },
+    "auto-copy": {
+        "type": "checkbox",
+        "default": false,
+        "description": "Automatically Copy To Clipboard"
     }
+    
 }

--- a/password-generator@spencerlommel.com/files/password-generator@spencerlommel.com/settings-schema.json
+++ b/password-generator@spencerlommel.com/files/password-generator@spencerlommel.com/settings-schema.json
@@ -1,4 +1,10 @@
+
+
 {
+    "password-settings-header" : {
+        "type" : "header",
+        "description" : "Password Settings"
+     },    
     "password-length": {
         "type": "spinbutton",
         "default": 12,
@@ -6,7 +12,8 @@
         "max": 32,
         "step": 1,
         "units": "characters",
-        "description": "Password Length"
+        "description": "Password Length",
+        "tooltip": "The password can be any length from 1 to 32 characters."
     },
     "include-lowercase": {
         "type": "checkbox",
@@ -28,11 +35,27 @@
         "default": true,
         "description": "Include Symbols"
     },
+    "copy-settings-header" : {
+        "type" : "header",
+        "description" : "Copy Settings"
+     }, 
     "auto-copy": {
         "type": "checkbox",
         "default": false,
         "description": "Automatically Copy To Clipboard",
         "tooltip": "When clicking the lock icon, instead of opening a window where the password can be copied it is instead automatically copied to your Clipboard."
+    },
+    "play-sound": {
+        "type": "checkbox",
+        "default": true,
+        "description": "Play sound on copy",
+        "tooltip": "Toggles whether or not a sound is played when the password is copied to the Clipboard"
+    },
+    "sound-file": {
+        "type": "soundfilechooser",
+        "default": "/usr/share/mint-artwork/sounds/map.oga",
+        "description": "Play sound on copy",
+        "tooltip": "Select a sound to play when the password is copied"
     }
-    
+        
 }


### PR DESCRIPTION
- Reorganized settings into password settings and copy settings
- Added a feature that auto copies the password to the clipboard when then icon is clicked (off by default)
- Added a checkbox to play a sound when the password is copied to the clipboard
- Added a soundfilechooser to change the sound that is played when the password is copied
- Ran makepot so new settings should be set for translations