### PR TITLE
color-picker@fmete: Fix stuck state when mouse already held down (#6019)

### DIFF
--- a/color-picker@fmete/files/color-picker@fmete/cp.py
+++ b/color-picker@fmete/files/color-picker@fmete/cp.py
@@ -22,6 +22,7 @@
 #
 import sys
 import subprocess
+import time
 import gi
 gi.require_version("Gdk", "3.0")
 from gi.repository import Gdk
@@ -71,7 +72,12 @@ def copy2Clipboard(text):
 def waitClick():
     display = Xlib.display.Display()
     root = display.screen().root
-    root.grab_pointer(1, X.ButtonReleaseMask, X.GrabModeAsync, X.GrabModeAsync, X.NONE, X.NONE, X.CurrentTime)
+
+    while 1:
+        # when grab_pointer fails, e.g. because the mouse button is still pressed (code AlreadyGrabbed), retry
+        if root.grab_pointer(1, X.ButtonReleaseMask, X.GrabModeAsync, X.GrabModeAsync, X.NONE, X.NONE, X.CurrentTime) == 0:
+            break
+        time.sleep(0.05)
 
     while 1:
         event = root.display.next_event()


### PR DESCRIPTION
This fixes an issue where the color picker spice gets stuck when starting color picking while the mouse button is already pressed.

It was caused because xlib returned an error status (`AlreadyGrabbed`) that wasn't handled, subsequently waiting for a mouse release event will never succeed.

Fixes #6019.