### PR TITLE
[CassiaWindowList@klangman] Three new features

### DIFF
--- a/CassiaWindowList@klangman/CHANGELOG.md
+++ b/CassiaWindowList@klangman/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.1.0
+
+* Added an option to configure what the "number label" content represents (Window count, Workspace index or Monitor number).
+* Added an option to show a vertical ellipsis character on grouped buttons to indicate a button represents a group of windows. Useful for users that decide to use the number label for Workspace/Monitor number and needs a new way to mark grouped buttons.
+* Added 4 new mouse action options that will activate windows 1-4 of a grouped button
+* Change the "2 or more window" option in the "Display number" drop-down to "Smart" so that it can apply to other number label options.
+* Removed the "Display number" "Never" option as now the "Number Style" option can disable the number label
+* In Launcher mode the "Number Style" option now appears but it's effects do not apply. This is because the dependency setting in the json only allows a single variable dependency and it is now dependant on the "Number Style" option. You can't use "and/or" logical operators to have better control when the option appears.
+* Clarified the tooltip text for the "Hover time before showing a full size window preview" option. 
+
 ## 2.0.4
 
 * When in button pooling mode with a thumbnail menu open showing more then one window, highlight the thumbnail menu item matching the window of the windlow-list button that is currently being hovered by the mouse pointer.

--- a/CassiaWindowList@klangman/README.md
+++ b/CassiaWindowList@klangman/README.md
@@ -1,23 +1,25 @@
-This is a Cinnamon window list and panel launcher applet based on CobiWindowList with a number of additional features
-designed to give you more control over how your window-list operates.
+This is a Cinnamon window list and panel launcher applet based on CobiWindowList with a number of additional features designed to give you more control over how your window-list operates.
 
-Recent new features (Aug 2023 - Mar 2024):
+Recent new features (Aug 2023 - May 2024):
 
-1.  Added a configuration option to set the delay length before showing full size preview windows
-2.  Mouse action options for window tiling, untiling and moving window to current workspace
-3.  Hover peek: Option to show a full size preview when hovering buttons/thumbnails
-4.  No Click activate: Option to automatically switch focus to the button/Thumbnail last hovered
-5.  Adjustable spacing between window-list buttons
-6.  Ability to disable the new window animation
-7.  Ability to change the icon saturation from grayscale (0%) to vivid (200%)
-8.  Ability to show windows from other workspaces
-9.  Restores custom group/ungroup application setting after reboot/cinnamon-restart
-10.  Hotkey option to assign a set of 1-9 hotkeys to all window-list buttons
-11.  Hotkey hints using the (`) grave key with any registered hotkey modifiers
-12. Added a Left-Click option to start new application windows in Launcher mode
-13. Ability to show a common set of pinned buttons on all workspaces
-14. Smart numeric hotkeys to assign a set of 1-9 hotkeys to a specific application
-15. A bunch of fixes
+* Added an option to configure the "number label" contents (added workspace and monitor number options)
+* Added an optional vertical ellipsis character to indicate a window-list button is grouped
+* Added 4 new mouse action options that will activate windows 1-4 of a grouped button
+* Added a configuration option to set the delay length before showing full size preview windows
+* Mouse action options for window tiling, untiling and moving window to current workspace
+* Hover peek: Option to show a full size preview when hovering buttons/thumbnails
+* No Click activate: Option to automatically switch focus to the button/Thumbnail last hovered
+* Adjustable spacing between window-list buttons
+* Ability to disable the new window animation
+* Ability to change the icon saturation from grayscale (0%) to vivid (200%)
+* Ability to show windows from other workspaces
+* Restores custom group/ungroup application setting after reboot/cinnamon-restart
+* Hotkey option to assign a set of 1-9 hotkeys to all window-list buttons
+* Hotkey hints using the (`) grave key with any registered hotkey modifiers
+* Added a Left-Click option to start new application windows in Launcher mode
+* Ability to show a common set of pinned buttons on all workspaces
+* Smart numeric hotkeys to assign a set of 1-9 hotkeys to a specific application
+* A bunch of fixes
 
 The design goals are to:
 
@@ -27,7 +29,7 @@ The design goals are to:
 4. A panel launcher that will activate existing windows rather then unconditionally launching new ones
 
 ## Requirements
-This applet requires at least Cinnamon 4.0
+This applet requires at least Cinnamon 4.0 but Cinnamon 6.0 is recommended
 
 ## Installation
 1. Right click on the cinnamon panel that you wish to add the CassiaWindowList to and click "Applets"
@@ -55,13 +57,11 @@ In addition to the features of the CobiWindowList...
  * Automatic configuration backup so you can restore your configuration after adding the applet to a panel again
  
 ## Feedback
-You can leave a comment here on cinnamon-spices.linuxmint.com or you can create an issue on my CassiaWindowList
-development GitHub repository:
+You can leave a comment here on cinnamon-spices.linuxmint.com or you can create an issue on my CassiaWindowList development GitHub repository:
 
 https://github.com/klangman/CassiaWindowList
 
 This is where I develop new features and test out any new ideas I have before pushing to cinnamon-spices.
 
-If you use this applet please let me know by liking it here and on my Github repository, that way I will be
-encouraged to continue working on the project.
+If you use this applet please let me know by liking it here and on my Github repository, that way I will be encouraged to continue working on the project.
 

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/applet.js
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/applet.js
@@ -150,11 +150,18 @@ const DisplayCaption = {
   One: 3            // Only one window (the last one in the window list) will have a caption (only really makes sense when also using GroupType.Pooled/Auto)
 }
 
-// The possible user Settings for how window list window counts should be displayed
+// The possible user Settings for how the number label should be displayed
 const DisplayNumber = {
-  No: 0,            // The number of windows attached to a window list button is never displayed
+  No: 0,            // The number label for a  window list button is never displayed
   All: 1,           // ... always displayed
   Smart: 2          // ... only displayed when 2 of more windows exist
+}
+
+const NumberType = {
+  Nothing:      0,  // Don't show any Number labels
+  GroupWindows: 1,  // Application Group Window Count
+  WorkspaceNum: 2,  // Workspace Number
+  MonitorNum:   3   // Monitor Number
 }
 
 // Possible values for the WindowListButton._grouped variable which determines how each individual windowlist button is currently grouped
@@ -204,7 +211,11 @@ const MouseAction = {
   TileBottom: 31,
   TileBottomLeft: 32,
   Untile: 33,            // Untile the window
-  MoveThisWorkspace: 34  // Move window to the current workspace
+  MoveThisWorkspace: 34, // Move window to the current workspace
+  GroupedWindow1: 35,    // Activate the 1st...4th window in a grouped button
+  GroupedWindow2: 36,
+  GroupedWindow3: 37,
+  GroupedWindow4: 38
 }
 
 // Possible settings for the left mouse action for grouped buttons (or Laucher with running windows)
