### PR TITLE
[CassiaWindowList@klangman] Improve thumbnail menu Highlighting

### DIFF
--- a/CassiaWindowList@klangman/CHANGELOG.md
+++ b/CassiaWindowList@klangman/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.4
+
+* When in button pooling mode with a thumbnail menu open showing more then one window, highlight the thumbnail menu item matching the window of the windlow-list button that is currently being hovered by the mouse pointer.
+
 ## 2.0.3
 
 * Don't close then reopen an existing thumbnail menu when the mouse hover moves between different buttons in the same application pool (as long as the menu does have an item for the currently hovered button's window). This removes the useless thumbnail menu close then open sequence when using the application pooling behaviour.

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/applet.js
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/applet.js
@@ -2549,12 +2549,14 @@ class WindowListButton {
     // If a thumbnail menu is open, then make sure it contains this buttons current window. Not open, then open one after a delay if needed
     let curMenu = this._workspace.currentMenu;
     if (curMenu && curMenu.isOpen) {
-       if (curMenu._findMenuItemForWindow(this._currentWindow)==null) {
+       let menuItem = curMenu._findMenuItemForWindow(this._currentWindow);
+       if (menuItem==null) {
           let holdPopup = this._workspace.holdPopup;
           this.closeThumbnailMenu();
           this.openThumbnailMenu();
           this._workspace.holdPopup = holdPopup;
        } else {
+          menuItem.actor.add_style_pseudo_class("active");
           this.removeThumbnailMenuDelay();
        }
     } else if (this._windows.length > 0 && this._settings.getValue("menu-show-on-hover")) {
@@ -2600,6 +2602,10 @@ class WindowListButton {
 
     let curMenu = this._workspace.currentMenu;
     if (curMenu) {
+       let menuItem = curMenu._findMenuItemForWindow(this._currentWindow);
+       if (menuItem) {
+          menuItem.actor.remove_style_pseudo_class("active");
+       }
        this.closeThumbnailMenuDelayed();
     } else {
        this.removeThumbnailMenuDelay();
@@ -3126,6 +3132,13 @@ class WindowListButton {
         this.menu.openMenu();
         this._workspace.currentMenu = this.menu;
         this.actor.set_hover(true);
+        let curMenu = this._workspace.currentMenu;
+        if (curMenu && curMenu.numMenuItems > 1) {
+           let menuItem = this._workspace.currentMenu._findMenuItemForWindow(this._currentWindow);
+           if (menuItem && this._grouped <= GroupingType.NotGrouped) {
+              menuItem.actor.add_style_pseudo_class("active");
+           }
+        }
      }
   }
 

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/metadata.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/metadata.json
@@ -5,6 +5,6 @@
     "max-instances": -1,
     "multiversion": true,
     "role": "panellauncher",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "author": "klangman"
 }

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: CassiaWindowList@klangman 2.0.3\n"
+"Project-Id-Version: CassiaWindowList@klangman 2.0.4\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-01 10:01-0400\n"
+"POT-Creation-Date: 2024-05-13 20:57-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,28 +21,28 @@ msgstr ""
 msgid "all buttons"
 msgstr ""
 
-#: 4.0/applet.js:2640 6.0/applet.js:2640
+#: 4.0/applet.js:2646 6.0/applet.js:2646
 msgid "Applet Preferences"
 msgstr ""
 
-#: 4.0/applet.js:2644 6.0/applet.js:2644
+#: 4.0/applet.js:2650 6.0/applet.js:2650
 msgid "About..."
 msgstr ""
 
-#: 4.0/applet.js:2648 6.0/applet.js:2648
+#: 4.0/applet.js:2654 6.0/applet.js:2654
 msgid "Configure..."
 msgstr ""
 
-#: 4.0/applet.js:2652 6.0/applet.js:2652
+#: 4.0/applet.js:2658 6.0/applet.js:2658
 msgid "Website"
 msgstr ""
 
-#: 4.0/applet.js:2656 6.0/applet.js:2656
+#: 4.0/applet.js:2662 6.0/applet.js:2662
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
 
-#: 4.0/applet.js:2658 6.0/applet.js:2658
+#: 4.0/applet.js:2664 6.0/applet.js:2664
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 
@@ -58,111 +58,111 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2667 6.0/applet.js:2667
+#: 4.0/applet.js:2673 6.0/applet.js:2673
 msgid "Open new window"
 msgstr ""
 
-#: 4.0/applet.js:2675 6.0/applet.js:2675
+#: 4.0/applet.js:2681 6.0/applet.js:2681
 msgid "Remove from panel"
 msgstr ""
 
-#: 4.0/applet.js:2677 6.0/applet.js:2677
+#: 4.0/applet.js:2683 6.0/applet.js:2683
 msgid "Remove from this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2683 6.0/applet.js:2683
+#: 4.0/applet.js:2689 6.0/applet.js:2689
 msgid "Pin to panel"
 msgstr ""
 
-#: 4.0/applet.js:2685 6.0/applet.js:2685
+#: 4.0/applet.js:2691 6.0/applet.js:2691
 msgid "Pin to this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2726 6.0/applet.js:2726
+#: 4.0/applet.js:2732 6.0/applet.js:2732
 msgid "Pin to other workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2747 6.0/applet.js:2747
+#: 4.0/applet.js:2753 6.0/applet.js:2753
 msgid "Pin to all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2765 6.0/applet.js:2765
+#: 4.0/applet.js:2771 6.0/applet.js:2771
 msgid "Pin to launcher"
 msgstr ""
 
-#: 4.0/applet.js:2783 4.0/applet.js:2966 6.0/applet.js:2783 6.0/applet.js:2966
+#: 4.0/applet.js:2789 4.0/applet.js:2972 6.0/applet.js:2789 6.0/applet.js:2972
 msgid "Add new Hotkey for"
 msgstr ""
 
-#: 4.0/applet.js:2797 6.0/applet.js:2797
+#: 4.0/applet.js:2803 6.0/applet.js:2803
 msgid "Recent files"
 msgstr ""
 
-#: 4.0/applet.js:2821 6.0/applet.js:2821
+#: 4.0/applet.js:2827 6.0/applet.js:2827
 msgid "Places"
 msgstr ""
 
-#: 4.0/applet.js:2863 6.0/applet.js:2863
+#: 4.0/applet.js:2869 6.0/applet.js:2869
 msgid "Only on this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2865 6.0/applet.js:2865
+#: 4.0/applet.js:2871 6.0/applet.js:2871
 msgid "Visible on all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2866 6.0/applet.js:2866
+#: 4.0/applet.js:2872 6.0/applet.js:2872
 msgid "Move to another workspace"
 msgstr ""
 
-#: 4.0/applet.js:2875 6.0/applet.js:2875
+#: 4.0/applet.js:2881 6.0/applet.js:2881
 msgid " (this workspace)"
 msgstr ""
 
-#: 4.0/applet.js:2888 6.0/applet.js:2888
+#: 4.0/applet.js:2894 6.0/applet.js:2894
 msgid "Move to another monitor"
 msgstr ""
 
-#: 4.0/applet.js:2896 6.0/applet.js:2896
+#: 4.0/applet.js:2902 6.0/applet.js:2902
 msgid "Monitor"
 msgstr ""
 
-#: 4.0/applet.js:2921 6.0/applet.js:2921
+#: 4.0/applet.js:2927 6.0/applet.js:2927
 msgid "unassigned"
 msgstr ""
 
-#: 4.0/applet.js:2932 4.0/applet.js:2963 6.0/applet.js:2932 6.0/applet.js:2963
+#: 4.0/applet.js:2938 4.0/applet.js:2969 6.0/applet.js:2938 6.0/applet.js:2969
 msgid "Assign window to a hotkey"
 msgstr ""
 
-#: 4.0/applet.js:2986 6.0/applet.js:2986
+#: 4.0/applet.js:2992 6.0/applet.js:2992
 msgid "Change application label contents"
 msgstr ""
 
-#: 4.0/applet.js:2989 6.0/applet.js:2989
+#: 4.0/applet.js:2995 6.0/applet.js:2995
 msgid "Remove custom setting"
 msgstr ""
 
-#: 4.0/applet.js:2996 6.0/applet.js:2996
+#: 4.0/applet.js:3002 6.0/applet.js:3002
 msgid "Use window title"
 msgstr ""
 
-#: 4.0/applet.js:3003 6.0/applet.js:3003
+#: 4.0/applet.js:3009 6.0/applet.js:3009
 msgid "Use application name"
 msgstr ""
 
-#: 4.0/applet.js:3010 6.0/applet.js:3010
+#: 4.0/applet.js:3016 6.0/applet.js:3016
 msgid "No label"
 msgstr ""
 
-#: 4.0/applet.js:3021 6.0/applet.js:3021
+#: 4.0/applet.js:3027 6.0/applet.js:3027
 msgid "Ungroup application windows"
 msgstr ""
 
-#: 4.0/applet.js:3030 6.0/applet.js:3030
+#: 4.0/applet.js:3036 6.0/applet.js:3036
 msgid "Group application windows"
 msgstr ""
 
-#: 4.0/applet.js:3043 6.0/applet.js:3043
+#: 4.0/applet.js:3049 6.0/applet.js:3049
 msgid "Automatic grouping/ungrouping"
 msgstr ""
 
@@ -178,31 +178,31 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3073 6.0/applet.js:3073
+#: 4.0/applet.js:3079 6.0/applet.js:3079
 msgid "Move titlebar on to screen"
 msgstr ""
 
-#: 4.0/applet.js:3078 6.0/applet.js:3078
+#: 4.0/applet.js:3084 6.0/applet.js:3084
 msgid "Restore"
 msgstr ""
 
-#: 4.0/applet.js:3082 6.0/applet.js:3082
+#: 4.0/applet.js:3088 6.0/applet.js:3088
 msgid "Minimize"
 msgstr ""
 
-#: 4.0/applet.js:3088 6.0/applet.js:3088
+#: 4.0/applet.js:3094 6.0/applet.js:3094
 msgid "Unmaximize"
 msgstr ""
 
-#: 4.0/applet.js:3095 6.0/applet.js:3095
+#: 4.0/applet.js:3101 6.0/applet.js:3101
 msgid "Close others"
 msgstr ""
 
-#: 4.0/applet.js:3106 6.0/applet.js:3106
+#: 4.0/applet.js:3112 6.0/applet.js:3112
 msgid "Close all"
 msgstr ""
 
-#: 4.0/applet.js:3115 6.0/applet.js:3115
+#: 4.0/applet.js:3121 6.0/applet.js:3121
 msgid "Close"
 msgstr ""
 

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/da.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/da.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-01 10:01-0400\n"
+"POT-Creation-Date: 2024-05-13 20:57-0400\n"
 "PO-Revision-Date: 2024-01-01 10:11+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "alle knapper"
 
-#: 4.0/applet.js:2640 6.0/applet.js:2640
+#: 4.0/applet.js:2646 6.0/applet.js:2646
 msgid "Applet Preferences"
 msgstr "Indstillinger"
 
-#: 4.0/applet.js:2644 6.0/applet.js:2644
+#: 4.0/applet.js:2650 6.0/applet.js:2650
 msgid "About..."
 msgstr "Om …"
 
-#: 4.0/applet.js:2648 6.0/applet.js:2648
+#: 4.0/applet.js:2654 6.0/applet.js:2654
 msgid "Configure..."
 msgstr "Konfigurér …"
 
-#: 4.0/applet.js:2652 6.0/applet.js:2652
+#: 4.0/applet.js:2658 6.0/applet.js:2658
 msgid "Website"
 msgstr ""
 
-#: 4.0/applet.js:2656 6.0/applet.js:2656
+#: 4.0/applet.js:2662 6.0/applet.js:2662
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Fjern “%s”"
 
-#: 4.0/applet.js:2658 6.0/applet.js:2658
+#: 4.0/applet.js:2664 6.0/applet.js:2664
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Vil du virkelig fjerne denne forekomst af CassiaVinduesliste?"
 
@@ -55,111 +55,111 @@ msgstr "Vil du virkelig fjerne denne forekomst af CassiaVinduesliste?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2667 6.0/applet.js:2667
+#: 4.0/applet.js:2673 6.0/applet.js:2673
 msgid "Open new window"
 msgstr "Åbn nyt vindue"
 
-#: 4.0/applet.js:2675 6.0/applet.js:2675
+#: 4.0/applet.js:2681 6.0/applet.js:2681
 msgid "Remove from panel"
 msgstr "Fjern fra panel"
 
-#: 4.0/applet.js:2677 6.0/applet.js:2677
+#: 4.0/applet.js:2683 6.0/applet.js:2683
 msgid "Remove from this workspace"
 msgstr "Fjern fra dette arbejdsområde"
 
-#: 4.0/applet.js:2683 6.0/applet.js:2683
+#: 4.0/applet.js:2689 6.0/applet.js:2689
 msgid "Pin to panel"
 msgstr "Fastgør til panel"
 
-#: 4.0/applet.js:2685 6.0/applet.js:2685
+#: 4.0/applet.js:2691 6.0/applet.js:2691
 msgid "Pin to this workspace"
 msgstr "Fastgør til dette arbejdsområde"
 
-#: 4.0/applet.js:2726 6.0/applet.js:2726
+#: 4.0/applet.js:2732 6.0/applet.js:2732
 msgid "Pin to other workspaces"
 msgstr "Fastgør til andre arbejdsområder"
 
-#: 4.0/applet.js:2747 6.0/applet.js:2747
+#: 4.0/applet.js:2753 6.0/applet.js:2753
 msgid "Pin to all workspaces"
 msgstr "Fastgør til alle arbejdsområder"
 
-#: 4.0/applet.js:2765 6.0/applet.js:2765
+#: 4.0/applet.js:2771 6.0/applet.js:2771
 msgid "Pin to launcher"
 msgstr "Fastgør til programstarter"
 
-#: 4.0/applet.js:2783 4.0/applet.js:2966 6.0/applet.js:2783 6.0/applet.js:2966
+#: 4.0/applet.js:2789 4.0/applet.js:2972 6.0/applet.js:2789 6.0/applet.js:2972
 msgid "Add new Hotkey for"
 msgstr "Tilføj ny genvejstast til"
 
-#: 4.0/applet.js:2797 6.0/applet.js:2797
+#: 4.0/applet.js:2803 6.0/applet.js:2803
 msgid "Recent files"
 msgstr "Seneste filer"
 
-#: 4.0/applet.js:2821 6.0/applet.js:2821
+#: 4.0/applet.js:2827 6.0/applet.js:2827
 msgid "Places"
 msgstr "Steder"
 
-#: 4.0/applet.js:2863 6.0/applet.js:2863
+#: 4.0/applet.js:2869 6.0/applet.js:2869
 msgid "Only on this workspace"
 msgstr "Kun på dette arbejdsområde"
 
-#: 4.0/applet.js:2865 6.0/applet.js:2865
+#: 4.0/applet.js:2871 6.0/applet.js:2871
 msgid "Visible on all workspaces"
 msgstr "Synlig på alle arbejdsområder"
 
-#: 4.0/applet.js:2866 6.0/applet.js:2866
+#: 4.0/applet.js:2872 6.0/applet.js:2872
 msgid "Move to another workspace"
 msgstr "Flyt til et andet arbejdsområde"
 
-#: 4.0/applet.js:2875 6.0/applet.js:2875
+#: 4.0/applet.js:2881 6.0/applet.js:2881
 msgid " (this workspace)"
 msgstr " (dette arbejdsområde)"
 
-#: 4.0/applet.js:2888 6.0/applet.js:2888
+#: 4.0/applet.js:2894 6.0/applet.js:2894
 msgid "Move to another monitor"
 msgstr "Flyt til en anden skærm"
 
-#: 4.0/applet.js:2896 6.0/applet.js:2896
+#: 4.0/applet.js:2902 6.0/applet.js:2902
 msgid "Monitor"
 msgstr "Skærm"
 
-#: 4.0/applet.js:2921 6.0/applet.js:2921
+#: 4.0/applet.js:2927 6.0/applet.js:2927
 msgid "unassigned"
 msgstr "ikke tildelt"
 
-#: 4.0/applet.js:2932 4.0/applet.js:2963 6.0/applet.js:2932 6.0/applet.js:2963
+#: 4.0/applet.js:2938 4.0/applet.js:2969 6.0/applet.js:2938 6.0/applet.js:2969
 msgid "Assign window to a hotkey"
 msgstr "Tildel en genvejstast til vindue"
 
-#: 4.0/applet.js:2986 6.0/applet.js:2986
+#: 4.0/applet.js:2992 6.0/applet.js:2992
 msgid "Change application label contents"
 msgstr "Ændr indholdet af programetiket"
 
-#: 4.0/applet.js:2989 6.0/applet.js:2989
+#: 4.0/applet.js:2995 6.0/applet.js:2995
 msgid "Remove custom setting"
 msgstr "Fjern brugerdefineret indstilling"
 
-#: 4.0/applet.js:2996 6.0/applet.js:2996
+#: 4.0/applet.js:3002 6.0/applet.js:3002
 msgid "Use window title"
 msgstr "Brug vinduestitel"
 
-#: 4.0/applet.js:3003 6.0/applet.js:3003
+#: 4.0/applet.js:3009 6.0/applet.js:3009
 msgid "Use application name"
 msgstr "Brug programnavn"
 
-#: 4.0/applet.js:3010 6.0/applet.js:3010
+#: 4.0/applet.js:3016 6.0/applet.js:3016
 msgid "No label"
 msgstr "Ingen etiket"
 
-#: 4.0/applet.js:3021 6.0/applet.js:3021
+#: 4.0/applet.js:3027 6.0/applet.js:3027
 msgid "Ungroup application windows"
 msgstr "Opsplit gruppen af programmervinduer"
 
-#: 4.0/applet.js:3030 6.0/applet.js:3030
+#: 4.0/applet.js:3036 6.0/applet.js:3036
 msgid "Group application windows"
 msgstr "Gruppér programvinduer"
 
-#: 4.0/applet.js:3043 6.0/applet.js:3043
+#: 4.0/applet.js:3049 6.0/applet.js:3049
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatisk gruppering/opsplitning af gruppe"
 
@@ -175,31 +175,31 @@ msgstr "Automatisk gruppering/opsplitning af gruppe"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3073 6.0/applet.js:3073
+#: 4.0/applet.js:3079 6.0/applet.js:3079
 msgid "Move titlebar on to screen"
 msgstr "Flyt titellinje til skærm"
 
-#: 4.0/applet.js:3078 6.0/applet.js:3078
+#: 4.0/applet.js:3084 6.0/applet.js:3084
 msgid "Restore"
 msgstr "Gendan"
 
-#: 4.0/applet.js:3082 6.0/applet.js:3082
+#: 4.0/applet.js:3088 6.0/applet.js:3088
 msgid "Minimize"
 msgstr "Minimér"
 
-#: 4.0/applet.js:3088 6.0/applet.js:3088
+#: 4.0/applet.js:3094 6.0/applet.js:3094
 msgid "Unmaximize"
 msgstr "Gendan"
 
-#: 4.0/applet.js:3095 6.0/applet.js:3095
+#: 4.0/applet.js:3101 6.0/applet.js:3101
 msgid "Close others"
 msgstr "Luk andre"
 
-#: 4.0/applet.js:3106 6.0/applet.js:3106
+#: 4.0/applet.js:3112 6.0/applet.js:3112
 msgid "Close all"
 msgstr "Luk alle"
 
-#: 4.0/applet.js:3115 6.0/applet.js:3115
+#: 4.0/applet.js:3121 6.0/applet.js:3121
 msgid "Close"
 msgstr "Luk"
 

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/es.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-01 10:01-0400\n"
+"POT-Creation-Date: 2024-05-13 20:57-0400\n"
 "PO-Revision-Date: 2024-03-27 20:14-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -22,28 +22,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "todos los botones"
 
-#: 4.0/applet.js:2640 6.0/applet.js:2640
+#: 4.0/applet.js:2646 6.0/applet.js:2646
 msgid "Applet Preferences"
 msgstr "Preferencias del applet"
 
-#: 4.0/applet.js:2644 6.0/applet.js:2644
+#: 4.0/applet.js:2650 6.0/applet.js:2650
 msgid "About..."
 msgstr "Acerca de..."
 
-#: 4.0/applet.js:2648 6.0/applet.js:2648
+#: 4.0/applet.js:2654 6.0/applet.js:2654
 msgid "Configure..."
 msgstr "Configurar..."
 
-#: 4.0/applet.js:2652 6.0/applet.js:2652
+#: 4.0/applet.js:2658 6.0/applet.js:2658
 msgid "Website"
 msgstr "Sitio web"
 
-#: 4.0/applet.js:2656 6.0/applet.js:2656
+#: 4.0/applet.js:2662 6.0/applet.js:2662
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eliminar '%s'"
 
-#: 4.0/applet.js:2658 6.0/applet.js:2658
+#: 4.0/applet.js:2664 6.0/applet.js:2664
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "¿Realmente desea eliminar esta instancia de CassiaWindowList?"
 
@@ -59,111 +59,111 @@ msgstr "¿Realmente desea eliminar esta instancia de CassiaWindowList?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2667 6.0/applet.js:2667
+#: 4.0/applet.js:2673 6.0/applet.js:2673
 msgid "Open new window"
 msgstr "Abrir nueva ventana"
 
-#: 4.0/applet.js:2675 6.0/applet.js:2675
+#: 4.0/applet.js:2681 6.0/applet.js:2681
 msgid "Remove from panel"
 msgstr "Quitar del panel"
 
-#: 4.0/applet.js:2677 6.0/applet.js:2677
+#: 4.0/applet.js:2683 6.0/applet.js:2683
 msgid "Remove from this workspace"
 msgstr "Eliminar de este espacio de trabajo"
 
-#: 4.0/applet.js:2683 6.0/applet.js:2683
+#: 4.0/applet.js:2689 6.0/applet.js:2689
 msgid "Pin to panel"
 msgstr "Anclar al panel"
 
-#: 4.0/applet.js:2685 6.0/applet.js:2685
+#: 4.0/applet.js:2691 6.0/applet.js:2691
 msgid "Pin to this workspace"
 msgstr "Anclar a este espacio de trabajo"
 
-#: 4.0/applet.js:2726 6.0/applet.js:2726
+#: 4.0/applet.js:2732 6.0/applet.js:2732
 msgid "Pin to other workspaces"
 msgstr "Anclar a otros espacios de trabajo"
 
-#: 4.0/applet.js:2747 6.0/applet.js:2747
+#: 4.0/applet.js:2753 6.0/applet.js:2753
 msgid "Pin to all workspaces"
 msgstr "Anclar a todos los espacios de trabajo"
 
-#: 4.0/applet.js:2765 6.0/applet.js:2765
+#: 4.0/applet.js:2771 6.0/applet.js:2771
 msgid "Pin to launcher"
 msgstr "Anclar al lanzador"
 
-#: 4.0/applet.js:2783 4.0/applet.js:2966 6.0/applet.js:2783 6.0/applet.js:2966
+#: 4.0/applet.js:2789 4.0/applet.js:2972 6.0/applet.js:2789 6.0/applet.js:2972
 msgid "Add new Hotkey for"
 msgstr "Añadir nueva tecla de acceso rápido para"
 
-#: 4.0/applet.js:2797 6.0/applet.js:2797
+#: 4.0/applet.js:2803 6.0/applet.js:2803
 msgid "Recent files"
 msgstr "Archivos recientes"
 
-#: 4.0/applet.js:2821 6.0/applet.js:2821
+#: 4.0/applet.js:2827 6.0/applet.js:2827
 msgid "Places"
 msgstr "Lugares"
 
-#: 4.0/applet.js:2863 6.0/applet.js:2863
+#: 4.0/applet.js:2869 6.0/applet.js:2869
 msgid "Only on this workspace"
 msgstr "Sólo en este espacio de trabajo"
 
-#: 4.0/applet.js:2865 6.0/applet.js:2865
+#: 4.0/applet.js:2871 6.0/applet.js:2871
 msgid "Visible on all workspaces"
 msgstr "Visible en todos los espacios de trabajo"
 
-#: 4.0/applet.js:2866 6.0/applet.js:2866
+#: 4.0/applet.js:2872 6.0/applet.js:2872
 msgid "Move to another workspace"
 msgstr "Mover a otro espacio de trabajo"
 
-#: 4.0/applet.js:2875 6.0/applet.js:2875
+#: 4.0/applet.js:2881 6.0/applet.js:2881
 msgid " (this workspace)"
 msgstr " (este espacio de trabajo)"
 
-#: 4.0/applet.js:2888 6.0/applet.js:2888
+#: 4.0/applet.js:2894 6.0/applet.js:2894
 msgid "Move to another monitor"
 msgstr "Mover a otro monitor"
 
-#: 4.0/applet.js:2896 6.0/applet.js:2896
+#: 4.0/applet.js:2902 6.0/applet.js:2902
 msgid "Monitor"
 msgstr "Monitor"
 
-#: 4.0/applet.js:2921 6.0/applet.js:2921
+#: 4.0/applet.js:2927 6.0/applet.js:2927
 msgid "unassigned"
 msgstr "no asignado"
 
-#: 4.0/applet.js:2932 4.0/applet.js:2963 6.0/applet.js:2932 6.0/applet.js:2963
+#: 4.0/applet.js:2938 4.0/applet.js:2969 6.0/applet.js:2938 6.0/applet.js:2969
 msgid "Assign window to a hotkey"
 msgstr "Asignar ventana a una tecla de acceso rápido"
 
-#: 4.0/applet.js:2986 6.0/applet.js:2986
+#: 4.0/applet.js:2992 6.0/applet.js:2992
 msgid "Change application label contents"
 msgstr "Cambiar el contenido de la etiqueta de la aplicación"
 
-#: 4.0/applet.js:2989 6.0/applet.js:2989
+#: 4.0/applet.js:2995 6.0/applet.js:2995
 msgid "Remove custom setting"
 msgstr "Eliminar configuración personalizada"
 
-#: 4.0/applet.js:2996 6.0/applet.js:2996
+#: 4.0/applet.js:3002 6.0/applet.js:3002
 msgid "Use window title"
 msgstr "Utilizar título de ventana"
 
-#: 4.0/applet.js:3003 6.0/applet.js:3003
+#: 4.0/applet.js:3009 6.0/applet.js:3009
 msgid "Use application name"
 msgstr "Utilizar nombre de aplicación"
 
-#: 4.0/applet.js:3010 6.0/applet.js:3010
+#: 4.0/applet.js:3016 6.0/applet.js:3016
 msgid "No label"
 msgstr "Sin etiqueta"
 
-#: 4.0/applet.js:3021 6.0/applet.js:3021
+#: 4.0/applet.js:3027 6.0/applet.js:3027
 msgid "Ungroup application windows"
 msgstr "Ventanas de aplicaciones separadas"
 
-#: 4.0/applet.js:3030 6.0/applet.js:3030
+#: 4.0/applet.js:3036 6.0/applet.js:3036
 msgid "Group application windows"
 msgstr "Ventanas de aplicaciones agrupadas"
 
-#: 4.0/applet.js:3043 6.0/applet.js:3043
+#: 4.0/applet.js:3049 6.0/applet.js:3049
 msgid "Automatic grouping/ungrouping"
 msgstr "Agrupación/desagrupación automática"
 
@@ -179,31 +179,31 @@ msgstr "Agrupación/desagrupación automática"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3073 6.0/applet.js:3073
+#: 4.0/applet.js:3079 6.0/applet.js:3079
 msgid "Move titlebar on to screen"
 msgstr "Mover la barra de título a la pantalla"
 
-#: 4.0/applet.js:3078 6.0/applet.js:3078
+#: 4.0/applet.js:3084 6.0/applet.js:3084
 msgid "Restore"
 msgstr "Restaurar"
 
-#: 4.0/applet.js:3082 6.0/applet.js:3082
+#: 4.0/applet.js:3088 6.0/applet.js:3088
 msgid "Minimize"
 msgstr "Minimizar"
 
-#: 4.0/applet.js:3088 6.0/applet.js:3088
+#: 4.0/applet.js:3094 6.0/applet.js:3094
 msgid "Unmaximize"
 msgstr "Desmaximizar"
 
-#: 4.0/applet.js:3095 6.0/applet.js:3095
+#: 4.0/applet.js:3101 6.0/applet.js:3101
 msgid "Close others"
 msgstr "Cerrar otros"
 
-#: 4.0/applet.js:3106 6.0/applet.js:3106
+#: 4.0/applet.js:3112 6.0/applet.js:3112
 msgid "Close all"
 msgstr "Cerrar todo"
 
-#: 4.0/applet.js:3115 6.0/applet.js:3115
+#: 4.0/applet.js:3121 6.0/applet.js:3121
 msgid "Close"
 msgstr "Cerrar"
 

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/fr.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-01 10:01-0400\n"
+"POT-Creation-Date: 2024-05-13 20:57-0400\n"
 "PO-Revision-Date: 2024-04-03 14:46+0200\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -23,28 +23,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "tous les boutons"
 
-#: 4.0/applet.js:2640 6.0/applet.js:2640
+#: 4.0/applet.js:2646 6.0/applet.js:2646
 msgid "Applet Preferences"
 msgstr "Préférences"
 
-#: 4.0/applet.js:2644 6.0/applet.js:2644
+#: 4.0/applet.js:2650 6.0/applet.js:2650
 msgid "About..."
 msgstr "À propos..."
 
-#: 4.0/applet.js:2648 6.0/applet.js:2648
+#: 4.0/applet.js:2654 6.0/applet.js:2654
 msgid "Configure..."
 msgstr "Configurer..."
 
-#: 4.0/applet.js:2652 6.0/applet.js:2652
+#: 4.0/applet.js:2658 6.0/applet.js:2658
 msgid "Website"
 msgstr "Site web"
 
-#: 4.0/applet.js:2656 6.0/applet.js:2656
+#: 4.0/applet.js:2662 6.0/applet.js:2662
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Supprimer '%s'"
 
-#: 4.0/applet.js:2658 6.0/applet.js:2658
+#: 4.0/applet.js:2664 6.0/applet.js:2664
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Voulez-vous vraiment supprimer cette instance de CassiaWindowList ?"
 
@@ -60,111 +60,111 @@ msgstr "Voulez-vous vraiment supprimer cette instance de CassiaWindowList ?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2667 6.0/applet.js:2667
+#: 4.0/applet.js:2673 6.0/applet.js:2673
 msgid "Open new window"
 msgstr "Ouvrir une nouvelle fenêtre"
 
-#: 4.0/applet.js:2675 6.0/applet.js:2675
+#: 4.0/applet.js:2681 6.0/applet.js:2681
 msgid "Remove from panel"
 msgstr "Retirer du panneau"
 
-#: 4.0/applet.js:2677 6.0/applet.js:2677
+#: 4.0/applet.js:2683 6.0/applet.js:2683
 msgid "Remove from this workspace"
 msgstr "Retirer de cet espace de travail"
 
-#: 4.0/applet.js:2683 6.0/applet.js:2683
+#: 4.0/applet.js:2689 6.0/applet.js:2689
 msgid "Pin to panel"
 msgstr "Épingler au panneau"
 
-#: 4.0/applet.js:2685 6.0/applet.js:2685
+#: 4.0/applet.js:2691 6.0/applet.js:2691
 msgid "Pin to this workspace"
 msgstr "Épingler à cet espace de travail"
 
-#: 4.0/applet.js:2726 6.0/applet.js:2726
+#: 4.0/applet.js:2732 6.0/applet.js:2732
 msgid "Pin to other workspaces"
 msgstr "Épingler aux autres espaces de travail"
 
-#: 4.0/applet.js:2747 6.0/applet.js:2747
+#: 4.0/applet.js:2753 6.0/applet.js:2753
 msgid "Pin to all workspaces"
 msgstr "Épingler à tous les espaces de travail"
 
-#: 4.0/applet.js:2765 6.0/applet.js:2765
+#: 4.0/applet.js:2771 6.0/applet.js:2771
 msgid "Pin to launcher"
 msgstr "Épingler au lanceur"
 
-#: 4.0/applet.js:2783 4.0/applet.js:2966 6.0/applet.js:2783 6.0/applet.js:2966
+#: 4.0/applet.js:2789 4.0/applet.js:2972 6.0/applet.js:2789 6.0/applet.js:2972
 msgid "Add new Hotkey for"
 msgstr "Ajouter un nouveau raccourci clavier pour"
 
-#: 4.0/applet.js:2797 6.0/applet.js:2797
+#: 4.0/applet.js:2803 6.0/applet.js:2803
 msgid "Recent files"
 msgstr "Fichiers récents"
 
-#: 4.0/applet.js:2821 6.0/applet.js:2821
+#: 4.0/applet.js:2827 6.0/applet.js:2827
 msgid "Places"
 msgstr "Emplacements"
 
-#: 4.0/applet.js:2863 6.0/applet.js:2863
+#: 4.0/applet.js:2869 6.0/applet.js:2869
 msgid "Only on this workspace"
 msgstr "Seulement sur cet espace de travail"
 
-#: 4.0/applet.js:2865 6.0/applet.js:2865
+#: 4.0/applet.js:2871 6.0/applet.js:2871
 msgid "Visible on all workspaces"
 msgstr "Visible sur tous les espaces de travail"
 
-#: 4.0/applet.js:2866 6.0/applet.js:2866
+#: 4.0/applet.js:2872 6.0/applet.js:2872
 msgid "Move to another workspace"
 msgstr "Déplacer vers un autre espace de travail"
 
-#: 4.0/applet.js:2875 6.0/applet.js:2875
+#: 4.0/applet.js:2881 6.0/applet.js:2881
 msgid " (this workspace)"
 msgstr " (cet espace de travail)"
 
-#: 4.0/applet.js:2888 6.0/applet.js:2888
+#: 4.0/applet.js:2894 6.0/applet.js:2894
 msgid "Move to another monitor"
 msgstr "Déplacer vers un autre moniteur"
 
-#: 4.0/applet.js:2896 6.0/applet.js:2896
+#: 4.0/applet.js:2902 6.0/applet.js:2902
 msgid "Monitor"
 msgstr "Moniteur"
 
-#: 4.0/applet.js:2921 6.0/applet.js:2921
+#: 4.0/applet.js:2927 6.0/applet.js:2927
 msgid "unassigned"
 msgstr "non attribué"
 
-#: 4.0/applet.js:2932 4.0/applet.js:2963 6.0/applet.js:2932 6.0/applet.js:2963
+#: 4.0/applet.js:2938 4.0/applet.js:2969 6.0/applet.js:2938 6.0/applet.js:2969
 msgid "Assign window to a hotkey"
 msgstr "Attribuer une fenêtre à un raccourci clavier"
 
-#: 4.0/applet.js:2986 6.0/applet.js:2986
+#: 4.0/applet.js:2992 6.0/applet.js:2992
 msgid "Change application label contents"
 msgstr "Modifier le libellé de l'étiquette de l'application"
 
-#: 4.0/applet.js:2989 6.0/applet.js:2989
+#: 4.0/applet.js:2995 6.0/applet.js:2995
 msgid "Remove custom setting"
 msgstr "Supprimer le paramètre personnalisé"
 
-#: 4.0/applet.js:2996 6.0/applet.js:2996
+#: 4.0/applet.js:3002 6.0/applet.js:3002
 msgid "Use window title"
 msgstr "Utiliser le titre de fenêtre"
 
-#: 4.0/applet.js:3003 6.0/applet.js:3003
+#: 4.0/applet.js:3009 6.0/applet.js:3009
 msgid "Use application name"
 msgstr "Utiliser le nom de l'application"
 
-#: 4.0/applet.js:3010 6.0/applet.js:3010
+#: 4.0/applet.js:3016 6.0/applet.js:3016
 msgid "No label"
 msgstr "Sans étiquette"
 
-#: 4.0/applet.js:3021 6.0/applet.js:3021
+#: 4.0/applet.js:3027 6.0/applet.js:3027
 msgid "Ungroup application windows"
 msgstr "Dégrouper les fenêtres de l'application"
 
-#: 4.0/applet.js:3030 6.0/applet.js:3030
+#: 4.0/applet.js:3036 6.0/applet.js:3036
 msgid "Group application windows"
 msgstr "Grouper les fenêtres par application"
 
-#: 4.0/applet.js:3043 6.0/applet.js:3043
+#: 4.0/applet.js:3049 6.0/applet.js:3049
 msgid "Automatic grouping/ungrouping"
 msgstr "Regrouper/dégrouper automatiquement"
 
@@ -180,31 +180,31 @@ msgstr "Regrouper/dégrouper automatiquement"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3073 6.0/applet.js:3073
+#: 4.0/applet.js:3079 6.0/applet.js:3079
 msgid "Move titlebar on to screen"
 msgstr "Déplacer la barre de titre sur l'écran"
 
-#: 4.0/applet.js:3078 6.0/applet.js:3078
+#: 4.0/applet.js:3084 6.0/applet.js:3084
 msgid "Restore"
 msgstr "Restaurer"
 
-#: 4.0/applet.js:3082 6.0/applet.js:3082
+#: 4.0/applet.js:3088 6.0/applet.js:3088
 msgid "Minimize"
 msgstr "Minimiser"
 
-#: 4.0/applet.js:3088 6.0/applet.js:3088
+#: 4.0/applet.js:3094 6.0/applet.js:3094
 msgid "Unmaximize"
 msgstr "Démaximiser"
 
-#: 4.0/applet.js:3095 6.0/applet.js:3095
+#: 4.0/applet.js:3101 6.0/applet.js:3101
 msgid "Close others"
 msgstr "Fermer les autres"
 
-#: 4.0/applet.js:3106 6.0/applet.js:3106
+#: 4.0/applet.js:3112 6.0/applet.js:3112
 msgid "Close all"
 msgstr "Tout fermer"
 
-#: 4.0/applet.js:3115 6.0/applet.js:3115
+#: 4.0/applet.js:3121 6.0/applet.js:3121
 msgid "Close"
 msgstr "Fermer"
 

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/hu.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-01 10:01-0400\n"
+"POT-Creation-Date: 2024-05-13 20:57-0400\n"
 "PO-Revision-Date: 2024-02-08 15:00+0100\n"
 "Last-Translator: Vajda Örs <ors0092@gmail.com>\n"
 "Language-Team: \n"
@@ -23,28 +23,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "minden gomb"
 
-#: 4.0/applet.js:2640 6.0/applet.js:2640
+#: 4.0/applet.js:2646 6.0/applet.js:2646
 msgid "Applet Preferences"
 msgstr "Kisalkalmazás beállítások"
 
-#: 4.0/applet.js:2644 6.0/applet.js:2644
+#: 4.0/applet.js:2650 6.0/applet.js:2650
 msgid "About..."
 msgstr "Névjegy…"
 
-#: 4.0/applet.js:2648 6.0/applet.js:2648
+#: 4.0/applet.js:2654 6.0/applet.js:2654
 msgid "Configure..."
 msgstr "Beállítások…"
 
-#: 4.0/applet.js:2652 6.0/applet.js:2652
+#: 4.0/applet.js:2658 6.0/applet.js:2658
 msgid "Website"
 msgstr "Weboldal"
 
-#: 4.0/applet.js:2656 6.0/applet.js:2656
+#: 4.0/applet.js:2662 6.0/applet.js:2662
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eltávolítás: „%s”"
 
-#: 4.0/applet.js:2658 6.0/applet.js:2658
+#: 4.0/applet.js:2664 6.0/applet.js:2664
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Valóban el szeretné távolítani ezt a CassiaWindowList ezen példányát?"
 
@@ -60,111 +60,111 @@ msgstr "Valóban el szeretné távolítani ezt a CassiaWindowList ezen példány
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2667 6.0/applet.js:2667
+#: 4.0/applet.js:2673 6.0/applet.js:2673
 msgid "Open new window"
 msgstr "Új ablak megnyitása"
 
-#: 4.0/applet.js:2675 6.0/applet.js:2675
+#: 4.0/applet.js:2681 6.0/applet.js:2681
 msgid "Remove from panel"
 msgstr "Eltávolítás a panelról"
 
-#: 4.0/applet.js:2677 6.0/applet.js:2677
+#: 4.0/applet.js:2683 6.0/applet.js:2683
 msgid "Remove from this workspace"
 msgstr "Eltávolítás erről a munkaterületről"
 
-#: 4.0/applet.js:2683 6.0/applet.js:2683
+#: 4.0/applet.js:2689 6.0/applet.js:2689
 msgid "Pin to panel"
 msgstr "Panelhez rögzítés"
 
-#: 4.0/applet.js:2685 6.0/applet.js:2685
+#: 4.0/applet.js:2691 6.0/applet.js:2691
 msgid "Pin to this workspace"
 msgstr "Erre a munkaterületre rögzítés"
 
-#: 4.0/applet.js:2726 6.0/applet.js:2726
+#: 4.0/applet.js:2732 6.0/applet.js:2732
 msgid "Pin to other workspaces"
 msgstr "Más munkaterületre rögzítés"
 
-#: 4.0/applet.js:2747 6.0/applet.js:2747
+#: 4.0/applet.js:2753 6.0/applet.js:2753
 msgid "Pin to all workspaces"
 msgstr "Az összes munkaterületre rögzítés"
 
-#: 4.0/applet.js:2765 6.0/applet.js:2765
+#: 4.0/applet.js:2771 6.0/applet.js:2771
 msgid "Pin to launcher"
 msgstr "Alkalmazásindítóhoz rögzítés"
 
-#: 4.0/applet.js:2783 4.0/applet.js:2966 6.0/applet.js:2783 6.0/applet.js:2966
+#: 4.0/applet.js:2789 4.0/applet.js:2972 6.0/applet.js:2789 6.0/applet.js:2972
 msgid "Add new Hotkey for"
 msgstr "Új gyorsbillentyű hozzáadása ehhez"
 
-#: 4.0/applet.js:2797 6.0/applet.js:2797
+#: 4.0/applet.js:2803 6.0/applet.js:2803
 msgid "Recent files"
 msgstr "Nemrég használt fájlok"
 
-#: 4.0/applet.js:2821 6.0/applet.js:2821
+#: 4.0/applet.js:2827 6.0/applet.js:2827
 msgid "Places"
 msgstr "Helyek"
 
-#: 4.0/applet.js:2863 6.0/applet.js:2863
+#: 4.0/applet.js:2869 6.0/applet.js:2869
 msgid "Only on this workspace"
 msgstr "Csak ezen a munkaterületen"
 
-#: 4.0/applet.js:2865 6.0/applet.js:2865
+#: 4.0/applet.js:2871 6.0/applet.js:2871
 msgid "Visible on all workspaces"
 msgstr "Minden munkaterületen látható"
 
-#: 4.0/applet.js:2866 6.0/applet.js:2866
+#: 4.0/applet.js:2872 6.0/applet.js:2872
 msgid "Move to another workspace"
 msgstr "Áthelyezés másik munkaterületre"
 
-#: 4.0/applet.js:2875 6.0/applet.js:2875
+#: 4.0/applet.js:2881 6.0/applet.js:2881
 msgid " (this workspace)"
 msgstr "(ez a munkaterület)"
 
-#: 4.0/applet.js:2888 6.0/applet.js:2888
+#: 4.0/applet.js:2894 6.0/applet.js:2894
 msgid "Move to another monitor"
 msgstr "Áthelyezés a másik kijelzőre"
 
-#: 4.0/applet.js:2896 6.0/applet.js:2896
+#: 4.0/applet.js:2902 6.0/applet.js:2902
 msgid "Monitor"
 msgstr "Kijelző"
 
-#: 4.0/applet.js:2921 6.0/applet.js:2921
+#: 4.0/applet.js:2927 6.0/applet.js:2927
 msgid "unassigned"
 msgstr "nincs társítva"
 
-#: 4.0/applet.js:2932 4.0/applet.js:2963 6.0/applet.js:2932 6.0/applet.js:2963
+#: 4.0/applet.js:2938 4.0/applet.js:2969 6.0/applet.js:2938 6.0/applet.js:2969
 msgid "Assign window to a hotkey"
 msgstr "Az ablak hozzárendelése egy gyorsbillentyűhöz"
 
-#: 4.0/applet.js:2986 6.0/applet.js:2986
+#: 4.0/applet.js:2992 6.0/applet.js:2992
 msgid "Change application label contents"
 msgstr "Az alkalmazáscímke tartalmának módosítása"
 
-#: 4.0/applet.js:2989 6.0/applet.js:2989
+#: 4.0/applet.js:2995 6.0/applet.js:2995
 msgid "Remove custom setting"
 msgstr "Egyéni beállítás eltávolítása"
 
-#: 4.0/applet.js:2996 6.0/applet.js:2996
+#: 4.0/applet.js:3002 6.0/applet.js:3002
 msgid "Use window title"
 msgstr "Ablakcím használata"
 
-#: 4.0/applet.js:3003 6.0/applet.js:3003
+#: 4.0/applet.js:3009 6.0/applet.js:3009
 msgid "Use application name"
 msgstr "Alkalmazásnév használata"
 
-#: 4.0/applet.js:3010 6.0/applet.js:3010
+#: 4.0/applet.js:3016 6.0/applet.js:3016
 msgid "No label"
 msgstr "Nincs címke"
 
-#: 4.0/applet.js:3021 6.0/applet.js:3021
+#: 4.0/applet.js:3027 6.0/applet.js:3027
 msgid "Ungroup application windows"
 msgstr "Ablakokat ne csoportosítsa alkalmazás szerint"
 
-#: 4.0/applet.js:3030 6.0/applet.js:3030
+#: 4.0/applet.js:3036 6.0/applet.js:3036
 msgid "Group application windows"
 msgstr "Alkalmazás ablakok csoportosítása"
 
-#: 4.0/applet.js:3043 6.0/applet.js:3043
+#: 4.0/applet.js:3049 6.0/applet.js:3049
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatikus csoportosítás létrehozása/megszűntetése"
 
@@ -180,31 +180,31 @@ msgstr "Automatikus csoportosítás létrehozása/megszűntetése"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3073 6.0/applet.js:3073
+#: 4.0/applet.js:3079 6.0/applet.js:3079
 msgid "Move titlebar on to screen"
 msgstr "Címsor mozgatása a kijelzőre"
 
-#: 4.0/applet.js:3078 6.0/applet.js:3078
+#: 4.0/applet.js:3084 6.0/applet.js:3084
 msgid "Restore"
 msgstr "Visszaállítás"
 
-#: 4.0/applet.js:3082 6.0/applet.js:3082
+#: 4.0/applet.js:3088 6.0/applet.js:3088
 msgid "Minimize"
 msgstr "Minimalizálás"
 
-#: 4.0/applet.js:3088 6.0/applet.js:3088
+#: 4.0/applet.js:3094 6.0/applet.js:3094
 msgid "Unmaximize"
 msgstr "Eredeti méret"
 
-#: 4.0/applet.js:3095 6.0/applet.js:3095
+#: 4.0/applet.js:3101 6.0/applet.js:3101
 msgid "Close others"
 msgstr "Többi bezárása"
 
-#: 4.0/applet.js:3106 6.0/applet.js:3106
+#: 4.0/applet.js:3112 6.0/applet.js:3112
 msgid "Close all"
 msgstr "Minden bezárása"
 
-#: 4.0/applet.js:3115 6.0/applet.js:3115
+#: 4.0/applet.js:3121 6.0/applet.js:3121
 msgid "Close"
 msgstr "Bezárás"
 

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/it.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-01 10:01-0400\n"
+"POT-Creation-Date: 2024-05-13 20:57-0400\n"
 "PO-Revision-Date: 2023-12-12 19:19+0100\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -23,28 +23,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "tutti i pulsanti"
 
-#: 4.0/applet.js:2640 6.0/applet.js:2640
+#: 4.0/applet.js:2646 6.0/applet.js:2646
 msgid "Applet Preferences"
 msgstr "Preferenze Applet"
 
-#: 4.0/applet.js:2644 6.0/applet.js:2644
+#: 4.0/applet.js:2650 6.0/applet.js:2650
 msgid "About..."
 msgstr "Informazioni su..."
 
-#: 4.0/applet.js:2648 6.0/applet.js:2648
+#: 4.0/applet.js:2654 6.0/applet.js:2654
 msgid "Configure..."
 msgstr "Configura..."
 
-#: 4.0/applet.js:2652 6.0/applet.js:2652
+#: 4.0/applet.js:2658 6.0/applet.js:2658
 msgid "Website"
 msgstr ""
 
-#: 4.0/applet.js:2656 6.0/applet.js:2656
+#: 4.0/applet.js:2662 6.0/applet.js:2662
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Rimuovi '%s'"
 
-#: 4.0/applet.js:2658 6.0/applet.js:2658
+#: 4.0/applet.js:2664 6.0/applet.js:2664
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Vuoi davvero rimuovere questa istanza di CassiaWindowList?"
 
@@ -60,111 +60,111 @@ msgstr "Vuoi davvero rimuovere questa istanza di CassiaWindowList?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2667 6.0/applet.js:2667
+#: 4.0/applet.js:2673 6.0/applet.js:2673
 msgid "Open new window"
 msgstr "Apri una nuova finestra"
 
-#: 4.0/applet.js:2675 6.0/applet.js:2675
+#: 4.0/applet.js:2681 6.0/applet.js:2681
 msgid "Remove from panel"
 msgstr "Rimuovi dal pannello"
 
-#: 4.0/applet.js:2677 6.0/applet.js:2677
+#: 4.0/applet.js:2683 6.0/applet.js:2683
 msgid "Remove from this workspace"
 msgstr "Rimuovi da questa area di lavoro"
 
-#: 4.0/applet.js:2683 6.0/applet.js:2683
+#: 4.0/applet.js:2689 6.0/applet.js:2689
 msgid "Pin to panel"
 msgstr "Appunta al pannello"
 
-#: 4.0/applet.js:2685 6.0/applet.js:2685
+#: 4.0/applet.js:2691 6.0/applet.js:2691
 msgid "Pin to this workspace"
 msgstr "Appunta a questo spazio di lavoro"
 
-#: 4.0/applet.js:2726 6.0/applet.js:2726
+#: 4.0/applet.js:2732 6.0/applet.js:2732
 msgid "Pin to other workspaces"
 msgstr "Appunta ad altre aree di lavoro"
 
-#: 4.0/applet.js:2747 6.0/applet.js:2747
+#: 4.0/applet.js:2753 6.0/applet.js:2753
 msgid "Pin to all workspaces"
 msgstr "Appunta in tutte le aree di lavoro"
 
-#: 4.0/applet.js:2765 6.0/applet.js:2765
+#: 4.0/applet.js:2771 6.0/applet.js:2771
 msgid "Pin to launcher"
 msgstr "Appunta al launcher"
 
-#: 4.0/applet.js:2783 4.0/applet.js:2966 6.0/applet.js:2783 6.0/applet.js:2966
+#: 4.0/applet.js:2789 4.0/applet.js:2972 6.0/applet.js:2789 6.0/applet.js:2972
 msgid "Add new Hotkey for"
 msgstr "Aggiungi un nuovo tasto di scelta rapida per"
 
-#: 4.0/applet.js:2797 6.0/applet.js:2797
+#: 4.0/applet.js:2803 6.0/applet.js:2803
 msgid "Recent files"
 msgstr "Recenti"
 
-#: 4.0/applet.js:2821 6.0/applet.js:2821
+#: 4.0/applet.js:2827 6.0/applet.js:2827
 msgid "Places"
 msgstr "Posizioni"
 
-#: 4.0/applet.js:2863 6.0/applet.js:2863
+#: 4.0/applet.js:2869 6.0/applet.js:2869
 msgid "Only on this workspace"
 msgstr "Solo su questo spazio di lavoro"
 
-#: 4.0/applet.js:2865 6.0/applet.js:2865
+#: 4.0/applet.js:2871 6.0/applet.js:2871
 msgid "Visible on all workspaces"
 msgstr "Visibile su tutte le aree di lavoro"
 
-#: 4.0/applet.js:2866 6.0/applet.js:2866
+#: 4.0/applet.js:2872 6.0/applet.js:2872
 msgid "Move to another workspace"
 msgstr "Sposta su un'altra area di lavoro"
 
-#: 4.0/applet.js:2875 6.0/applet.js:2875
+#: 4.0/applet.js:2881 6.0/applet.js:2881
 msgid " (this workspace)"
 msgstr " (questa area di lavoro)"
 
-#: 4.0/applet.js:2888 6.0/applet.js:2888
+#: 4.0/applet.js:2894 6.0/applet.js:2894
 msgid "Move to another monitor"
 msgstr "Sposta su un altro schermo"
 
-#: 4.0/applet.js:2896 6.0/applet.js:2896
+#: 4.0/applet.js:2902 6.0/applet.js:2902
 msgid "Monitor"
 msgstr "Monitor"
 
-#: 4.0/applet.js:2921 6.0/applet.js:2921
+#: 4.0/applet.js:2927 6.0/applet.js:2927
 msgid "unassigned"
 msgstr "non assegnato"
 
-#: 4.0/applet.js:2932 4.0/applet.js:2963 6.0/applet.js:2932 6.0/applet.js:2963
+#: 4.0/applet.js:2938 4.0/applet.js:2969 6.0/applet.js:2938 6.0/applet.js:2969
 msgid "Assign window to a hotkey"
 msgstr "Assegna finestra ad un tasto di scelta rapida"
 
-#: 4.0/applet.js:2986 6.0/applet.js:2986
+#: 4.0/applet.js:2992 6.0/applet.js:2992
 msgid "Change application label contents"
 msgstr "Cambia il contenuto dell'etichetta dell'applicazione"
 
-#: 4.0/applet.js:2989 6.0/applet.js:2989
+#: 4.0/applet.js:2995 6.0/applet.js:2995
 msgid "Remove custom setting"
 msgstr "Rimuovi impostazioni personalizzate"
 
-#: 4.0/applet.js:2996 6.0/applet.js:2996
+#: 4.0/applet.js:3002 6.0/applet.js:3002
 msgid "Use window title"
 msgstr "Usa il titolo della finestra"
 
-#: 4.0/applet.js:3003 6.0/applet.js:3003
+#: 4.0/applet.js:3009 6.0/applet.js:3009
 msgid "Use application name"
 msgstr "Usa il nome dell'applicazione"
 
-#: 4.0/applet.js:3010 6.0/applet.js:3010
+#: 4.0/applet.js:3016 6.0/applet.js:3016
 msgid "No label"
 msgstr "Nessuna etichetta"
 
-#: 4.0/applet.js:3021 6.0/applet.js:3021
+#: 4.0/applet.js:3027 6.0/applet.js:3027
 msgid "Ungroup application windows"
 msgstr "Separa le finestre dell'applicazione"
 
-#: 4.0/applet.js:3030 6.0/applet.js:3030
+#: 4.0/applet.js:3036 6.0/applet.js:3036
 msgid "Group application windows"
 msgstr "Raggruppa le finestre dell'applicazione"
 
-#: 4.0/applet.js:3043 6.0/applet.js:3043
+#: 4.0/applet.js:3049 6.0/applet.js:3049
 msgid "Automatic grouping/ungrouping"
 msgstr "Raggruppamento/separazione automatica"
 
@@ -180,31 +180,31 @@ msgstr "Raggruppamento/separazione automatica"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3073 6.0/applet.js:3073
+#: 4.0/applet.js:3079 6.0/applet.js:3079
 msgid "Move titlebar on to screen"
 msgstr "Sposta la barra del titolo sullo schermo"
 
-#: 4.0/applet.js:3078 6.0/applet.js:3078
+#: 4.0/applet.js:3084 6.0/applet.js:3084
 msgid "Restore"
 msgstr "Ripristina"
 
-#: 4.0/applet.js:3082 6.0/applet.js:3082
+#: 4.0/applet.js:3088 6.0/applet.js:3088
 msgid "Minimize"
 msgstr "Minimizza"
 
-#: 4.0/applet.js:3088 6.0/applet.js:3088
+#: 4.0/applet.js:3094 6.0/applet.js:3094
 msgid "Unmaximize"
 msgstr "De-massimizza"
 
-#: 4.0/applet.js:3095 6.0/applet.js:3095
+#: 4.0/applet.js:3101 6.0/applet.js:3101
 msgid "Close others"
 msgstr "Chiudi altri"
 
-#: 4.0/applet.js:3106 6.0/applet.js:3106
+#: 4.0/applet.js:3112 6.0/applet.js:3112
 msgid "Close all"
 msgstr "Chiudi tutto"
 
-#: 4.0/applet.js:3115 6.0/applet.js:3115
+#: 4.0/applet.js:3121 6.0/applet.js:3121
 msgid "Close"
 msgstr "Chiudi"
 

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/nl.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.0.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-01 10:01-0400\n"
+"POT-Creation-Date: 2024-05-13 20:57-0400\n"
 "PO-Revision-Date: 2024-04-20 10:46+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -20,28 +20,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "alle knoppen"
 
-#: 4.0/applet.js:2640 6.0/applet.js:2640
+#: 4.0/applet.js:2646 6.0/applet.js:2646
 msgid "Applet Preferences"
 msgstr "Applet Voorkeuren"
 
-#: 4.0/applet.js:2644 6.0/applet.js:2644
+#: 4.0/applet.js:2650 6.0/applet.js:2650
 msgid "About..."
 msgstr "Over..."
 
-#: 4.0/applet.js:2648 6.0/applet.js:2648
+#: 4.0/applet.js:2654 6.0/applet.js:2654
 msgid "Configure..."
 msgstr "Configureren..."
 
-#: 4.0/applet.js:2652 6.0/applet.js:2652
+#: 4.0/applet.js:2658 6.0/applet.js:2658
 msgid "Website"
 msgstr "Website"
 
-#: 4.0/applet.js:2656 6.0/applet.js:2656
+#: 4.0/applet.js:2662 6.0/applet.js:2662
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Verwijder '%s'"
 
-#: 4.0/applet.js:2658 6.0/applet.js:2658
+#: 4.0/applet.js:2664 6.0/applet.js:2664
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 "Weet u zeker dat u deze instantie van CassiaWindowList wilt verwijderen?"
@@ -58,111 +58,111 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2667 6.0/applet.js:2667
+#: 4.0/applet.js:2673 6.0/applet.js:2673
 msgid "Open new window"
 msgstr "Open een nieuw venster"
 
-#: 4.0/applet.js:2675 6.0/applet.js:2675
+#: 4.0/applet.js:2681 6.0/applet.js:2681
 msgid "Remove from panel"
 msgstr "Verwijderen van paneel"
 
-#: 4.0/applet.js:2677 6.0/applet.js:2677
+#: 4.0/applet.js:2683 6.0/applet.js:2683
 msgid "Remove from this workspace"
 msgstr "Verwijderen van deze werkruimte"
 
-#: 4.0/applet.js:2683 6.0/applet.js:2683
+#: 4.0/applet.js:2689 6.0/applet.js:2689
 msgid "Pin to panel"
 msgstr "Vastmaken aan paneel"
 
-#: 4.0/applet.js:2685 6.0/applet.js:2685
+#: 4.0/applet.js:2691 6.0/applet.js:2691
 msgid "Pin to this workspace"
 msgstr "Vastmaken aan deze werkruimte"
 
-#: 4.0/applet.js:2726 6.0/applet.js:2726
+#: 4.0/applet.js:2732 6.0/applet.js:2732
 msgid "Pin to other workspaces"
 msgstr "Vastmaken aan andere werkruimtes"
 
-#: 4.0/applet.js:2747 6.0/applet.js:2747
+#: 4.0/applet.js:2753 6.0/applet.js:2753
 msgid "Pin to all workspaces"
 msgstr "Vastmaken aan alle werkruimtes"
 
-#: 4.0/applet.js:2765 6.0/applet.js:2765
+#: 4.0/applet.js:2771 6.0/applet.js:2771
 msgid "Pin to launcher"
 msgstr "Vastmaken aan launcher"
 
-#: 4.0/applet.js:2783 4.0/applet.js:2966 6.0/applet.js:2783 6.0/applet.js:2966
+#: 4.0/applet.js:2789 4.0/applet.js:2972 6.0/applet.js:2789 6.0/applet.js:2972
 msgid "Add new Hotkey for"
 msgstr "Voeg nieuwe sneltoets toe voor"
 
-#: 4.0/applet.js:2797 6.0/applet.js:2797
+#: 4.0/applet.js:2803 6.0/applet.js:2803
 msgid "Recent files"
 msgstr "Recente bestanden"
 
-#: 4.0/applet.js:2821 6.0/applet.js:2821
+#: 4.0/applet.js:2827 6.0/applet.js:2827
 msgid "Places"
 msgstr "Locaties"
 
-#: 4.0/applet.js:2863 6.0/applet.js:2863
+#: 4.0/applet.js:2869 6.0/applet.js:2869
 msgid "Only on this workspace"
 msgstr "Alleen op deze werkruimte"
 
-#: 4.0/applet.js:2865 6.0/applet.js:2865
+#: 4.0/applet.js:2871 6.0/applet.js:2871
 msgid "Visible on all workspaces"
 msgstr "Zichtbaar op alle werkruimtes"
 
-#: 4.0/applet.js:2866 6.0/applet.js:2866
+#: 4.0/applet.js:2872 6.0/applet.js:2872
 msgid "Move to another workspace"
 msgstr "Verplaatsen naar een andere werkruimte"
 
-#: 4.0/applet.js:2875 6.0/applet.js:2875
+#: 4.0/applet.js:2881 6.0/applet.js:2881
 msgid " (this workspace)"
 msgstr " (deze werkruimte)"
 
-#: 4.0/applet.js:2888 6.0/applet.js:2888
+#: 4.0/applet.js:2894 6.0/applet.js:2894
 msgid "Move to another monitor"
 msgstr "Verplaatsen naar een ander beeldscherm"
 
-#: 4.0/applet.js:2896 6.0/applet.js:2896
+#: 4.0/applet.js:2902 6.0/applet.js:2902
 msgid "Monitor"
 msgstr "Beeldscherm"
 
-#: 4.0/applet.js:2921 6.0/applet.js:2921
+#: 4.0/applet.js:2927 6.0/applet.js:2927
 msgid "unassigned"
 msgstr "niet toegewezen"
 
-#: 4.0/applet.js:2932 4.0/applet.js:2963 6.0/applet.js:2932 6.0/applet.js:2963
+#: 4.0/applet.js:2938 4.0/applet.js:2969 6.0/applet.js:2938 6.0/applet.js:2969
 msgid "Assign window to a hotkey"
 msgstr "Wijs venster toe aan een sneltoets"
 
-#: 4.0/applet.js:2986 6.0/applet.js:2986
+#: 4.0/applet.js:2992 6.0/applet.js:2992
 msgid "Change application label contents"
 msgstr "Wijzig inhoud van applicatielabel"
 
-#: 4.0/applet.js:2989 6.0/applet.js:2989
+#: 4.0/applet.js:2995 6.0/applet.js:2995
 msgid "Remove custom setting"
 msgstr "Verwijder aangepaste instelling"
 
-#: 4.0/applet.js:2996 6.0/applet.js:2996
+#: 4.0/applet.js:3002 6.0/applet.js:3002
 msgid "Use window title"
 msgstr "Gebruik venstertitel"
 
-#: 4.0/applet.js:3003 6.0/applet.js:3003
+#: 4.0/applet.js:3009 6.0/applet.js:3009
 msgid "Use application name"
 msgstr "Gebruik applicatienaam"
 
-#: 4.0/applet.js:3010 6.0/applet.js:3010
+#: 4.0/applet.js:3016 6.0/applet.js:3016
 msgid "No label"
 msgstr "Geen label"
 
-#: 4.0/applet.js:3021 6.0/applet.js:3021
+#: 4.0/applet.js:3027 6.0/applet.js:3027
 msgid "Ungroup application windows"
 msgstr "Applicatie-vensters niet groeperen"
 
-#: 4.0/applet.js:3030 6.0/applet.js:3030
+#: 4.0/applet.js:3036 6.0/applet.js:3036
 msgid "Group application windows"
 msgstr "Applicatie-vensters groeperen"
 
-#: 4.0/applet.js:3043 6.0/applet.js:3043
+#: 4.0/applet.js:3049 6.0/applet.js:3049
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatisch groeperen/ongroeperen"
 
@@ -178,31 +178,31 @@ msgstr "Automatisch groeperen/ongroeperen"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3073 6.0/applet.js:3073
+#: 4.0/applet.js:3079 6.0/applet.js:3079
 msgid "Move titlebar on to screen"
 msgstr "Verplaats titelbalk naar het scherm"
 
-#: 4.0/applet.js:3078 6.0/applet.js:3078
+#: 4.0/applet.js:3084 6.0/applet.js:3084
 msgid "Restore"
 msgstr "Herstellen"
 
-#: 4.0/applet.js:3082 6.0/applet.js:3082
+#: 4.0/applet.js:3088 6.0/applet.js:3088
 msgid "Minimize"
 msgstr "Minimaliseren"
 
-#: 4.0/applet.js:3088 6.0/applet.js:3088
+#: 4.0/applet.js:3094 6.0/applet.js:3094
 msgid "Unmaximize"
 msgstr "Ontmaximaliseren"
 
-#: 4.0/applet.js:3095 6.0/applet.js:3095
+#: 4.0/applet.js:3101 6.0/applet.js:3101
 msgid "Close others"
 msgstr "Sluit anderen"
 
-#: 4.0/applet.js:3106 6.0/applet.js:3106
+#: 4.0/applet.js:3112 6.0/applet.js:3112
 msgid "Close all"
 msgstr "Sluit alle"
 
-#: 4.0/applet.js:3115 6.0/applet.js:3115
+#: 4.0/applet.js:3121 6.0/applet.js:3121
 msgid "Close"
 msgstr "Sluiten"
 

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ru.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ru.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-01 10:01-0400\n"
+"POT-Creation-Date: 2024-05-13 20:57-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 msgid "all buttons"
 msgstr "все кнопки"
 
-#: 4.0/applet.js:2640 6.0/applet.js:2640
+#: 4.0/applet.js:2646 6.0/applet.js:2646
 msgid "Applet Preferences"
 msgstr "Настройки Апплета"
 
-#: 4.0/applet.js:2644 6.0/applet.js:2644
+#: 4.0/applet.js:2650 6.0/applet.js:2650
 msgid "About..."
 msgstr "О Апплете..."
 
-#: 4.0/applet.js:2648 6.0/applet.js:2648
+#: 4.0/applet.js:2654 6.0/applet.js:2654
 msgid "Configure..."
 msgstr "Настроить..."
 
-#: 4.0/applet.js:2652 6.0/applet.js:2652
+#: 4.0/applet.js:2658 6.0/applet.js:2658
 msgid "Website"
 msgstr ""
 
-#: 4.0/applet.js:2656 6.0/applet.js:2656
+#: 4.0/applet.js:2662 6.0/applet.js:2662
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Удалить '%s'"
 
-#: 4.0/applet.js:2658 6.0/applet.js:2658
+#: 4.0/applet.js:2664 6.0/applet.js:2664
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Вы действительно хотите удалить этот экземпляр CassiaWindowList?"
 
@@ -55,112 +55,112 @@ msgstr "Вы действительно хотите удалить этот э�
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2667 6.0/applet.js:2667
+#: 4.0/applet.js:2673 6.0/applet.js:2673
 msgid "Open new window"
 msgstr "Открыть новое окно"
 
-#: 4.0/applet.js:2675 6.0/applet.js:2675
+#: 4.0/applet.js:2681 6.0/applet.js:2681
 msgid "Remove from panel"
 msgstr "Удалить с панели"
 
-#: 4.0/applet.js:2677 6.0/applet.js:2677
+#: 4.0/applet.js:2683 6.0/applet.js:2683
 msgid "Remove from this workspace"
 msgstr "Удалить из этого рабочего стола"
 
-#: 4.0/applet.js:2683 6.0/applet.js:2683
+#: 4.0/applet.js:2689 6.0/applet.js:2689
 msgid "Pin to panel"
 msgstr "Закрепить на панели"
 
-#: 4.0/applet.js:2685 6.0/applet.js:2685
+#: 4.0/applet.js:2691 6.0/applet.js:2691
 msgid "Pin to this workspace"
 msgstr "Закрепить на этом рабочем столе"
 
-#: 4.0/applet.js:2726 6.0/applet.js:2726
+#: 4.0/applet.js:2732 6.0/applet.js:2732
 msgid "Pin to other workspaces"
 msgstr "Закрепить на другом рабочем столе"
 
-#: 4.0/applet.js:2747 6.0/applet.js:2747
+#: 4.0/applet.js:2753 6.0/applet.js:2753
 msgid "Pin to all workspaces"
 msgstr "Закрепить на всех рабочих столах"
 
-#: 4.0/applet.js:2765 6.0/applet.js:2765
+#: 4.0/applet.js:2771 6.0/applet.js:2771
 msgid "Pin to launcher"
 msgstr "Закрепить в лаунчере"
 
-#: 4.0/applet.js:2783 4.0/applet.js:2966 6.0/applet.js:2783 6.0/applet.js:2966
+#: 4.0/applet.js:2789 4.0/applet.js:2972 6.0/applet.js:2789 6.0/applet.js:2972
 msgid "Add new Hotkey for"
 msgstr "Добавить новую горячую клавишу для"
 
-#: 4.0/applet.js:2797 6.0/applet.js:2797
+#: 4.0/applet.js:2803 6.0/applet.js:2803
 msgid "Recent files"
 msgstr "Недавние файлы"
 
-#: 4.0/applet.js:2821 6.0/applet.js:2821
+#: 4.0/applet.js:2827 6.0/applet.js:2827
 msgid "Places"
 msgstr "Места"
 
-#: 4.0/applet.js:2863 6.0/applet.js:2863
+#: 4.0/applet.js:2869 6.0/applet.js:2869
 msgid "Only on this workspace"
 msgstr "Только на этом рабочем столе"
 
-#: 4.0/applet.js:2865 6.0/applet.js:2865
+#: 4.0/applet.js:2871 6.0/applet.js:2871
 msgid "Visible on all workspaces"
 msgstr "Видно на всех рабочих столах"
 
-#: 4.0/applet.js:2866 6.0/applet.js:2866
+#: 4.0/applet.js:2872 6.0/applet.js:2872
 msgid "Move to another workspace"
 msgstr "Переместить на другой рабочий стол"
 
-#: 4.0/applet.js:2875 6.0/applet.js:2875
+#: 4.0/applet.js:2881 6.0/applet.js:2881
 #, fuzzy
 msgid " (this workspace)"
 msgstr "Закрепить на этом рабочем столе"
 
-#: 4.0/applet.js:2888 6.0/applet.js:2888
+#: 4.0/applet.js:2894 6.0/applet.js:2894
 msgid "Move to another monitor"
 msgstr "Переместить на другой монитор"
 
-#: 4.0/applet.js:2896 6.0/applet.js:2896
+#: 4.0/applet.js:2902 6.0/applet.js:2902
 msgid "Monitor"
 msgstr "Монитор"
 
-#: 4.0/applet.js:2921 6.0/applet.js:2921
+#: 4.0/applet.js:2927 6.0/applet.js:2927
 msgid "unassigned"
 msgstr "не назначено"
 
-#: 4.0/applet.js:2932 4.0/applet.js:2963 6.0/applet.js:2932 6.0/applet.js:2963
+#: 4.0/applet.js:2938 4.0/applet.js:2969 6.0/applet.js:2938 6.0/applet.js:2969
 msgid "Assign window to a hotkey"
 msgstr "Назначить окно горячей клавише"
 
-#: 4.0/applet.js:2986 6.0/applet.js:2986
+#: 4.0/applet.js:2992 6.0/applet.js:2992
 msgid "Change application label contents"
 msgstr "Изменить текст названия приложения"
 
-#: 4.0/applet.js:2989 6.0/applet.js:2989
+#: 4.0/applet.js:2995 6.0/applet.js:2995
 msgid "Remove custom setting"
 msgstr "Удалить свои настройки"
 
-#: 4.0/applet.js:2996 6.0/applet.js:2996
+#: 4.0/applet.js:3002 6.0/applet.js:3002
 msgid "Use window title"
 msgstr "Использовать заголовок окон"
 
-#: 4.0/applet.js:3003 6.0/applet.js:3003
+#: 4.0/applet.js:3009 6.0/applet.js:3009
 msgid "Use application name"
 msgstr "Использовать названия программ"
 
-#: 4.0/applet.js:3010 6.0/applet.js:3010
+#: 4.0/applet.js:3016 6.0/applet.js:3016
 msgid "No label"
 msgstr "Без названий"
 
-#: 4.0/applet.js:3021 6.0/applet.js:3021
+#: 4.0/applet.js:3027 6.0/applet.js:3027
 msgid "Ungroup application windows"
 msgstr "Не группировать окна приложений"
 
-#: 4.0/applet.js:3030 6.0/applet.js:3030
+#: 4.0/applet.js:3036 6.0/applet.js:3036
 msgid "Group application windows"
 msgstr "Группировать окна приложений"
 
-#: 4.0/applet.js:3043 6.0/applet.js:3043
+#: 4.0/applet.js:3049 6.0/applet.js:3049
 msgid "Automatic grouping/ungrouping"
 msgstr "Автоматически группировать/разгруппировать"
 
@@ -176,31 +176,31 @@ msgstr "Автоматически группировать/разгруппир
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3073 6.0/applet.js:3073
+#: 4.0/applet.js:3079 6.0/applet.js:3079
 msgid "Move titlebar on to screen"
 msgstr "Переместить на другой экран"
 
-#: 4.0/applet.js:3078 6.0/applet.js:3078
+#: 4.0/applet.js:3084 6.0/applet.js:3084
 msgid "Restore"
 msgstr "Восстановить"
 
-#: 4.0/applet.js:3082 6.0/applet.js:3082
+#: 4.0/applet.js:3088 6.0/applet.js:3088
 msgid "Minimize"
 msgstr "Свернуть"
 
-#: 4.0/applet.js:3088 6.0/applet.js:3088
+#: 4.0/applet.js:3094 6.0/applet.js:3094
 msgid "Unmaximize"
 msgstr "Обычный размер"
 
-#: 4.0/applet.js:3095 6.0/applet.js:3095
+#: 4.0/applet.js:3101 6.0/applet.js:3101
 msgid "Close others"
 msgstr "Закрыть другие"
 
-#: 4.0/applet.js:3106 6.0/applet.js:3106
+#: 4.0/applet.js:3112 6.0/applet.js:3112
 msgid "Close all"
 msgstr "Закрыть всё"
 
-#: 4.0/applet.js:3115 6.0/applet.js:3115
+#: 4.0/applet.js:3121 6.0/applet.js:3121
 msgid "Close"
 msgstr "Закрыть"
 


### PR DESCRIPTION
When in button pooling mode with a thumbnail menu open showing more then one window, highlight the thumbnail menu item matching the window of the windlow-list button that is currently being hovered by the mouse pointer.