@@ -1275,11 +1286,13 @@ class WindowListButton {
     this._signalManager.connect(this._settings, "changed::display-caption-for-pined", this._updateLabel, this);
     this._signalManager.connect(this._settings, "changed::hide-caption-for-minimized", this._updateLabel, this);
     this._signalManager.connect(this._settings, "changed::display-caption-for", this._updateLabel, this);
+    this._signalManager.connect(this._settings, "changed::show-ellipsis-for-groups", this._updateLabel, this);
     this._signalManager.connect(this._settings, "changed::display-number", this._updateNumber, this);
     this._signalManager.connect(this._settings, "changed::menu-show-on-hover", this._updateTooltip, this);
     this._signalManager.connect(this._settings, "changed::grouped-mouse-action-btn1", this._updateTooltip, this);
     this._signalManager.connect(this._settings, "changed::show-tooltips", this._updateTooltip, this);
     this._signalManager.connect(this._settings, "changed::number-style", Lang.bind(this, function() { this._updateNumber(); this._updateLabel(); }), this);
+    this._signalManager.connect(this._settings, "changed::number-type", Lang.bind(this, function() { this._updateNumber(); this._updateLabel(); }), this);
     this._signalManager.connect(this._settings, "changed::label-width", this._updateLabel, this);
     this._signalManager.connect(this._settings, "changed::button-spacing", this._updateSpacing, this);
     this._signalManager.connect(this.actor, "enter-event", this._onEnterEvent, this);
@@ -1730,6 +1743,7 @@ class WindowListButton {
   }
 
   _updateNumber() {
+    let numberType = this._settings.getValue("number-type");
     let setting = this._settings.getValue("display-number");
     let style = this._settings.getValue("number-style");
     let groupType = this._settings.getValue("group-windows");
@@ -1739,14 +1753,22 @@ class WindowListButton {
     if (this._grouped === GroupingType.Auto && number < 2) {
        this._grouped = GroupingType.NotGrouped;
     }
-    if ( (setting == DisplayNumber.All && number >= 1)    ||
-         ((setting == DisplayNumber.Smart && number >= 2) &&
-         (groupType == GroupType.Grouped || groupType == GroupType.Launcher || this._grouped > GroupingType.NotGrouped))) {
-      text += number;
-    }
 
     if (style == 1 && (groupType == GroupType.Launcher || (this._applet.orientation == St.Side.LEFT || this._applet.orientation == St.Side.RIGHT)))
        style = 0;  // No space for a label based window group counter, so force the icon overlay option if it's not disabled!
+
+    if (style === 0 && numberType !== NumberType.Nothing) {
+       if (numberType === NumberType.GroupWindows && ( (setting == DisplayNumber.All && number >= 1) ||
+          ((setting == DisplayNumber.Smart && number >= 2) &&
+          (groupType == GroupType.Grouped || groupType == GroupType.Launcher || this._grouped > GroupingType.NotGrouped))))
+       {
+          text += number;
+       } else if (numberType === NumberType.WorkspaceNum && this._currentWindow && (setting === DisplayNumber.All || this.isOnOtherWorkspace())) {
+          text += this._currentWindow.get_workspace().index()+1;
+       } else if (numberType === NumberType.MonitorNum && this._currentWindow && (setting === DisplayNumber.All || this.isOnOtherMonitor())) {
+          text += this._currentWindow.get_monitor()+1;
+       }
+    }
 
     if (text == "" || style == 1) {
       this._labelNumberBox.hide();
@@ -1788,7 +1810,9 @@ class WindowListButton {
     let pinnedSetting = this._settings.getValue("display-caption-for-pined");
     let minimizedSetting = this._settings.getValue("hide-caption-for-minimized");
     let style = this._settings.getValue("number-style");
+    let numberType = this._settings.getValue("number-type");
     let preferredWidth = this._settings.getValue("label-width");
+    let ellipsis = this._settings.getValue("show-ellipsis-for-groups");
     let number = this._windows.length;
     let text = "";
     let width = preferredWidth;
@@ -1868,15 +1892,25 @@ class WindowListButton {
        this._shrukenLabel = true;
     }
 
-    // Do we need a window number char
-    if (style === 1 && ((numSetting === DisplayNumber.All && number >= 1) || ((numSetting === DisplayNumber.Smart && number >= 2) &&
-       (groupSetting === 0 || this._grouped > GroupingType.NotGrouped))))
-    {
-      if (number > 20) {
-        text = "\u{24A8} " + text; // The Unicode character "(m)"
-      } else {
-        text = String.fromCharCode(9331+number) + " " + text; // Bracketed number
-      }
+    // Do we need a number label char
+    if (numberType !== NumberType.Nothing && style === 1) {
+       let labelNum = 0;
+       if (numberType === NumberType.GroupWindows && ((numSetting === DisplayNumber.All && number >= 1) || ((numSetting === DisplayNumber.Smart && number >= 2) &&
+          (groupSetting === 0 || this._grouped > GroupingType.NotGrouped))))
+       {
+          labelNum = number;
+       } else if (numberType === NumberType.WorkspaceNum && this._currentWindow && (numSetting === DisplayNumber.All || this.isOnOtherWorkspace())) {
+         labelNum =  this._currentWindow.get_workspace().index()+1;
+       } else if (numberType === NumberType.MonitorNum && this._currentWindow && (numSetting === DisplayNumber.All || this.isOnOtherMonitor())) {
+         labelNum = this._currentWindow.get_monitor()+1;
+       }
+       if (labelNum > 0) {
+         if (labelNum > 20) {
+           text = "\u{24A8} " + text; // The Unicode character "(m)"
+         } else {
+           text = String.fromCharCode(9331+labelNum) + " " + text; // Bracketed number
+         }
+       }
     }
     // Do we need a minimized char
     if (this._currentWindow && this._currentWindow.minimized && (this._applet.indicators&IndicatorType.Minimized) && this._workspace.autoIndicatorsOff==false) {
@@ -1885,6 +1919,11 @@ class WindowListButton {
     // Do we need a pinned char
     if (this._pinned && (this._applet.indicators&IndicatorType.Pinned) && this._workspace.autoIndicatorsOff==false) {
         text = "\u{1F4CC}" + text; // Unicode for the "push pin" character
+    }
+    // Do we need a group ellipsis char
+    if (ellipsis === true && number >= 2)
+    {
+       text = "\u{22EE}" + text;  // The Unicode character "Vertical Ellipsis"
     }
 
     // If we don't have a minimum label size, calculate it now!
@@ -2479,6 +2518,26 @@ class WindowListButton {
            if (window && nWorkspace > 1) {
               let curWorkspace = this._applet.getCurrentWorkSpace()._wsNum;
               window.change_workspace_by_index(curWorkspace, false);
+           }
+           break;
+        case MouseAction.GroupedWindow1:
+           if (this._windows.length > 0){
+              Main.activateWindow(this._windows[0]);
+           }
+           break;
+        case MouseAction.GroupedWindow2:
+           if (this._windows.length > 1){
+              Main.activateWindow(this._windows[1]);
+           }
+           break;
+        case MouseAction.GroupedWindow3:
+           if (this._windows.length > 2){
+              Main.activateWindow(this._windows[2]);
+           }
+           break;
+        case MouseAction.GroupedWindow4:
+           if (this._windows.length > 3){
+              Main.activateWindow(this._windows[3]);
            }
            break;
       }
@@ -5059,6 +5118,11 @@ class WindowList extends Applet.Applet {
               } else {
                 workspace._windowRemoved(window);
               }
+           } else if (this._settings.getValue("number-type")===NumberType.WorkspaceNum){
+             let btn = workspace._lookupAppButtonForWindow(window);
+             if (btn) {
+               btn._updateNumber(); // In case the number is showing the workspace index
+             }
            }
          }
        }
@@ -5068,11 +5132,12 @@ class WindowList extends Applet.Applet {
   windowMonitorChanged(screen, window, monitor) {
     if (!this._settings.getValue("show-windows-for-current-monitor")) {
       let ws = this.getCurrentWorkSpace();
-      if (ws.saturationType == SaturationType.OtherMonitors && ws.iconSaturation!=100) {
-        let btn = ws._lookupAppButtonForWindow(window);
-        if (btn) {
-          btn.updateIconSelection();
-        }
+      let btn = ws._lookupAppButtonForWindow(window);
+      if (btn) {
+         btn._updateNumber(); // In case the number is showing the monitor index
+         if (ws.saturationType == SaturationType.OtherMonitors && ws.iconSaturation!=100) {
+            btn.updateIconSelection();
+         }
       }
       return;
     }

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/4.0/settings-schema.json
@@ -37,12 +37,12 @@
       "type" : "section",
       "title" : "Window list button label settings",
       "dependency" : "group-windows<4",
-      "keys" : ["caption-type", "display-caption-for", "display-caption-for-pined", "hide-caption-for-minimized", "display-indicators", "label-width", "label-animation", "label-animation-time"]
+      "keys" : ["caption-type", "display-caption-for", "display-caption-for-pined", "hide-caption-for-minimized", "display-indicators", "show-ellipsis-for-groups", "label-width", "label-animation", "label-animation-time"]
     },
     "caption-number-settings" : {
       "type" : "section",
-      "title" : "Application groups number label settings",
-      "keys" : ["display-number", "number-style"]
+      "title" : "Number label settings",
+      "keys" : ["number-type", "display-number", "number-style"]
     },
     "general-settings" : {
       "type" : "section",
@@ -133,6 +133,13 @@
     "description": "Display status indicators",
     "tooltip": "Choose if the minimized and the pinned indicator characters will be prepended to button label text. Buttons without a text label will not reserve as much space.\nAutomatic: The minimized and pinned indicators will only show when space is not constrained."
   },
+  "show-ellipsis-for-groups": {
+    "type": "switch",
+    "default": 0,
+    "dependency" : "group-windows<4",
+    "description": "Show a vertical ellipsis (...) for grouped buttons",
+    "tooltip": "Prepend a vertical ellipsis unicode charter to the labels for grouped window-list buttons with more then one window. When on a vertical panel this option is not possible and the setting will be ignored."
+  },
   "trailing-pinned-behaviour": {
     "type": "switch",
     "default": false,
@@ -158,7 +165,7 @@
     "units": "milliseconds",
     "step": 20,
     "description": "Hover time before showing a full size window preview",
-    "tooltip": "This defines the mouse hover time before a full size window preview will appear. It applies to both window-list buttons and thumbnail menu items (of course one of the full size window preview options must be enabled for this option to have any effect)"
+    "tooltip": "This defines the mouse hover time before a full size window preview will appear. It applies when hovering over either window-list buttons or thumbnail menu items (of course one of the full size window preview options must be enabled for this option to have any effect)"
   },
   "label-width": {
     "type": "spinbutton",
@@ -185,15 +192,27 @@
     "dependency": "label-animation",
     "description": "Label animation duration"
   },
+  "number-type": {
+    "type": "combobox",
+    "default": 1,
+    "options": {
+      "Nothing": 0,
+      "Application group window count": 1,
+      "Workspace number": 2,
+      "Monitor number": 3
+    },
+    "description": "Number label contents"
+  },
   "display-number": {
     "type": "combobox",
     "default": 2,
     "options": {
-      "Never": 0,
       "Always": 1,
-      "2 or more windows": 2
+      "Smart": 2
     },
-    "description": "Display number"
+    "dependency" : "number-type>0",
+    "description": "Display number",
+    "tooltip": "Controls when the number label is used. Smart means the the label will only appear when it is appropriate depending on the number label contents setting above. i.e. When there is two or more windows in a group, or when the windows workspace or monitor does not match the current one."
   },
   "number-style": {
     "type": "combobox",
@@ -202,9 +221,9 @@
       "Icon overlay": 0,
       "Label prepend": 1
     },
-    "dependency" : "group-windows<4",
+    "dependency" : "number-type>0",
     "description": "Number style",
-    "tooltip": "Controls how the number of windows in a grouped button is presented. When on a vertical panel, the \"label prepend\" option is not possible so \"icon overlay\" will be used instead"
+    "tooltip": "Controls how the number label is presented. When on a vertical panel or when in launcher mode, the \"label prepend\" option is not possible so \"icon overlay\" will be used instead"
   },
 
 
@@ -523,6 +542,10 @@
       "Minimize/Restore": 3,
       "Maximize/Restore": 4,
       "Restore most recent application window": 13,
+      "Activate 1st window in grouped button": 35,
+      "Activate 2nd window in grouped button": 36,
+      "Activate 3rd window in grouped button": 37,
+      "Activate 4th window in grouped button": 38,
       "Group/Ungroup windows": 5,
       "Open new window": 6,
       "Move to workspace 1": 7,
@@ -566,6 +589,10 @@
       "Minimize/Restore": 3,
       "Maximize/Restore": 4,
       "Restore most recent application window": 13,
+      "Activate 1st window in grouped button": 35,
+      "Activate 2nd window in grouped button": 36,
+      "Activate 3rd window in grouped button": 37,
+      "Activate 4th window in grouped button": 38,
       "Group/Ungroup windows": 5,
       "Open new window": 6,
       "Move to workspace 1": 7,
@@ -609,6 +636,10 @@
       "Minimize/Restore": 3,
       "Maximize/Restore": 4,
       "Restore most recent application window": 13,
+      "Activate 1st window in grouped button": 35,
+      "Activate 2nd window in grouped button": 36,
+      "Activate 3rd window in grouped button": 37,
+      "Activate 4th window in grouped button": 38,
       "Group/Ungroup windows": 5,
       "Open new window": 6,
       "Move to workspace 1": 7,
@@ -742,6 +773,10 @@
            "Minimize/Restore": 3,
            "Maximize/Restore": 4,
            "Restore most recent application window": 13,
+           "Activate 1st window in grouped button": 35,
+           "Activate 2nd window in grouped button": 36,
+           "Activate 3rd window in grouped button": 37,
+           "Activate 4th window in grouped button": 38,
            "Group/Ungroup windows": 5,
            "Open new window": 6,
            "Move to workspace 1": 7,

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/6.0/settings-schema.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/6.0/settings-schema.json
@@ -37,12 +37,12 @@
       "type" : "section",
       "title" : "Window list button label settings",
       "dependency" : "group-windows<4",
-      "keys" : ["caption-type", "display-caption-for", "display-caption-for-pined", "hide-caption-for-minimized", "display-indicators", "label-width", "label-animation", "label-animation-time"]
+      "keys" : ["caption-type", "display-caption-for", "display-caption-for-pined", "hide-caption-for-minimized", "display-indicators", "show-ellipsis-for-groups", "label-width", "label-animation", "label-animation-time"]
     },
     "caption-number-settings" : {
       "type" : "section",
-      "title" : "Application groups number label settings",
-      "keys" : ["display-number", "number-style"]
+      "title" : "Number label settings",
+      "keys" : ["number-type", "display-number", "number-style"]
     },
     "general-settings" : {
       "type" : "section",
@@ -133,6 +133,13 @@
     "description": "Display status indicators",
     "tooltip": "Choose if the minimized and the pinned indicator characters will be prepended to button label text. Buttons without a text label will not reserve as much space.\nAutomatic: The minimized and pinned indicators will only show when space is not constrained."
   },
+  "show-ellipsis-for-groups": {
+    "type": "switch",
+    "default": 0,
+    "dependency" : "group-windows<4",
+    "description": "Show a vertical ellipsis (...) for grouped buttons",
+    "tooltip": "Prepend a vertical ellipsis unicode charter to the labels for grouped window-list buttons with more then one window. When on a vertical panel this option is not possible and the setting will be ignored."
+  },
   "trailing-pinned-behaviour": {
     "type": "switch",
     "default": false,
@@ -158,7 +165,7 @@
     "units": "milliseconds",
     "step": 20,
     "description": "Hover time before showing a full size window preview",
-    "tooltip": "This defines the mouse hover time before a full size window preview will appear. It applies to both window-list buttons and thumbnail menu items (of course one of the full size window preview options must be enabled for this option to have any effect)"
+    "tooltip": "This defines the mouse hover time before a full size window preview will appear. It applies when hovering over either window-list buttons or thumbnail menu items (of course one of the full size window preview options must be enabled for this option to have any effect)"
   },
   "label-width": {
     "type": "spinbutton",
@@ -185,15 +192,27 @@
     "dependency": "label-animation",
     "description": "Label animation duration"
   },
+  "number-type": {
+    "type": "combobox",
+    "default": 1,
+    "options": {
+      "Nothing": 0,
+      "Application group window count": 1,
+      "Workspace number": 2,
+      "Monitor number": 3
+    },
+    "description": "Number label contents"
+  },
   "display-number": {
     "type": "combobox",
     "default": 2,
     "options": {
-      "Never": 0,
       "Always": 1,
-      "2 or more windows": 2
+      "Smart": 2
     },
-    "description": "Display number"
+    "dependency" : "number-type>0",
+    "description": "Display number",
+    "tooltip": "Controls when the number label is used. Smart means the the label will only appear when it is appropriate depending on the number label contents setting above. i.e. When there is two or more windows in a group, or when the windows workspace or monitor does not match the current one."
   },
   "number-style": {
     "type": "combobox",
@@ -202,9 +221,9 @@
       "Icon overlay": 0,
       "Label prepend": 1
     },
-    "dependency" : "group-windows<4",
+    "dependency" : "number-type>0",
     "description": "Number style",
-    "tooltip": "Controls how the number of windows in a grouped button is presented. When on a vertical panel, the \"label prepend\" option is not possible so \"icon overlay\" will be used instead"
+    "tooltip": "Controls how the number label is presented. When on a vertical panel or when in launcher mode, the \"label prepend\" option is not possible so \"icon overlay\" will be used instead"
   },
 
 
@@ -523,6 +542,10 @@
       "Minimize/Restore": 3,
       "Maximize/Restore": 4,
       "Restore most recent application window": 13,
+      "Activate 1st window in grouped button": 35,
+      "Activate 2nd window in grouped button": 36,
+      "Activate 3rd window in grouped button": 37,
+      "Activate 4th window in grouped button": 38,
       "Group/Ungroup windows": 5,
       "Open new window": 6,
       "Move to workspace 1": 7,
@@ -566,6 +589,10 @@
       "Minimize/Restore": 3,
       "Maximize/Restore": 4,
       "Restore most recent application window": 13,
+      "Activate 1st window in grouped button": 35,
+      "Activate 2nd window in grouped button": 36,
+      "Activate 3rd window in grouped button": 37,
+      "Activate 4th window in grouped button": 38,
       "Group/Ungroup windows": 5,
       "Open new window": 6,
       "Move to workspace 1": 7,
@@ -609,6 +636,10 @@
       "Minimize/Restore": 3,
       "Maximize/Restore": 4,
       "Restore most recent application window": 13,
+      "Activate 1st window in grouped button": 35,
+      "Activate 2nd window in grouped button": 36,
+      "Activate 3rd window in grouped button": 37,
+      "Activate 4th window in grouped button": 38,
       "Group/Ungroup windows": 5,
       "Open new window": 6,
       "Move to workspace 1": 7,
@@ -742,6 +773,10 @@
            "Minimize/Restore": 3,
            "Maximize/Restore": 4,
            "Restore most recent application window": 13,
+           "Activate 1st window in grouped button": 35,
+           "Activate 2nd window in grouped button": 36,
+           "Activate 3rd window in grouped button": 37,
+           "Activate 4th window in grouped button": 38,
            "Group/Ungroup windows": 5,
            "Open new window": 6,
            "Move to workspace 1": 7,

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/metadata.json
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/metadata.json
@@ -5,6 +5,6 @@
     "max-instances": -1,
     "multiversion": true,
     "role": "panellauncher",
-    "version": "2.0.4",
+    "version": "2.1.0",
     "author": "klangman"
 }

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: CassiaWindowList@klangman 2.0.4\n"
+"Project-Id-Version: CassiaWindowList@klangman 2.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-13 20:57-0400\n"
+"POT-Creation-Date: 2024-05-27 19:07-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,32 +17,32 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: 4.0/applet.js:536 6.0/applet.js:536
+#: 4.0/applet.js:547 6.0/applet.js:547
 msgid "all buttons"
 msgstr ""
 
-#: 4.0/applet.js:2646 6.0/applet.js:2646
+#: 4.0/applet.js:2705 6.0/applet.js:2705
 msgid "Applet Preferences"
 msgstr ""
 
-#: 4.0/applet.js:2650 6.0/applet.js:2650
+#: 4.0/applet.js:2709 6.0/applet.js:2709
 msgid "About..."
 msgstr ""
 
-#: 4.0/applet.js:2654 6.0/applet.js:2654
+#: 4.0/applet.js:2713 6.0/applet.js:2713
 msgid "Configure..."
 msgstr ""
 
-#: 4.0/applet.js:2658 6.0/applet.js:2658
+#: 4.0/applet.js:2717 6.0/applet.js:2717
 msgid "Website"
 msgstr ""
 
-#: 4.0/applet.js:2662 6.0/applet.js:2662
+#: 4.0/applet.js:2721 6.0/applet.js:2721
 #, javascript-format
 msgid "Remove '%s'"
 msgstr ""
 
-#: 4.0/applet.js:2664 6.0/applet.js:2664
+#: 4.0/applet.js:2723 6.0/applet.js:2723
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 
@@ -58,111 +58,111 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2673 6.0/applet.js:2673
+#: 4.0/applet.js:2732 6.0/applet.js:2732
 msgid "Open new window"
 msgstr ""
 
-#: 4.0/applet.js:2681 6.0/applet.js:2681
+#: 4.0/applet.js:2740 6.0/applet.js:2740
 msgid "Remove from panel"
 msgstr ""
 
-#: 4.0/applet.js:2683 6.0/applet.js:2683
+#: 4.0/applet.js:2742 6.0/applet.js:2742
 msgid "Remove from this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2689 6.0/applet.js:2689
+#: 4.0/applet.js:2748 6.0/applet.js:2748
 msgid "Pin to panel"
 msgstr ""
 
-#: 4.0/applet.js:2691 6.0/applet.js:2691
+#: 4.0/applet.js:2750 6.0/applet.js:2750
 msgid "Pin to this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2732 6.0/applet.js:2732
+#: 4.0/applet.js:2791 6.0/applet.js:2791
 msgid "Pin to other workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2753 6.0/applet.js:2753
+#: 4.0/applet.js:2812 6.0/applet.js:2812
 msgid "Pin to all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:2830 6.0/applet.js:2830
 msgid "Pin to launcher"
 msgstr ""
 
-#: 4.0/applet.js:2789 4.0/applet.js:2972 6.0/applet.js:2789 6.0/applet.js:2972
+#: 4.0/applet.js:2848 4.0/applet.js:3031 6.0/applet.js:2848 6.0/applet.js:3031
 msgid "Add new Hotkey for"
 msgstr ""
 
-#: 4.0/applet.js:2803 6.0/applet.js:2803
+#: 4.0/applet.js:2862 6.0/applet.js:2862
 msgid "Recent files"
 msgstr ""
 
-#: 4.0/applet.js:2827 6.0/applet.js:2827
+#: 4.0/applet.js:2886 6.0/applet.js:2886
 msgid "Places"
 msgstr ""
 
-#: 4.0/applet.js:2869 6.0/applet.js:2869
+#: 4.0/applet.js:2928 6.0/applet.js:2928
 msgid "Only on this workspace"
 msgstr ""
 
-#: 4.0/applet.js:2871 6.0/applet.js:2871
+#: 4.0/applet.js:2930 6.0/applet.js:2930
 msgid "Visible on all workspaces"
 msgstr ""
 
-#: 4.0/applet.js:2872 6.0/applet.js:2872
+#: 4.0/applet.js:2931 6.0/applet.js:2931
 msgid "Move to another workspace"
 msgstr ""
 
-#: 4.0/applet.js:2881 6.0/applet.js:2881
+#: 4.0/applet.js:2940 6.0/applet.js:2940
 msgid " (this workspace)"
 msgstr ""
 
-#: 4.0/applet.js:2894 6.0/applet.js:2894
+#: 4.0/applet.js:2953 6.0/applet.js:2953
 msgid "Move to another monitor"
 msgstr ""
 
-#: 4.0/applet.js:2902 6.0/applet.js:2902
+#: 4.0/applet.js:2961 6.0/applet.js:2961
 msgid "Monitor"
 msgstr ""
 
-#: 4.0/applet.js:2927 6.0/applet.js:2927
+#: 4.0/applet.js:2986 6.0/applet.js:2986
 msgid "unassigned"
 msgstr ""
 
-#: 4.0/applet.js:2938 4.0/applet.js:2969 6.0/applet.js:2938 6.0/applet.js:2969
+#: 4.0/applet.js:2997 4.0/applet.js:3028 6.0/applet.js:2997 6.0/applet.js:3028
 msgid "Assign window to a hotkey"
 msgstr ""
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3051 6.0/applet.js:3051
 msgid "Change application label contents"
 msgstr ""
 
-#: 4.0/applet.js:2995 6.0/applet.js:2995
+#: 4.0/applet.js:3054 6.0/applet.js:3054
 msgid "Remove custom setting"
 msgstr ""
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3061 6.0/applet.js:3061
 msgid "Use window title"
 msgstr ""
 
-#: 4.0/applet.js:3009 6.0/applet.js:3009
+#: 4.0/applet.js:3068 6.0/applet.js:3068
 msgid "Use application name"
 msgstr ""
 
-#: 4.0/applet.js:3016 6.0/applet.js:3016
+#: 4.0/applet.js:3075 6.0/applet.js:3075
 msgid "No label"
 msgstr ""
 
-#: 4.0/applet.js:3027 6.0/applet.js:3027
+#: 4.0/applet.js:3086 6.0/applet.js:3086
 msgid "Ungroup application windows"
 msgstr ""
 
-#: 4.0/applet.js:3036 6.0/applet.js:3036
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Group application windows"
 msgstr ""
 
-#: 4.0/applet.js:3049 6.0/applet.js:3049
+#: 4.0/applet.js:3108 6.0/applet.js:3108
 msgid "Automatic grouping/ungrouping"
 msgstr ""
 
@@ -178,31 +178,31 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3079 6.0/applet.js:3079
+#: 4.0/applet.js:3138 6.0/applet.js:3138
 msgid "Move titlebar on to screen"
 msgstr ""
 
-#: 4.0/applet.js:3084 6.0/applet.js:3084
+#: 4.0/applet.js:3143 6.0/applet.js:3143
 msgid "Restore"
 msgstr ""
 
-#: 4.0/applet.js:3088 6.0/applet.js:3088
+#: 4.0/applet.js:3147 6.0/applet.js:3147
 msgid "Minimize"
 msgstr ""
 
-#: 4.0/applet.js:3094 6.0/applet.js:3094
+#: 4.0/applet.js:3153 6.0/applet.js:3153
 msgid "Unmaximize"
 msgstr ""
 
-#: 4.0/applet.js:3101 6.0/applet.js:3101
+#: 4.0/applet.js:3160 6.0/applet.js:3160
 msgid "Close others"
 msgstr ""
 
-#: 4.0/applet.js:3112 6.0/applet.js:3112
+#: 4.0/applet.js:3171 6.0/applet.js:3171
 msgid "Close all"
 msgstr ""
 
-#: 4.0/applet.js:3121 6.0/applet.js:3121
+#: 4.0/applet.js:3180 6.0/applet.js:3180
 msgid "Close"
 msgstr ""
 
@@ -260,7 +260,7 @@ msgstr ""
 
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
-msgid "Application groups number label settings"
+msgid "Number label settings"
 msgstr ""
 
 #. 4.0->settings-schema.json->general-settings->title
@@ -317,10 +317,8 @@ msgstr ""
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 msgid "Never"
 msgstr ""
 
@@ -433,6 +431,19 @@ msgid ""
 "not constrained."
 msgstr ""
 
+#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
+#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
+msgid "Show a vertical ellipsis (...) for grouped buttons"
+msgstr ""
+
+#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+msgid ""
+"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
+"list buttons with more then one window. When on a vertical panel this option "
+"is not possible and the setting will be ignored."
+msgstr ""
+
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
 #. 6.0->settings-schema.json->trailing-pinned-behaviour->description
 msgid "Add new window buttons ahead of trailing pinned buttons"
@@ -480,9 +491,9 @@ msgstr ""
 #. 6.0->settings-schema.json->hover-peek-delay->tooltip
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies to both window-list buttons and thumbnail menu items (of "
-"course one of the full size window preview options must be enabled for this "
-"option to have any effect)"
+"appear. It applies when hovering over either window-list buttons or "
+"thumbnail menu items (of course one of the full size window preview options "
+"must be enabled for this option to have any effect)"
 msgstr ""
 
 #. 4.0->settings-schema.json->label-width->units
@@ -512,14 +523,48 @@ msgstr ""
 msgid "Label animation duration"
 msgstr ""
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+msgid "Nothing"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+msgid "Application group window count"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+msgid "Workspace number"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+msgid "Monitor number"
+msgstr ""
+
+#. 4.0->settings-schema.json->number-type->description
+#. 6.0->settings-schema.json->number-type->description
+msgid "Number label contents"
+msgstr ""
+
 #. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-number->options
-msgid "2 or more windows"
+msgid "Smart"
 msgstr ""
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 msgid "Display number"
+msgstr ""
+
+#. 4.0->settings-schema.json->display-number->tooltip
+#. 6.0->settings-schema.json->display-number->tooltip
+msgid ""
+"Controls when the number label is used. Smart means the the label will only "
+"appear when it is appropriate depending on the number label contents setting "
+"above. i.e. When there is two or more windows in a group, or when the "
+"windows workspace or monitor does not match the current one."
 msgstr ""
 
 #. 4.0->settings-schema.json->number-style->options
@@ -540,8 +585,8 @@ msgstr ""
 #. 4.0->settings-schema.json->number-style->tooltip
 #. 6.0->settings-schema.json->number-style->tooltip
 msgid ""
-"Controls how the number of windows in a grouped button is presented. When on "
-"a vertical panel, the \"label prepend\" option is not possible so \"icon "
+"Controls how the number label is presented. When on a vertical panel or when "
+"in launcher mode, the \"label prepend\" option is not possible so \"icon "
 "overlay\" will be used instead"
 msgstr ""
 
@@ -1385,6 +1430,42 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
 msgid "Restore most recent application window"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 1st window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 2nd window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 3rd window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 4th window in grouped button"
 msgstr ""
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/da.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/da.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-13 20:57-0400\n"
+"POT-Creation-Date: 2024-05-27 19:07-0400\n"
 "PO-Revision-Date: 2024-01-01 10:11+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -14,32 +14,32 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: 4.0/applet.js:536 6.0/applet.js:536
+#: 4.0/applet.js:547 6.0/applet.js:547
 msgid "all buttons"
 msgstr "alle knapper"
 
-#: 4.0/applet.js:2646 6.0/applet.js:2646
+#: 4.0/applet.js:2705 6.0/applet.js:2705
 msgid "Applet Preferences"
 msgstr "Indstillinger"
 
-#: 4.0/applet.js:2650 6.0/applet.js:2650
+#: 4.0/applet.js:2709 6.0/applet.js:2709
 msgid "About..."
 msgstr "Om …"
 
-#: 4.0/applet.js:2654 6.0/applet.js:2654
+#: 4.0/applet.js:2713 6.0/applet.js:2713
 msgid "Configure..."
 msgstr "Konfigurér …"
 
-#: 4.0/applet.js:2658 6.0/applet.js:2658
+#: 4.0/applet.js:2717 6.0/applet.js:2717
 msgid "Website"
 msgstr ""
 
-#: 4.0/applet.js:2662 6.0/applet.js:2662
+#: 4.0/applet.js:2721 6.0/applet.js:2721
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Fjern “%s”"
 
-#: 4.0/applet.js:2664 6.0/applet.js:2664
+#: 4.0/applet.js:2723 6.0/applet.js:2723
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Vil du virkelig fjerne denne forekomst af CassiaVinduesliste?"
 
@@ -55,111 +55,111 @@ msgstr "Vil du virkelig fjerne denne forekomst af CassiaVinduesliste?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2673 6.0/applet.js:2673
+#: 4.0/applet.js:2732 6.0/applet.js:2732
 msgid "Open new window"
 msgstr "Åbn nyt vindue"
 
-#: 4.0/applet.js:2681 6.0/applet.js:2681
+#: 4.0/applet.js:2740 6.0/applet.js:2740
 msgid "Remove from panel"
 msgstr "Fjern fra panel"
 
-#: 4.0/applet.js:2683 6.0/applet.js:2683
+#: 4.0/applet.js:2742 6.0/applet.js:2742
 msgid "Remove from this workspace"
 msgstr "Fjern fra dette arbejdsområde"
 
-#: 4.0/applet.js:2689 6.0/applet.js:2689
+#: 4.0/applet.js:2748 6.0/applet.js:2748
 msgid "Pin to panel"
 msgstr "Fastgør til panel"
 
-#: 4.0/applet.js:2691 6.0/applet.js:2691
+#: 4.0/applet.js:2750 6.0/applet.js:2750
 msgid "Pin to this workspace"
 msgstr "Fastgør til dette arbejdsområde"
 
-#: 4.0/applet.js:2732 6.0/applet.js:2732
+#: 4.0/applet.js:2791 6.0/applet.js:2791
 msgid "Pin to other workspaces"
 msgstr "Fastgør til andre arbejdsområder"
 
-#: 4.0/applet.js:2753 6.0/applet.js:2753
+#: 4.0/applet.js:2812 6.0/applet.js:2812
 msgid "Pin to all workspaces"
 msgstr "Fastgør til alle arbejdsområder"
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:2830 6.0/applet.js:2830
 msgid "Pin to launcher"
 msgstr "Fastgør til programstarter"
 
-#: 4.0/applet.js:2789 4.0/applet.js:2972 6.0/applet.js:2789 6.0/applet.js:2972
+#: 4.0/applet.js:2848 4.0/applet.js:3031 6.0/applet.js:2848 6.0/applet.js:3031
 msgid "Add new Hotkey for"
 msgstr "Tilføj ny genvejstast til"
 
-#: 4.0/applet.js:2803 6.0/applet.js:2803
+#: 4.0/applet.js:2862 6.0/applet.js:2862
 msgid "Recent files"
 msgstr "Seneste filer"
 
-#: 4.0/applet.js:2827 6.0/applet.js:2827
+#: 4.0/applet.js:2886 6.0/applet.js:2886
 msgid "Places"
 msgstr "Steder"
 
-#: 4.0/applet.js:2869 6.0/applet.js:2869
+#: 4.0/applet.js:2928 6.0/applet.js:2928
 msgid "Only on this workspace"
 msgstr "Kun på dette arbejdsområde"
 
-#: 4.0/applet.js:2871 6.0/applet.js:2871
+#: 4.0/applet.js:2930 6.0/applet.js:2930
 msgid "Visible on all workspaces"
 msgstr "Synlig på alle arbejdsområder"
 
-#: 4.0/applet.js:2872 6.0/applet.js:2872
+#: 4.0/applet.js:2931 6.0/applet.js:2931
 msgid "Move to another workspace"
 msgstr "Flyt til et andet arbejdsområde"
 
-#: 4.0/applet.js:2881 6.0/applet.js:2881
+#: 4.0/applet.js:2940 6.0/applet.js:2940
 msgid " (this workspace)"
 msgstr " (dette arbejdsområde)"
 
-#: 4.0/applet.js:2894 6.0/applet.js:2894
+#: 4.0/applet.js:2953 6.0/applet.js:2953
 msgid "Move to another monitor"
 msgstr "Flyt til en anden skærm"
 
-#: 4.0/applet.js:2902 6.0/applet.js:2902
+#: 4.0/applet.js:2961 6.0/applet.js:2961
 msgid "Monitor"
 msgstr "Skærm"
 
-#: 4.0/applet.js:2927 6.0/applet.js:2927
+#: 4.0/applet.js:2986 6.0/applet.js:2986
 msgid "unassigned"
 msgstr "ikke tildelt"
 
-#: 4.0/applet.js:2938 4.0/applet.js:2969 6.0/applet.js:2938 6.0/applet.js:2969
+#: 4.0/applet.js:2997 4.0/applet.js:3028 6.0/applet.js:2997 6.0/applet.js:3028
 msgid "Assign window to a hotkey"
 msgstr "Tildel en genvejstast til vindue"
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3051 6.0/applet.js:3051
 msgid "Change application label contents"
 msgstr "Ændr indholdet af programetiket"
 
-#: 4.0/applet.js:2995 6.0/applet.js:2995
+#: 4.0/applet.js:3054 6.0/applet.js:3054
 msgid "Remove custom setting"
 msgstr "Fjern brugerdefineret indstilling"
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3061 6.0/applet.js:3061
 msgid "Use window title"
 msgstr "Brug vinduestitel"
 
-#: 4.0/applet.js:3009 6.0/applet.js:3009
+#: 4.0/applet.js:3068 6.0/applet.js:3068
 msgid "Use application name"
 msgstr "Brug programnavn"
 
-#: 4.0/applet.js:3016 6.0/applet.js:3016
+#: 4.0/applet.js:3075 6.0/applet.js:3075
 msgid "No label"
 msgstr "Ingen etiket"
 
-#: 4.0/applet.js:3027 6.0/applet.js:3027
+#: 4.0/applet.js:3086 6.0/applet.js:3086
 msgid "Ungroup application windows"
 msgstr "Opsplit gruppen af programmervinduer"
 
-#: 4.0/applet.js:3036 6.0/applet.js:3036
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Group application windows"
 msgstr "Gruppér programvinduer"
 
-#: 4.0/applet.js:3049 6.0/applet.js:3049
+#: 4.0/applet.js:3108 6.0/applet.js:3108
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatisk gruppering/opsplitning af gruppe"
 
@@ -175,31 +175,31 @@ msgstr "Automatisk gruppering/opsplitning af gruppe"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3079 6.0/applet.js:3079
+#: 4.0/applet.js:3138 6.0/applet.js:3138
 msgid "Move titlebar on to screen"
 msgstr "Flyt titellinje til skærm"
 
-#: 4.0/applet.js:3084 6.0/applet.js:3084
+#: 4.0/applet.js:3143 6.0/applet.js:3143
 msgid "Restore"
 msgstr "Gendan"
 
-#: 4.0/applet.js:3088 6.0/applet.js:3088
+#: 4.0/applet.js:3147 6.0/applet.js:3147
 msgid "Minimize"
 msgstr "Minimér"
 
-#: 4.0/applet.js:3094 6.0/applet.js:3094
+#: 4.0/applet.js:3153 6.0/applet.js:3153
 msgid "Unmaximize"
 msgstr "Gendan"
 
-#: 4.0/applet.js:3101 6.0/applet.js:3101
+#: 4.0/applet.js:3160 6.0/applet.js:3160
 msgid "Close others"
 msgstr "Luk andre"
 
-#: 4.0/applet.js:3112 6.0/applet.js:3112
+#: 4.0/applet.js:3171 6.0/applet.js:3171
 msgid "Close all"
 msgstr "Luk alle"
 
-#: 4.0/applet.js:3121 6.0/applet.js:3121
+#: 4.0/applet.js:3180 6.0/applet.js:3180
 msgid "Close"
 msgstr "Luk"
 
@@ -259,7 +259,8 @@ msgstr "Indstillinger for vindueslisteknappernes etiketter"
 
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
-msgid "Application groups number label settings"
+#, fuzzy
+msgid "Number label settings"
 msgstr "Indstillinger for programgruppernes nummeretiketter"
 
 #. 4.0->settings-schema.json->general-settings->title
@@ -316,10 +317,8 @@ msgstr "Indholdet af etiketten"
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 msgid "Never"
 msgstr "Aldrig"
 
@@ -447,6 +446,19 @@ msgstr ""
 "Automatisk: De minimerede og fastgjorte indikatorer vises kun, når der ikke "
 "er begrænset plads."
 
+#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
+#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
+msgid "Show a vertical ellipsis (...) for grouped buttons"
+msgstr ""
+
+#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+msgid ""
+"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
+"list buttons with more then one window. When on a vertical panel this option "
+"is not possible and the setting will be ignored."
+msgstr ""
+
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
 #. 6.0->settings-schema.json->trailing-pinned-behaviour->description
 msgid "Add new window buttons ahead of trailing pinned buttons"
@@ -499,9 +511,9 @@ msgstr "Tidsforsinkelse før menuen vises"
 #. 6.0->settings-schema.json->hover-peek-delay->tooltip
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies to both window-list buttons and thumbnail menu items (of "
-"course one of the full size window preview options must be enabled for this "
-"option to have any effect)"
+"appear. It applies when hovering over either window-list buttons or "
+"thumbnail menu items (of course one of the full size window preview options "
+"must be enabled for this option to have any effect)"
 msgstr ""
 
 #. 4.0->settings-schema.json->label-width->units
@@ -532,15 +544,54 @@ msgstr "Animér etiket"
 msgid "Label animation duration"
 msgstr "Varighed af etiketanimation"
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Nothing"
+msgstr "Gør intet"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Application group window count"
+msgstr "Gruppér programvinduer"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Workspace number"
+msgstr "Vis antal"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Monitor number"
+msgstr "Skærm"
+
+#. 4.0->settings-schema.json->number-type->description
+#. 6.0->settings-schema.json->number-type->description
+#, fuzzy
+msgid "Number label contents"
+msgstr "Etiketindhold"
+
 #. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-number->options
-msgid "2 or more windows"
-msgstr "To eller flere vinduer"
+msgid "Smart"
+msgstr ""
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 msgid "Display number"
 msgstr "Vis antal"
+
+#. 4.0->settings-schema.json->display-number->tooltip
+#. 6.0->settings-schema.json->display-number->tooltip
+msgid ""
+"Controls when the number label is used. Smart means the the label will only "
+"appear when it is appropriate depending on the number label contents setting "
+"above. i.e. When there is two or more windows in a group, or when the "
+"windows workspace or monitor does not match the current one."
+msgstr ""
 
 #. 4.0->settings-schema.json->number-style->options
 #. 6.0->settings-schema.json->number-style->options
@@ -559,9 +610,10 @@ msgstr "Antalsstil"
 
 #. 4.0->settings-schema.json->number-style->tooltip
 #. 6.0->settings-schema.json->number-style->tooltip
+#, fuzzy
 msgid ""
-"Controls how the number of windows in a grouped button is presented. When on "
-"a vertical panel, the \"label prepend\" option is not possible so \"icon "
+"Controls how the number label is presented. When on a vertical panel or when "
+"in launcher mode, the \"label prepend\" option is not possible so \"icon "
 "overlay\" will be used instead"
 msgstr ""
 "Styrer, hvordan antallet af vinduer i en grupperet knap præsenteres. På et "
@@ -1453,6 +1505,42 @@ msgstr "Hold miniaturemenu nede"
 #. 6.0->settings-schema.json->mouse-action-btn9->options
 msgid "Restore most recent application window"
 msgstr "Gendan seneste programvindue"
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 1st window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 2nd window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 3rd window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 4th window in grouped button"
+msgstr ""
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description
 #. 6.0->settings-schema.json->mouse-action-btn2->description

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/es.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-13 20:57-0400\n"
+"POT-Creation-Date: 2024-05-27 19:07-0400\n"
 "PO-Revision-Date: 2024-03-27 20:14-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,32 +18,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: 4.0/applet.js:536 6.0/applet.js:536
+#: 4.0/applet.js:547 6.0/applet.js:547
 msgid "all buttons"
 msgstr "todos los botones"
 
-#: 4.0/applet.js:2646 6.0/applet.js:2646
+#: 4.0/applet.js:2705 6.0/applet.js:2705
 msgid "Applet Preferences"
 msgstr "Preferencias del applet"
 
-#: 4.0/applet.js:2650 6.0/applet.js:2650
+#: 4.0/applet.js:2709 6.0/applet.js:2709
 msgid "About..."
 msgstr "Acerca de..."
 
-#: 4.0/applet.js:2654 6.0/applet.js:2654
+#: 4.0/applet.js:2713 6.0/applet.js:2713
 msgid "Configure..."
 msgstr "Configurar..."
 
-#: 4.0/applet.js:2658 6.0/applet.js:2658
+#: 4.0/applet.js:2717 6.0/applet.js:2717
 msgid "Website"
 msgstr "Sitio web"
 
-#: 4.0/applet.js:2662 6.0/applet.js:2662
+#: 4.0/applet.js:2721 6.0/applet.js:2721
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eliminar '%s'"
 
-#: 4.0/applet.js:2664 6.0/applet.js:2664
+#: 4.0/applet.js:2723 6.0/applet.js:2723
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "¿Realmente desea eliminar esta instancia de CassiaWindowList?"
 
@@ -59,111 +59,111 @@ msgstr "¿Realmente desea eliminar esta instancia de CassiaWindowList?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2673 6.0/applet.js:2673
+#: 4.0/applet.js:2732 6.0/applet.js:2732
 msgid "Open new window"
 msgstr "Abrir nueva ventana"
 
-#: 4.0/applet.js:2681 6.0/applet.js:2681
+#: 4.0/applet.js:2740 6.0/applet.js:2740
 msgid "Remove from panel"
 msgstr "Quitar del panel"
 
-#: 4.0/applet.js:2683 6.0/applet.js:2683
+#: 4.0/applet.js:2742 6.0/applet.js:2742
 msgid "Remove from this workspace"
 msgstr "Eliminar de este espacio de trabajo"
 
-#: 4.0/applet.js:2689 6.0/applet.js:2689
+#: 4.0/applet.js:2748 6.0/applet.js:2748
 msgid "Pin to panel"
 msgstr "Anclar al panel"
 
-#: 4.0/applet.js:2691 6.0/applet.js:2691
+#: 4.0/applet.js:2750 6.0/applet.js:2750
 msgid "Pin to this workspace"
 msgstr "Anclar a este espacio de trabajo"
 
-#: 4.0/applet.js:2732 6.0/applet.js:2732
+#: 4.0/applet.js:2791 6.0/applet.js:2791
 msgid "Pin to other workspaces"
 msgstr "Anclar a otros espacios de trabajo"
 
-#: 4.0/applet.js:2753 6.0/applet.js:2753
+#: 4.0/applet.js:2812 6.0/applet.js:2812
 msgid "Pin to all workspaces"
 msgstr "Anclar a todos los espacios de trabajo"
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:2830 6.0/applet.js:2830
 msgid "Pin to launcher"
 msgstr "Anclar al lanzador"
 
-#: 4.0/applet.js:2789 4.0/applet.js:2972 6.0/applet.js:2789 6.0/applet.js:2972
+#: 4.0/applet.js:2848 4.0/applet.js:3031 6.0/applet.js:2848 6.0/applet.js:3031
 msgid "Add new Hotkey for"
 msgstr "Añadir nueva tecla de acceso rápido para"
 
-#: 4.0/applet.js:2803 6.0/applet.js:2803
+#: 4.0/applet.js:2862 6.0/applet.js:2862
 msgid "Recent files"
 msgstr "Archivos recientes"
 
-#: 4.0/applet.js:2827 6.0/applet.js:2827
+#: 4.0/applet.js:2886 6.0/applet.js:2886
 msgid "Places"
 msgstr "Lugares"
 
-#: 4.0/applet.js:2869 6.0/applet.js:2869
+#: 4.0/applet.js:2928 6.0/applet.js:2928
 msgid "Only on this workspace"
 msgstr "Sólo en este espacio de trabajo"
 
-#: 4.0/applet.js:2871 6.0/applet.js:2871
+#: 4.0/applet.js:2930 6.0/applet.js:2930
 msgid "Visible on all workspaces"
 msgstr "Visible en todos los espacios de trabajo"
 
-#: 4.0/applet.js:2872 6.0/applet.js:2872
+#: 4.0/applet.js:2931 6.0/applet.js:2931
 msgid "Move to another workspace"
 msgstr "Mover a otro espacio de trabajo"
 
-#: 4.0/applet.js:2881 6.0/applet.js:2881
+#: 4.0/applet.js:2940 6.0/applet.js:2940
 msgid " (this workspace)"
 msgstr " (este espacio de trabajo)"
 
-#: 4.0/applet.js:2894 6.0/applet.js:2894
+#: 4.0/applet.js:2953 6.0/applet.js:2953
 msgid "Move to another monitor"
 msgstr "Mover a otro monitor"
 
-#: 4.0/applet.js:2902 6.0/applet.js:2902
+#: 4.0/applet.js:2961 6.0/applet.js:2961
 msgid "Monitor"
 msgstr "Monitor"
 
-#: 4.0/applet.js:2927 6.0/applet.js:2927
+#: 4.0/applet.js:2986 6.0/applet.js:2986
 msgid "unassigned"
 msgstr "no asignado"
 
-#: 4.0/applet.js:2938 4.0/applet.js:2969 6.0/applet.js:2938 6.0/applet.js:2969
+#: 4.0/applet.js:2997 4.0/applet.js:3028 6.0/applet.js:2997 6.0/applet.js:3028
 msgid "Assign window to a hotkey"
 msgstr "Asignar ventana a una tecla de acceso rápido"
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3051 6.0/applet.js:3051
 msgid "Change application label contents"
 msgstr "Cambiar el contenido de la etiqueta de la aplicación"
 
-#: 4.0/applet.js:2995 6.0/applet.js:2995
+#: 4.0/applet.js:3054 6.0/applet.js:3054
 msgid "Remove custom setting"
 msgstr "Eliminar configuración personalizada"
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3061 6.0/applet.js:3061
 msgid "Use window title"
 msgstr "Utilizar título de ventana"
 
-#: 4.0/applet.js:3009 6.0/applet.js:3009
+#: 4.0/applet.js:3068 6.0/applet.js:3068
 msgid "Use application name"
 msgstr "Utilizar nombre de aplicación"
 
-#: 4.0/applet.js:3016 6.0/applet.js:3016
+#: 4.0/applet.js:3075 6.0/applet.js:3075
 msgid "No label"
 msgstr "Sin etiqueta"
 
-#: 4.0/applet.js:3027 6.0/applet.js:3027
+#: 4.0/applet.js:3086 6.0/applet.js:3086
 msgid "Ungroup application windows"
 msgstr "Ventanas de aplicaciones separadas"
 
-#: 4.0/applet.js:3036 6.0/applet.js:3036
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Group application windows"
 msgstr "Ventanas de aplicaciones agrupadas"
 
-#: 4.0/applet.js:3049 6.0/applet.js:3049
+#: 4.0/applet.js:3108 6.0/applet.js:3108
 msgid "Automatic grouping/ungrouping"
 msgstr "Agrupación/desagrupación automática"
 
@@ -179,31 +179,31 @@ msgstr "Agrupación/desagrupación automática"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3079 6.0/applet.js:3079
+#: 4.0/applet.js:3138 6.0/applet.js:3138
 msgid "Move titlebar on to screen"
 msgstr "Mover la barra de título a la pantalla"
 
-#: 4.0/applet.js:3084 6.0/applet.js:3084
+#: 4.0/applet.js:3143 6.0/applet.js:3143
 msgid "Restore"
 msgstr "Restaurar"
 
-#: 4.0/applet.js:3088 6.0/applet.js:3088
+#: 4.0/applet.js:3147 6.0/applet.js:3147
 msgid "Minimize"
 msgstr "Minimizar"
 
-#: 4.0/applet.js:3094 6.0/applet.js:3094
+#: 4.0/applet.js:3153 6.0/applet.js:3153
 msgid "Unmaximize"
 msgstr "Desmaximizar"
 
-#: 4.0/applet.js:3101 6.0/applet.js:3101
+#: 4.0/applet.js:3160 6.0/applet.js:3160
 msgid "Close others"
 msgstr "Cerrar otros"
 
-#: 4.0/applet.js:3112 6.0/applet.js:3112
+#: 4.0/applet.js:3171 6.0/applet.js:3171
 msgid "Close all"
 msgstr "Cerrar todo"
 
-#: 4.0/applet.js:3121 6.0/applet.js:3121
+#: 4.0/applet.js:3180 6.0/applet.js:3180
 msgid "Close"
 msgstr "Cerrar"
 
@@ -263,7 +263,8 @@ msgstr "Configuración de la etiqueta del botón de la lista de ventanas"
 
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
-msgid "Application groups number label settings"
+#, fuzzy
+msgid "Number label settings"
 msgstr "Configuración de etiquetas numéricas del grupo de aplicaciones"
 
 #. 4.0->settings-schema.json->general-settings->title
@@ -320,10 +321,8 @@ msgstr "Cuál será el contenido de la etiqueta"
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 msgid "Never"
 msgstr "Nunca"
 
@@ -453,6 +452,19 @@ msgstr ""
 "Automático: Los indicadores de minimizado y anclado sólo se mostrarán cuando "
 "no haya restricciones de espacio."
 
+#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
+#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
+msgid "Show a vertical ellipsis (...) for grouped buttons"
+msgstr ""
+
+#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+msgid ""
+"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
+"list buttons with more then one window. When on a vertical panel this option "
+"is not possible and the setting will be ignored."
+msgstr ""
+
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
 #. 6.0->settings-schema.json->trailing-pinned-behaviour->description
 msgid "Add new window buttons ahead of trailing pinned buttons"
@@ -507,11 +519,12 @@ msgstr ""
 
 #. 4.0->settings-schema.json->hover-peek-delay->tooltip
 #. 6.0->settings-schema.json->hover-peek-delay->tooltip
+#, fuzzy
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies to both window-list buttons and thumbnail menu items (of "
-"course one of the full size window preview options must be enabled for this "
-"option to have any effect)"
+"appear. It applies when hovering over either window-list buttons or "
+"thumbnail menu items (of course one of the full size window preview options "
+"must be enabled for this option to have any effect)"
 msgstr ""
 "Define el tiempo que pasa el ratón por encima antes de que aparezca una "
 "vista previa de la ventana a tamaño completo. Se aplica tanto a los botones "
@@ -548,15 +561,54 @@ msgstr "Etiqueta animada"
 msgid "Label animation duration"
 msgstr "Duración de la animación de la etiqueta"
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Nothing"
+msgstr "No hacer nada"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Application group window count"
+msgstr "Ventanas de aplicaciones agrupadas"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Workspace number"
+msgstr "Mostrar número"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Monitor number"
+msgstr "Monitor"
+
+#. 4.0->settings-schema.json->number-type->description
+#. 6.0->settings-schema.json->number-type->description
+#, fuzzy
+msgid "Number label contents"
+msgstr "Contenido de la etiqueta"
+
 #. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-number->options
-msgid "2 or more windows"
-msgstr "2 o más ventanas"
+msgid "Smart"
+msgstr ""
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 msgid "Display number"
 msgstr "Mostrar número"
+
+#. 4.0->settings-schema.json->display-number->tooltip
+#. 6.0->settings-schema.json->display-number->tooltip
+msgid ""
+"Controls when the number label is used. Smart means the the label will only "
+"appear when it is appropriate depending on the number label contents setting "
+"above. i.e. When there is two or more windows in a group, or when the "
+"windows workspace or monitor does not match the current one."
+msgstr ""
 
 #. 4.0->settings-schema.json->number-style->options
 #. 6.0->settings-schema.json->number-style->options
@@ -575,9 +627,10 @@ msgstr "Estilo de número"
 
 #. 4.0->settings-schema.json->number-style->tooltip
 #. 6.0->settings-schema.json->number-style->tooltip
+#, fuzzy
 msgid ""
-"Controls how the number of windows in a grouped button is presented. When on "
-"a vertical panel, the \"label prepend\" option is not possible so \"icon "
+"Controls how the number label is presented. When on a vertical panel or when "
+"in launcher mode, the \"label prepend\" option is not possible so \"icon "
 "overlay\" will be used instead"
 msgstr ""
 "Controla cómo se presenta el número de ventanas en un botón agrupado. En un "
@@ -1496,6 +1549,42 @@ msgstr "Mantener el menú de miniaturas"
 #. 6.0->settings-schema.json->mouse-action-btn9->options
 msgid "Restore most recent application window"
 msgstr "Restaurar la ventana de la aplicación más reciente"
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 1st window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 2nd window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 3rd window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 4th window in grouped button"
+msgstr ""
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description
 #. 6.0->settings-schema.json->mouse-action-btn2->description

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/fr.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-13 20:57-0400\n"
+"POT-Creation-Date: 2024-05-27 19:07-0400\n"
 "PO-Revision-Date: 2024-04-03 14:46+0200\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -19,32 +19,32 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: 4.0/applet.js:536 6.0/applet.js:536
+#: 4.0/applet.js:547 6.0/applet.js:547
 msgid "all buttons"
 msgstr "tous les boutons"
 
-#: 4.0/applet.js:2646 6.0/applet.js:2646
+#: 4.0/applet.js:2705 6.0/applet.js:2705
 msgid "Applet Preferences"
 msgstr "Préférences"
 
-#: 4.0/applet.js:2650 6.0/applet.js:2650
+#: 4.0/applet.js:2709 6.0/applet.js:2709
 msgid "About..."
 msgstr "À propos..."
 
-#: 4.0/applet.js:2654 6.0/applet.js:2654
+#: 4.0/applet.js:2713 6.0/applet.js:2713
 msgid "Configure..."
 msgstr "Configurer..."
 
-#: 4.0/applet.js:2658 6.0/applet.js:2658
+#: 4.0/applet.js:2717 6.0/applet.js:2717
 msgid "Website"
 msgstr "Site web"
 
-#: 4.0/applet.js:2662 6.0/applet.js:2662
+#: 4.0/applet.js:2721 6.0/applet.js:2721
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Supprimer '%s'"
 
-#: 4.0/applet.js:2664 6.0/applet.js:2664
+#: 4.0/applet.js:2723 6.0/applet.js:2723
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Voulez-vous vraiment supprimer cette instance de CassiaWindowList ?"
 
@@ -60,111 +60,111 @@ msgstr "Voulez-vous vraiment supprimer cette instance de CassiaWindowList ?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2673 6.0/applet.js:2673
+#: 4.0/applet.js:2732 6.0/applet.js:2732
 msgid "Open new window"
 msgstr "Ouvrir une nouvelle fenêtre"
 
-#: 4.0/applet.js:2681 6.0/applet.js:2681
+#: 4.0/applet.js:2740 6.0/applet.js:2740
 msgid "Remove from panel"
 msgstr "Retirer du panneau"
 
-#: 4.0/applet.js:2683 6.0/applet.js:2683
+#: 4.0/applet.js:2742 6.0/applet.js:2742
 msgid "Remove from this workspace"
 msgstr "Retirer de cet espace de travail"
 
-#: 4.0/applet.js:2689 6.0/applet.js:2689
+#: 4.0/applet.js:2748 6.0/applet.js:2748
 msgid "Pin to panel"
 msgstr "Épingler au panneau"
 
-#: 4.0/applet.js:2691 6.0/applet.js:2691
+#: 4.0/applet.js:2750 6.0/applet.js:2750
 msgid "Pin to this workspace"
 msgstr "Épingler à cet espace de travail"
 
-#: 4.0/applet.js:2732 6.0/applet.js:2732
+#: 4.0/applet.js:2791 6.0/applet.js:2791
 msgid "Pin to other workspaces"
 msgstr "Épingler aux autres espaces de travail"
 
-#: 4.0/applet.js:2753 6.0/applet.js:2753
+#: 4.0/applet.js:2812 6.0/applet.js:2812
 msgid "Pin to all workspaces"
 msgstr "Épingler à tous les espaces de travail"
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:2830 6.0/applet.js:2830
 msgid "Pin to launcher"
 msgstr "Épingler au lanceur"
 
-#: 4.0/applet.js:2789 4.0/applet.js:2972 6.0/applet.js:2789 6.0/applet.js:2972
+#: 4.0/applet.js:2848 4.0/applet.js:3031 6.0/applet.js:2848 6.0/applet.js:3031
 msgid "Add new Hotkey for"
 msgstr "Ajouter un nouveau raccourci clavier pour"
 
-#: 4.0/applet.js:2803 6.0/applet.js:2803
+#: 4.0/applet.js:2862 6.0/applet.js:2862
 msgid "Recent files"
 msgstr "Fichiers récents"
 
-#: 4.0/applet.js:2827 6.0/applet.js:2827
+#: 4.0/applet.js:2886 6.0/applet.js:2886
 msgid "Places"
 msgstr "Emplacements"
 
-#: 4.0/applet.js:2869 6.0/applet.js:2869
+#: 4.0/applet.js:2928 6.0/applet.js:2928
 msgid "Only on this workspace"
 msgstr "Seulement sur cet espace de travail"
 
-#: 4.0/applet.js:2871 6.0/applet.js:2871
+#: 4.0/applet.js:2930 6.0/applet.js:2930
 msgid "Visible on all workspaces"
 msgstr "Visible sur tous les espaces de travail"
 
-#: 4.0/applet.js:2872 6.0/applet.js:2872
+#: 4.0/applet.js:2931 6.0/applet.js:2931
 msgid "Move to another workspace"
 msgstr "Déplacer vers un autre espace de travail"
 
-#: 4.0/applet.js:2881 6.0/applet.js:2881
+#: 4.0/applet.js:2940 6.0/applet.js:2940
 msgid " (this workspace)"
 msgstr " (cet espace de travail)"
 
-#: 4.0/applet.js:2894 6.0/applet.js:2894
+#: 4.0/applet.js:2953 6.0/applet.js:2953
 msgid "Move to another monitor"
 msgstr "Déplacer vers un autre moniteur"
 
-#: 4.0/applet.js:2902 6.0/applet.js:2902
+#: 4.0/applet.js:2961 6.0/applet.js:2961
 msgid "Monitor"
 msgstr "Moniteur"
 
-#: 4.0/applet.js:2927 6.0/applet.js:2927
+#: 4.0/applet.js:2986 6.0/applet.js:2986
 msgid "unassigned"
 msgstr "non attribué"
 
-#: 4.0/applet.js:2938 4.0/applet.js:2969 6.0/applet.js:2938 6.0/applet.js:2969
+#: 4.0/applet.js:2997 4.0/applet.js:3028 6.0/applet.js:2997 6.0/applet.js:3028
 msgid "Assign window to a hotkey"
 msgstr "Attribuer une fenêtre à un raccourci clavier"
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3051 6.0/applet.js:3051
 msgid "Change application label contents"
 msgstr "Modifier le libellé de l'étiquette de l'application"
 
-#: 4.0/applet.js:2995 6.0/applet.js:2995
+#: 4.0/applet.js:3054 6.0/applet.js:3054
 msgid "Remove custom setting"
 msgstr "Supprimer le paramètre personnalisé"
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3061 6.0/applet.js:3061
 msgid "Use window title"
 msgstr "Utiliser le titre de fenêtre"
 
-#: 4.0/applet.js:3009 6.0/applet.js:3009
+#: 4.0/applet.js:3068 6.0/applet.js:3068
 msgid "Use application name"
 msgstr "Utiliser le nom de l'application"
 
-#: 4.0/applet.js:3016 6.0/applet.js:3016
+#: 4.0/applet.js:3075 6.0/applet.js:3075
 msgid "No label"
 msgstr "Sans étiquette"
 
-#: 4.0/applet.js:3027 6.0/applet.js:3027
+#: 4.0/applet.js:3086 6.0/applet.js:3086
 msgid "Ungroup application windows"
 msgstr "Dégrouper les fenêtres de l'application"
 
-#: 4.0/applet.js:3036 6.0/applet.js:3036
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Group application windows"
 msgstr "Grouper les fenêtres par application"
 
-#: 4.0/applet.js:3049 6.0/applet.js:3049
+#: 4.0/applet.js:3108 6.0/applet.js:3108
 msgid "Automatic grouping/ungrouping"
 msgstr "Regrouper/dégrouper automatiquement"
 
@@ -180,31 +180,31 @@ msgstr "Regrouper/dégrouper automatiquement"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3079 6.0/applet.js:3079
+#: 4.0/applet.js:3138 6.0/applet.js:3138
 msgid "Move titlebar on to screen"
 msgstr "Déplacer la barre de titre sur l'écran"
 
-#: 4.0/applet.js:3084 6.0/applet.js:3084
+#: 4.0/applet.js:3143 6.0/applet.js:3143
 msgid "Restore"
 msgstr "Restaurer"
 
-#: 4.0/applet.js:3088 6.0/applet.js:3088
+#: 4.0/applet.js:3147 6.0/applet.js:3147
 msgid "Minimize"
 msgstr "Minimiser"
 
-#: 4.0/applet.js:3094 6.0/applet.js:3094
+#: 4.0/applet.js:3153 6.0/applet.js:3153
 msgid "Unmaximize"
 msgstr "Démaximiser"
 
-#: 4.0/applet.js:3101 6.0/applet.js:3101
+#: 4.0/applet.js:3160 6.0/applet.js:3160
 msgid "Close others"
 msgstr "Fermer les autres"
 
-#: 4.0/applet.js:3112 6.0/applet.js:3112
+#: 4.0/applet.js:3171 6.0/applet.js:3171
 msgid "Close all"
 msgstr "Tout fermer"
 
-#: 4.0/applet.js:3121 6.0/applet.js:3121
+#: 4.0/applet.js:3180 6.0/applet.js:3180
 msgid "Close"
 msgstr "Fermer"
 
@@ -264,7 +264,8 @@ msgstr "Paramètres des étiquettes de bouton de la liste des fenêtres"
 
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
-msgid "Application groups number label settings"
+#, fuzzy
+msgid "Number label settings"
 msgstr "Paramètres des étiquettes de numéros des groupes d'application"
 
 #. 4.0->settings-schema.json->general-settings->title
@@ -321,10 +322,8 @@ msgstr "Contenu de l'étiquette"
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 msgid "Never"
 msgstr "Jamais"
 
@@ -455,6 +454,19 @@ msgstr ""
 "Automatique : Les indicateurs de minimisation et d'épinglage ne s'affichent "
 "que lorsque l'espace n'est pas limité."
 
+#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
+#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
+msgid "Show a vertical ellipsis (...) for grouped buttons"
+msgstr ""
+
+#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+msgid ""
+"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
+"list buttons with more then one window. When on a vertical panel this option "
+"is not possible and the setting will be ignored."
+msgstr ""
+
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
 #. 6.0->settings-schema.json->trailing-pinned-behaviour->description
 msgid "Add new window buttons ahead of trailing pinned buttons"
@@ -510,11 +522,12 @@ msgstr ""
 
 #. 4.0->settings-schema.json->hover-peek-delay->tooltip
 #. 6.0->settings-schema.json->hover-peek-delay->tooltip
+#, fuzzy
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies to both window-list buttons and thumbnail menu items (of "
-"course one of the full size window preview options must be enabled for this "
-"option to have any effect)"
+"appear. It applies when hovering over either window-list buttons or "
+"thumbnail menu items (of course one of the full size window preview options "
+"must be enabled for this option to have any effect)"
 msgstr ""
 "Cette option définit le temps de survol de la souris avant qu'un aperçu de "
 "la fenêtre en taille réelle n'apparaisse. Elle s'applique aux boutons de la "
@@ -550,15 +563,54 @@ msgstr "Étiquette animée"
 msgid "Label animation duration"
 msgstr "Durée d'animation des étiquettes"
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Nothing"
+msgstr "Ne rien faire"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Application group window count"
+msgstr "Grouper les fenêtres par application"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Workspace number"
+msgstr "Afficher le nombre"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Monitor number"
+msgstr "Moniteur"
+
+#. 4.0->settings-schema.json->number-type->description
+#. 6.0->settings-schema.json->number-type->description
+#, fuzzy
+msgid "Number label contents"
+msgstr "Contenu de l'étiquette"
+
 #. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-number->options
-msgid "2 or more windows"
-msgstr "2 fenêtres ou davantage"
+msgid "Smart"
+msgstr ""
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 msgid "Display number"
 msgstr "Afficher le nombre"
+
+#. 4.0->settings-schema.json->display-number->tooltip
+#. 6.0->settings-schema.json->display-number->tooltip
+msgid ""
+"Controls when the number label is used. Smart means the the label will only "
+"appear when it is appropriate depending on the number label contents setting "
+"above. i.e. When there is two or more windows in a group, or when the "
+"windows workspace or monitor does not match the current one."
+msgstr ""
 
 #. 4.0->settings-schema.json->number-style->options
 #. 6.0->settings-schema.json->number-style->options
@@ -577,9 +629,10 @@ msgstr "Style de numérotation"
 
 #. 4.0->settings-schema.json->number-style->tooltip
 #. 6.0->settings-schema.json->number-style->tooltip
+#, fuzzy
 msgid ""
-"Controls how the number of windows in a grouped button is presented. When on "
-"a vertical panel, the \"label prepend\" option is not possible so \"icon "
+"Controls how the number label is presented. When on a vertical panel or when "
+"in launcher mode, the \"label prepend\" option is not possible so \"icon "
 "overlay\" will be used instead"
 msgstr ""
 "Contrôle la manière dont le nombre de fenêtres d'un bouton groupé est "
@@ -1508,6 +1561,42 @@ msgstr "Maintien du menu miniature"
 #. 6.0->settings-schema.json->mouse-action-btn9->options
 msgid "Restore most recent application window"
 msgstr "Rétablir la fenêtre de l'application la plus récente"
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 1st window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 2nd window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 3rd window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 4th window in grouped button"
+msgstr ""
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description
 #. 6.0->settings-schema.json->mouse-action-btn2->description

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/hu.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-13 20:57-0400\n"
+"POT-Creation-Date: 2024-05-27 19:07-0400\n"
 "PO-Revision-Date: 2024-02-08 15:00+0100\n"
 "Last-Translator: Vajda Örs <ors0092@gmail.com>\n"
 "Language-Team: \n"
@@ -19,32 +19,32 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: 4.0/applet.js:536 6.0/applet.js:536
+#: 4.0/applet.js:547 6.0/applet.js:547
 msgid "all buttons"
 msgstr "minden gomb"
 
-#: 4.0/applet.js:2646 6.0/applet.js:2646
+#: 4.0/applet.js:2705 6.0/applet.js:2705
 msgid "Applet Preferences"
 msgstr "Kisalkalmazás beállítások"
 
-#: 4.0/applet.js:2650 6.0/applet.js:2650
+#: 4.0/applet.js:2709 6.0/applet.js:2709
 msgid "About..."
 msgstr "Névjegy…"
 
-#: 4.0/applet.js:2654 6.0/applet.js:2654
+#: 4.0/applet.js:2713 6.0/applet.js:2713
 msgid "Configure..."
 msgstr "Beállítások…"
 
-#: 4.0/applet.js:2658 6.0/applet.js:2658
+#: 4.0/applet.js:2717 6.0/applet.js:2717
 msgid "Website"
 msgstr "Weboldal"
 
-#: 4.0/applet.js:2662 6.0/applet.js:2662
+#: 4.0/applet.js:2721 6.0/applet.js:2721
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Eltávolítás: „%s”"
 
-#: 4.0/applet.js:2664 6.0/applet.js:2664
+#: 4.0/applet.js:2723 6.0/applet.js:2723
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Valóban el szeretné távolítani ezt a CassiaWindowList ezen példányát?"
 
@@ -60,111 +60,111 @@ msgstr "Valóban el szeretné távolítani ezt a CassiaWindowList ezen példány
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2673 6.0/applet.js:2673
+#: 4.0/applet.js:2732 6.0/applet.js:2732
 msgid "Open new window"
 msgstr "Új ablak megnyitása"
 
-#: 4.0/applet.js:2681 6.0/applet.js:2681
+#: 4.0/applet.js:2740 6.0/applet.js:2740
 msgid "Remove from panel"
 msgstr "Eltávolítás a panelról"
 
-#: 4.0/applet.js:2683 6.0/applet.js:2683
+#: 4.0/applet.js:2742 6.0/applet.js:2742
 msgid "Remove from this workspace"
 msgstr "Eltávolítás erről a munkaterületről"
 
-#: 4.0/applet.js:2689 6.0/applet.js:2689
+#: 4.0/applet.js:2748 6.0/applet.js:2748
 msgid "Pin to panel"
 msgstr "Panelhez rögzítés"
 
-#: 4.0/applet.js:2691 6.0/applet.js:2691
+#: 4.0/applet.js:2750 6.0/applet.js:2750
 msgid "Pin to this workspace"
 msgstr "Erre a munkaterületre rögzítés"
 
-#: 4.0/applet.js:2732 6.0/applet.js:2732
+#: 4.0/applet.js:2791 6.0/applet.js:2791
 msgid "Pin to other workspaces"
 msgstr "Más munkaterületre rögzítés"
 
-#: 4.0/applet.js:2753 6.0/applet.js:2753
+#: 4.0/applet.js:2812 6.0/applet.js:2812
 msgid "Pin to all workspaces"
 msgstr "Az összes munkaterületre rögzítés"
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:2830 6.0/applet.js:2830
 msgid "Pin to launcher"
 msgstr "Alkalmazásindítóhoz rögzítés"
 
-#: 4.0/applet.js:2789 4.0/applet.js:2972 6.0/applet.js:2789 6.0/applet.js:2972
+#: 4.0/applet.js:2848 4.0/applet.js:3031 6.0/applet.js:2848 6.0/applet.js:3031
 msgid "Add new Hotkey for"
 msgstr "Új gyorsbillentyű hozzáadása ehhez"
 
-#: 4.0/applet.js:2803 6.0/applet.js:2803
+#: 4.0/applet.js:2862 6.0/applet.js:2862
 msgid "Recent files"
 msgstr "Nemrég használt fájlok"
 
-#: 4.0/applet.js:2827 6.0/applet.js:2827
+#: 4.0/applet.js:2886 6.0/applet.js:2886
 msgid "Places"
 msgstr "Helyek"
 
-#: 4.0/applet.js:2869 6.0/applet.js:2869
+#: 4.0/applet.js:2928 6.0/applet.js:2928
 msgid "Only on this workspace"
 msgstr "Csak ezen a munkaterületen"
 
-#: 4.0/applet.js:2871 6.0/applet.js:2871
+#: 4.0/applet.js:2930 6.0/applet.js:2930
 msgid "Visible on all workspaces"
 msgstr "Minden munkaterületen látható"
 
-#: 4.0/applet.js:2872 6.0/applet.js:2872
+#: 4.0/applet.js:2931 6.0/applet.js:2931
 msgid "Move to another workspace"
 msgstr "Áthelyezés másik munkaterületre"
 
-#: 4.0/applet.js:2881 6.0/applet.js:2881
+#: 4.0/applet.js:2940 6.0/applet.js:2940
 msgid " (this workspace)"
 msgstr "(ez a munkaterület)"
 
-#: 4.0/applet.js:2894 6.0/applet.js:2894
+#: 4.0/applet.js:2953 6.0/applet.js:2953
 msgid "Move to another monitor"
 msgstr "Áthelyezés a másik kijelzőre"
 
-#: 4.0/applet.js:2902 6.0/applet.js:2902
+#: 4.0/applet.js:2961 6.0/applet.js:2961
 msgid "Monitor"
 msgstr "Kijelző"
 
-#: 4.0/applet.js:2927 6.0/applet.js:2927
+#: 4.0/applet.js:2986 6.0/applet.js:2986
 msgid "unassigned"
 msgstr "nincs társítva"
 
-#: 4.0/applet.js:2938 4.0/applet.js:2969 6.0/applet.js:2938 6.0/applet.js:2969
+#: 4.0/applet.js:2997 4.0/applet.js:3028 6.0/applet.js:2997 6.0/applet.js:3028
 msgid "Assign window to a hotkey"
 msgstr "Az ablak hozzárendelése egy gyorsbillentyűhöz"
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3051 6.0/applet.js:3051
 msgid "Change application label contents"
 msgstr "Az alkalmazáscímke tartalmának módosítása"
 
-#: 4.0/applet.js:2995 6.0/applet.js:2995
+#: 4.0/applet.js:3054 6.0/applet.js:3054
 msgid "Remove custom setting"
 msgstr "Egyéni beállítás eltávolítása"
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3061 6.0/applet.js:3061
 msgid "Use window title"
 msgstr "Ablakcím használata"
 
-#: 4.0/applet.js:3009 6.0/applet.js:3009
+#: 4.0/applet.js:3068 6.0/applet.js:3068
 msgid "Use application name"
 msgstr "Alkalmazásnév használata"
 
-#: 4.0/applet.js:3016 6.0/applet.js:3016
+#: 4.0/applet.js:3075 6.0/applet.js:3075
 msgid "No label"
 msgstr "Nincs címke"
 
-#: 4.0/applet.js:3027 6.0/applet.js:3027
+#: 4.0/applet.js:3086 6.0/applet.js:3086
 msgid "Ungroup application windows"
 msgstr "Ablakokat ne csoportosítsa alkalmazás szerint"
 
-#: 4.0/applet.js:3036 6.0/applet.js:3036
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Group application windows"
 msgstr "Alkalmazás ablakok csoportosítása"
 
-#: 4.0/applet.js:3049 6.0/applet.js:3049
+#: 4.0/applet.js:3108 6.0/applet.js:3108
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatikus csoportosítás létrehozása/megszűntetése"
 
@@ -180,31 +180,31 @@ msgstr "Automatikus csoportosítás létrehozása/megszűntetése"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3079 6.0/applet.js:3079
+#: 4.0/applet.js:3138 6.0/applet.js:3138
 msgid "Move titlebar on to screen"
 msgstr "Címsor mozgatása a kijelzőre"
 
-#: 4.0/applet.js:3084 6.0/applet.js:3084
+#: 4.0/applet.js:3143 6.0/applet.js:3143
 msgid "Restore"
 msgstr "Visszaállítás"
 
-#: 4.0/applet.js:3088 6.0/applet.js:3088
+#: 4.0/applet.js:3147 6.0/applet.js:3147
 msgid "Minimize"
 msgstr "Minimalizálás"
 
-#: 4.0/applet.js:3094 6.0/applet.js:3094
+#: 4.0/applet.js:3153 6.0/applet.js:3153
 msgid "Unmaximize"
 msgstr "Eredeti méret"
 
-#: 4.0/applet.js:3101 6.0/applet.js:3101
+#: 4.0/applet.js:3160 6.0/applet.js:3160
 msgid "Close others"
 msgstr "Többi bezárása"
 
-#: 4.0/applet.js:3112 6.0/applet.js:3112
+#: 4.0/applet.js:3171 6.0/applet.js:3171
 msgid "Close all"
 msgstr "Minden bezárása"
 
-#: 4.0/applet.js:3121 6.0/applet.js:3121
+#: 4.0/applet.js:3180 6.0/applet.js:3180
 msgid "Close"
 msgstr "Bezárás"
 
@@ -263,7 +263,8 @@ msgstr "Ablaklista gomb címke beállításai"
 
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
-msgid "Application groups number label settings"
+#, fuzzy
+msgid "Number label settings"
 msgstr "Alkalmazáscsoportok számcímke beállításai"
 
 #. 4.0->settings-schema.json->general-settings->title
@@ -320,10 +321,8 @@ msgstr "Mi lesz a címke tartalma"
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 msgid "Never"
 msgstr "Soha"
 
@@ -451,6 +450,19 @@ msgstr ""
 "Automatikus: A kicsinyített és rögzített jelzők csak akkor jelennek meg, ha "
 "nincs szűk hely."
 
+#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
+#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
+msgid "Show a vertical ellipsis (...) for grouped buttons"
+msgstr ""
+
+#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+msgid ""
+"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
+"list buttons with more then one window. When on a vertical panel this option "
+"is not possible and the setting will be ignored."
+msgstr ""
+
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
 #. 6.0->settings-schema.json->trailing-pinned-behaviour->description
 msgid "Add new window buttons ahead of trailing pinned buttons"
@@ -504,9 +516,9 @@ msgstr "Lebegtetési idő a menü megjelenítése előtt"
 #. 6.0->settings-schema.json->hover-peek-delay->tooltip
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies to both window-list buttons and thumbnail menu items (of "
-"course one of the full size window preview options must be enabled for this "
-"option to have any effect)"
+"appear. It applies when hovering over either window-list buttons or "
+"thumbnail menu items (of course one of the full size window preview options "
+"must be enabled for this option to have any effect)"
 msgstr ""
 
 #. 4.0->settings-schema.json->label-width->units
@@ -536,15 +548,54 @@ msgstr "Címke animálása"
 msgid "Label animation duration"
 msgstr "A címke animációs ideje"
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Nothing"
+msgstr "Ne tegyen semmit"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Application group window count"
+msgstr "Alkalmazás ablakok csoportosítása"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Workspace number"
+msgstr "Kijelző sorszáma"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Monitor number"
+msgstr "Kijelző"
+
+#. 4.0->settings-schema.json->number-type->description
+#. 6.0->settings-schema.json->number-type->description
+#, fuzzy
+msgid "Number label contents"
+msgstr "Címke tartalma"
+
 #. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-number->options
-msgid "2 or more windows"
-msgstr "Kettő vagy több ablak"
+msgid "Smart"
+msgstr ""
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 msgid "Display number"
 msgstr "Kijelző sorszáma"
+
+#. 4.0->settings-schema.json->display-number->tooltip
+#. 6.0->settings-schema.json->display-number->tooltip
+msgid ""
+"Controls when the number label is used. Smart means the the label will only "
+"appear when it is appropriate depending on the number label contents setting "
+"above. i.e. When there is two or more windows in a group, or when the "
+"windows workspace or monitor does not match the current one."
+msgstr ""
 
 #. 4.0->settings-schema.json->number-style->options
 #. 6.0->settings-schema.json->number-style->options
@@ -563,9 +614,10 @@ msgstr "Számstílus"
 
 #. 4.0->settings-schema.json->number-style->tooltip
 #. 6.0->settings-schema.json->number-style->tooltip
+#, fuzzy
 msgid ""
-"Controls how the number of windows in a grouped button is presented. When on "
-"a vertical panel, the \"label prepend\" option is not possible so \"icon "
+"Controls how the number label is presented. When on a vertical panel or when "
+"in launcher mode, the \"label prepend\" option is not possible so \"icon "
 "overlay\" will be used instead"
 msgstr ""
 "Szabályozza, hogyan jelenjen meg a csoportosított gomb ablakainak száma. "
@@ -1476,6 +1528,42 @@ msgstr "Miniatűr menü tartása"
 #. 6.0->settings-schema.json->mouse-action-btn9->options
 msgid "Restore most recent application window"
 msgstr "A legutóbbi alkalmazásablak visszaállítása"
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 1st window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 2nd window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 3rd window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 4th window in grouped button"
+msgstr ""
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description
 #. 6.0->settings-schema.json->mouse-action-btn2->description

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/it.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-13 20:57-0400\n"
+"POT-Creation-Date: 2024-05-27 19:07-0400\n"
 "PO-Revision-Date: 2023-12-12 19:19+0100\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -19,32 +19,32 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: 4.0/applet.js:536 6.0/applet.js:536
+#: 4.0/applet.js:547 6.0/applet.js:547
 msgid "all buttons"
 msgstr "tutti i pulsanti"
 
-#: 4.0/applet.js:2646 6.0/applet.js:2646
+#: 4.0/applet.js:2705 6.0/applet.js:2705
 msgid "Applet Preferences"
 msgstr "Preferenze Applet"
 
-#: 4.0/applet.js:2650 6.0/applet.js:2650
+#: 4.0/applet.js:2709 6.0/applet.js:2709
 msgid "About..."
 msgstr "Informazioni su..."
 
-#: 4.0/applet.js:2654 6.0/applet.js:2654
+#: 4.0/applet.js:2713 6.0/applet.js:2713
 msgid "Configure..."
 msgstr "Configura..."
 
-#: 4.0/applet.js:2658 6.0/applet.js:2658
+#: 4.0/applet.js:2717 6.0/applet.js:2717
 msgid "Website"
 msgstr ""
 
-#: 4.0/applet.js:2662 6.0/applet.js:2662
+#: 4.0/applet.js:2721 6.0/applet.js:2721
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Rimuovi '%s'"
 
-#: 4.0/applet.js:2664 6.0/applet.js:2664
+#: 4.0/applet.js:2723 6.0/applet.js:2723
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Vuoi davvero rimuovere questa istanza di CassiaWindowList?"
 
@@ -60,111 +60,111 @@ msgstr "Vuoi davvero rimuovere questa istanza di CassiaWindowList?"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2673 6.0/applet.js:2673
+#: 4.0/applet.js:2732 6.0/applet.js:2732
 msgid "Open new window"
 msgstr "Apri una nuova finestra"
 
-#: 4.0/applet.js:2681 6.0/applet.js:2681
+#: 4.0/applet.js:2740 6.0/applet.js:2740
 msgid "Remove from panel"
 msgstr "Rimuovi dal pannello"
 
-#: 4.0/applet.js:2683 6.0/applet.js:2683
+#: 4.0/applet.js:2742 6.0/applet.js:2742
 msgid "Remove from this workspace"
 msgstr "Rimuovi da questa area di lavoro"
 
-#: 4.0/applet.js:2689 6.0/applet.js:2689
+#: 4.0/applet.js:2748 6.0/applet.js:2748
 msgid "Pin to panel"
 msgstr "Appunta al pannello"
 
-#: 4.0/applet.js:2691 6.0/applet.js:2691
+#: 4.0/applet.js:2750 6.0/applet.js:2750
 msgid "Pin to this workspace"
 msgstr "Appunta a questo spazio di lavoro"
 
-#: 4.0/applet.js:2732 6.0/applet.js:2732
+#: 4.0/applet.js:2791 6.0/applet.js:2791
 msgid "Pin to other workspaces"
 msgstr "Appunta ad altre aree di lavoro"
 
-#: 4.0/applet.js:2753 6.0/applet.js:2753
+#: 4.0/applet.js:2812 6.0/applet.js:2812
 msgid "Pin to all workspaces"
 msgstr "Appunta in tutte le aree di lavoro"
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:2830 6.0/applet.js:2830
 msgid "Pin to launcher"
 msgstr "Appunta al launcher"
 
-#: 4.0/applet.js:2789 4.0/applet.js:2972 6.0/applet.js:2789 6.0/applet.js:2972
+#: 4.0/applet.js:2848 4.0/applet.js:3031 6.0/applet.js:2848 6.0/applet.js:3031
 msgid "Add new Hotkey for"
 msgstr "Aggiungi un nuovo tasto di scelta rapida per"
 
-#: 4.0/applet.js:2803 6.0/applet.js:2803
+#: 4.0/applet.js:2862 6.0/applet.js:2862
 msgid "Recent files"
 msgstr "Recenti"
 
-#: 4.0/applet.js:2827 6.0/applet.js:2827
+#: 4.0/applet.js:2886 6.0/applet.js:2886
 msgid "Places"
 msgstr "Posizioni"
 
-#: 4.0/applet.js:2869 6.0/applet.js:2869
+#: 4.0/applet.js:2928 6.0/applet.js:2928
 msgid "Only on this workspace"
 msgstr "Solo su questo spazio di lavoro"
 
-#: 4.0/applet.js:2871 6.0/applet.js:2871
+#: 4.0/applet.js:2930 6.0/applet.js:2930
 msgid "Visible on all workspaces"
 msgstr "Visibile su tutte le aree di lavoro"
 
-#: 4.0/applet.js:2872 6.0/applet.js:2872
+#: 4.0/applet.js:2931 6.0/applet.js:2931
 msgid "Move to another workspace"
 msgstr "Sposta su un'altra area di lavoro"
 
-#: 4.0/applet.js:2881 6.0/applet.js:2881
+#: 4.0/applet.js:2940 6.0/applet.js:2940
 msgid " (this workspace)"
 msgstr " (questa area di lavoro)"
 
-#: 4.0/applet.js:2894 6.0/applet.js:2894
+#: 4.0/applet.js:2953 6.0/applet.js:2953
 msgid "Move to another monitor"
 msgstr "Sposta su un altro schermo"
 
-#: 4.0/applet.js:2902 6.0/applet.js:2902
+#: 4.0/applet.js:2961 6.0/applet.js:2961
 msgid "Monitor"
 msgstr "Monitor"
 
-#: 4.0/applet.js:2927 6.0/applet.js:2927
+#: 4.0/applet.js:2986 6.0/applet.js:2986
 msgid "unassigned"
 msgstr "non assegnato"
 
-#: 4.0/applet.js:2938 4.0/applet.js:2969 6.0/applet.js:2938 6.0/applet.js:2969
+#: 4.0/applet.js:2997 4.0/applet.js:3028 6.0/applet.js:2997 6.0/applet.js:3028
 msgid "Assign window to a hotkey"
 msgstr "Assegna finestra ad un tasto di scelta rapida"
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3051 6.0/applet.js:3051
 msgid "Change application label contents"
 msgstr "Cambia il contenuto dell'etichetta dell'applicazione"
 
-#: 4.0/applet.js:2995 6.0/applet.js:2995
+#: 4.0/applet.js:3054 6.0/applet.js:3054
 msgid "Remove custom setting"
 msgstr "Rimuovi impostazioni personalizzate"
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3061 6.0/applet.js:3061
 msgid "Use window title"
 msgstr "Usa il titolo della finestra"
 
-#: 4.0/applet.js:3009 6.0/applet.js:3009
+#: 4.0/applet.js:3068 6.0/applet.js:3068
 msgid "Use application name"
 msgstr "Usa il nome dell'applicazione"
 
-#: 4.0/applet.js:3016 6.0/applet.js:3016
+#: 4.0/applet.js:3075 6.0/applet.js:3075
 msgid "No label"
 msgstr "Nessuna etichetta"
 
-#: 4.0/applet.js:3027 6.0/applet.js:3027
+#: 4.0/applet.js:3086 6.0/applet.js:3086
 msgid "Ungroup application windows"
 msgstr "Separa le finestre dell'applicazione"
 
-#: 4.0/applet.js:3036 6.0/applet.js:3036
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Group application windows"
 msgstr "Raggruppa le finestre dell'applicazione"
 
-#: 4.0/applet.js:3049 6.0/applet.js:3049
+#: 4.0/applet.js:3108 6.0/applet.js:3108
 msgid "Automatic grouping/ungrouping"
 msgstr "Raggruppamento/separazione automatica"
 
@@ -180,31 +180,31 @@ msgstr "Raggruppamento/separazione automatica"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3079 6.0/applet.js:3079
+#: 4.0/applet.js:3138 6.0/applet.js:3138
 msgid "Move titlebar on to screen"
 msgstr "Sposta la barra del titolo sullo schermo"
 
-#: 4.0/applet.js:3084 6.0/applet.js:3084
+#: 4.0/applet.js:3143 6.0/applet.js:3143
 msgid "Restore"
 msgstr "Ripristina"
 
-#: 4.0/applet.js:3088 6.0/applet.js:3088
+#: 4.0/applet.js:3147 6.0/applet.js:3147
 msgid "Minimize"
 msgstr "Minimizza"
 
-#: 4.0/applet.js:3094 6.0/applet.js:3094
+#: 4.0/applet.js:3153 6.0/applet.js:3153
 msgid "Unmaximize"
 msgstr "De-massimizza"
 
-#: 4.0/applet.js:3101 6.0/applet.js:3101
+#: 4.0/applet.js:3160 6.0/applet.js:3160
 msgid "Close others"
 msgstr "Chiudi altri"
 
-#: 4.0/applet.js:3112 6.0/applet.js:3112
+#: 4.0/applet.js:3171 6.0/applet.js:3171
 msgid "Close all"
 msgstr "Chiudi tutto"
 
-#: 4.0/applet.js:3121 6.0/applet.js:3121
+#: 4.0/applet.js:3180 6.0/applet.js:3180
 msgid "Close"
 msgstr "Chiudi"
 
@@ -264,7 +264,8 @@ msgstr "Impostazioni dell'etichetta del pulsante dell'elenco delle finestre"
 
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
-msgid "Application groups number label settings"
+#, fuzzy
+msgid "Number label settings"
 msgstr "Impostazioni delle etichette numeriche dei gruppi di applicazioni"
 
 #. 4.0->settings-schema.json->general-settings->title
@@ -321,10 +322,8 @@ msgstr "Quale sarà il contenuto dell'etichetta"
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 msgid "Never"
 msgstr "Mai"
 
@@ -454,6 +453,19 @@ msgstr ""
 "Automatico: gli indicatori ridotti a icona e bloccati verranno visualizzati "
 "solo quando lo spazio non è limitato."
 
+#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
+#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
+msgid "Show a vertical ellipsis (...) for grouped buttons"
+msgstr ""
+
+#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+msgid ""
+"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
+"list buttons with more then one window. When on a vertical panel this option "
+"is not possible and the setting will be ignored."
+msgstr ""
+
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
 #. 6.0->settings-schema.json->trailing-pinned-behaviour->description
 msgid "Add new window buttons ahead of trailing pinned buttons"
@@ -507,9 +519,9 @@ msgstr "Passa il mouse prima di visualizzare il menù"
 #. 6.0->settings-schema.json->hover-peek-delay->tooltip
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies to both window-list buttons and thumbnail menu items (of "
-"course one of the full size window preview options must be enabled for this "
-"option to have any effect)"
+"appear. It applies when hovering over either window-list buttons or "
+"thumbnail menu items (of course one of the full size window preview options "
+"must be enabled for this option to have any effect)"
 msgstr ""
 
 #. 4.0->settings-schema.json->label-width->units
@@ -542,15 +554,54 @@ msgstr "Etichetta animata"
 msgid "Label animation duration"
 msgstr "Tempo animazione etichetta"
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Nothing"
+msgstr "Non fare niente"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Application group window count"
+msgstr "Raggruppa le finestre dell'applicazione"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Workspace number"
+msgstr "Mostra numero"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Monitor number"
+msgstr "Monitor"
+
+#. 4.0->settings-schema.json->number-type->description
+#. 6.0->settings-schema.json->number-type->description
+#, fuzzy
+msgid "Number label contents"
+msgstr "Contenuto dell'etichetta"
+
 #. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-number->options
-msgid "2 or more windows"
-msgstr "2 o più finestre"
+msgid "Smart"
+msgstr ""
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 msgid "Display number"
 msgstr "Mostra numero"
+
+#. 4.0->settings-schema.json->display-number->tooltip
+#. 6.0->settings-schema.json->display-number->tooltip
+msgid ""
+"Controls when the number label is used. Smart means the the label will only "
+"appear when it is appropriate depending on the number label contents setting "
+"above. i.e. When there is two or more windows in a group, or when the "
+"windows workspace or monitor does not match the current one."
+msgstr ""
 
 #. 4.0->settings-schema.json->number-style->options
 #. 6.0->settings-schema.json->number-style->options
@@ -569,9 +620,10 @@ msgstr "Stile numero"
 
 #. 4.0->settings-schema.json->number-style->tooltip
 #. 6.0->settings-schema.json->number-style->tooltip
+#, fuzzy
 msgid ""
-"Controls how the number of windows in a grouped button is presented. When on "
-"a vertical panel, the \"label prepend\" option is not possible so \"icon "
+"Controls how the number label is presented. When on a vertical panel or when "
+"in launcher mode, the \"label prepend\" option is not possible so \"icon "
 "overlay\" will be used instead"
 msgstr ""
 "Controlla il modo in cui viene presentato il numero di finestre in un "
@@ -1478,6 +1530,42 @@ msgstr "Blocco del menù delle miniature"
 #. 6.0->settings-schema.json->mouse-action-btn9->options
 msgid "Restore most recent application window"
 msgstr "Ripristina la finestra dell'applicazione più recente"
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 1st window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 2nd window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 3rd window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 4th window in grouped button"
+msgstr ""
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description
 #. 6.0->settings-schema.json->mouse-action-btn2->description

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/nl.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CassiaWindowList@klangman 2.0.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-13 20:57-0400\n"
+"POT-Creation-Date: 2024-05-27 19:07-0400\n"
 "PO-Revision-Date: 2024-04-20 10:46+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,32 +16,32 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: 4.0/applet.js:536 6.0/applet.js:536
+#: 4.0/applet.js:547 6.0/applet.js:547
 msgid "all buttons"
 msgstr "alle knoppen"
 
-#: 4.0/applet.js:2646 6.0/applet.js:2646
+#: 4.0/applet.js:2705 6.0/applet.js:2705
 msgid "Applet Preferences"
 msgstr "Applet Voorkeuren"
 
-#: 4.0/applet.js:2650 6.0/applet.js:2650
+#: 4.0/applet.js:2709 6.0/applet.js:2709
 msgid "About..."
 msgstr "Over..."
 
-#: 4.0/applet.js:2654 6.0/applet.js:2654
+#: 4.0/applet.js:2713 6.0/applet.js:2713
 msgid "Configure..."
 msgstr "Configureren..."
 
-#: 4.0/applet.js:2658 6.0/applet.js:2658
+#: 4.0/applet.js:2717 6.0/applet.js:2717
 msgid "Website"
 msgstr "Website"
 
-#: 4.0/applet.js:2662 6.0/applet.js:2662
+#: 4.0/applet.js:2721 6.0/applet.js:2721
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Verwijder '%s'"
 
-#: 4.0/applet.js:2664 6.0/applet.js:2664
+#: 4.0/applet.js:2723 6.0/applet.js:2723
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr ""
 "Weet u zeker dat u deze instantie van CassiaWindowList wilt verwijderen?"
@@ -58,111 +58,111 @@ msgstr ""
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2673 6.0/applet.js:2673
+#: 4.0/applet.js:2732 6.0/applet.js:2732
 msgid "Open new window"
 msgstr "Open een nieuw venster"
 
-#: 4.0/applet.js:2681 6.0/applet.js:2681
+#: 4.0/applet.js:2740 6.0/applet.js:2740
 msgid "Remove from panel"
 msgstr "Verwijderen van paneel"
 
-#: 4.0/applet.js:2683 6.0/applet.js:2683
+#: 4.0/applet.js:2742 6.0/applet.js:2742
 msgid "Remove from this workspace"
 msgstr "Verwijderen van deze werkruimte"
 
-#: 4.0/applet.js:2689 6.0/applet.js:2689
+#: 4.0/applet.js:2748 6.0/applet.js:2748
 msgid "Pin to panel"
 msgstr "Vastmaken aan paneel"
 
-#: 4.0/applet.js:2691 6.0/applet.js:2691
+#: 4.0/applet.js:2750 6.0/applet.js:2750
 msgid "Pin to this workspace"
 msgstr "Vastmaken aan deze werkruimte"
 
-#: 4.0/applet.js:2732 6.0/applet.js:2732
+#: 4.0/applet.js:2791 6.0/applet.js:2791
 msgid "Pin to other workspaces"
 msgstr "Vastmaken aan andere werkruimtes"
 
-#: 4.0/applet.js:2753 6.0/applet.js:2753
+#: 4.0/applet.js:2812 6.0/applet.js:2812
 msgid "Pin to all workspaces"
 msgstr "Vastmaken aan alle werkruimtes"
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:2830 6.0/applet.js:2830
 msgid "Pin to launcher"
 msgstr "Vastmaken aan launcher"
 
-#: 4.0/applet.js:2789 4.0/applet.js:2972 6.0/applet.js:2789 6.0/applet.js:2972
+#: 4.0/applet.js:2848 4.0/applet.js:3031 6.0/applet.js:2848 6.0/applet.js:3031
 msgid "Add new Hotkey for"
 msgstr "Voeg nieuwe sneltoets toe voor"
 
-#: 4.0/applet.js:2803 6.0/applet.js:2803
+#: 4.0/applet.js:2862 6.0/applet.js:2862
 msgid "Recent files"
 msgstr "Recente bestanden"
 
-#: 4.0/applet.js:2827 6.0/applet.js:2827
+#: 4.0/applet.js:2886 6.0/applet.js:2886
 msgid "Places"
 msgstr "Locaties"
 
-#: 4.0/applet.js:2869 6.0/applet.js:2869
+#: 4.0/applet.js:2928 6.0/applet.js:2928
 msgid "Only on this workspace"
 msgstr "Alleen op deze werkruimte"
 
-#: 4.0/applet.js:2871 6.0/applet.js:2871
+#: 4.0/applet.js:2930 6.0/applet.js:2930
 msgid "Visible on all workspaces"
 msgstr "Zichtbaar op alle werkruimtes"
 
-#: 4.0/applet.js:2872 6.0/applet.js:2872
+#: 4.0/applet.js:2931 6.0/applet.js:2931
 msgid "Move to another workspace"
 msgstr "Verplaatsen naar een andere werkruimte"
 
-#: 4.0/applet.js:2881 6.0/applet.js:2881
+#: 4.0/applet.js:2940 6.0/applet.js:2940
 msgid " (this workspace)"
 msgstr " (deze werkruimte)"
 
-#: 4.0/applet.js:2894 6.0/applet.js:2894
+#: 4.0/applet.js:2953 6.0/applet.js:2953
 msgid "Move to another monitor"
 msgstr "Verplaatsen naar een ander beeldscherm"
 
-#: 4.0/applet.js:2902 6.0/applet.js:2902
+#: 4.0/applet.js:2961 6.0/applet.js:2961
 msgid "Monitor"
 msgstr "Beeldscherm"
 
-#: 4.0/applet.js:2927 6.0/applet.js:2927
+#: 4.0/applet.js:2986 6.0/applet.js:2986
 msgid "unassigned"
 msgstr "niet toegewezen"
 
-#: 4.0/applet.js:2938 4.0/applet.js:2969 6.0/applet.js:2938 6.0/applet.js:2969
+#: 4.0/applet.js:2997 4.0/applet.js:3028 6.0/applet.js:2997 6.0/applet.js:3028
 msgid "Assign window to a hotkey"
 msgstr "Wijs venster toe aan een sneltoets"
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3051 6.0/applet.js:3051
 msgid "Change application label contents"
 msgstr "Wijzig inhoud van applicatielabel"
 
-#: 4.0/applet.js:2995 6.0/applet.js:2995
+#: 4.0/applet.js:3054 6.0/applet.js:3054
 msgid "Remove custom setting"
 msgstr "Verwijder aangepaste instelling"
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3061 6.0/applet.js:3061
 msgid "Use window title"
 msgstr "Gebruik venstertitel"
 
-#: 4.0/applet.js:3009 6.0/applet.js:3009
+#: 4.0/applet.js:3068 6.0/applet.js:3068
 msgid "Use application name"
 msgstr "Gebruik applicatienaam"
 
-#: 4.0/applet.js:3016 6.0/applet.js:3016
+#: 4.0/applet.js:3075 6.0/applet.js:3075
 msgid "No label"
 msgstr "Geen label"
 
-#: 4.0/applet.js:3027 6.0/applet.js:3027
+#: 4.0/applet.js:3086 6.0/applet.js:3086
 msgid "Ungroup application windows"
 msgstr "Applicatie-vensters niet groeperen"
 
-#: 4.0/applet.js:3036 6.0/applet.js:3036
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Group application windows"
 msgstr "Applicatie-vensters groeperen"
 
-#: 4.0/applet.js:3049 6.0/applet.js:3049
+#: 4.0/applet.js:3108 6.0/applet.js:3108
 msgid "Automatic grouping/ungrouping"
 msgstr "Automatisch groeperen/ongroeperen"
 
@@ -178,31 +178,31 @@ msgstr "Automatisch groeperen/ongroeperen"
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3079 6.0/applet.js:3079
+#: 4.0/applet.js:3138 6.0/applet.js:3138
 msgid "Move titlebar on to screen"
 msgstr "Verplaats titelbalk naar het scherm"
 
-#: 4.0/applet.js:3084 6.0/applet.js:3084
+#: 4.0/applet.js:3143 6.0/applet.js:3143
 msgid "Restore"
 msgstr "Herstellen"
 
-#: 4.0/applet.js:3088 6.0/applet.js:3088
+#: 4.0/applet.js:3147 6.0/applet.js:3147
 msgid "Minimize"
 msgstr "Minimaliseren"
 
-#: 4.0/applet.js:3094 6.0/applet.js:3094
+#: 4.0/applet.js:3153 6.0/applet.js:3153
 msgid "Unmaximize"
 msgstr "Ontmaximaliseren"
 
-#: 4.0/applet.js:3101 6.0/applet.js:3101
+#: 4.0/applet.js:3160 6.0/applet.js:3160
 msgid "Close others"
 msgstr "Sluit anderen"
 
-#: 4.0/applet.js:3112 6.0/applet.js:3112
+#: 4.0/applet.js:3171 6.0/applet.js:3171
 msgid "Close all"
 msgstr "Sluit alle"
 
-#: 4.0/applet.js:3121 6.0/applet.js:3121
+#: 4.0/applet.js:3180 6.0/applet.js:3180
 msgid "Close"
 msgstr "Sluiten"
 
@@ -262,7 +262,8 @@ msgstr "Instellingen voor labels van knoppen van vensterlijsten"
 
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
-msgid "Application groups number label settings"
+#, fuzzy
+msgid "Number label settings"
 msgstr "Instellingen voor labelnummers van applicatiegroepen"
 
 #. 4.0->settings-schema.json->general-settings->title
@@ -319,10 +320,8 @@ msgstr "Wat de inhoud van het label zal zijn"
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 msgid "Never"
 msgstr "Nooit"
 
@@ -450,6 +449,19 @@ msgstr ""
 "Automatisch: De indicatoren voor geminimaliseerd en vastgemaakt worden "
 "alleen weergegeven wanneer er geen beperkte ruimte is."
 
+#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
+#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
+msgid "Show a vertical ellipsis (...) for grouped buttons"
+msgstr ""
+
+#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+msgid ""
+"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
+"list buttons with more then one window. When on a vertical panel this option "
+"is not possible and the setting will be ignored."
+msgstr ""
+
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
 #. 6.0->settings-schema.json->trailing-pinned-behaviour->description
 msgid "Add new window buttons ahead of trailing pinned buttons"
@@ -503,11 +515,12 @@ msgstr ""
 
 #. 4.0->settings-schema.json->hover-peek-delay->tooltip
 #. 6.0->settings-schema.json->hover-peek-delay->tooltip
+#, fuzzy
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies to both window-list buttons and thumbnail menu items (of "
-"course one of the full size window preview options must be enabled for this "
-"option to have any effect)"
+"appear. It applies when hovering over either window-list buttons or "
+"thumbnail menu items (of course one of the full size window preview options "
+"must be enabled for this option to have any effect)"
 msgstr ""
 "Dit definieert de muiszweeftijd voordat een volledige grootte "
 "voorbeeldvenster wordt weergegeven. Het is van toepassing op zowel de "
@@ -543,15 +556,54 @@ msgstr "Label animeren"
 msgid "Label animation duration"
 msgstr "Duur van de labelanimatie"
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Nothing"
+msgstr "Doe niets"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Application group window count"
+msgstr "Applicatie-vensters groeperen"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Workspace number"
+msgstr "Weergavenummer"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Monitor number"
+msgstr "Beeldscherm"
+
+#. 4.0->settings-schema.json->number-type->description
+#. 6.0->settings-schema.json->number-type->description
+#, fuzzy
+msgid "Number label contents"
+msgstr "Labelinhoud"
+
 #. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-number->options
-msgid "2 or more windows"
-msgstr "2 of meer vensters"
+msgid "Smart"
+msgstr ""
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 msgid "Display number"
 msgstr "Weergavenummer"
+
+#. 4.0->settings-schema.json->display-number->tooltip
+#. 6.0->settings-schema.json->display-number->tooltip
+msgid ""
+"Controls when the number label is used. Smart means the the label will only "
+"appear when it is appropriate depending on the number label contents setting "
+"above. i.e. When there is two or more windows in a group, or when the "
+"windows workspace or monitor does not match the current one."
+msgstr ""
 
 #. 4.0->settings-schema.json->number-style->options
 #. 6.0->settings-schema.json->number-style->options
@@ -570,9 +622,10 @@ msgstr "Nummerstijl"
 
 #. 4.0->settings-schema.json->number-style->tooltip
 #. 6.0->settings-schema.json->number-style->tooltip
+#, fuzzy
 msgid ""
-"Controls how the number of windows in a grouped button is presented. When on "
-"a vertical panel, the \"label prepend\" option is not possible so \"icon "
+"Controls how the number label is presented. When on a vertical panel or when "
+"in launcher mode, the \"label prepend\" option is not possible so \"icon "
 "overlay\" will be used instead"
 msgstr ""
 "Bepaalt hoe het aantal vensters in een gegroepeerde knop wordt "
@@ -1494,6 +1547,42 @@ msgstr "Miniaturenmenu ingedrukt houden"
 #. 6.0->settings-schema.json->mouse-action-btn9->options
 msgid "Restore most recent application window"
 msgstr "Meest recente applicatievenster herstellen"
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 1st window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 2nd window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 3rd window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 4th window in grouped button"
+msgstr ""
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description
 #. 6.0->settings-schema.json->mouse-action-btn2->description

--- a/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ru.po
+++ b/CassiaWindowList@klangman/files/CassiaWindowList@klangman/po/ru.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-applets/"
 "issues\n"
-"POT-Creation-Date: 2024-05-13 20:57-0400\n"
+"POT-Creation-Date: 2024-05-27 19:07-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -14,32 +14,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.1\n"
 
-#: 4.0/applet.js:536 6.0/applet.js:536
+#: 4.0/applet.js:547 6.0/applet.js:547
 msgid "all buttons"
 msgstr "все кнопки"
 
-#: 4.0/applet.js:2646 6.0/applet.js:2646
+#: 4.0/applet.js:2705 6.0/applet.js:2705
 msgid "Applet Preferences"
 msgstr "Настройки Апплета"
 
-#: 4.0/applet.js:2650 6.0/applet.js:2650
+#: 4.0/applet.js:2709 6.0/applet.js:2709
 msgid "About..."
 msgstr "О Апплете..."
 
-#: 4.0/applet.js:2654 6.0/applet.js:2654
+#: 4.0/applet.js:2713 6.0/applet.js:2713
 msgid "Configure..."
 msgstr "Настроить..."
 
-#: 4.0/applet.js:2658 6.0/applet.js:2658
+#: 4.0/applet.js:2717 6.0/applet.js:2717
 msgid "Website"
 msgstr ""
 
-#: 4.0/applet.js:2662 6.0/applet.js:2662
+#: 4.0/applet.js:2721 6.0/applet.js:2721
 #, javascript-format
 msgid "Remove '%s'"
 msgstr "Удалить '%s'"
 
-#: 4.0/applet.js:2664 6.0/applet.js:2664
+#: 4.0/applet.js:2723 6.0/applet.js:2723
 msgid "Do you really want to remove this instance of CassiaWindowList?"
 msgstr "Вы действительно хотите удалить этот экземпляр CassiaWindowList?"
 
@@ -55,112 +55,112 @@ msgstr "Вы действительно хотите удалить этот э�
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:2673 6.0/applet.js:2673
+#: 4.0/applet.js:2732 6.0/applet.js:2732
 msgid "Open new window"
 msgstr "Открыть новое окно"
 
-#: 4.0/applet.js:2681 6.0/applet.js:2681
+#: 4.0/applet.js:2740 6.0/applet.js:2740
 msgid "Remove from panel"
 msgstr "Удалить с панели"
 
-#: 4.0/applet.js:2683 6.0/applet.js:2683
+#: 4.0/applet.js:2742 6.0/applet.js:2742
 msgid "Remove from this workspace"
 msgstr "Удалить из этого рабочего стола"
 
-#: 4.0/applet.js:2689 6.0/applet.js:2689
+#: 4.0/applet.js:2748 6.0/applet.js:2748
 msgid "Pin to panel"
 msgstr "Закрепить на панели"
 
-#: 4.0/applet.js:2691 6.0/applet.js:2691
+#: 4.0/applet.js:2750 6.0/applet.js:2750
 msgid "Pin to this workspace"
 msgstr "Закрепить на этом рабочем столе"
 
-#: 4.0/applet.js:2732 6.0/applet.js:2732
+#: 4.0/applet.js:2791 6.0/applet.js:2791
 msgid "Pin to other workspaces"
 msgstr "Закрепить на другом рабочем столе"
 
-#: 4.0/applet.js:2753 6.0/applet.js:2753
+#: 4.0/applet.js:2812 6.0/applet.js:2812
 msgid "Pin to all workspaces"
 msgstr "Закрепить на всех рабочих столах"
 
-#: 4.0/applet.js:2771 6.0/applet.js:2771
+#: 4.0/applet.js:2830 6.0/applet.js:2830
 msgid "Pin to launcher"
 msgstr "Закрепить в лаунчере"
 
-#: 4.0/applet.js:2789 4.0/applet.js:2972 6.0/applet.js:2789 6.0/applet.js:2972
+#: 4.0/applet.js:2848 4.0/applet.js:3031 6.0/applet.js:2848 6.0/applet.js:3031
 msgid "Add new Hotkey for"
 msgstr "Добавить новую горячую клавишу для"
 
-#: 4.0/applet.js:2803 6.0/applet.js:2803
+#: 4.0/applet.js:2862 6.0/applet.js:2862
 msgid "Recent files"
 msgstr "Недавние файлы"
 
-#: 4.0/applet.js:2827 6.0/applet.js:2827
+#: 4.0/applet.js:2886 6.0/applet.js:2886
 msgid "Places"
 msgstr "Места"
 
-#: 4.0/applet.js:2869 6.0/applet.js:2869
+#: 4.0/applet.js:2928 6.0/applet.js:2928
 msgid "Only on this workspace"
 msgstr "Только на этом рабочем столе"
 
-#: 4.0/applet.js:2871 6.0/applet.js:2871
+#: 4.0/applet.js:2930 6.0/applet.js:2930
 msgid "Visible on all workspaces"
 msgstr "Видно на всех рабочих столах"
 
-#: 4.0/applet.js:2872 6.0/applet.js:2872
+#: 4.0/applet.js:2931 6.0/applet.js:2931
 msgid "Move to another workspace"
 msgstr "Переместить на другой рабочий стол"
 
-#: 4.0/applet.js:2881 6.0/applet.js:2881
+#: 4.0/applet.js:2940 6.0/applet.js:2940
 #, fuzzy
 msgid " (this workspace)"
 msgstr "Закрепить на этом рабочем столе"
 
-#: 4.0/applet.js:2894 6.0/applet.js:2894
+#: 4.0/applet.js:2953 6.0/applet.js:2953
 msgid "Move to another monitor"
 msgstr "Переместить на другой монитор"
 
-#: 4.0/applet.js:2902 6.0/applet.js:2902
+#: 4.0/applet.js:2961 6.0/applet.js:2961
 msgid "Monitor"
 msgstr "Монитор"
 
-#: 4.0/applet.js:2927 6.0/applet.js:2927
+#: 4.0/applet.js:2986 6.0/applet.js:2986
 msgid "unassigned"
 msgstr "не назначено"
 
-#: 4.0/applet.js:2938 4.0/applet.js:2969 6.0/applet.js:2938 6.0/applet.js:2969
+#: 4.0/applet.js:2997 4.0/applet.js:3028 6.0/applet.js:2997 6.0/applet.js:3028
 msgid "Assign window to a hotkey"
 msgstr "Назначить окно горячей клавише"
 
-#: 4.0/applet.js:2992 6.0/applet.js:2992
+#: 4.0/applet.js:3051 6.0/applet.js:3051
 msgid "Change application label contents"
 msgstr "Изменить текст названия приложения"
 
-#: 4.0/applet.js:2995 6.0/applet.js:2995
+#: 4.0/applet.js:3054 6.0/applet.js:3054
 msgid "Remove custom setting"
 msgstr "Удалить свои настройки"
 
-#: 4.0/applet.js:3002 6.0/applet.js:3002
+#: 4.0/applet.js:3061 6.0/applet.js:3061
 msgid "Use window title"
 msgstr "Использовать заголовок окон"
 
-#: 4.0/applet.js:3009 6.0/applet.js:3009
+#: 4.0/applet.js:3068 6.0/applet.js:3068
 msgid "Use application name"
 msgstr "Использовать названия программ"
 
-#: 4.0/applet.js:3016 6.0/applet.js:3016
+#: 4.0/applet.js:3075 6.0/applet.js:3075
 msgid "No label"
 msgstr "Без названий"
 
-#: 4.0/applet.js:3027 6.0/applet.js:3027
+#: 4.0/applet.js:3086 6.0/applet.js:3086
 msgid "Ungroup application windows"
 msgstr "Не группировать окна приложений"
 
-#: 4.0/applet.js:3036 6.0/applet.js:3036
+#: 4.0/applet.js:3095 6.0/applet.js:3095
 msgid "Group application windows"
 msgstr "Группировать окна приложений"
 
-#: 4.0/applet.js:3049 6.0/applet.js:3049
+#: 4.0/applet.js:3108 6.0/applet.js:3108
 msgid "Automatic grouping/ungrouping"
 msgstr "Автоматически группировать/разгруппировать"
 
@@ -176,31 +176,31 @@ msgstr "Автоматически группировать/разгруппир
 #. 6.0->settings-schema.json->mouse-action-btn2->options
 #. 6.0->settings-schema.json->mouse-action-btn8->options
 #. 6.0->settings-schema.json->mouse-action-btn9->options
-#: 4.0/applet.js:3079 6.0/applet.js:3079
+#: 4.0/applet.js:3138 6.0/applet.js:3138
 msgid "Move titlebar on to screen"
 msgstr "Переместить на другой экран"
 
-#: 4.0/applet.js:3084 6.0/applet.js:3084
+#: 4.0/applet.js:3143 6.0/applet.js:3143
 msgid "Restore"
 msgstr "Восстановить"
 
-#: 4.0/applet.js:3088 6.0/applet.js:3088
+#: 4.0/applet.js:3147 6.0/applet.js:3147
 msgid "Minimize"
 msgstr "Свернуть"
 
-#: 4.0/applet.js:3094 6.0/applet.js:3094
+#: 4.0/applet.js:3153 6.0/applet.js:3153
 msgid "Unmaximize"
 msgstr "Обычный размер"
 
-#: 4.0/applet.js:3101 6.0/applet.js:3101
+#: 4.0/applet.js:3160 6.0/applet.js:3160
 msgid "Close others"
 msgstr "Закрыть другие"
 
-#: 4.0/applet.js:3112 6.0/applet.js:3112
+#: 4.0/applet.js:3171 6.0/applet.js:3171
 msgid "Close all"
 msgstr "Закрыть всё"
 
-#: 4.0/applet.js:3121 6.0/applet.js:3121
+#: 4.0/applet.js:3180 6.0/applet.js:3180
 msgid "Close"
 msgstr "Закрыть"
 
@@ -260,7 +260,8 @@ msgstr "Настройки списка окон"
 
 #. 4.0->settings-schema.json->caption-number-settings->title
 #. 6.0->settings-schema.json->caption-number-settings->title
-msgid "Application groups number label settings"
+#, fuzzy
+msgid "Number label settings"
 msgstr "Настройки надписей номеров группировки"
 
 #. 4.0->settings-schema.json->general-settings->title
@@ -317,10 +318,8 @@ msgstr "Когда будут надписи"
 
 #. 4.0->settings-schema.json->display-caption-for->options
 #. 4.0->settings-schema.json->display-caption-for-pined->options
-#. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-caption-for->options
 #. 6.0->settings-schema.json->display-caption-for-pined->options
-#. 6.0->settings-schema.json->display-number->options
 msgid "Never"
 msgstr "Никогда"
 
@@ -446,6 +445,19 @@ msgstr ""
 "Автоматически: Индикация свёрнутых и закреплённых окон отображается только "
 "если есть место."
 
+#. 4.0->settings-schema.json->show-ellipsis-for-groups->description
+#. 6.0->settings-schema.json->show-ellipsis-for-groups->description
+msgid "Show a vertical ellipsis (...) for grouped buttons"
+msgstr ""
+
+#. 4.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+#. 6.0->settings-schema.json->show-ellipsis-for-groups->tooltip
+msgid ""
+"Prepend a vertical ellipsis unicode charter to the labels for grouped window-"
+"list buttons with more then one window. When on a vertical panel this option "
+"is not possible and the setting will be ignored."
+msgstr ""
+
 #. 4.0->settings-schema.json->trailing-pinned-behaviour->description
 #. 6.0->settings-schema.json->trailing-pinned-behaviour->description
 msgid "Add new window buttons ahead of trailing pinned buttons"
@@ -497,9 +509,9 @@ msgstr "Задержка отображения меню после наведе
 #. 6.0->settings-schema.json->hover-peek-delay->tooltip
 msgid ""
 "This defines the mouse hover time before a full size window preview will "
-"appear. It applies to both window-list buttons and thumbnail menu items (of "
-"course one of the full size window preview options must be enabled for this "
-"option to have any effect)"
+"appear. It applies when hovering over either window-list buttons or "
+"thumbnail menu items (of course one of the full size window preview options "
+"must be enabled for this option to have any effect)"
 msgstr ""
 
 #. 4.0->settings-schema.json->label-width->units
@@ -530,15 +542,54 @@ msgstr "Анимировать надписи"
 msgid "Label animation duration"
 msgstr "Время анимации надписи"
 
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Nothing"
+msgstr "Ничего не делать"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Application group window count"
+msgstr "Группировать окна приложений"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Workspace number"
+msgstr "Номер дисплея"
+
+#. 4.0->settings-schema.json->number-type->options
+#. 6.0->settings-schema.json->number-type->options
+#, fuzzy
+msgid "Monitor number"
+msgstr "Монитор"
+
+#. 4.0->settings-schema.json->number-type->description
+#. 6.0->settings-schema.json->number-type->description
+#, fuzzy
+msgid "Number label contents"
+msgstr "Текст надписей"
+
 #. 4.0->settings-schema.json->display-number->options
 #. 6.0->settings-schema.json->display-number->options
-msgid "2 or more windows"
-msgstr "два или более окон"
+msgid "Smart"
+msgstr ""
 
 #. 4.0->settings-schema.json->display-number->description
 #. 6.0->settings-schema.json->display-number->description
 msgid "Display number"
 msgstr "Номер дисплея"
+
+#. 4.0->settings-schema.json->display-number->tooltip
+#. 6.0->settings-schema.json->display-number->tooltip
+msgid ""
+"Controls when the number label is used. Smart means the the label will only "
+"appear when it is appropriate depending on the number label contents setting "
+"above. i.e. When there is two or more windows in a group, or when the "
+"windows workspace or monitor does not match the current one."
+msgstr ""
 
 #. 4.0->settings-schema.json->number-style->options
 #. 6.0->settings-schema.json->number-style->options
@@ -557,9 +608,10 @@ msgstr "Стиль чисел"
 
 #. 4.0->settings-schema.json->number-style->tooltip
 #. 6.0->settings-schema.json->number-style->tooltip
+#, fuzzy
 msgid ""
-"Controls how the number of windows in a grouped button is presented. When on "
-"a vertical panel, the \"label prepend\" option is not possible so \"icon "
+"Controls how the number label is presented. When on a vertical panel or when "
+"in launcher mode, the \"label prepend\" option is not possible so \"icon "
 "overlay\" will be used instead"
 msgstr "Определяет вид на вертикальной панели"
 
@@ -1448,6 +1500,42 @@ msgstr "Удержание меню миниатюр"
 #. 6.0->settings-schema.json->mouse-action-btn9->options
 msgid "Restore most recent application window"
 msgstr "Восстановить последнее окно приложения"
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 1st window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 2nd window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 3rd window in grouped button"
+msgstr ""
+
+#. 4.0->settings-schema.json->mouse-action-btn2->options
+#. 4.0->settings-schema.json->mouse-action-btn8->options
+#. 4.0->settings-schema.json->mouse-action-btn9->options
+#. 6.0->settings-schema.json->mouse-action-btn2->options
+#. 6.0->settings-schema.json->mouse-action-btn8->options
+#. 6.0->settings-schema.json->mouse-action-btn9->options
+msgid "Activate 4th window in grouped button"
+msgstr ""
 
 #. 4.0->settings-schema.json->mouse-action-btn2->description
 #. 6.0->settings-schema.json->mouse-action-btn2->description


### PR DESCRIPTION
1. Added an option to configure what the "number label" content represents (Window count, Workspace index or Monitor number).
2. Added an option to show a vertical ellipsis character on grouped buttons to indicate a button represents a group of windows. Useful when the user decides to use the number label for Workspace/Monitor number and needs a new way to mark grouped buttons.
3. Added 4 new mouse action options that will activate windows 1-4 of a grouped button
4. Change the "2 or more window" option in the "Display number" drop-down to "Smart" so that it can apply to other number label options.
5. Removed the "Display number" "Never" option as now the "Number Style" option can disable the number label
6. In Launcher mode the "Number Style" option now appears but it's effects do not apply. This is because the dependency setting in the json only allows a single variable dependency and it is now dependant on the "Number Style" option. You can't use "and/or" logical operators to have better control when the option appears.
7. Clarified the tooltip text for the "Hover time before showing a full size window preview" option.